### PR TITLE
feat: Add Custom Fields on Customer Doctype

### DIFF
--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -67,13 +67,13 @@ app_license = "mit"
 # Installation
 # ------------
 
-# before_install = "beams.install.before_install"
-# after_install = "beams.install.after_install"
+after_install = "beams.install.after_install"
+after_migrate = "beams.setup.after_migrate"
 
 # Uninstallation
 # ------------
 
-# before_uninstall = "beams.uninstall.before_uninstall"
+before_uninstall = "beams.uninstall.before_uninstall"
 # after_uninstall = "beams.uninstall.after_uninstall"
 
 # Integration Setup
@@ -226,4 +226,3 @@ app_license = "mit"
 # default_log_clearing_doctypes = {
 # 	"Logging DocType Name": 30  # days to retain logs
 # }
-

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -1,0 +1,61 @@
+import os
+import click
+import frappe
+from frappe import _
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+
+def after_install():
+    create_custom_fields(get_customer_custom_fields(), ignore_validate=True)
+
+def after_migrate():
+    after_install()
+
+def before_uninstall():
+    delete_custom_fields(get_customer_custom_fields())
+
+def delete_custom_fields(custom_fields: dict):
+    '''
+    Method to Delete custom fields
+    args:
+        custom_fields: a dict like `{'Task': [{fieldname: 'your_fieldname', ...}]}`
+    '''
+    for doctype, fields in custom_fields.items():
+        frappe.db.delete(
+            "Custom Field",
+            {
+                "fieldname": ("in", [field["fieldname"] for field in fields]),
+                "dt": doctype,
+            },
+        )
+        frappe.clear_cache(doctype=doctype)
+
+def get_customer_custom_fields():
+    '''
+    Custom fields that need to be added to the Customer Doctype
+    '''
+    return {
+        "Customer": [
+            {
+                "fieldname": "msme_status",
+                "fieldtype": "Select",
+                "label": "MSME Status",
+                "options":"\nMSME\nNon-MSME",
+                "insert_after": "customer_group"
+            },
+            {
+                "fieldname": "is_agent",
+                "fieldtype": "Check",
+                "label": "Is Agent",
+                "insert_after": "msme_status"
+            },
+            {
+                "fieldname": "agent_of",
+                "fieldtype": "Link",
+                "label": "Agent Of",
+                "options": "Customer",
+                "depends_on": "eval:doc.is_agent == 1",
+                "insert_after": "is_agent"
+            }
+
+        ]
+    }


### PR DESCRIPTION
## Feature description
-Add Custom Fields on Customer Doctype.
   -"MSME Status" (Select/Options: MSME/Non-MSMSE)
   -"Is Agent" (Checkbox)
   -"Agent of" (Link/Customer/depends on Is Agent == True)

## Solution description
 -Added Custom Fields on Customer Doctype.

## Output
![image](https://github.com/user-attachments/assets/1be1479a-9a1d-4f32-b353-dda1bd1bbb0d)
![image](https://github.com/user-attachments/assets/7e71e794-758a-44c2-be0b-9d31d5ebaa71)

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox