### PR TITLE
fix: Update logic for include_in_ibf field based on customer and is_barter_invoice status

### DIFF
--- a/beams/public/js/sales_invoice.js
+++ b/beams/public/js/sales_invoice.js
@@ -1,51 +1,60 @@
 frappe.ui.form.on('Sales Invoice', {
-  // Function triggered on form load
-    onload: function(frm) {
-      // Hide 'actual_customer' and 'actual_customer_group' fields by default
-        frm.toggle_display('actual_customer', false);
-        frm.toggle_display('actual_customer_group', false);
-        // Set a filter for 'actual_customer' to show only non-agent customers
-        frm.set_query('actual_customer', function() {
+  onload: function(frm) {
+    frm.toggle_display('actual_customer', false);
+    frm.toggle_display('actual_customer_group', false);
+    frm.trigger('customer');
+    // Set a filter for 'actual_customer' to show only non-agent customers
+    frm.set_query('actual_customer', function() {
             return {
                 filters: {
                     'is_agent': 0
                 }
             };
         });
-    },
-    customer: function(frm) {
-        if (frm.doc.customer) {
-            frappe.db.get_value('Customer', frm.doc.customer, ['is_agent'], function(value) {
-                if (value && value.is_agent) {
-                    frm.toggle_display('actual_customer', true);
-                    frm.set_value('actual_customer', '');
-                    frm.toggle_display('actual_customer_group', false);
-                } else {
-                    frm.toggle_display('actual_customer', false);
-                    frm.toggle_display('actual_customer_group', false);
-                }
-                frm.refresh_field('actual_customer');
-            });
+
+  },
+  customer: function(frm) {
+    if (frm.doc.customer) {
+      frappe.db.get_value('Customer', frm.doc.customer, ['is_agent'], function(value) {
+        if (value && value.is_agent) {
+          frm.toggle_display('actual_customer', true);
+          frm.set_value('actual_customer', '');
+          frm.toggle_display('actual_customer_group', false);
+
+          if (!frm.doc.is_barter_invoice) {
+            frm.set_value('include_in_ibf', 1);
+          }
         } else {
-            frm.toggle_display('actual_customer', false);
-            frm.toggle_display('actual_customer_group', false);
+          frm.toggle_display('actual_customer', false);
+          frm.toggle_display('actual_customer_group', false);
+          frm.set_value('include_in_ibf', 0);
         }
-    },
-    actual_customer: function(frm) {
-        if (frm.doc.actual_customer) {
-          // Fetch the 'customer_group' of the selected 'actual_customer'
-            frappe.db.get_value('Customer', frm.doc.actual_customer, 'customer_group', function(response) {
-                if (response && response.customer_group) {
-                    frm.toggle_display('actual_customer_group', true);
-                    frm.set_value('actual_customer_group', response.customer_group);
-                } else {
-                    frm.set_value('actual_customer_group', '');
-                    frm.toggle_display('actual_customer_group', false);
-                }
-            });
-        } else {
-            frm.set_value('actual_customer_group', '');
-            frm.toggle_display('actual_customer_group', false);
-        }
+        frm.refresh_field('actual_customer');
+      });
+    } else {
+      frm.toggle_display('actual_customer', false);
+      frm.toggle_display('actual_customer_group', false);
+      frm.set_value('include_in_ibf', 0);
     }
-    });
+  },
+  actual_customer: function(frm) {
+    if (frm.doc.actual_customer) {
+      frappe.db.get_value('Customer', frm.doc.actual_customer, 'customer_group', function(response) {
+        if (response && response.customer_group) {
+          frm.toggle_display('actual_customer_group', true);
+          frm.set_value('actual_customer_group', response.customer_group);
+        } else {
+          frm.set_value('actual_customer_group', '');
+          frm.toggle_display('actual_customer_group', false);
+        }
+      });
+    } else {
+      frm.set_value('actual_customer_group', '');
+      frm.toggle_display('actual_customer_group', false);
+    }
+  },
+  is_barter_invoice: function(frm) {
+    frm.set_value('include_in_ibf', 0);
+    frm.trigger('customer');
+  }
+});

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -9,6 +9,7 @@ def after_install():
     create_custom_fields(get_sales_invoice_custom_fields(), ignore_validate=True)
     create_custom_fields(get_quotation_custom_fields(), ignore_validate=True)
     create_custom_fields(get_purchase_invoice_custom_fields(), ignore_validate=True)
+    create_custom_fields(get_quotation_item_custom_fields(), ignore_validate=True)
 
 def after_migrate():
     after_install()
@@ -18,6 +19,8 @@ def before_uninstall():
     delete_custom_fields(get_sales_invoice_custom_fields())
     delete_custom_fields(get_quotation_custom_fields())
     delete_custom_fields(get_purchase_invoice_custom_fields())
+    delete_custom_fields(get_quotation_item_custom_fields())
+
 
 def delete_custom_fields(custom_fields: dict):
     '''
@@ -110,17 +113,25 @@ def get_quotation_custom_fields():
     return {
         "Quotation": [
             {
-                "fieldname": "customer_purchase_reference_id",
+                "fieldname": "customer_purchase_order_reference",
                 "fieldtype": "Data",
-                "label": "Customer Purchase Reference ID",
+                "label": "Customer Purchase Order Reference",
                 "insert_after": "valid_till"
+            },
+            {
+                "fieldname": "albatross_ro_id",
+                "fieldtype": "Data",
+                "label": "Albatross RO ID",
+                "in_standard_filter": 1,
+                "insert_after": "order_type"
             },
             {
                 "fieldname": "is_barter",
                 "fieldtype": "Check",
                 "label": "Is Barter",
-                "insert_after": "order_type"
-            }
+                "insert_after": "albatross_ro_id"
+            },
+
         ]
     }
 
@@ -143,6 +154,22 @@ def get_purchase_invoice_custom_fields():
                 "options": "Quotation",
                 "insert_after": "barter_invoice"
 
+            }
+        ]
+    }
+
+def get_quotation_item_custom_fields():
+    '''
+    Custom fields that need to be added to the Quotation Item Doctype
+    '''
+    return {
+        "Quotation Item": [
+            {
+                "fieldname": "item_type",
+                "fieldtype": "Link",
+                "options": "Item Type",
+                "label": "Item Type",
+                "insert_after": "item_name"
             }
         ]
     }


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- Feature

## Clearly and concisely describe the feature, chore or bug.
-  Include in IBF checkbox in Sales Invoice is checked based on whether the customer is agent and the type of barter invoice
- Added Item Type in items child table quotation.

## Solution description 
- An event listener is added to the customer field that activates when a user selects a customer from the dropdown.
- When a customer is selected, the system checks if that customer is an agent.
- If the is_barter_invoice field on Sales Invoice is not checked and customer is agent it will updates the include_in_ibf field   based on that.
- Added Item Type in items table in Quotation.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/770374b1-7b0f-4ffb-8611-3c6d6747a190)
![image](https://github.com/user-attachments/assets/73df3f42-a24c-487e-ba58-a19aacca4655)

## Areas affected and ensured
-`beams/public/js/sales_invoice.js`

## Is there any existing behavior change of other features due to this code change?
- No

## Did you test with the following dataset?
- Existing Data
- New Data
