### PR TITLE
feat: Purchase Invoice Amount should be equal to Quotation Amount

### DIFF
--- a/beams/beams/custom_scripts/purchase_invoice/purchase_invoice.py
+++ b/beams/beams/custom_scripts/purchase_invoice/purchase_invoice.py
@@ -1,0 +1,11 @@
+import frappe
+from frappe import _
+def validate_purchase_invoice(doc, method):
+    if doc.quotation:  # assuming you have a field that links the Purchase Invoice to a Quotation
+        quotation = frappe.get_doc('Quotation', doc.quotation)
+
+        if doc.rounded_total != quotation.rounded_total:
+            frappe.throw(_("The rounded total amount of the Purchase Invoice does not match the Quotation amount. Please check and try again."))
+
+def before_save(doc, method):
+    validate_purchase_invoice(doc, method)

--- a/beams/beams/custom_scripts/purchase_invoice/purchase_invoice.py
+++ b/beams/beams/custom_scripts/purchase_invoice/purchase_invoice.py
@@ -1,11 +1,18 @@
 import frappe
 from frappe import _
+
+def before_save(doc, method):
+    """
+    Validate that the rounded total of the Purchase Invoice matches the linked Quotation before saving.
+    """
+    validate_purchase_invoice(doc, method)
+
 def validate_purchase_invoice(doc, method):
+    """
+    Checks if the rounded total of the Purchase Invoice matches the rounded total of the linked Quotation.
+    """
     if doc.quotation:  # assuming you have a field that links the Purchase Invoice to a Quotation
         quotation = frappe.get_doc('Quotation', doc.quotation)
 
         if doc.rounded_total != quotation.rounded_total:
-            frappe.throw(_("The rounded total amount of the Purchase Invoice does not match the Quotation amount. Please check and try again."))
-
-def before_save(doc, method):
-    validate_purchase_invoice(doc, method)
+            frappe.throw(_("The total amount of the Purchase Invoice does not match the Quotation amount. Please check and try again."))

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -131,6 +131,9 @@ doc_events = {
     },
     "Quotation": {
         "validate": "beams.beams.custom_scripts.quotation.quotation.validate_is_barter"
+    },
+    "Purchase Invoice": {
+        "before_save": "beams.beams.custom_scripts.purchase_invoice.purchase_invoice.before_save"
     }
 }
 

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -127,6 +127,7 @@ def get_quotation_custom_fields():
                 "fieldtype": "Data",
                 "label": "Albatross RO ID",
                 "in_standard_filter": 1,
+                "reqd":1,
                 "insert_after": "order_type"
             },
             {
@@ -149,12 +150,15 @@ def get_purchase_invoice_custom_fields():
                 "fieldname": "barter_invoice",
                 "fieldtype": "Check",
                 "label": "Barter Invoice",
+                "read_only": 1,
+                "fetch_from": "quotation.is_barter",
                 "insert_after": "supplier"
             },
             {
                 "fieldname": "quotation",
                 "fieldtype": "Link",
                 "label": "Quotation",
+                "read_only": 1,
                 "options": "Quotation",
                 "insert_after": "barter_invoice"
 


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- Feature

## Feature description
- Validation on amount(Purchase Amount=Quotation Amount)
-To automatically set the "Is Barter Invoice" checkbox in the Purchase Invoice doct-ype whenever a Purchase invoice is created from a Barter Release Order(Is Barter checked).
-Barter Invoice(Read Only)
-Quotation(Read Only)
-Albatros RO ID(Mandatory in Quotation) 

## Solution description 
- Validated purchase amount == quotation amount before save
- Automated Barter invoice on basis of is_barter


## Output screenshots(optional)
[Screencast from 20-08-24 04:35:46 PM IST.webm](https://github.com/user-attachments/assets/d09a8e7e-9d4c-4567-acf3-026c00c45d33)


## Areas affected and ensured
- `beams/hooks.py`
- `beams/setup.py`

## Did you test with the following dataset?
- Existing Data
- New Data
