### PR TITLE
fix: Update Doctype Adhoc Budget

### DIFF
--- a/beams/beams/doctype/accounts/accounts.json
+++ b/beams/beams/doctype/accounts/accounts.json
@@ -1,0 +1,40 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2024-08-21 09:39:30.146818",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "company",
+  "default_account"
+ ],
+ "fields": [
+  {
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Company",
+   "options": "Company"
+  },
+  {
+   "fieldname": "default_account",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Default Account",
+   "options": "Account"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2024-08-21 09:47:36.824116",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "Accounts",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/beams/beams/doctype/accounts/accounts.py
+++ b/beams/beams/doctype/accounts/accounts.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class Accounts(Document):
+	pass

--- a/beams/beams/doctype/adhoc_budget/adhoc_budget.json
+++ b/beams/beams/doctype/adhoc_budget/adhoc_budget.json
@@ -8,24 +8,21 @@
  "field_order": [
   "project",
   "fiscal_year",
-  "column_break_aybs",
-  "start_date",
-  "end_date",
-  "section_break_egqo",
-  "budget_expen",
-  "amended_from",
-  "section_break_fhpd",
-  "total_amount",
-  "column_break_apuq",
   "expected_revenue",
+  "expected_revenue_reached",
+  "column_break_zhmw",
+  "posting_date",
+  "expected_start_date",
+  "expected_end_date",
+  "section_break_fzul",
+  "budget_expense",
+  "column_break_mjii",
+  "total_budget_amount",
   "section_break_yiku",
-  "remarks"
+  "remarks",
+  "amended_from"
  ],
  "fields": [
-  {
-   "fieldname": "section_break_egqo",
-   "fieldtype": "Section Break"
-  },
   {
    "fieldname": "project",
    "fieldtype": "Link",
@@ -42,24 +39,49 @@
    "reqd": 1
   },
   {
-   "fieldname": "budget_expen",
+   "fieldname": "expected_revenue",
+   "fieldtype": "Currency",
+   "label": "Expected Revenue",
+   "non_negative": 1,
+   "precision": "2",
+   "reqd": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "depends_on": "eval:doc.docstatus==1",
+   "fieldname": "remarks",
+   "fieldtype": "Long Text",
+   "label": "Remarks"
+  },
+  {
+   "fieldname": "section_break_yiku",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "expected_start_date",
+   "fieldtype": "Date",
+   "label": "Expected Start Date"
+  },
+  {
+   "fieldname": "expected_end_date",
+   "fieldtype": "Date",
+   "label": "Expected End Date"
+  },
+  {
+   "fieldname": "posting_date",
+   "fieldtype": "Date",
+   "label": "Posting Date"
+  },
+  {
+   "fieldname": "section_break_fzul",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "budget_expense",
    "fieldtype": "Table",
    "label": "Budget Expense",
-   "options": "Budget Expense"
-  },
-  {
-   "fieldname": "column_break_aybs",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "start_date",
-   "fieldtype": "Date",
-   "label": "Start Date"
-  },
-  {
-   "fieldname": "end_date",
-   "fieldtype": "Date",
-   "label": "End Date"
+   "options": "Budget Expense",
+   "reqd": 1
   },
   {
    "fieldname": "amended_from",
@@ -72,45 +94,33 @@
    "search_index": 1
   },
   {
-   "fieldname": "total_amount",
+   "default": "0",
+   "fieldname": "expected_revenue_reached",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Expected Revenue Reached"
+  },
+  {
+   "fieldname": "total_budget_amount",
    "fieldtype": "Currency",
-   "label": "Total Amount",
+   "label": "Total Budget Amount",
    "non_negative": 1,
    "precision": "2",
    "reqd": 1
   },
   {
-   "fieldname": "expected_revenue",
-   "fieldtype": "Currency",
-   "label": "Expected Revenue",
-   "non_negative": 1,
-   "precision": "2",
-   "reqd": 1
-  },
-  {
-   "fieldname": "section_break_fhpd",
-   "fieldtype": "Section Break"
-  },
-  {
-   "fieldname": "column_break_apuq",
+   "fieldname": "column_break_mjii",
    "fieldtype": "Column Break"
   },
   {
-   "allow_on_submit": 1,
-   "depends_on": "eval:doc.docstatus==1",
-   "fieldname": "remarks",
-   "fieldtype": "Long Text",
-   "label": "Remarks"
-  },
-  {
-   "fieldname": "section_break_yiku",
-   "fieldtype": "Section Break"
+   "fieldname": "column_break_zhmw",
+   "fieldtype": "Column Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-08-19 11:58:04.796340",
+ "modified": "2024-08-21 10:31:52.509675",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Adhoc Budget",

--- a/beams/beams/doctype/budget_expense_type/budget_expense_type.json
+++ b/beams/beams/doctype/budget_expense_type/budget_expense_type.json
@@ -8,7 +8,8 @@
  "field_order": [
   "section_break_2qa9",
   "budget_expense_type",
-  "amended_from"
+  "accounts",
+  "description"
  ],
  "fields": [
   {
@@ -19,25 +20,26 @@
    "fieldname": "budget_expense_type",
    "fieldtype": "Data",
    "in_list_view": 1,
-   "label": "Budget Expense Type",
+   "label": "Budget  Expense Type",
    "reqd": 1,
    "unique": 1
   },
   {
-   "fieldname": "amended_from",
-   "fieldtype": "Link",
-   "label": "Amended From",
-   "no_copy": 1,
-   "options": "Budget Expense Type",
-   "print_hide": 1,
-   "read_only": 1,
-   "search_index": 1
+   "fieldname": "accounts",
+   "fieldtype": "Table",
+   "label": "Accounts",
+   "options": "Accounts"
+  },
+  {
+   "fieldname": "description",
+   "fieldtype": "Small Text",
+   "label": "Description"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-08-16 16:32:37.500264",
+ "modified": "2024-08-21 10:13:22.241024",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Budget Expense Type",


### PR DESCRIPTION
## Feature description
-Update Doctype Adhoc Budget

## Solution description
-Updated Budget Expense Type Doctype.
-Created Child table Accounts.
-Updated Adhoc Budget Doctype

## Output
![image](https://github.com/user-attachments/assets/2283f26b-6eb5-46b0-b4f8-b8a029453803)
![image](https://github.com/user-attachments/assets/53f114e0-5b4d-4bea-9224-2bc53007d353)
![image](https://github.com/user-attachments/assets/d8d8f1fd-c09b-452b-a580-770cfa72dd44)

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox