### PR TITLE
feat: Create Approval workflow on Driver Batta Claim.

### DIFF
--- a/beams/fixtures/workflow_action_master.json
+++ b/beams/fixtures/workflow_action_master.json
@@ -9,13 +9,6 @@
  {
   "docstatus": 0,
   "doctype": "Workflow Action Master",
-  "modified": "2024-08-16 14:50:26.425434",
-  "name": "Submit for Approval",
-  "workflow_action_name": "Submit for Approval"
- },
- {
-  "docstatus": 0,
-  "doctype": "Workflow Action Master",
   "modified": "2024-08-21 09:48:56.345580",
   "name": "Send For Finance Verification",
   "workflow_action_name": "Send For Finance Verification"
@@ -33,6 +26,13 @@
   "modified": "2024-08-28 08:49:11.130190",
   "name": "Send for Approval",
   "workflow_action_name": "Send for Approval"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Workflow Action Master",
+  "modified": "2024-08-16 14:50:26.425434",
+  "name": "Submit for Approval",
+  "workflow_action_name": "Submit for Approval"
  },
  {
   "docstatus": 0,

--- a/beams/fixtures/workflow_state.json
+++ b/beams/fixtures/workflow_state.json
@@ -3,15 +3,6 @@
   "docstatus": 0,
   "doctype": "Workflow State",
   "icon": "",
-  "modified": "2024-08-20 14:52:12.123094",
-  "name": "Pending Approval",
-  "style": "Info",
-  "workflow_state_name": "Pending Approval"
- },
- {
-  "docstatus": 0,
-  "doctype": "Workflow State",
-  "icon": "",
   "modified": "2024-08-21 10:32:58.704051",
   "name": "Pending Finance Verification",
   "style": "Info",
@@ -25,24 +16,6 @@
   "name": "Verified By Finance",
   "style": "Primary",
   "workflow_state_name": "Verified By Finance"
- },
- {
-  "docstatus": 0,
-  "doctype": "Workflow State",
-  "icon": "",
-  "modified": "2024-08-17 14:26:48.530305",
-  "name": "Draft",
-  "style": "",
-  "workflow_state_name": "Draft"
- },
- {
-  "docstatus": 0,
-  "doctype": "Workflow State",
-  "icon": "remove",
-  "modified": "2024-08-03 14:59:52.136137",
-  "name": "Rejected",
-  "style": "Danger",
-  "workflow_state_name": "Rejected"
  },
  {
   "docstatus": 0,
@@ -65,6 +38,24 @@
  {
   "docstatus": 0,
   "doctype": "Workflow State",
+  "icon": "",
+  "modified": "2024-08-22 09:42:18.336199",
+  "name": "Pending Finance Approval",
+  "style": "Info",
+  "workflow_state_name": "Pending Finance Approval"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Workflow State",
+  "icon": "",
+  "modified": "2024-08-17 14:26:48.530305",
+  "name": "Draft",
+  "style": "",
+  "workflow_state_name": "Draft"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Workflow State",
   "icon": "ok-sign",
   "modified": "2024-08-03 14:59:52.132982",
   "name": "Approved",
@@ -74,10 +65,19 @@
  {
   "docstatus": 0,
   "doctype": "Workflow State",
+  "icon": "remove",
+  "modified": "2024-08-03 14:59:52.136137",
+  "name": "Rejected",
+  "style": "Danger",
+  "workflow_state_name": "Rejected"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Workflow State",
   "icon": "",
-  "modified": "2024-08-22 09:42:18.336199",
-  "name": "Pending Finance Approval",
+  "modified": "2024-08-20 14:52:12.123094",
+  "name": "Pending Approval",
   "style": "Info",
-  "workflow_state_name": "Pending Finance Approval"
+  "workflow_state_name": "Pending Approval"
  }
 ]

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -251,7 +251,7 @@ doc_events = {
 # }
 fixtures = [
     {"dt": "Workflow", "filters": [
-        ["name", "in", ["Customer Approval", "Account Approval", "Adhoc Budget","Supplier Approval", "Purchase Order Approval" , "Budget Approval"]]
+        ["name", "in", ["Customer Approval", "Account Approval", "Adhoc Budget","Supplier Approval", "Purchase Order Approval" , "Budget Approval" , "Driver Batta Claim Approval"]]
     ]},
     {"dt": "Workflow State", "filters": [
         ["name", "in", ["Draft", "Pending Approval", "Approved", "Rejected", "Pending Finance Verification", "Verified By Finance","Rejected By Finance", "Pending Finance Approval", "Approved by Finance"]]


### PR DESCRIPTION
## Feature description
- A Workflow has to be created for doctype Driver Batta Claim.

## Solution description
 A workflow was created for the Driver Batta Claim doctype to manage the approval process and state transitions.

## Output
![Screenshot from 2024-08-28 16-10-41](https://github.com/user-attachments/assets/c05dde82-2fb9-4229-9425-3d73de4a8647)
![Screenshot from 2024-08-28 16-10-49](https://github.com/user-attachments/assets/6a812e5a-0e78-4c81-a1be-5b414c5794ed)
![Screenshot from 2024-08-28 16-11-05](https://github.com/user-attachments/assets/98bd1ad5-15a8-4642-97bd-ac1080214829)
![image](https://github.com/user-attachments/assets/a10ea447-3bcf-423a-87f5-78bbe44cc0d4)


## Areas affected and ensured
- Driver Batta Claim doctype

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox