### PR TITLE
feat:create Sales Invoice from Quotation

### DIFF
--- a/beams/beams/custom_scripts/quotation/quotation.py
+++ b/beams/beams/custom_scripts/quotation/quotation.py
@@ -1,0 +1,56 @@
+
+import frappe
+from frappe.model.mapper import get_mapped_doc
+
+@frappe.whitelist()
+def make_sales_invoice(source_name, target_doc=None, ignore_permissions=False):
+    '''
+    Method: Creates a Sales Invoice from a Quotation document.
+    Output: A new or updated Sales Invoice document mapped from the Quotation.
+    '''
+
+    def set_missing_values(source, target):
+
+
+        target.customer = source.party_name
+        target.run_method("set_missing_values")
+        target.run_method("calculate_taxes_and_totals")
+
+    doclist = get_mapped_doc(
+        "Quotation",
+        source_name,
+        {
+            "Quotation": {
+                "doctype": "Sales Invoice",
+                "validation": {"docstatus": ["=", 1]},
+                "field_map": {
+                    "party_name": "customer"
+                }
+            },
+            "Quotation Item": {
+                "doctype": "Sales Invoice Item",
+                "field_map": {
+                    "parent": "quotation",
+                    "name": "quotation_item"
+                },
+
+            },
+            "Sales Taxes and Charges": {
+                "doctype": "Sales Taxes and Charges",
+                "add_if_empty": True
+            },
+            "Sales Team": {
+                "doctype": "Sales Team",
+                "add_if_empty": True
+            },
+            "Payment Schedule": {
+                "doctype": "Payment Schedule",
+                "add_if_empty": True
+            },
+        },
+        target_doc,
+        set_missing_values,
+        ignore_permissions=ignore_permissions,
+    )
+
+    return doclist

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -29,7 +29,8 @@ app_license = "mit"
 
 # include js in doctype views
 doctype_js = {
-    "Sales Invoice": "public/js/sales_invoice.js"
+    "Sales Invoice": "public/js/sales_invoice.js",
+    "Quotation": "public/js/quotation.js"
 }
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}

--- a/beams/public/js/quotation.js
+++ b/beams/public/js/quotation.js
@@ -1,0 +1,13 @@
+
+frappe.ui.form.on('Quotation', {
+    refresh: function(frm) {
+        if (frm.doc.docstatus == 1) {  
+            frm.add_custom_button(__('Sales Invoice'), function() {
+                frappe.model.open_mapped_doc({
+                    method: "beams.beams.custom_scripts.quotation.quotation.make_sales_invoice",
+                    frm: frm
+                });
+            }, __('Create'));
+        }
+    }
+});


### PR DESCRIPTION
## Feature description
-create Sales Invoice from Quotation
-Implemented a new function `make_sales_invoice` to map and create a Sales Invoice from a Quotation document. 


## Solution description
 -Created Sales Invoice from Quotation
 -Created a new function make_sales_invoice to map and generate a Sales Invoice from a Quotation document

## Output
![image](https://github.com/user-attachments/assets/1324445f-bca6-4971-9bcf-ad5bb17d0b0d)
![image](https://github.com/user-attachments/assets/02fa8323-143b-4c90-be3c-14a340320a82)
![image](https://github.com/user-attachments/assets/7c6e85a7-e0c3-4d6a-88a2-bdb12959e7b9)


## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox