### PR TITLE
fix : Hide the button sales invoice when the limit of amount from quo…

### DIFF
--- a/beams/beams/custom_scripts/quotation/quotation.py
+++ b/beams/beams/custom_scripts/quotation/quotation.py
@@ -3,15 +3,15 @@ from frappe.model.mapper import get_mapped_doc
 
 @frappe.whitelist()
 def make_sales_invoice(source_name, target_doc=None, ignore_permissions=False):
-    '''
+    """
     Method: Creates a Sales Invoice from a Quotation document.
     Output: A new or updated Sales Invoice document mapped from the Quotation.
-    '''
+    """
 
     def set_missing_values(source, target):
-
-
         target.customer = source.party_name
+        target.expected_total = source.rounded_total  # Ensure expected_total is set
+
         target.run_method("set_missing_values")
         target.run_method("calculate_taxes_and_totals")
 
@@ -23,7 +23,8 @@ def make_sales_invoice(source_name, target_doc=None, ignore_permissions=False):
                 "doctype": "Sales Invoice",
                 "validation": {"docstatus": ["=", 1]},
                 "field_map": {
-                    "party_name": "customer"
+                    "party_name": "customer",
+                    "rounded_total": "expected_total"  # Map total to expected_total
                 }
             },
             "Quotation Item": {
@@ -32,7 +33,6 @@ def make_sales_invoice(source_name, target_doc=None, ignore_permissions=False):
                     "parent": "quotation",
                     "name": "quotation_item"
                 },
-
             },
             "Sales Taxes and Charges": {
                 "doctype": "Sales Taxes and Charges",
@@ -52,7 +52,12 @@ def make_sales_invoice(source_name, target_doc=None, ignore_permissions=False):
         ignore_permissions=ignore_permissions,
     )
 
+    # Manually trigger validation
+    if doclist:
+        doclist.run_method("validate")
+
     return doclist
+
 
 @frappe.whitelist()
 def make_purchase_invoice(source_name, target_doc=None, ignore_permissions=False):
@@ -82,3 +87,15 @@ def make_purchase_invoice(source_name, target_doc=None, ignore_permissions=False
     )
 
     return doclist
+
+@frappe.whitelist()
+def get_total_sales_invoice_amount(quotation_name):
+    '''
+    Method: Calculates the total amount of all Sales Invoices linked to the Quotation using rounded_total.
+    '''
+    total_amount = frappe.db.sql("""
+        SELECT SUM(rounded_total) FROM `tabSales Invoice`
+        WHERE reference_id = %s AND docstatus = 1
+    """, quotation_name)[0][0]
+
+    return total_amount or 0

--- a/beams/beams/custom_scripts/sales_invoice/sales_invoice.py
+++ b/beams/beams/custom_scripts/sales_invoice/sales_invoice.py
@@ -1,7 +1,5 @@
-
 import frappe
 from frappe import _
-
 @frappe.whitelist()
 def validate_sales_invoice_amount_with_quotation(doc, method):
     '''

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -131,6 +131,7 @@ doc_events = {
     }
 }
 
+
 # Scheduled Tasks
 # ---------------
 

--- a/beams/public/js/quotation.js
+++ b/beams/public/js/quotation.js
@@ -1,15 +1,7 @@
 frappe.ui.form.on('Quotation', {
     refresh: function(frm) {
         if (frm.doc.docstatus == 1) {
-            // Show the Sales Invoice button
-            frm.add_custom_button(__('Sales Invoice'), function() {
-                frappe.model.open_mapped_doc({
-                    method: "beams.beams.custom_scripts.quotation.quotation.make_sales_invoice",
-                    frm: frm
-                });
-            }, __('Create'));
-
-            // Show the Purchase Invoice button only if is_barter is checked
+            // Check if the is_barter checkbox is checked and show the Purchase Invoice button
             if (frm.doc.is_barter) {
                 frm.add_custom_button(__('Purchase Invoice'), function() {
                     frappe.model.open_mapped_doc({
@@ -18,6 +10,26 @@ frappe.ui.form.on('Quotation', {
                     });
                 }, __('Create'));
             }
+
+            // Check the total amount of linked Sales Invoices
+            frappe.call({
+                method: "beams.beams.custom_scripts.quotation.quotation.get_total_sales_invoice_amount",
+                args: {
+                    quotation_name: frm.doc.name
+                },
+                callback: function(r) {
+                    if (r.message < frm.doc.total) {
+                        frm.add_custom_button(__('Sales Invoice'), function() {
+                            frappe.model.open_mapped_doc({
+                                method: "beams.beams.custom_scripts.quotation.quotation.make_sales_invoice",
+                                frm: frm
+                            });
+                        }, __('Create'));
+                    } else {
+                        frappe.msgprint(__('The total amount of Sales Invoices for this Quotation has reached or exceeded the limit.'));
+                    }
+                }
+            });
         }
     }
 });


### PR DESCRIPTION
## Feature description
- Hide Sales Invoice Button When the Amount from the Release Order is Equals to Total of Sales Invoice .

## Solution description
 Hidden the button sales invoice when the total sales amount  is equals to total amount quotation

## Output
[Screencast from 13-08-24 03:23:53 PM IST.webm](https://github.com/user-attachments/assets/96902bb3-37c7-4517-baef-6e4f9847528a)

## Feature description
- Hide Sales Invoice Button When the Amount from the Release Order is Equals to Total of Sales Invoice .

## Solution description
 Hidden the button sales invoice when the total sales amount  is equals to total amount quotation

## Output
/home/nidha/Videos/Screencasts/Screencast from 13-08-24 03:23:53 PM IST.webm

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox