### PR TITLE
feat:Auto-check 'Is Barter Invoice' when Sales Invoice is created from Release Order

### DIFF
--- a/beams/setup.py
+++ b/beams/setup.py
@@ -89,7 +89,9 @@ def get_sales_invoice_custom_fields():
                 "fieldname": "is_barter_invoice",
                 "fieldtype": "Check",
                 "label": "Is Barter Invoice",
-                "insert_after": "include_in_ibf"
+                "read_only": 1,
+                "insert_after": "include_in_ibf",
+                "fetch_from": "reference_id.is_barter"
             },
             {
                 "fieldname": "reference_id",


### PR DESCRIPTION
## Feature description
- Automatically set the 'Is Barter Invoice' checkbox to be checked in the Sales Invoice doctype whenever a Sales Invoice is created from a Release Order.

## Solution description
- Implemented logic to auto-check the 'Is Barter Invoice' field when a Sales Invoice is generated from a Release Order.

## Output
[Screencast from 13-08-24 03:19:08 PM IST.webm](https://github.com/user-attachments/assets/c2c955a3-9745-4a3f-b673-195c41a55e27)

## Is there any existing behavior change of other features due to this code change?
- No

## Was this feature tested on the browsers?
- Mozilla Firefox"