### PR TITLE
fix:Rename Quotation Reference to Quotation

### DIFF
--- a/beams/beams/custom_scripts/quotation/quotation.py
+++ b/beams/beams/custom_scripts/quotation/quotation.py
@@ -57,12 +57,12 @@ def make_sales_invoice(source_name, target_doc=None, ignore_permissions=False):
 @frappe.whitelist()
 def make_purchase_invoice(source_name, target_doc=None, ignore_permissions=False):
     '''
-    Method: Maps the Quotation ID to the quotation_reference field in Purchase Invoice.
-    Output: A new Purchase Invoice document with the Quotation ID mapped to quotation_reference.
+    Method: Maps the Quotation ID to the quotation field in Purchase Invoice.
+    Output: A new Purchase Invoice document with the Quotation ID mapped to quotation.
     '''
 
     def set_missing_values(source, target):
-        target.quotation_reference = source.name  
+        target.quotation = source.name
 
     doclist = get_mapped_doc(
         "Quotation",
@@ -72,7 +72,7 @@ def make_purchase_invoice(source_name, target_doc=None, ignore_permissions=False
                 "doctype": "Purchase Invoice",
                 "validation": {"docstatus": ["=", 1]},
                 "field_map": {
-                    "name": "quotation_reference"
+                    "name": "quotation"
                 }
             }
         },

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -139,7 +139,7 @@ def get_purchase_invoice_custom_fields():
             {
                 "fieldname": "quotation_reference",
                 "fieldtype": "Link",
-                "label": "Quotation Reference",
+                "label": "Quotation",
                 "options": "Quotation",
                 "insert_after": "barter_invoice"
 

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -137,7 +137,7 @@ def get_purchase_invoice_custom_fields():
                 "insert_after": "supplier"
             },
             {
-                "fieldname": "quotation_reference",
+                "fieldname": "quotation",
                 "fieldtype": "Link",
                 "label": "Quotation",
                 "options": "Quotation",


### PR DESCRIPTION
## Feature description
-Rename Quotation Reference To Quotation in Purchase Invoice Doctype.

## Solution description
 The label "Quotation Reference" in the Purchase Invoice doctype is renamed to "Quotation"

## Output
![image](https://github.com/user-attachments/assets/99ba5eae-df44-4093-bcf4-33a0a22bc799)

## Areas affected and ensured
-This change is reflected in the UI where the field appears.

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox