### PR TITLE
feat: Customize Item Type Doctype

### DIFF
--- a/beams/setup.py
+++ b/beams/setup.py
@@ -272,7 +272,15 @@ def get_item_custom_fields():
                 "fieldtype": "Check",
                 "label": "Is Production Item",
                 "insert_after": "stock_uom"
-            }
+            },
+            {
+                "fieldname": "sales_type",
+                "fieldtype": "Link",
+                "label": "Sales Type",
+                "options": "Sales Type",
+                "insert_after": "is_production_item"
+           }
+
         ]
     }
 


### PR DESCRIPTION
## Feature description
-add 'Sales Type' field to Item doctype

## Solution description
 -added 'Sales Type' field to Item doctype

## Output
![image](https://github.com/user-attachments/assets/388bf0c8-7fad-4b9b-94cc-be81799ecfe0)

## Is there any existing behavior change of other features due to this code change?
-no

## Was this feature tested on the browsers?
  - Mozilla Firefox