### PR TITLE
fix:Rename Item Type Doctype To Sales Type

### DIFF
--- a/beams/beams/doctype/sales_type/sales_type.js
+++ b/beams/beams/doctype/sales_type/sales_type.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2024, efeone and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Item Type", {
+// frappe.ui.form.on("Sales Type", {
 // 	refresh(frm) {
 
 // 	},

--- a/beams/beams/doctype/sales_type/sales_type.json
+++ b/beams/beams/doctype/sales_type/sales_type.json
@@ -7,7 +7,9 @@
  "engine": "InnoDB",
  "field_order": [
   "section_break_szxw",
-  "item_type"
+  "item_type",
+  "is_digital_sales",
+  "amended_from"
  ],
  "fields": [
   {
@@ -21,15 +23,31 @@
    "label": "Item Type",
    "reqd": 1,
    "unique": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "is_digital_sales",
+   "fieldtype": "Check",
+   "label": "Is Digital Sales"
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "Sales Type",
+   "print_hide": 1,
+   "read_only": 1,
+   "search_index": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-08-12 10:36:01.308217",
+ "modified": "2024-08-30 09:40:06.978975",
  "modified_by": "Administrator",
  "module": "BEAMS",
- "name": "Item Type",
+ "name": "Sales Type",
  "naming_rule": "By fieldname",
  "owner": "Administrator",
  "permissions": [

--- a/beams/beams/doctype/sales_type/sales_type.py
+++ b/beams/beams/doctype/sales_type/sales_type.py
@@ -5,5 +5,5 @@
 from frappe.model.document import Document
 
 
-class ItemType(Document):
+class SalesType(Document):
 	pass

--- a/beams/beams/doctype/sales_type/test_sales_type.py
+++ b/beams/beams/doctype/sales_type/test_sales_type.py
@@ -5,5 +5,5 @@
 from frappe.tests.utils import FrappeTestCase
 
 
-class TestItemType(FrappeTestCase):
+class TestSalesType(FrappeTestCase):
 	pass

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -252,10 +252,10 @@ def get_quotation_item_custom_fields():
     return {
         "Quotation Item": [
             {
-                "fieldname": "item_type",
+                "fieldname": "sales_type",
                 "fieldtype": "Link",
-                "options": "Item Type",
-                "label": "Item Type",
+                "options": "Sales Type",
+                "label": "Sales Type",
                 "insert_after": "item_name"
             }
         ]


### PR DESCRIPTION
## Feature description
-Rename Item Type to Sales Type and add 'Is Digital Sales' checkbox

## Solution description
 -Created "Sales Type" by renaming "Item Type" and added 'Is Digital Sales' checkbox.

## Output
![image](https://github.com/user-attachments/assets/8c20dbbf-60d1-453f-827f-9588f07cf27a)

## Is there any existing behavior change of other features due to this code change?
-no

## Was this feature tested on the browsers?
  - Mozilla Firefox