### PR TITLE
fix: Purchase Order Rework

### DIFF
--- a/beams/beams/custom_scripts/purchase_order/purchase_order.py
+++ b/beams/beams/custom_scripts/purchase_order/purchase_order.py
@@ -1,0 +1,48 @@
+
+import frappe
+from frappe.desk.form.assign_to import add as add_assign
+from frappe.utils.user import get_users_with_role
+
+@frappe.whitelist()
+def create_todo_on_finance_verification(doc, method):
+    """
+        Create a ToDo for the CEO when a Purchase Order is either approved or rejected by Finance.
+    """
+    ceo_users = get_users_with_role("CEO")
+
+    if not ceo_users:
+        return
+
+    if doc.workflow_state == "Approved by Finance":
+        description = f"Approved by Finance: Purchase Order-{doc.supplier}.<br>Please proceed with the next step."
+    elif doc.workflow_state == "Rejected By Finance":
+        description = f"Rejected by Finance: Purchase Order-{doc.supplier}.<br>Please review and revise, or proceed with their feedback."
+    else:
+        return
+
+    if not frappe.db.exists('ToDo', {
+        'reference_name': doc.name,
+        'reference_type': 'Purchase Order',
+        'description': description
+    }):
+        add_assign({
+            "assign_to": ceo_users,
+            "doctype": "Purchase Order",
+            "name": doc.name,
+            "description": description
+        })
+
+def create_todo_on_purchase_order_creation(doc, method):
+    """
+        Create a ToDo for  Accounts User when a new Purchase Order is created.
+    """
+    users = get_users_with_role("Accounts User")
+
+    if users:
+        description = f"New Purchase Order Created: {doc.supplier}.<br>Please review and update details or take necessary actions."
+        add_assign({
+            "assign_to": users,
+            "doctype": "Purchase Order",
+            "name": doc.name,
+            "description": description
+        })

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -143,6 +143,10 @@ doc_events = {
     },
     "Supplier": {
         "after_insert": "beams.beams.custom_scripts.account.account.create_todo_on_creation_for_supplier"
+    },
+    "Purchase Order": {
+        "on_update": "beams.beams.custom_scripts.purchase_order.purchase_order.create_todo_on_finance_verification",
+        "after_insert": "beams.beams.custom_scripts.purchase_order.purchase_order.create_todo_on_purchase_order_creation"
     }
 }
 


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- Fix

## Clearly and concisely describe the feature, chore or bug.
- Auto-assign ToDo for the CEO when a Purchase Order is either approved or rejected by Finance.
- Creates a ToDo for  Accounts User when a new Purchase Order is created.

## Solution description 
- When a new Purchase Order is created, a ToDo is automatically assigned to all users with the role "Accounts User."
- When a Purchase Order reaches specific workflow states, namely "Approved by Finance" or "Rejected by Finance," a ToDo is created for all users with the role "CEO."

## Output screenshots (optional)
[Screencast from 08-22-2024 10:15:45 AM.webm](https://github.com/user-attachments/assets/db952f82-1fca-41dd-adf5-b31c29d2f018)

## Areas affected and ensured
- Purchase Order DocType-Affects the creation of Purchase Orders by adding automation to generate ToDos.

## Did you test with the following dataset?
- Existing Data
- New Data
