### PR TITLE
feat: add custom fields to Sales Invoice Doctype

### DIFF
--- a/beams/setup.py
+++ b/beams/setup.py
@@ -6,12 +6,14 @@ from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 
 def after_install():
     create_custom_fields(get_customer_custom_fields(), ignore_validate=True)
+    create_custom_fields(get_sales_invoice_custom_fields(), ignore_validate=True)
 
 def after_migrate():
     after_install()
 
 def before_uninstall():
     delete_custom_fields(get_customer_custom_fields())
+    delete_custom_fields(get_sales_invoice_custom_fields())
 
 def delete_custom_fields(custom_fields: dict):
     '''
@@ -57,5 +59,40 @@ def get_customer_custom_fields():
                 "insert_after": "is_agent"
             }
 
+        ]
+    }
+
+def get_sales_invoice_custom_fields():
+    '''
+    Custom fields that need to be added to the Sales Invoice Doctype
+    '''
+    return {
+        "Sales Invoice": [
+            {
+                "fieldname": "actual_customer",
+                "fieldtype": "Link",
+                "label": "Actual Customer",
+                "options": "Customer",
+                "insert_after": "customer"
+            },
+            {
+                "fieldname": "actual_customer_group",
+                "fieldtype": "Link",
+                "label": "Actual Customer Group",
+                "options": "Customer Group",
+                "insert_after": "actual_customer"
+            },
+            {
+                "fieldname": "include_in_ibf",
+                "fieldtype": "Check",
+                "label": "Include in IBF",
+                "insert_after": "actual_customer_group"
+            },
+            {
+                "fieldname": "is_barter_invoice",
+                "fieldtype": "Check",
+                "label": "Is Barter Invoice",
+                "insert_after": "include_in_ibf"
+            }
         ]
     }


### PR DESCRIPTION
## Feature description
-Add Custom Fields on Sales Invoice DocType.
 -  "Actual Customer" (Link/Customer)
 - "Actual Customer Group" (Link/Customer Group)
 - "Include in IBF" (Checkbox)
 - "Is Barter Invoice" (Checkbox)

## Solution description
 -Added Custom Fields on Sales Invoice DocType.

## Output
![image](https://github.com/user-attachments/assets/78dbe6d4-1dd4-4b3d-aeda-f9d437767c03)
