### PR TITLE
fix: fix the missing argument

### DIFF
--- a/beams/beams/custom_scripts/quotation/quotation.py
+++ b/beams/beams/custom_scripts/quotation/quotation.py
@@ -161,7 +161,7 @@ def get_total_sales_invoice_amount(quotation_name):
     return total_amount or 0
 
 @frappe.whitelist()
-def validate_is_barter(quotation):
+def validate_is_barter(quotation,method=None):
     '''
     Method: Checking Whether enable_common_party_accounting checked or not.
     '''


### PR DESCRIPTION
## Feature description
-Fix the Missing Argument in Quotation.

## Solution description
Added Missing argument in Quotation .

## Output
![image](https://github.com/user-attachments/assets/208bf973-a235-42a8-aece-237036ca5bef)

## Is there any existing behavior change of other features due to this code change?
-yes

## Was this feature tested on the browsers?
  - Mozilla Firefox