### PR TITLE
feat:Added naming rule through child table

### DIFF
--- a/beams/beams/custom_scripts/sales_order/sales_order.py
+++ b/beams/beams/custom_scripts/sales_order/sales_order.py
@@ -1,0 +1,24 @@
+import frappe
+from frappe.utils import nowdate
+from frappe.model.naming import make_autoname
+from datetime import datetime
+from frappe import _
+
+def autoname(doc, method=None):
+    beams_accounts_settings = frappe.get_doc("Beams Accounts Settings")
+    sales_order_naming_series = ''
+
+    for rule in beams_accounts_settings.beams_naming_rule:
+        # Check if the rule applies to the "Quotation" doctype
+        if rule.doc_type == "Sales Order" and rule.naming_series:
+            sales_order_naming_series = rule.naming_series
+            if sales_order_naming_series:
+                if "{MM}" in sales_order_naming_series or "{DD}" in sales_order_naming_series or "{YY}" in sales_order_naming_series:
+                    sales_order_naming_series = sales_order_naming_series.replace("{MM}", datetime.now().strftime("%m"))
+                    sales_order_naming_series = sales_order_naming_series.replace("{DD}", datetime.now().strftime("%d"))
+                    sales_order_naming_series = sales_order_naming_series.replace("{YY}", datetime.now().strftime("%y"))
+
+                # Generate the name using the updated naming series
+                doc.name = frappe.model.naming.make_autoname(sales_order_naming_series )
+            else:
+                frappe.throw(_("No valid naming series found for Sales Order doctype"))

--- a/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.js
+++ b/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.js
@@ -1,8 +1,11 @@
-// Copyright (c) 2024, efeone and contributors
-// For license information, please see license.txt
-
-// frappe.ui.form.on("Beams Accounts Settings", {
-// 	refresh(frm) {
-
-// 	},
-// });
+frappe.ui.form.on('Beams Accounts Settings', {
+    setup: function(frm) {
+        frm.set_query('doc_type', 'beams_naming_rule', function() {
+            return {
+                filters: {
+                    name: ['in', ['Quotation', 'Sales Order', 'Sales Invoice']]
+                }
+            };
+        });
+    },
+});

--- a/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.py
+++ b/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.py
@@ -1,9 +1,20 @@
-# Copyright (c) 2024, efeone and contributors
-# For license information, please see license.txt
-
-# import frappe
+import frappe
 from frappe.model.document import Document
 
-
 class BeamsAccountsSettings(Document):
-	pass
+    def before_save(self):
+        for rule in self.beams_naming_rule:
+            if rule.doc_type and rule.naming_series:
+                self.update_naming_series(rule.doc_type, rule.naming_series)
+
+    def autoname(self):
+        """Define autoname logic here if needed"""
+        # You can use self.name = make_autoname(...) if you need to generate a custom name
+
+    def update_naming_series( doc_type, naming_series,company):
+        try:
+            # Assuming autoname should be the naming_series itself
+            frappe.db.set_value("DocType", doc_type, "autoname", naming_series)
+            frappe.msgprint(f"Naming series for {doc_type} updated to {naming_series}")
+        except Exception as e:
+            frappe.throw(f"Error updating naming series for {doc_type}: {str(e)}")

--- a/beams/beams/doctype/beams_naming_rule/beams_naming_rule.json
+++ b/beams/beams/doctype/beams_naming_rule/beams_naming_rule.json
@@ -1,0 +1,50 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "naming_series:",
+ "creation": "2024-08-29 10:04:04.579186",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "company",
+  "doc_type",
+  "naming_series"
+ ],
+ "fields": [
+  {
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Company",
+   "options": "Company"
+  },
+  {
+   "fieldname": "doc_type",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Doctype",
+   "options": "DocType"
+  },
+  {
+   "fieldname": "naming_series",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Naming Series",
+   "length": 16
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2024-08-29 16:03:08.314964",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "Beams Naming Rule",
+ "naming_rule": "By \"Naming Series\" field",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -128,11 +128,15 @@ before_uninstall = "beams.uninstall.before_uninstall"
 
 doc_events = {
     "Sales Invoice": {
-        "before_save": "beams.beams.custom_scripts.sales_invoice.sales_invoice.validate_sales_invoice_amount_with_quotation"
+        "before_save": "beams.beams.custom_scripts.sales_invoice.sales_invoice.validate_sales_invoice_amount_with_quotation",
+        "autoname": "beams.beams.custom_scripts.sales_invoice.sales_invoice.autoname"
+
     },
     "Quotation": {
         "validate": "beams.beams.custom_scripts.quotation.quotation.validate_is_barter",
-        "on_submit": "beams.beams.custom_scripts.quotation.quotation.create_tasks_for_production_items"
+        "on_submit": "beams.beams.custom_scripts.quotation.quotation.create_tasks_for_production_items",
+        "autoname": "beams.beams.custom_scripts.quotation.quotation.autoname"
+
     },
     "Purchase Invoice": {
         "before_save": "beams.beams.custom_scripts.purchase_invoice.purchase_invoice.before_save"
@@ -149,7 +153,10 @@ doc_events = {
     "Purchase Order": {
         "on_update": "beams.beams.custom_scripts.purchase_order.purchase_order.create_todo_on_finance_verification",
         "after_insert": "beams.beams.custom_scripts.purchase_order.purchase_order.create_todo_on_purchase_order_creation"
-    }
+    },
+    "Sales Order": {
+        "autoname": "beams.beams.custom_scripts.sales_order.sales_order.autoname"
+        }
 }
 
 


### PR DESCRIPTION
## Feature description
  Add naming rule for Quotation,Sales Order and Sales Invoice through child table Beams naming rule.
Apply filters to doctype field of childtable Beams naming rule to list only  Quotation,Sales Order and Sales Invoice.


## Solution description
Applied  filters to doctype field of childtable Beams naming rule to list only  Quotation,Sales Order and Sales Invoice.
Defined naming series in child table Beams Naming Rule of Beams Account Settings doctype and  the rule is made applicable for naming Quotation,Sales Order and Sales Invoice.

## Output
![image](https://github.com/user-attachments/assets/0797bf99-97c4-4cd1-8654-5801581ddeb5)
![image](https://github.com/user-attachments/assets/9caa9161-0b01-4be3-9fcf-252d0369e225)
![image](https://github.com/user-attachments/assets/3fc16f97-f0fb-4098-acc8-cf4b2b4e2566)
![image](https://github.com/user-attachments/assets/0a861e49-8de8-4802-8fd2-c0e7ad5a8f3e)
![image](https://github.com/user-attachments/assets/26bc76e1-c335-4c8f-88c1-f689ba3d3a2a)


## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox