### PR TITLE
feat: Set the Values in  Adhoc Budget Doctype

### DIFF
--- a/beams/beams/doctype/adhoc_budget/adhoc_budget.js
+++ b/beams/beams/doctype/adhoc_budget/adhoc_budget.js
@@ -1,8 +1,76 @@
-// Copyright (c) 2024, efeone and contributors
-// For license information, please see license.txt
+frappe.ui.form.on('Adhoc Budget', {
+    onload: function(frm) {
+        if (!frm.doc.posting_date) {
+            frm.set_value('posting_date', frappe.datetime.nowdate());
+        }
+        check_expected_revenue_reached(frm, false);
+    },
+    refresh: function(frm) {
+        if (!frm.doc.posting_date) {
+            frm.set_value('posting_date', frappe.datetime.nowdate());
+        }
+        check_expected_revenue_reached(frm, false);
+    },
+    project: function(frm) {
+        if (frm.doc.project) {
+            frappe.db.get_value('Project', frm.doc.project, ['expected_start_date', 'expected_end_date'], function(r) {
+                if (r) {
+                    frm.set_value('expected_start_date', r.expected_start_date);
+                    frm.set_value('expected_end_date', r.expected_end_date);
+                }
+            });
+        } else {
+            frm.set_value('expected_start_date', null);
+            frm.set_value('expected_end_date', null);
+        }
+    },
+    expected_revenue: function(frm) {
+        check_expected_revenue_reached(frm, true);
+    },
+    total_budget_amount: function(frm) {
+        check_expected_revenue_reached(frm, false);
+    }
+});
 
-// frappe.ui.form.on("Adhoc Budget", {
-// 	refresh(frm) {
+frappe.ui.form.on('Budget Expense', {
+    budget_amount: function(frm, cdt, cdn) {
+        calculate_total_budget_amount(frm);
+    }
+});
 
-// 	},
-// });
+function calculate_total_budget_amount(frm) {
+    let total = 0;
+    frm.doc.budget_expense.forEach(function(row) {
+        if (row.budget_amount) {
+            total += row.budget_amount;
+        }
+    });
+    frm.set_value('total_budget_amount', total);
+    check_expected_revenue_reached(frm, false);
+}
+
+function check_expected_revenue_reached(frm, show_warning) {
+    frappe.db.get_single_value('Additional Account Settings', 'adhoc_budget_revenue_expectation')
+        .then(value => {
+            if (value) {
+                let revenue_expectation = parseFloat(value);
+                if (frm.doc.expected_revenue >= 3 * frm.doc.total_budget_amount &&
+                    frm.doc.expected_revenue <= revenue_expectation) {
+                    frm.set_value('expected_revenue_reached', 1);
+                    frm.set_intro('Expected Revenue has reached three times the total budget amount and is within the allowed expectation.', 'blue');
+                } else {
+                    frm.set_value('expected_revenue_reached', 0);
+                    frm.set_intro('');
+                    if (show_warning) {
+                        frappe.msgprint({
+                            title: __('Warning'),
+                            indicator: 'orange',
+                            message: __('Expected Revenue does not meet the Required Criteria.')
+                        });
+                    }
+                }
+            } else {
+                console.error('Failed to fetch Additional Account Settings');
+            }
+        });
+}

--- a/beams/beams/doctype/adhoc_budget/adhoc_budget.js
+++ b/beams/beams/doctype/adhoc_budget/adhoc_budget.js
@@ -1,6 +1,7 @@
 frappe.ui.form.on('Adhoc Budget', {
     onload: function(frm) {
         if (!frm.doc.posting_date) {
+          // Set the posting date to today if not already set
             frm.set_value('posting_date', frappe.datetime.nowdate());
         }
         check_expected_revenue_reached(frm, false);
@@ -12,6 +13,7 @@ frappe.ui.form.on('Adhoc Budget', {
         check_expected_revenue_reached(frm, false);
     },
     project: function(frm) {
+       // Fetch expected start date and end date from the selected project
         if (frm.doc.project) {
             frappe.db.get_value('Project', frm.doc.project, ['expected_start_date', 'expected_end_date'], function(r) {
                 if (r) {
@@ -25,6 +27,7 @@ frappe.ui.form.on('Adhoc Budget', {
         }
     },
     expected_revenue: function(frm) {
+      // Validate expected revenue against the criteria
         check_expected_revenue_reached(frm, true);
     },
     total_budget_amount: function(frm) {
@@ -40,27 +43,35 @@ frappe.ui.form.on('Budget Expense', {
 
 function calculate_total_budget_amount(frm) {
     let total = 0;
+    // Sum all budget amounts from the Budget Expense child table
     frm.doc.budget_expense.forEach(function(row) {
         if (row.budget_amount) {
             total += row.budget_amount;
         }
     });
+    // Set the total budget amount field with the calculated sum
     frm.set_value('total_budget_amount', total);
     check_expected_revenue_reached(frm, false);
 }
 
 function check_expected_revenue_reached(frm, show_warning) {
+   // Fetch the adhoc_budget_revenue_expectation from Additional Account Settings
     frappe.db.get_single_value('Additional Account Settings', 'adhoc_budget_revenue_expectation')
         .then(value => {
             if (value) {
+              // Check if the expected revenue meets both criteria
                 let revenue_expectation = parseFloat(value);
                 if (frm.doc.expected_revenue >= 3 * frm.doc.total_budget_amount &&
                     frm.doc.expected_revenue <= revenue_expectation) {
+                      // If criteria met, check the expected_revenue_reached checkbox
                     frm.set_value('expected_revenue_reached', 1);
+                    // Set an intro message to indicate success
                     frm.set_intro('Expected Revenue has reached three times the total budget amount and is within the allowed expectation.', 'blue');
                 } else {
+                  // If criteria not met, uncheck the expected_revenue_reached checkbox
                     frm.set_value('expected_revenue_reached', 0);
                     frm.set_intro('');
+                    // Show a warning message if the show_warning flag is true
                     if (show_warning) {
                         frappe.msgprint({
                             title: __('Warning'),

--- a/beams/beams/doctype/adhoc_budget/adhoc_budget.json
+++ b/beams/beams/doctype/adhoc_budget/adhoc_budget.json
@@ -19,8 +19,8 @@
   "column_break_mjii",
   "total_budget_amount",
   "section_break_yiku",
-  "remarks",
-  "amended_from"
+  "amended_from",
+  "remarks"
  ],
  "fields": [
   {
@@ -95,9 +95,9 @@
   },
   {
    "default": "0",
+   "depends_on": "eval:doc.expected_revenue_reached",
    "fieldname": "expected_revenue_reached",
    "fieldtype": "Check",
-   "hidden": 1,
    "label": "Expected Revenue Reached"
   },
   {
@@ -106,6 +106,7 @@
    "label": "Total Budget Amount",
    "non_negative": 1,
    "precision": "2",
+   "read_only": 1,
    "reqd": 1
   },
   {
@@ -114,14 +115,12 @@
   },
   {
    "allow_on_submit": 1,
-   "depends_on": "eval: doc.workflow_state !== 'Draft'",
+   "depends_on": "eval:doc.docstatus==1",
    "fieldname": "remarks",
    "fieldtype": "Long Text",
    "label": "Remarks"
   },
   {
-   "fieldname": "section_break_yiku",
-   "fieldtype": "Section Break",
    "fieldname": "column_break_zhmw",
    "fieldtype": "Column Break"
   }
@@ -129,7 +128,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-08-21 10:31:52.509675",
+ "modified": "2024-08-22 10:50:33.253518",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Adhoc Budget",


### PR DESCRIPTION
## Feature description
-Set the Values in Adhoc Budget Doctype.

## Solution description
 -The Total Budget Amount field is now set to read-only to prevent manual changes after it's calculated.
-The Total Budget Amount is automatically calculated based on the sum of the Budget Amount fields in the Budget Expense child table. This value is updated dynamically whenever the Budget Amount is modified.
-Posting Date is set to Today.
-Fetched Expected Start Date and Expected End Date from Project.
-The Expected Revenue Reached checkbox is automatically checked when the Expected Revenue is at least three times the Total Budget Amount and does not exceed the Adhoc Budget Revenue Expectation set in the Additional Account Settings. An introductory message is displayed to indicate whether the criteria have been met

## Output
[Screencast from 22-08-24 12:28:52 PM IST.webm](https://github.com/user-attachments/assets/33f547ef-5ace-4890-8511-585ac64663a6)


## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox