### PR TITLE
feat:Create child table Beams Naming Rule

### DIFF
--- a/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.json
+++ b/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.json
@@ -8,7 +8,9 @@
   "adhoc_budget_threshold",
   "equalize_purchase_and_quotation_amounts",
   "tab_break_4hid",
-  "default_working_hours"
+  "default_working_hours",
+  "naming_rule_tab",
+  "beams_naming_rule"
  ],
  "fields": [
   {
@@ -32,12 +34,23 @@
    "fieldname": "default_working_hours",
    "fieldtype": "Float",
    "label": "Default Working Hours"
+  },
+  {
+   "fieldname": "naming_rule_tab",
+   "fieldtype": "Tab Break",
+   "label": "Naming Rule"
+  },
+  {
+   "fieldname": "beams_naming_rule",
+   "fieldtype": "Table",
+   "label": "Beams Naming Rule",
+   "options": "Beams Naming Rule"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-08-27 16:14:50.632078",
+ "modified": "2024-08-29 10:14:41.594535",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Beams Accounts Settings",

--- a/beams/beams/doctype/beams_naming_rule/beams_naming_rule.json
+++ b/beams/beams/doctype/beams_naming_rule/beams_naming_rule.json
@@ -1,0 +1,49 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "naming_series:",
+ "creation": "2024-08-29 10:04:04.579186",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "company",
+  "doc_type",
+  "naming_series"
+ ],
+ "fields": [
+  {
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Company",
+   "options": "Company"
+  },
+  {
+   "fieldname": "doc_type",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Doctype",
+   "options": "DocType"
+  },
+  {
+   "fieldname": "naming_series",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Naming Series"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2024-08-29 10:15:02.553265",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "Beams Naming Rule",
+ "naming_rule": "By \"Naming Series\" field",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/beams/beams/doctype/beams_naming_rule/beams_naming_rule.py
+++ b/beams/beams/doctype/beams_naming_rule/beams_naming_rule.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class BeamsNamingRule(Document):
+	pass


### PR DESCRIPTION
## Feature description
Create  child table Beams Naming Rule.

## Solution description
 Created child table Beams Naming Rule to Beams Accounts Settings.This Child table can be used to set naming series for any doctype.

## Output
![image](https://github.com/user-attachments/assets/fb46060f-d884-48cd-a509-0ea4aae2f902)





## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox