### PR TITLE
feat: Create Purchase Invoice From Release Order

### DIFF
--- a/beams/beams/custom_scripts/quotation/quotation.py
+++ b/beams/beams/custom_scripts/quotation/quotation.py
@@ -53,3 +53,32 @@ def make_sales_invoice(source_name, target_doc=None, ignore_permissions=False):
     )
 
     return doclist
+
+@frappe.whitelist()
+def make_purchase_invoice(source_name, target_doc=None, ignore_permissions=False):
+    '''
+    Method: Maps the Quotation ID to the quotation_reference field in Purchase Invoice.
+    Output: A new Purchase Invoice document with the Quotation ID mapped to quotation_reference.
+    '''
+
+    def set_missing_values(source, target):
+        target.quotation_reference = source.name  
+
+    doclist = get_mapped_doc(
+        "Quotation",
+        source_name,
+        {
+            "Quotation": {
+                "doctype": "Purchase Invoice",
+                "validation": {"docstatus": ["=", 1]},
+                "field_map": {
+                    "name": "quotation_reference"
+                }
+            }
+        },
+        target_doc,
+        set_missing_values,
+        ignore_permissions=ignore_permissions,
+    )
+
+    return doclist

--- a/beams/public/js/quotation.js
+++ b/beams/public/js/quotation.js
@@ -1,12 +1,23 @@
 frappe.ui.form.on('Quotation', {
     refresh: function(frm) {
         if (frm.doc.docstatus == 1) {
+            // Show the Sales Invoice button
             frm.add_custom_button(__('Sales Invoice'), function() {
                 frappe.model.open_mapped_doc({
                     method: "beams.beams.custom_scripts.quotation.quotation.make_sales_invoice",
                     frm: frm
                 });
             }, __('Create'));
+
+            // Show the Purchase Invoice button only if is_barter is checked
+            if (frm.doc.is_barter) {
+                frm.add_custom_button(__('Purchase Invoice'), function() {
+                    frappe.model.open_mapped_doc({
+                        method: "beams.beams.custom_scripts.quotation.quotation.make_purchase_invoice",
+                        frm: frm
+                    });
+                }, __('Create'));
+            }
         }
     }
 });


### PR DESCRIPTION
## Feature description
-Create Button Purchase Invoice on Release Order.
-Fetch Quotation Reference to the Purchase Invoice.
-Display Purchase Invoice button if is_barter is Checked

## Solution description
- Created Button Purchase Invoice on Release Order.
- Fetched the Quotation Reference to the Purchase Invoice.
- Displayed Purchase invoice button only when the is_barter is Checked.

## Output
![image](https://github.com/user-attachments/assets/5ed001a0-2555-4ccf-8f14-fe6dacd55b8f)
![image](https://github.com/user-attachments/assets/323981fd-76ce-4541-9dff-c6f1c6a88e44)
![image](https://github.com/user-attachments/assets/6ba382ff-9df9-4fdc-bdf9-6a0e00da2bfb)


## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox