### PR TITLE
feat:Apply Filters in Actual Customer

### DIFF
--- a/beams/public/js/sales_invoice.js
+++ b/beams/public/js/sales_invoice.js
@@ -4,6 +4,14 @@ frappe.ui.form.on('Sales Invoice', {
       // Hide 'actual_customer' and 'actual_customer_group' fields by default
         frm.toggle_display('actual_customer', false);
         frm.toggle_display('actual_customer_group', false);
+        // Set a filter for 'actual_customer' to show only non-agent customers
+        frm.set_query('actual_customer', function() {
+            return {
+                filters: {
+                    'is_agent': 0
+                }
+            };
+        });
     },
     customer: function(frm) {
         if (frm.doc.customer) {


### PR DESCRIPTION
## Feature description
-Ensure that only non-agent customers are visible in the actual_customer field of the Sales Invoice doctype.

## Solution description
 -Applied a filter to the actual_customer field in the Sales Invoice doctype to ensure that only non-agent customers (where is_agent is false) are displayed.

## Output
![image](https://github.com/user-attachments/assets/d6624b39-e4c1-4bf3-9e42-37861214edcd)

## Areas affected and ensured
-This filter enhances data accuracy by preventing agent customers from being selected where only non-agent customers are relevant.

## Is there any existing behavior change of other features due to this code change?
-yes.

## Was this feature tested on the browsers?
  - Mozilla Firefox