### PR TITLE
feat: Customize Purchase Invoice

### DIFF
--- a/beams/beams/doctype/stringer_work_details/stringer_work_details.json
+++ b/beams/beams/doctype/stringer_work_details/stringer_work_details.json
@@ -1,0 +1,53 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2024-08-27 10:47:37.632448",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "from_time",
+  "to_time",
+  "hrs",
+  "bureau"
+ ],
+ "fields": [
+  {
+   "fieldname": "from_time",
+   "fieldtype": "Datetime",
+   "in_list_view": 1,
+   "label": "From Date and Time"
+  },
+  {
+   "fieldname": "to_time",
+   "fieldtype": "Datetime",
+   "in_list_view": 1,
+   "label": "To Date and Time"
+  },
+  {
+   "fieldname": "hrs",
+   "fieldtype": "Float",
+   "in_list_view": 1,
+   "label": "Hrs"
+  },
+  {
+   "fieldname": "bureau",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Bureau",
+   "options": "Bureau"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2024-08-27 13:46:33.083574",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "Stringer Work Details",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/beams/beams/doctype/stringer_work_details/stringer_work_details.py
+++ b/beams/beams/doctype/stringer_work_details/stringer_work_details.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class StringerWorkDetails(Document):
+	pass

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -30,7 +30,8 @@ app_license = "mit"
 # include js in doctype views
 doctype_js = {
     "Sales Invoice": "public/js/sales_invoice.js",
-    "Quotation": "public/js/quotation.js"
+    "Quotation": "public/js/quotation.js",
+    "Purchase Invoice": "public/js/purchase_invoice.js"
 }
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}

--- a/beams/public/js/purchase_invoice.js
+++ b/beams/public/js/purchase_invoice.js
@@ -1,0 +1,67 @@
+frappe.ui.form.on('Purchase Invoice', {
+  invoice_type: function(frm) {
+    if (frm.doc.invoice_type === 'Stringer Bill') {
+      frm.fields_dict['items'].grid.get_field('item_code').get_query = function(doc, cdt, cdn) {
+        return {
+          filters: [
+            ["is_stock_item", "=", 0]
+          ]
+        };
+      };
+      frm.set_query('supplier', function() {
+        return {
+          "filters": {
+            is_stringer: 1
+          }
+        };
+      });
+    }
+  },
+  supplier: function(frm) {
+    if (frm.doc.supplier) {
+      frappe.db.get_value('Supplier', frm.doc.supplier, ['is_stringer', 'bureau'], function(r) {
+        frm.doc.supplier_bureau = r.bureau;
+        frm.refresh_field('supplier_bureau');
+
+        frm.doc.stringer_work_details.forEach(row => {
+          if (r.is_stringer && frm.doc.supplier_bureau) {
+            frappe.model.set_value(row.doctype, row.name, 'bureau', frm.doc.supplier_bureau);
+          }
+        });
+
+        frm.refresh_field('stringer_work_details');
+      });
+    }
+  }
+});
+
+frappe.ui.form.on('Stringer Work Details', {
+  from_time: function (frm, cdt, cdn) {
+    calculate_hours(frm, cdt, cdn);
+  },
+  to_time: function (frm, cdt, cdn) {
+    calculate_hours(frm, cdt, cdn);
+  },
+  stringer_work_details_add: function(frm, cdt, cdn) {
+    let row = locals[cdt][cdn];
+
+    if (frm.doc.supplier_bureau) {
+      frappe.model.set_value(cdt, cdn, 'bureau', frm.doc.supplier_bureau);
+    }
+  }
+});
+
+function calculate_hours(frm, cdt, cdn) {
+  /**
+  * Function to calculate hours based on from time and to time.
+  */
+  var row = locals[cdt][cdn];
+  if (row.from_time && row.to_time) {
+    var from_time = new Date(row.from_time);
+    var to_time = new Date(row.to_time);
+    var diff = (to_time - from_time) / (1000 * 60 * 60);
+    frappe.model.set_value(cdt, cdn, 'hrs', diff.toFixed(2));
+  } else {
+    frappe.model.set_value(cdt, cdn, 'hrs', 0);
+  }
+}

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -124,8 +124,6 @@ def get_sales_invoice_custom_fields():
         ]
     }
 
-
-
 def get_quotation_custom_fields():
     '''
     Custom fields that need to be added to the Quotation DocType
@@ -151,7 +149,7 @@ def get_quotation_custom_fields():
                 "fieldtype": "Check",
                 "label": "Is Barter",
                 "insert_after": "albatross_ro_id"
-            },
+            }
 
         ]
     }
@@ -178,6 +176,21 @@ def get_purchase_invoice_custom_fields():
                 "options": "Quotation",
                 "insert_after": "barter_invoice"
 
+            },
+            {
+                "fieldname": "invoice_type",
+                "fieldtype": "Select",
+                "options": "\nGeneral\nStringer Bill",
+                "default": "General",
+                "label": "Invoice Type",
+                "insert_after": "naming_series"
+            },
+            {
+                "fieldname": "stringer_work_details",
+                "fieldtype": "Table",
+                "label": "Stringer Work Details",
+                "options": "Stringer Work Details",
+                "insert_after": "items"
             }
         ]
     }
@@ -305,5 +318,4 @@ def get_property_setters():
             "property_type": "Check",
             "value": 1
         }
-
     ]


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- Feature

## Clearly and concisely describe the feature, chore or bug.
-  This feature enhance the Purchase Invoice DocType with a new invoice type field, conditional filters, and a child table for   stringer work details.
## Solution description 
- Added field Invoice Type to Purchase Invoice.
- Applied Item field filtering-Show only service items in the Item field when Invoice Type is "Stringer Bill."
- Supplier field filtering-Show only stringer suppliers in the Supplier field when Invoice Type is "Stringer Bill."
- Added Child table 'Stringer Work Details' in Purchase Invoice. 
- Bureau from the supplier fetched into the Stringer Work Details table based on whether the supplier is a stringer.


## Output screenshots (optional)
[Screencast from 08-28-2024 09:36:14 AM.webm](https://github.com/user-attachments/assets/f3387449-2cf5-410d-bd39-4365712e6768)

## Areas affected and ensured
Purchase Invoice.

## Did you test with the following dataset?
- Existing Data
- New Data
