### PR TITLE
fix: Correct validation of sales invoice amounts against quotation am…

### DIFF
--- a/beams/beams/custom_scripts/sales_invoice/sales_invoice.py
+++ b/beams/beams/custom_scripts/sales_invoice/sales_invoice.py
@@ -1,22 +1,25 @@
 import frappe
 from frappe import _
+
 @frappe.whitelist()
 def validate_sales_invoice_amount_with_quotation(doc, method):
     '''
-        Method to validate the sum of total amount in Sales Invoices against the total amount in the Quotation.
+    Method to validate the sum of total amount in Sales Invoices against the total amount in the Quotation.
     '''
 
     if doc.reference_id:
         quotation = frappe.get_doc('Quotation', doc.reference_id)
         sales_invoices = frappe.get_all('Sales Invoice',
-                                         filters={'reference_id': doc.reference_id, 'docstatus': 1},  # Only consider submitted invoices
-                                         fields=['grand_total'])
+        filters={'reference_id': doc.reference_id, 'docstatus': 1},  # Only consider submitted invoices
+        fields=['grand_total'])
+
+        total_grand_total = 0
 
         if sales_invoices:
             for invoice in sales_invoices:
                 grand_total = invoice.grand_total
-                total_grand_total = doc.grand_total + grand_total
+                total_grand_total += grand_total
                 if total_grand_total > quotation.grand_total:
                     frappe.throw(_(
-                        "The total amount of Sales Invoices for this Quotation cannot exceed the total amount in the Quotation."
+                    "The total amount of Sales Invoices for this Quotation cannot exceed the total amount in the Quotation."
                     ))


### PR DESCRIPTION
…ount

## Is this a Feature, Chore or Bug?
- Fix

## Clearly and concisely describe the feature, chore or bug.
- initially when amounts on sales invoices equals quotation amount, validation error occurred.

## Solution description 
- Changed the validation logic in Sales Invoice to allow the total amount to equal the corresponding Quotation total. 
## Output screenshots(optional)
[Screencast from 08-14-2024 02:28:36 PM.webm](https://github.com/user-attachments/assets/a16718bc-e9d3-4c88-ad21-8faa0571cce3)


## Areas affected and ensured
-`beams/beams/custom_scripts/sales_invoice/sales_invoice.py`

## Did you test with the following dataset?
- Existing Data
- New Data
