### PR TITLE
feat: Enhance Sales Invoice form behavior based on customer selection

### DIFF
--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -28,7 +28,9 @@ app_license = "mit"
 # page_js = {"page" : "public/js/file.js"}
 
 # include js in doctype views
-# doctype_js = {"doctype" : "public/js/doctype.js"}
+doctype_js = {
+    "Sales Invoice": "public/js/sales_invoice.js"
+}
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}
 # doctype_calendar_js = {"doctype" : "public/js/doctype_calendar.js"}

--- a/beams/public/js/sales_invoice.js
+++ b/beams/public/js/sales_invoice.js
@@ -1,0 +1,40 @@
+frappe.ui.form.on('Sales Invoice', {
+    onload: function(frm) {
+        frm.toggle_display('actual_customer', false);
+        frm.toggle_display('actual_customer_group', false);
+    },
+    customer: function(frm) {
+        if (frm.doc.customer) {
+            frappe.db.get_value('Customer', frm.doc.customer, ['is_agent'], function(value) {
+                if (value && value.is_agent) {
+                    frm.toggle_display('actual_customer', true);
+                    frm.set_value('actual_customer', '');
+                    frm.toggle_display('actual_customer_group', false);
+                } else {
+                    frm.toggle_display('actual_customer', false);
+                    frm.toggle_display('actual_customer_group', false);
+                }
+                frm.refresh_field('actual_customer');
+            });
+        } else {
+            frm.toggle_display('actual_customer', false);
+            frm.toggle_display('actual_customer_group', false);
+        }
+    },
+    actual_customer: function(frm) {
+        if (frm.doc.actual_customer) {
+            frappe.db.get_value('Customer', frm.doc.actual_customer, 'customer_group', function(response) {
+                if (response && response.customer_group) {
+                    frm.toggle_display('actual_customer_group', true);
+                    frm.set_value('actual_customer_group', response.customer_group);
+                } else {
+                    frm.set_value('actual_customer_group', '');
+                    frm.toggle_display('actual_customer_group', false);
+                }
+            });
+        } else {
+            frm.set_value('actual_customer_group', '');
+            frm.toggle_display('actual_customer_group', false);
+        }
+    }
+});

--- a/beams/public/js/sales_invoice.js
+++ b/beams/public/js/sales_invoice.js
@@ -1,5 +1,7 @@
 frappe.ui.form.on('Sales Invoice', {
+  // Function triggered on form load
     onload: function(frm) {
+      // Hide 'actual_customer' and 'actual_customer_group' fields by default
         frm.toggle_display('actual_customer', false);
         frm.toggle_display('actual_customer_group', false);
     },
@@ -23,6 +25,7 @@ frappe.ui.form.on('Sales Invoice', {
     },
     actual_customer: function(frm) {
         if (frm.doc.actual_customer) {
+          // Fetch the 'customer_group' of the selected 'actual_customer'
             frappe.db.get_value('Customer', frm.doc.actual_customer, 'customer_group', function(response) {
                 if (response && response.customer_group) {
                     frm.toggle_display('actual_customer_group', true);


### PR DESCRIPTION
## Feature description
- Hide 'actual_customer' and 'actual_customer_group' fields by default on form load.
- Display 'actual_customer' field and clear its value if the selected customer is an agent.
- Populate 'actual_customer_group' based on the 'customer_group' of the selected 'actual_customer'.
- Hide 'actual_customer_group' if 'actual_customer' is not selected.

## Solution description
-Hid actual_customer and actual_customer_group fields by default on form load.
-Displayed actual_customer field and cleared its value if the selected customer was an agent.
-Populated actual_customer_group based on the customer_group of the selected actual_customer.
-Hid actual_customer_group if no actual_customer was selected.

## Output
![image](https://github.com/user-attachments/assets/e8297d61-925a-4471-89e3-d6ae18d54b04)
![image](https://github.com/user-attachments/assets/108b6050-58f7-4e60-8243-4429c6f1f120)
![image](https://github.com/user-attachments/assets/38563c2f-1f2d-4291-9db0-cc33861fb686)
![image](https://github.com/user-attachments/assets/1a66e3c6-c14f-48d4-b77e-9a15f96eefab)


## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox