### PR TITLE
fix: Missing of a comma

### DIFF
--- a/beams/fixtures/workflow_state.json
+++ b/beams/fixtures/workflow_state.json
@@ -47,7 +47,7 @@
   "docstatus": 0,
   "doctype": "Workflow State",
   "icon": "",
-  "modified": "2024-08-17 15:00:11.970925"
+  "modified": "2024-08-17 15:00:11.970925",
   "name": "Pending Approval",
   "style": "",
   "workflow_state_name": "Pending Approval"


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- Feature

## Clearly and concisely describe the feature, chore or bug.
- A Workflow has to be created for doct-ype Adhoc Budget.
- A field Remarks only visible for workflow state with docstatus == 1.

## Solution description 
- Created workflow for Adhoc Budget and hide the field remarks for state with docstatus ==0 



## Output screenshots(optional)

[Screencast from 19-08-24 12:13:55 PM IST.webm](https://github.com/user-attachments/assets/0e3d1c7a-3533-406f-9c71-0a21f4f7912b)

## Areas affected and ensured
-`beams/hooks.py`
-`beams/fixtures/`

## Did you test with the following dataset?
- Existing Data
- New Data
