### PR TITLE
feat: Add checkbox Budget Exceeded on Material Request

### DIFF
--- a/beams/beams/doctype/driver_batta_claim/driver_batta_claim.json
+++ b/beams/beams/doctype/driver_batta_claim/driver_batta_claim.json
@@ -1,6 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
+ "autoname": "format: {DBC}-{MM}{YY}{####}",
  "creation": "2024-08-27 15:06:17.164899",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -111,10 +112,11 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-08-28 09:46:56.735004",
+ "modified": "2024-08-30 10:17:50.320792",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Driver Batta Claim",
+ "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [
   {

--- a/beams/beams/doctype/driver_batta_claim/driver_batta_claim.json
+++ b/beams/beams/doctype/driver_batta_claim/driver_batta_claim.json
@@ -1,7 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
- "autoname": "format: {DBC}-{MM}{YY}{####}",
+ "autoname": "format: {DBC}-{YYYY}-{####}",
  "creation": "2024-08-27 15:06:17.164899",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -112,7 +112,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-08-30 10:17:50.320792",
+ "modified": "2024-08-30 11:18:46.827644",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Driver Batta Claim",

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -14,6 +14,7 @@ def after_install():
     create_custom_fields(get_item_custom_fields(), ignore_validate=True)
     create_custom_fields(get_driver_custom_fields(), ignore_validate=True)
     create_property_setters(get_property_setters())
+    create_custom_fields(get_material_request_custom_fields(), ignore_validate=True)
 
 
 def after_migrate():
@@ -27,6 +28,7 @@ def before_uninstall():
     delete_custom_fields(get_quotation_item_custom_fields())
     delete_custom_fields(get_supplier_custom_fields())
     delete_custom_fields(get_driver_custom_fields())
+    delete_custom_fields(get_material_request_custom_fields())
 
 
 def delete_custom_fields(custom_fields: dict):
@@ -345,3 +347,17 @@ def get_property_setters():
             "value": 1
         }
     ]
+def get_material_request_custom_fields():
+    '''
+    Custom fields that need to be added to the Material Request Doctype
+    '''
+    return {
+        "Material Request": [
+            {
+                "fieldname": "budget_exceeded",
+                "fieldtype": "Check",
+                "label": "Budget Exceeded",
+                "insert_after": "schedule_date"
+            }
+        ]
+    }


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- Feature

## Solution description
- Added checkbox "Budget Exceeded" on Material Request.
- Applied Naming Series for Driver Batta Claim.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/95c6e4c5-4ef9-47b4-ac9b-9606a482775e)
![image](https://github.com/user-attachments/assets/33d52789-cd9b-4e6f-a090-ccf158149780)

## Areas affected and ensured
Sales Order.
Driver Batta Claim.

## Did you test with the following dataset?
- Existing Data
- New Data
