### PR TITLE
feat : Task is created to production manager on release order

### DIFF
--- a/beams/beams/custom_scripts/quotation/quotation.py
+++ b/beams/beams/custom_scripts/quotation/quotation.py
@@ -175,6 +175,9 @@ def validate_is_barter(quotation,method=None):
 
 @frappe.whitelist()
 def create_tasks_for_production_items(doc, method):
+    '''
+    Method: Creating task for production items.
+    '''
     if doc.docstatus == 1:  # Ensure it's only triggered on submit
         for item in doc.items:
             # Fetch `is_production_item` from the Item DocType using item_code from the child table
@@ -186,6 +189,9 @@ def create_tasks_for_production_items(doc, method):
                     create_task(item.item_code, doc.name)
 
 def create_task(item_code, quotation_name):
+    '''
+    Method: Task Creation and Assigning to Production Manager.
+    '''
     # Check if the task already exists
     if frappe.db.exists("Task", {"description": f'Production task for item {item_code} in Quotation {quotation_name}'}):
         return False
@@ -219,6 +225,9 @@ def create_task(item_code, quotation_name):
     return True
 
 def get_production_managers():
+    '''
+    Method: Getting User Id for Production Manager Role.
+    '''
     # Fetch all users with the Production Manager role
     try:
         users = frappe.get_all('User', filters={'roles': ['Production Manager']}, fields=['name'])

--- a/beams/fixtures/role.json
+++ b/beams/fixtures/role.json
@@ -19,5 +19,26 @@
   "timeline": 1,
   "two_factor_auth": 0,
   "view_switcher": 1
+ },
+ {
+  "bulk_actions": 1,
+  "dashboard": 1,
+  "desk_access": 1,
+  "disabled": 0,
+  "docstatus": 0,
+  "doctype": "Role",
+  "form_sidebar": 1,
+  "home_page": null,
+  "is_custom": 0,
+  "list_sidebar": 1,
+  "modified": "2024-08-27 12:58:51.080566",
+  "name": "Production Manager",
+  "notifications": 1,
+  "restrict_to_domain": null,
+  "role_name": "Production Manager",
+  "search_bar": 1,
+  "timeline": 1,
+  "two_factor_auth": 0,
+  "view_switcher": 1
  }
 ]

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -130,7 +130,8 @@ doc_events = {
         "before_save": "beams.beams.custom_scripts.sales_invoice.sales_invoice.validate_sales_invoice_amount_with_quotation"
     },
     "Quotation": {
-        "validate": "beams.beams.custom_scripts.quotation.quotation.validate_is_barter"
+        "validate": "beams.beams.custom_scripts.quotation.quotation.validate_is_barter",
+        "on_submit": "beams.beams.custom_scripts.quotation.quotation.create_tasks_for_production_items"
     },
     "Purchase Invoice": {
         "before_save": "beams.beams.custom_scripts.purchase_invoice.purchase_invoice.before_save"
@@ -258,6 +259,6 @@ fixtures = [
         ["name", "in", ["Submit for Approval","Reopen", "Approve", "Reject", "Sent For Finance Verification", "Verify", "Sent for Approval"]]
     ]},
     {"dt": "Role", "filters": [
-        ["name", "in", ["CEO"]]
+        ["name", "in", ["CEO","Production Manager"]]
     ]}
 ]

--- a/beams/public/js/quotation.js
+++ b/beams/public/js/quotation.js
@@ -33,23 +33,4 @@ frappe.ui.form.on('Quotation', {
             })
         }
     },
-
-    before_save: function(frm) {
-        // Check the total amount of linked Sales Invoices before saving
-        return frappe.call({
-            method: "beams.beams.custom_scripts.quotation.quotation.get_total_sales_invoice_amount",
-            args: {
-                quotation_name: frm.doc.name
-            },
-            callback: function(r) {
-                if (r.message < frm.doc.total) {
-                    // Allow saving
-                    return true;
-                } else {
-                    frappe.msgprint(__('The total amount of Sales Invoices for this Quotation has reached or exceeded the limit.'));
-                    frappe.validated = false; // Prevent saving
-                }
-            }
-        });
-    }
 });

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -11,6 +11,7 @@ def after_install():
     create_custom_fields(get_purchase_invoice_custom_fields(), ignore_validate=True)
     create_custom_fields(get_quotation_item_custom_fields(), ignore_validate=True)
     create_custom_fields(get_supplier_custom_fields(), ignore_validate=True)
+    create_custom_fields(get_item_custom_fields(), ignore_validate=True)
     create_property_setters(get_property_setters())
 
 
@@ -220,6 +221,22 @@ def get_quotation_item_custom_fields():
             }
         ]
     }
+
+def get_item_custom_fields():
+    '''
+    Custom fields that need to be added to the Quotation Item Doctype
+    '''
+    return {
+        "Item": [
+            {
+                "fieldname": "is_production_item",
+                "fieldtype": "Check",
+                "label": "Is Production Item",
+                "insert_after": "stock_uom"
+            }
+        ]
+    }
+
 
 def create_property_setters(property_setter_datas):
     '''


### PR DESCRIPTION
Feature Description.

- Add a Checkbox is_production_item in doctype item
- Create a Task to Production Manager when the release order with item that checkbox  is_production_item checked is submitted

Solution Description.

 - Added Checkbox is_production_item
 - A task is generated to the particular release order

Output. 

[Screencast from 27-08-24 03:09:16 PM IST.webm](https://github.com/user-attachments/assets/fbd9c9b1-1ff4-40a1-b51b-99d412d63fe7)

Is there any existing change.

No

Was the feature tested on the browsers.

Mozilla Firefox