### PR TITLE
feat: Added custom fields 'Barter Invoice' and 'Quotation Reference' to Purchase Invoice Doctype

### DIFF
--- a/beams/setup.py
+++ b/beams/setup.py
@@ -8,6 +8,7 @@ def after_install():
     create_custom_fields(get_customer_custom_fields(), ignore_validate=True)
     create_custom_fields(get_sales_invoice_custom_fields(), ignore_validate=True)
     create_custom_fields(get_quotation_custom_fields(), ignore_validate=True)
+    create_custom_fields(get_purchase_invoice_custom_fields(), ignore_validate=True)
 
 def after_migrate():
     after_install()
@@ -16,7 +17,7 @@ def before_uninstall():
     delete_custom_fields(get_customer_custom_fields())
     delete_custom_fields(get_sales_invoice_custom_fields())
     delete_custom_fields(get_quotation_custom_fields())
-
+    delete_custom_fields(get_purchase_invoice_custom_fields())
 
 def delete_custom_fields(custom_fields: dict):
     '''
@@ -117,6 +118,29 @@ def get_quotation_custom_fields():
                 "fieldtype": "Check",
                 "label": "Is Barter",
                 "insert_after": "order_type"
+            }
+        ]
+    }
+
+def get_purchase_invoice_custom_fields():
+    '''
+    Custom fields that need to be added to the Purchase Invoice Doctype
+    '''
+    return {
+        "Purchase Invoice": [
+            {
+                "fieldname": "barter_invoice",
+                "fieldtype": "Check",
+                "label": "Barter Invoice",
+                "insert_after": "supplier"
+            },
+            {
+                "fieldname": "quotation_reference",
+                "fieldtype": "Link",
+                "label": "Quotation Reference",
+                "options": "Quotation",
+                "insert_after": "barter_invoice"
+
             }
         ]
     }


### PR DESCRIPTION
## Feature description
-Add Custom Fields on  Purchase Invoice Doctype.
-Barter Invoice(Checkbox)
 -Quotation Referance(Link/Quotation)

## Solution description
 -Added Custom Fields on Purchase Invoice Doctype.

## Output
![image](https://github.com/user-attachments/assets/6a4cd27a-491d-448b-b84c-e82f75c0d429)
![image](https://github.com/user-attachments/assets/1e915a91-816d-440c-9584-ef906a40fdba)

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox