### PR TITLE
fix : Company filter is applied to the default account in doctype Bud…

### DIFF
--- a/beams/beams/doctype/budget_expense_type/budget_expense_type.js
+++ b/beams/beams/doctype/budget_expense_type/budget_expense_type.js
@@ -1,8 +1,21 @@
 // Copyright (c) 2024, efeone and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Budget Expense Type", {
-// 	refresh(frm) {
+frappe.ui.form.on('Accounts', {
+    company: function(frm, cdt, cdn) {
+        set_account_query(frm);
+    },
+    accounts_add: function(frm, cdt, cdn) {
+        set_account_query(frm);
+    }
+});
 
-// 	},
-// });
+// Set query to filter 'default_account' based on the selected company
+function set_account_query(frm) {
+    frm.fields_dict['accounts'].grid.get_field("default_account").get_query = function(doc, cdt, cdn) {
+        let row = locals[cdt][cdn];
+        return {
+            filters: {'company': row.company}
+        };
+    };
+}


### PR DESCRIPTION
## Issue description
- No Filter applied for company default account in Budget  Expense Type

## Solution description 
- Filter applied for company default account in Budget  Expense Type 

## Output
![image](https://github.com/user-attachments/assets/53a4efa6-954d-4edc-9157-c1c1272dd865)

## Is there any existing behavior change of other features due to this code change?
-No.

## Was this feature tested on the browsers?
  - Mozilla Firefox