### PR TITLE
feat:workflow for Supplier Approval

### DIFF
--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -231,8 +231,9 @@ doc_events = {
 # default_log_clearing_doctypes = {
 # 	"Logging DocType Name": 30  # days to retain logs
 # }
+  
 fixtures = [
-    {"dt":"Workflow","filters":[["name","in",["Customer Approval", "Account Approval"]]]},
+    {"dt":"Workflow","filters":[["name","in",["Customer Approval", "Account Approval","Supplier Approval"]]]},
     {"dt":"Workflow State","filters":[["name","in",["Draft", "Pending Approval", "Approved", "Rejected"]]]},
     {"dt":"Workflow Action Master","filters":[["name","in",["Submit for Approval", "Approve", "Reject", "Change Request"]]]},
 ]

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -12,7 +12,6 @@ def after_install():
     create_custom_fields(get_quotation_item_custom_fields(), ignore_validate=True)
     create_property_setters(get_property_setters())
 
-
 def after_migrate():
     after_install()
 
@@ -194,7 +193,7 @@ def create_property_setters(property_setter_datas):
 
 def get_property_setters():
     '''
-        BEAMS specific property setters that need to be added to the Customer and Account DocTypes
+        BEAMS specific property setters that need to be added to the Customer, Account and supplier DocTypes
     '''
     return [
         {
@@ -212,5 +211,14 @@ def get_property_setters():
             "property": "default",
             "property_type": "Check",
             "value": 1
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Supplier",
+            "field_name": "disabled",
+            "property": "default",
+            "property_type": "Check",
+            "value": 1
         }
+
     ]


### PR DESCRIPTION
## Feature description
-Add approval workflow for enabling new  Supplier

## Solution description
 -Created workflow for Supplier Approval 
- New Suppliers are now disabled by default.
- Suppliers will be enabled only after approval through the defined workflow.


## Output
![image](https://github.com/user-attachments/assets/745c13f0-0dde-441e-a35a-4e51611ffacd)
![image](https://github.com/user-attachments/assets/8465e197-52cf-4b3a-a0c4-75a5deefcb45)

## Is there any existing behavior change of other features due to this code change?
-yes.

## Was this feature tested on the browsers?
  - Mozilla Firefox