### PR TITLE
feat: Customize Sales Invoice DocType

### DIFF
--- a/beams/public/js/sales_invoice.js
+++ b/beams/public/js/sales_invoice.js
@@ -39,22 +39,5 @@ frappe.ui.form.on('Sales Invoice', {
             frm.set_value('actual_customer_group', '');
             frm.toggle_display('actual_customer_group', false);
         }
-    },
-    customer: function(frm) {
-          if (frm.doc.customer) {
-              frappe.db.get_value('Customer', frm.doc.customer, 'territory', (r) => {
-                  if (r.territory === 'India' && !frm.doc.is_barter_invoice) {
-                      frm.set_value('include_in_ibf', 1);
-                  } else {
-                      frm.set_value('include_in_ibf', 0);
-                  }
-              });
-          } else {
-              frm.set_value('include_in_ibf', 0);
-          }
-      },
-      is_barter_invoice: function(frm) {
-          frm.trigger('customer');
-      }
-
-});
+    }
+    });

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -90,6 +90,7 @@ def get_sales_invoice_custom_fields():
                 "fieldname": "include_in_ibf",
                 "fieldtype": "Check",
                 "label": "Include in IBF",
+                "read_only": 1,
                 "insert_after": "actual_customer_group"
             },
             {
@@ -99,14 +100,23 @@ def get_sales_invoice_custom_fields():
                 "insert_after": "include_in_ibf"
             },
             {
+                "fieldname": "quotation_reference",
+                "fieldtype": "Link",
+                "label": "Quotation Reference",
+                "options": "Quotation",
+                "insert_after": "is_barter_invoice"
+            },
+            {
                 "fieldname": "reference_id",
                 "fieldtype": "Link",
                 "options":"Quotation",
                 "label": "Reference ID",
-                "insert_after": "customer"
+                "insert_after": "naming_series"
             },
         ]
     }
+
+
 
 def get_quotation_custom_fields():
     '''

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -103,7 +103,7 @@ def get_sales_invoice_custom_fields():
                 "fieldname": "reference_id",
                 "fieldtype": "Link",
                 "options":"Quotation",
-                "label": "Quotation Reference",
+                "label": "Quotation",
                 "insert_after": "naming_series"
             },
         ]

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -100,17 +100,10 @@ def get_sales_invoice_custom_fields():
                 "insert_after": "include_in_ibf"
             },
             {
-                "fieldname": "quotation_reference",
-                "fieldtype": "Link",
-                "label": "Quotation Reference",
-                "options": "Quotation",
-                "insert_after": "is_barter_invoice"
-            },
-            {
                 "fieldname": "reference_id",
                 "fieldtype": "Link",
                 "options":"Quotation",
-                "label": "Reference ID",
+                "label": "Quotation Reference",
                 "insert_after": "naming_series"
             },
         ]


### PR DESCRIPTION
## Feature description
-Add Custom Fields on Sales Invoice Doctype.
    -"Actual Customer" (Link/Customer)
    -"Actual Customer Group" (Link/Customer Group)
    -"Include in IBF" (Checkbox/Read Only)
    -"Is Barter Invoice" (Checkbox)
   -"Quotation "(Link/Quotation)
-remove include in IBF conditions in sales invoice 

## Solution description
 -Added Custom Fields on Sales Invoice Doctype.

## Output
![image](https://github.com/user-attachments/assets/bc901051-c2f9-4dff-b312-6069a9ba3d41)
![image](https://github.com/user-attachments/assets/237bdc00-81a2-4678-a9b9-8fde2066af40)


## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox