### PR TITLE
feat: Create Purchase Invoice on the Approval of Driver Batta Claim

### DIFF
--- a/beams/beams/doctype/driver_batta_claim/driver_batta_claim.js
+++ b/beams/beams/doctype/driver_batta_claim/driver_batta_claim.js
@@ -6,8 +6,15 @@ frappe.ui.form.on('Driver Batta Claim', {
         calculate_totals(frm);
     },
     refresh: function (frm) {
+        frm.set_query('driver', function() {
+              return {
+                  filters: {
+                      'is_internal': 0
+                  }
+              };
+          });
         calculate_totals(frm);
-    }
+    },
 });
 
 frappe.ui.form.on('Work Details', {

--- a/beams/beams/doctype/driver_batta_claim/driver_batta_claim.py
+++ b/beams/beams/doctype/driver_batta_claim/driver_batta_claim.py
@@ -1,9 +1,27 @@
 # Copyright (c) 2024, efeone and contributors
 # For license information, please see license.txt
 
-
+import frappe
 from frappe.model.document import Document
 
-
 class DriverBattaClaim(Document):
-    pass
+    def on_submit(self):
+        if self.workflow_state == 'Approved':
+            self.create_purchase_invoice_from_driver_batta_claim()
+
+    def create_purchase_invoice_from_driver_batta_claim(self):
+        """
+            Creation of Purchase Invoice On The Approval Of the Driver Batta Claim.
+        """
+        purchase_invoice = frappe.new_doc('Purchase Invoice')
+        driver = frappe.get_doc("Driver", self.driver)
+        purchase_invoice.supplier = driver.transporter
+        purchase_invoice.posting_date = frappe.utils.nowdate()
+        purchase_invoice.append('items', {
+            'item_code': 'Driver Batta Claim',  # Static item code
+            'rate': self.total_driver_batta,  # Assuming total_driver_batta is the rate
+            'qty': 1  # Adjust quantity as needed
+        })
+
+        purchase_invoice.insert()
+        purchase_invoice.submit()

--- a/beams/public/js/purchase_invoice.js
+++ b/beams/public/js/purchase_invoice.js
@@ -19,6 +19,11 @@ frappe.ui.form.on('Purchase Invoice', {
         };
       });
     }
+    frm.clear_table('stringer_work_details');
+    frm.clear_table('items');
+    frm.refresh_field('stringer_work_details');
+    frm.refresh_field('items');
+    frm.set_value('supplier','');
   },
   supplier: function(frm) {
     if (frm.doc.supplier) {
@@ -40,10 +45,12 @@ frappe.ui.form.on('Purchase Invoice', {
 
 frappe.ui.form.on('Stringer Work Details', {
   from_time: function (frm, cdt, cdn) {
-    calculate_hours(frm, cdt, cdn);
+    validate_time_and_calculate_hours(frm, cdt, cdn);
+    validate_row_dates(frm, cdt, cdn);
   },
   to_time: function (frm, cdt, cdn) {
-    calculate_hours(frm, cdt, cdn);
+    validate_time_and_calculate_hours(frm, cdt, cdn);
+    validate_row_dates(frm, cdt, cdn);
   },
   stringer_work_details_add: function(frm, cdt, cdn) {
     let row = locals[cdt][cdn];
@@ -54,18 +61,49 @@ frappe.ui.form.on('Stringer Work Details', {
   }
 });
 
-function calculate_hours(frm, cdt, cdn) {
+function validate_time_and_calculate_hours(frm, cdt, cdn) {
   /**
-  * Function to calculate hours based on from time and to time.
-  */
+   * Function for validating from_time and to_time and calculating hours.
+   */
   var row = locals[cdt][cdn];
   if (row.from_time && row.to_time) {
     var from_time = new Date(row.from_time);
     var to_time = new Date(row.to_time);
-    var diff = (to_time - from_time) / (1000 * 60 * 60);
-    frappe.model.set_value(cdt, cdn, 'hrs', diff.toFixed(2));
+
+    if (from_time >= to_time) {
+      frappe.msgprint(__('From Date and Time cannot be after or equal to To Date and Time.'));
+      frappe.model.set_value(cdt, cdn, 'to_time', null);
+      frappe.model.set_value(cdt, cdn, 'hrs', 0);
+    } else {
+      var diff = (to_time - from_time) / (1000 * 60 * 60);
+      frappe.model.set_value(cdt, cdn, 'hrs', diff.toFixed(2));
+    }
   } else {
     frappe.model.set_value(cdt, cdn, 'hrs', 0);
+  }
+}
+
+function validate_row_dates(frm, cdt, cdn) {
+  /**
+    Ensures that all rows in the 'stringer_work_details' table have the same date.
+   */
+  var row = locals[cdt][cdn];
+
+  if (row.from_time) {
+    let first_row_date = null;
+    let current_row_date = new Date(row.from_time).toDateString();
+
+    frm.doc.stringer_work_details.forEach(existing_row => {
+      if (existing_row.from_time && !first_row_date) {
+        first_row_date = new Date(existing_row.from_time).toDateString();
+      }
+    });
+
+    if (first_row_date && current_row_date !== first_row_date) {
+      frappe.msgprint(__('All rows must have the same date'));
+      frappe.model.set_value(cdt, cdn, 'from_time', null);
+      frappe.model.set_value(cdt, cdn, 'to_time', null);
+    }
   }
 }
 

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -209,7 +209,8 @@ def get_purchase_invoice_custom_fields():
                 "fieldtype": "Table",
                 "label": "Stringer Work Details",
                 "options": "Stringer Work Details",
-                "insert_after": "items"
+                "insert_after": "items",
+                "depends_on": "eval:doc.invoice_type == 'Stringer Bill'"
             },
             {
                 "fieldname": "purchase_order_id",


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- Feature

## Clearly and concisely describe the feature, chore or bug.
-  This feature Auto create Purchase Invoice when the Driver Batta Claim is Approved.
- Validate time fields and calculate hours based on it in Stringer Work Table in Purchase Invoice.
- Applied filters for Driver in Driver Batta Claim,
- Applied Validation that ensures that all rows in the 'stringer_work_details' table have the same date.

## Output screenshots (optional)
[Screencast from 08-30-2024 09:58:16 AM.webm](https://github.com/user-attachments/assets/1db7b2c7-3d58-4250-a7d2-2f6b86594e1a)
![image](https://github.com/user-attachments/assets/644c95c2-9894-4bf8-821e-50c60a3c5635)
![image](https://github.com/user-attachments/assets/c62b6852-5f6f-4b50-b5bd-5dfeb6d34668)


## Areas affected and ensured
Purchase Invoice.
Driver Batta Claim.

## Did you test with the following dataset?
- Existing Data
- New Data
