### PR TITLE
feat: Customize Sales Invoice & Sales Order

### DIFF
--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -32,7 +32,8 @@ doctype_js = {
     "Sales Invoice": "public/js/sales_invoice.js",
     "Quotation": "public/js/quotation.js",
     "Purchase Invoice": "public/js/purchase_invoice.js",
-    "Driver":"public/js/driver.js"
+    "Driver":"public/js/driver.js",
+    "Sales Order": "public/js/sales_order.js"
 }
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}

--- a/beams/public/js/sales_invoice.js
+++ b/beams/public/js/sales_invoice.js
@@ -8,6 +8,19 @@ frappe.ui.form.on('Sales Invoice', {
       };
     });
   },
+  sales_type: function(frm) {
+      if (frm.doc.sales_type) {
+        frm.fields_dict['items'].grid.get_field('item_code').get_query = function(doc, cdt, cdn) {
+          return {
+            filters: {
+              'sales_type': frm.doc.sales_type
+            }
+         };
+      };
+    }
+    frm.clear_table('items');
+    frm.refresh_field('items');
+  },
   customer: function(frm) {
     if (frm.doc.customer) {
       if (!frm.doc.is_barter_invoice) {

--- a/beams/public/js/sales_order.js
+++ b/beams/public/js/sales_order.js
@@ -1,6 +1,8 @@
 frappe.ui.form.on('Sales Order', {
+  // Trigger the function when the 'sales_type' field changes
   sales_type: function(frm) {
       if (frm.doc.sales_type) {
+        // Set a custom query filter for the 'item_code' field in the 'items' child table
         frm.fields_dict['items'].grid.get_field('item_code').get_query = function(doc, cdt, cdn) {
           return {
             filters: {

--- a/beams/public/js/sales_order.js
+++ b/beams/public/js/sales_order.js
@@ -1,0 +1,15 @@
+frappe.ui.form.on('Sales Order', {
+  sales_type: function(frm) {
+      if (frm.doc.sales_type) {
+        frm.fields_dict['items'].grid.get_field('item_code').get_query = function(doc, cdt, cdn) {
+          return {
+            filters: {
+              'sales_type': frm.doc.sales_type
+            }
+         };
+      };
+    }
+    frm.clear_table('items');
+    frm.refresh_field('items');
+  }
+});

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -15,6 +15,7 @@ def after_install():
     create_custom_fields(get_driver_custom_fields(), ignore_validate=True)
     create_property_setters(get_property_setters())
     create_custom_fields(get_material_request_custom_fields(), ignore_validate=True)
+    create_custom_fields(get_sales_order_custom_fields(), ignore_validate=True)
 
 
 def after_migrate():
@@ -29,6 +30,7 @@ def before_uninstall():
     delete_custom_fields(get_supplier_custom_fields())
     delete_custom_fields(get_driver_custom_fields())
     delete_custom_fields(get_material_request_custom_fields())
+    delete_custom_fields(get_sales_order_custom_fields())
 
 
 def delete_custom_fields(custom_fields: dict):
@@ -142,6 +144,13 @@ def get_sales_invoice_custom_fields():
                 "read_only":1,
                 "insert_after": "naming_series"
             },
+            {
+                "fieldname": "sales_type",
+                "fieldtype": "Link",
+                "label": "Sales Type",
+                "insert_after": "naming_series",
+                "options": "Sales Type"
+            }
         ]
     }
 
@@ -367,6 +376,22 @@ def get_material_request_custom_fields():
                 "fieldtype": "Check",
                 "label": "Budget Exceeded",
                 "insert_after": "schedule_date"
+            }
+        ]
+    }
+
+def get_sales_order_custom_fields():
+    '''
+    Custom fields that need to be added to the Sales Order Doctype
+    '''
+    return {
+        "Sales Order": [
+            {
+                "fieldname": "sales_type",
+                "fieldtype": "Link",
+                "label": "Sales Type",
+                "insert_after": "naming_series",
+                "options": "Sales Type"
             }
         ]
     }


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- Feature

## Solution description 
- Add field Sales Type  in Sales Order & Sales Invoice.
- Applied filters for items of Sales Order and Sales Invoice.

## Output screenshots (optional)
[Screencast from 08-30-2024 12:31:03 PM.webm](https://github.com/user-attachments/assets/523b8dff-fa0e-41e7-a5af-71b86cb2b359)

## Areas affected and ensured
Sales Invoice.
Sales Order.

## Did you test with the following dataset?
- Existing Data
- New Data
