### PR TITLE
fix : Sales amount less than quotation amount cannot be saved

### DIFF
--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -127,7 +127,7 @@ before_uninstall = "beams.uninstall.before_uninstall"
 
 doc_events = {
     "Sales Invoice": {
-        "on_submit": "beams.beams.custom_scripts.sales_invoice.sales_invoice.validate_sales_invoice_amount_with_quotation"
+        "before_save": "beams.beams.custom_scripts.sales_invoice.sales_invoice.validate_sales_invoice_amount_with_quotation"
     },
     "Quotation": {
         "validate": "beams.beams.custom_scripts.quotation.quotation.validate_is_barter"


### PR DESCRIPTION
## Issue description.
- Sales invoice less than quotation amount is saved
- it works on submit

## Solution description
 - Sales invoice validation  is given on both limit which exceed and less.
 - set to before save

## Output
[Screencast from 26-08-24 11:17:43 AM IST.webm](https://github.com/user-attachments/assets/7f2bd9a4-9352-43d3-8216-598d73a13c41)


## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox