### PR TITLE
feat:Create ToDo for Accounts User on Supplier creation

### DIFF
--- a/beams/beams/custom_scripts/account/account.py
+++ b/beams/beams/custom_scripts/account/account.py
@@ -20,3 +20,6 @@ def create_todo_on_creation_for_account(doc, method):
 
 def create_todo_on_creation_for_customer(doc, method):
     create_todo_on_creation(doc, method, "Customer", "Please review and update details or take necessary actions.")
+
+def create_todo_on_creation_for_supplier(doc, method):
+    create_todo_on_creation(doc, method, "Supplier", "Please review and update details or take necessary actions.")

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -140,6 +140,9 @@ doc_events = {
     },
     "Customer": {
         "after_insert": "beams.beams.custom_scripts.account.account.create_todo_on_creation_for_customer"
+    },
+    "Supplier": {
+        "after_insert": "beams.beams.custom_scripts.account.account.create_todo_on_creation_for_supplier"
     }
 }
 


### PR DESCRIPTION
## Feature description
-Automatically generate review ToDo for Accounts User on new Supplier creation

## Solution description
 -Implemented automatic ToDo creation for Accounts User to review new Suppliers upon their creation.

## Output
![image](https://github.com/user-attachments/assets/786d76e0-5e7b-4a4d-9a3a-8f61602cc9ff)
![image](https://github.com/user-attachments/assets/a54f88da-9930-4208-9f8f-f3c64e087b8d)

## Areas affected and ensured
-Supplier Doctype.
-User Notifications

## Is there any existing behavior change of other features due to this code change?
-yes.

## Was this feature tested on the browsers?
  - Mozilla Firefox