### PR TITLE
feat: Create Sales Invoice From Quotation

### DIFF
--- a/beams/beams/custom_scripts/quotation/quotation.py
+++ b/beams/beams/custom_scripts/quotation/quotation.py
@@ -1,0 +1,55 @@
+import frappe
+from frappe.model.mapper import get_mapped_doc
+
+@frappe.whitelist()
+def make_sales_invoice(source_name, target_doc=None, ignore_permissions=False):
+    '''
+    Method: Creates a Sales Invoice from a Quotation document.
+    Output: A new or updated Sales Invoice document mapped from the Quotation.
+    '''
+
+    def set_missing_values(source, target):
+
+
+        target.customer = source.party_name
+        target.run_method("set_missing_values")
+        target.run_method("calculate_taxes_and_totals")
+
+    doclist = get_mapped_doc(
+        "Quotation",
+        source_name,
+        {
+            "Quotation": {
+                "doctype": "Sales Invoice",
+                "validation": {"docstatus": ["=", 1]},
+                "field_map": {
+                    "party_name": "customer"
+                }
+            },
+            "Quotation Item": {
+                "doctype": "Sales Invoice Item",
+                "field_map": {
+                    "parent": "quotation",
+                    "name": "quotation_item"
+                },
+
+            },
+            "Sales Taxes and Charges": {
+                "doctype": "Sales Taxes and Charges",
+                "add_if_empty": True
+            },
+            "Sales Team": {
+                "doctype": "Sales Team",
+                "add_if_empty": True
+            },
+            "Payment Schedule": {
+                "doctype": "Payment Schedule",
+                "add_if_empty": True
+            },
+        },
+        target_doc,
+        set_missing_values,
+        ignore_permissions=ignore_permissions,
+    )
+
+    return doclist

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -29,7 +29,8 @@ app_license = "mit"
 
 # include js in doctype views
 doctype_js = {
-    "Sales Invoice": "public/js/sales_invoice.js"
+    "Sales Invoice": "public/js/sales_invoice.js",
+    "Quotation": "public/js/quotation.js"
 }
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}

--- a/beams/public/js/quotation.js
+++ b/beams/public/js/quotation.js
@@ -1,0 +1,12 @@
+frappe.ui.form.on('Quotation', {
+    refresh: function(frm) {
+        if (frm.doc.docstatus == 1) {
+            frm.add_custom_button(__('Sales Invoice'), function() {
+                frappe.model.open_mapped_doc({
+                    method: "beams.beams.custom_scripts.quotation.quotation.make_sales_invoice",
+                    frm: frm
+                });
+            }, __('Create'));
+        }
+    }
+});


### PR DESCRIPTION
## Feature description
-Create sales invoice from quotation
-implement a new function make_sales_invoice to map and create a sales invoice from a quotation document.

## Solution description
 -Created sales invoice from quotation
-implemented a new function make_sales_invoice to map and create a sales invoice from a quotation document.

## Output
![image](https://github.com/user-attachments/assets/8aae94ec-5b89-4f3b-9b81-ed7f39434470)
![image](https://github.com/user-attachments/assets/ad579d49-31e4-4030-837f-67cbc572e981)
![image](https://github.com/user-attachments/assets/a2e2bfa2-1a2f-42a2-8460-85aa81b3a851)
![image](https://github.com/user-attachments/assets/f06a6430-1ba1-4461-a2e8-c2a39ffa4fcb)
![image](https://github.com/user-attachments/assets/aeddd253-abf5-44bf-a344-c19735c66903)

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox