### PR TITLE
feat: Validate Sales Invoice amounts based on Release Order

### DIFF
--- a/beams/beams/custom_scripts/sales_invoice/sales_invoice.py
+++ b/beams/beams/custom_scripts/sales_invoice/sales_invoice.py
@@ -3,7 +3,7 @@ import frappe
 from frappe import _
 
 @frappe.whitelist()
-def validate_sales_order_amount(doc, method):
+def validate_sales_invoice_amount_with_quotation(doc, method):
     '''
         Method to validate the sum of total amount in Sales Invoices against the total amount in the Quotation.
     '''

--- a/beams/beams/custom_scripts/sales_invoice/sales_invoice.py
+++ b/beams/beams/custom_scripts/sales_invoice/sales_invoice.py
@@ -4,12 +4,21 @@ from frappe import _
 
 @frappe.whitelist()
 def validate_sales_order_amount(doc, method):
-    """
-        Method to validate the grand total in  Sales Invoice and grand total in  Quotation.
-    """
+    '''
+        Method to validate the sum of total amount in Sales Invoices against the total amount in the Quotation.
+    '''
+
     if doc.reference_id:
         quotation = frappe.get_doc('Quotation', doc.reference_id)
-        if doc.grand_total != quotation.grand_total:
-            frappe.throw(_(
-                "The total amount in the Sales Invoice must match the total amount in the Quotation."
-            ))
+        sales_invoices = frappe.get_all('Sales Invoice',
+                                         filters={'reference_id': doc.reference_id, 'docstatus': 1},  # Only consider submitted invoices
+                                         fields=['grand_total'])
+
+        if sales_invoices:
+            for invoice in sales_invoices:
+                grand_total = invoice.grand_total
+                total_grand_total = doc.grand_total + grand_total
+                if total_grand_total > quotation.grand_total:
+                    frappe.throw(_(
+                        "The total amount of Sales Invoices for this Quotation cannot exceed the total amount in the Quotation."
+                    ))

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -127,7 +127,7 @@ before_uninstall = "beams.uninstall.before_uninstall"
 
 doc_events = {
     "Sales Invoice": {
-        "on_submit": "beams.beams.custom_scripts.sales_invoice.sales_invoice.validate_sales_order_amount"
+        "on_submit": "beams.beams.custom_scripts.sales_invoice.sales_invoice.validate_sales_invoice_amount_with_quotation"
     }
 }
 


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- Feature

## Clearly and concisely describe the feature, chore or bug.
- Added Validation to ensure that total of amounts on sales invoices does not exceed the  total amount on Release Order

## Solution description 
- Implemented a method to compare the sales invoice amount with the total amount of the associated Release Order.
- Display an error message if they do not match, preventing the invoice from being submitted.

## Output screenshots(optional)
[Screencast from 08-13-2024 11:35:34 AM.webm](https://github.com/user-attachments/assets/79fb8c53-c7f5-4a3c-873f-874bbbc2a6d3)

## Areas affected and ensured
-`beams/beams/custom_scripts/sales_invoice/sales_invoice.py`

## Did you test with the following dataset?
- Existing Data
- New Data
