### PR TITLE
fix:Rename to Sales Type, add checkbox

### DIFF
--- a/beams/beams/doctype/sales_type/sales_type.json
+++ b/beams/beams/doctype/sales_type/sales_type.json
@@ -8,7 +8,7 @@
  "field_order": [
   "section_break_szxw",
   "item_type",
-  "is_digital_sales",
+  "is_time_sales",
   "amended_from"
  ],
  "fields": [
@@ -26,9 +26,9 @@
   },
   {
    "default": "0",
-   "fieldname": "is_digital_sales",
+   "fieldname": "is_time_sales",
    "fieldtype": "Check",
-   "label": "Is Digital Sales"
+   "label": "Is Time Sales"
   },
   {
    "fieldname": "amended_from",
@@ -44,7 +44,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-08-30 09:40:06.978975",
+ "modified": "2024-08-31 11:12:58.556883",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Sales Type",

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -9,7 +9,6 @@ def after_install():
     create_custom_fields(get_sales_invoice_custom_fields(), ignore_validate=True)
     create_custom_fields(get_quotation_custom_fields(), ignore_validate=True)
     create_custom_fields(get_purchase_invoice_custom_fields(), ignore_validate=True)
-    create_custom_fields(get_quotation_item_custom_fields(), ignore_validate=True)
     create_custom_fields(get_supplier_custom_fields(), ignore_validate=True)
     create_custom_fields(get_item_custom_fields(), ignore_validate=True)
     create_custom_fields(get_driver_custom_fields(), ignore_validate=True)
@@ -25,7 +24,6 @@ def before_uninstall():
     delete_custom_fields(get_sales_invoice_custom_fields())
     delete_custom_fields(get_quotation_custom_fields())
     delete_custom_fields(get_purchase_invoice_custom_fields())
-    delete_custom_fields(get_quotation_item_custom_fields())
     delete_custom_fields(get_supplier_custom_fields())
     delete_custom_fields(get_driver_custom_fields())
     delete_custom_fields(get_material_request_custom_fields())
@@ -244,22 +242,6 @@ def get_supplier_custom_fields():
                 "depends_on": "eval:doc.is_stringer == 1",
                 "insert_after": "is_stringer"
 
-            }
-        ]
-    }
-
-def get_quotation_item_custom_fields():
-    '''
-    Custom fields that need to be added to the Quotation Item Doctype
-    '''
-    return {
-        "Quotation Item": [
-            {
-                "fieldname": "sales_type",
-                "fieldtype": "Link",
-                "options": "Sales Type",
-                "label": "Sales Type",
-                "insert_after": "item_name"
             }
         ]
     }


### PR DESCRIPTION
## Feature description
-Rename "Digital Sales" checkbox to "Is Time Sales

-## Solution description
-Renamed"Digital Sales" checkbox to "Is Time Sales
-Sales Type field has been removed from the child table because the field had already been created in the main doctype

 -## Output
![image](https://github.com/user-attachments/assets/dd0dc769-529f-4b15-99e5-552d01402333)


## Is there any existing behavior change of other features due to this code change?
-no

## Was this feature tested on the browsers?
  - Mozilla Firefox