### PR TITLE
Validation of common party

### DIFF
--- a/beams/beams/custom_scripts/sales_invoice/sales_invoice.py
+++ b/beams/beams/custom_scripts/sales_invoice/sales_invoice.py
@@ -1,17 +1,23 @@
 import frappe
 from frappe import _
+from beams.beams.custom_scripts.quotation.quotation import create_common_party_and_supplier
 
 @frappe.whitelist()
 def validate_sales_invoice_amount_with_quotation(doc, method):
     '''
     Method to validate the sum of total amount in Sales Invoices against the total amount in the Quotation.
+    Also checks if the `is_barter` checkbox is checked and ensures that a corresponding Purchase Invoice exists with the same customer.
+    Creates common party and supplier if necessary.
     '''
 
     if doc.reference_id:
+        # Fetch the Quotation document
         quotation = frappe.get_doc('Quotation', doc.reference_id)
+
+        # Validate the sum of Sales Invoice amounts against the Quotation
         sales_invoices = frappe.get_all('Sales Invoice',
-        filters={'reference_id': doc.reference_id, 'docstatus': 1},  # Only consider submitted invoices
-        fields=['grand_total'])
+            filters={'reference_id': doc.reference_id, 'docstatus': 1},  # Only consider submitted invoices
+            fields=['grand_total'])
 
         total_grand_total = 0
 
@@ -21,5 +27,28 @@ def validate_sales_invoice_amount_with_quotation(doc, method):
                 total_grand_total += grand_total
                 if total_grand_total > quotation.grand_total:
                     frappe.throw(_(
-                    "The total amount of Sales Invoices for this Quotation cannot exceed the total amount in the Quotation."
+                        "The total amount of Sales Invoices for this Quotation cannot exceed the total amount in the Quotation."
                     ))
+
+        # Check if `is_barter` is checked in the Quotation
+        if quotation.is_barter:
+            # Check if there is a Purchase Invoice for the same Quotation
+            purchase_invoices = frappe.get_all('Purchase Invoice',
+                filters={'quotation': doc.reference_id, 'docstatus': 1},
+                fields=['supplier'])
+
+            if purchase_invoices:
+                # Ensure the customer exists in the Purchase Invoice
+                customer = doc.customer
+                for purchase_invoice in purchase_invoices:
+                    supplier = purchase_invoice.supplier
+                    if customer:
+                        # Ensure common party accounting is enabled
+                        if frappe.db.get_single_value("Accounts Settings", "enable_common_party_accounting"):
+                            common_party = create_common_party_and_supplier(customer)
+                            if common_party:
+                                frappe.msgprint(f'Common Party and Supplier {common_party} created and linked.', indicator="green", alert=1)
+            else:
+                frappe.throw(_(
+                    "No Purchase Invoice found for the Quotation."
+                ))

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -128,6 +128,9 @@ before_uninstall = "beams.uninstall.before_uninstall"
 doc_events = {
     "Sales Invoice": {
         "on_submit": "beams.beams.custom_scripts.sales_invoice.sales_invoice.validate_sales_invoice_amount_with_quotation"
+    },
+    "Quotation": {
+        "validate": "beams.beams.custom_scripts.quotation.quotation.validate_is_barter"
     }
 }
 

--- a/beams/public/js/quotation.js
+++ b/beams/public/js/quotation.js
@@ -31,5 +31,18 @@ frappe.ui.form.on('Quotation', {
                 }
             });
         }
+    },
+
+    is_barter: function(frm) {
+        if (frm.doc.is_barter) {
+            frappe.db.get_single_value('Accounts Settings', 'enable_common_party_accounting')
+            .then(check => {
+              if (!check) {
+                  frm.set_value('is_barter', 0); // Uncheck the checkbox if validation fails
+                  frm.refresh_fields()
+                  frappe.msgprint("Please enable 'Common Party Accounting' in the Accounts Settings to proceed with barter transactions.");
+              }
+            })
+        }
     }
 });


### PR DESCRIPTION
## Feature description
- if it is a barter, a validation is needed to ensure that the parties involved are common parties.
- When creating a Sales Invoice from a Release Order , validate that a Purchase Invoice has already been submitted against the common party.

## Solution description
 - Warning message to enable common party in accounts settings while triggering is_barter checkbox in quotation.
 - Common party link is created at the time of mapping to purchase invoice from quotation. 
 - Alert message on creation of barter sales invoice without purchase invoice

## Output
[Screencast from 17-08-24 10:36:52 AM IST.webm](https://github.com/user-attachments/assets/c7928ad3-4460-4a7c-94b2-49beb25c8dd5)

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox