### PR TITLE
fix: Remove Agent Of Field from Customer Doctype

### DIFF
--- a/beams/setup.py
+++ b/beams/setup.py
@@ -53,14 +53,6 @@ def get_customer_custom_fields():
                 "fieldtype": "Check",
                 "label": "Is Agent",
                 "insert_after": "msme_status"
-            },
-            {
-                "fieldname": "agent_of",
-                "fieldtype": "Link",
-                "label": "Agent Of",
-                "options": "Customer",
-                "depends_on": "eval:doc.is_agent == 1",
-                "insert_after": "is_agent"
             }
 
         ]


### PR DESCRIPTION
## Feature description
-Remove 'Agent Of' Field from Customer Doctype.

## Solution description
 -The 'Agent Of' field has been removed from the Customer Doctype to streamline the form and eliminate unnecessary fields.

## Output
![image](https://github.com/user-attachments/assets/4e51738d-1716-4103-8a63-794aa9ae5eef)

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox