### PR TITLE
feat: Auto-check 'Is Barter Invoice' when Sales Invoice is created from Release Order

### DIFF
--- a/beams/public/js/sales_invoice.js
+++ b/beams/public/js/sales_invoice.js
@@ -4,7 +4,12 @@ frappe.ui.form.on('Sales Invoice', {
       // Hide 'actual_customer' and 'actual_customer_group' fields by default
         frm.toggle_display('actual_customer', false);
         frm.toggle_display('actual_customer_group', false);
-    },
+
+        // Check the "Is Barter Invoice" checkbox by default when the Sales Invoice is created
+        if(frm.is_new()) {
+            frm.set_value('is_barter_invoice', 1);
+        }
+   },
     customer: function(frm) {
         if (frm.doc.customer) {
             frappe.db.get_value('Customer', frm.doc.customer, ['is_agent'], function(value) {


### PR DESCRIPTION
## Feature description
- Automatically set the 'Is Barter Invoice' checkbox to be checked in the Sales Invoice doctype whenever a Sales Invoice is created from a Release Order.

## Solution description
- Implemented logic to auto-check the 'Is Barter Invoice' field when a Sales Invoice is generated from a Release Order.

## Output
![image](https://github.com/user-attachments/assets/d150ecc3-274c-4711-8d2f-67fa710fdc41)
![image](https://github.com/user-attachments/assets/432bc2fe-679e-4a00-8925-5873b0858910)
![image](https://github.com/user-attachments/assets/cac4b60f-3a1d-4546-8436-5f3829bcd6a5)
![image](https://github.com/user-attachments/assets/7b72ebcd-026d-47b7-bbdf-e15c31c03047)


## Is there any existing behavior change of other features due to this code change?
- No

## Was this feature tested on the browsers?
- Mozilla Firefox"