### PR TITLE
feat:Added naming rule for Quotation,Sales Order and Sales Invoice through child table

### DIFF
--- a/beams/beams/custom_scripts/quotation/quotation.py
+++ b/beams/beams/custom_scripts/quotation/quotation.py
@@ -4,6 +4,31 @@ from frappe import _
 from frappe.utils import nowdate
 from frappe.desk.form.assign_to import add as add_assign
 from frappe.utils.user import get_users_with_role
+from frappe.model.naming import make_autoname
+from datetime import datetime
+
+def autoname(doc, method=None):
+    """Automatically generate a name for the Quotation document based on custom naming rules defined
+    in the 'Beams Accounts Settings' doctype."""
+    beams_accounts_settings = frappe.get_doc("Beams Accounts Settings")
+    quotation_naming_series = ''
+
+     # Iterate through the naming rules
+    for rule in beams_accounts_settings.beams_naming_rule:
+        # Check if the rule applies to the "Quotation" doctype
+        if rule.doc_type == "Quotation" and rule.naming_series:
+            quotation_naming_series = rule.naming_series
+            if quotation_naming_series:
+            # Replace date placeholders with current date values
+                if "{MM}" in quotation_naming_series or "{DD}" in quotation_naming_series or "{YY}" in quotation_naming_series:
+                    quotation_naming_series = quotation_naming_series.replace("{MM}", datetime.now().strftime("%m"))
+                    quotation_naming_series = quotation_naming_series.replace("{DD}", datetime.now().strftime("%d"))
+                    quotation_naming_series = quotation_naming_series.replace("{YY}", datetime.now().strftime("%y"))
+
+                # Generate the name using the updated naming series
+                doc.name = frappe.model.naming.make_autoname(quotation_naming_series )
+            else:
+                frappe.throw(_("No valid naming series found for Quotation doctype"))
 
 
 @frappe.whitelist()
@@ -222,5 +247,4 @@ def create_task(item_code, quotation_name):
             "name": task.name,
             "description": f'You are assigned a production task for item {item_code} in Quotation {quotation_name}.'
         })
-
     return True

--- a/beams/beams/custom_scripts/sales_order/sales_order.py
+++ b/beams/beams/custom_scripts/sales_order/sales_order.py
@@ -1,0 +1,28 @@
+import frappe
+from frappe.utils import nowdate
+from frappe.model.naming import make_autoname
+from datetime import datetime
+from frappe import _
+
+def autoname(doc, method=None):
+    """Automatically generate a name for the Sales Order document based on custom naming rules defined
+    in the 'Beams Accounts Settings' doctype."""
+    beams_accounts_settings = frappe.get_doc("Beams Accounts Settings")
+    sales_order_naming_series = ''
+
+    # Iterate through the naming rules
+    for rule in beams_accounts_settings.beams_naming_rule:
+        # Check if the rule applies to the "Quotation" doctype
+        if rule.doc_type == "Sales Order" and rule.naming_series:
+            sales_order_naming_series = rule.naming_series
+            if sales_order_naming_series:
+            # Replace date placeholders with current date values
+                if "{MM}" in sales_order_naming_series or "{DD}" in sales_order_naming_series or "{YY}" in sales_order_naming_series:
+                    sales_order_naming_series = sales_order_naming_series.replace("{MM}", datetime.now().strftime("%m"))
+                    sales_order_naming_series = sales_order_naming_series.replace("{DD}", datetime.now().strftime("%d"))
+                    sales_order_naming_series = sales_order_naming_series.replace("{YY}", datetime.now().strftime("%y"))
+
+                # Generate the name using the updated naming series
+                doc.name = frappe.model.naming.make_autoname(sales_order_naming_series )
+            else:
+                frappe.throw(_("No valid naming series found for Sales Order doctype"))

--- a/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.js
+++ b/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.js
@@ -1,8 +1,11 @@
-// Copyright (c) 2024, efeone and contributors
-// For license information, please see license.txt
-
-// frappe.ui.form.on("Beams Accounts Settings", {
-// 	refresh(frm) {
-
-// 	},
-// });
+frappe.ui.form.on('Beams Accounts Settings', {
+    setup: function(frm) {
+        frm.set_query('doc_type', 'beams_naming_rule', function() {
+            return {
+                filters: {
+                    name: ['in', ['Quotation', 'Sales Order', 'Sales Invoice']]
+                }
+            };
+        });
+    },
+});

--- a/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.js
+++ b/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.js
@@ -1,3 +1,12 @@
+// Copyright (c) 2024, efeone and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Beams Accounts Settings", {
+// 	refresh(frm) {
+
+// 	},
+// });
+
 frappe.ui.form.on('Beams Accounts Settings', {
     setup: function(frm) {
         frm.set_query('doc_type', 'beams_naming_rule', function() {

--- a/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.py
+++ b/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.py
@@ -1,9 +1,5 @@
-# Copyright (c) 2024, efeone and contributors
-# For license information, please see license.txt
-
-# import frappe
+import frappe
 from frappe.model.document import Document
 
-
 class BeamsAccountsSettings(Document):
-	pass
+  pass

--- a/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.py
+++ b/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024, efeone and contributors
+# For license information, please see license.txt
+
 import frappe
 from frappe.model.document import Document
 

--- a/beams/beams/doctype/beams_naming_rule/beams_naming_rule.json
+++ b/beams/beams/doctype/beams_naming_rule/beams_naming_rule.json
@@ -30,13 +30,14 @@
    "fieldname": "naming_series",
    "fieldtype": "Data",
    "in_list_view": 1,
-   "label": "Naming Series"
+   "label": "Naming Series",
+   "length": 16
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-08-29 10:15:02.553265",
+ "modified": "2024-08-29 16:03:08.314964",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Beams Naming Rule",

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -31,7 +31,9 @@ app_license = "mit"
 doctype_js = {
     "Sales Invoice": "public/js/sales_invoice.js",
     "Quotation": "public/js/quotation.js",
-    "Purchase Invoice": "public/js/purchase_invoice.js"
+    "Purchase Invoice": "public/js/purchase_invoice.js",
+    "Driver":"public/js/driver.js",
+    "Sales Order": "public/js/sales_order.js"
 }
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -31,9 +31,7 @@ app_license = "mit"
 doctype_js = {
     "Sales Invoice": "public/js/sales_invoice.js",
     "Quotation": "public/js/quotation.js",
-    "Purchase Invoice": "public/js/purchase_invoice.js",
-    "Driver":"public/js/driver.js",
-    "Sales Order": "public/js/sales_order.js"
+    "Purchase Invoice": "public/js/purchase_invoice.js"
 }
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}
@@ -131,11 +129,15 @@ before_uninstall = "beams.uninstall.before_uninstall"
 doc_events = {
     "Sales Invoice": {
         "before_save": "beams.beams.custom_scripts.sales_invoice.sales_invoice.validate_sales_invoice_amount_with_quotation",
-         "on_submit":  "beams.beams.custom_scripts.sales_invoice.sales_invoice.send_email_to_party"
+        "on_submit":  "beams.beams.custom_scripts.sales_invoice.sales_invoice.send_email_to_party"
+        "autoname": "beams.beams.custom_scripts.sales_invoice.sales_invoice.autoname"
+
     },
     "Quotation": {
         "validate": "beams.beams.custom_scripts.quotation.quotation.validate_is_barter",
-        "on_submit": "beams.beams.custom_scripts.quotation.quotation.create_tasks_for_production_items"
+        "on_submit": "beams.beams.custom_scripts.quotation.quotation.create_tasks_for_production_items",
+        "autoname": "beams.beams.custom_scripts.quotation.quotation.autoname"
+
     },
     "Purchase Invoice": {
         "before_save": "beams.beams.custom_scripts.purchase_invoice.purchase_invoice.before_save"
@@ -152,7 +154,10 @@ doc_events = {
     "Purchase Order": {
         "on_update": "beams.beams.custom_scripts.purchase_order.purchase_order.create_todo_on_finance_verification",
         "after_insert": "beams.beams.custom_scripts.purchase_order.purchase_order.create_todo_on_purchase_order_creation"
-    }
+    },
+    "Sales Order": {
+        "autoname": "beams.beams.custom_scripts.sales_order.sales_order.autoname"
+        }
 }
 
 
@@ -264,5 +269,5 @@ fixtures = [
     ]},
     {"dt": "Role", "filters": [
         ["name", "in", ["CEO","Production Manager"]]
-    ]}
+        ]}
 ]

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -129,7 +129,7 @@ before_uninstall = "beams.uninstall.before_uninstall"
 doc_events = {
     "Sales Invoice": {
         "before_save": "beams.beams.custom_scripts.sales_invoice.sales_invoice.validate_sales_invoice_amount_with_quotation",
-        "on_submit":  "beams.beams.custom_scripts.sales_invoice.sales_invoice.send_email_to_party"
+        "on_submit":  "beams.beams.custom_scripts.sales_invoice.sales_invoice.send_email_to_party",
         "autoname": "beams.beams.custom_scripts.sales_invoice.sales_invoice.autoname"
 
     },


### PR DESCRIPTION
## Feature description
  Add naming rule for Quotation,Sales Order and Sales Invoice through child table Beams naming rule.
Apply filters to doctype field of childtable Beams naming rule to list only  Quotation,Sales Order and Sales Invoice.


## Solution description
Applied  filters to doctype field of childtable Beams naming rule to list only  Quotation,Sales Order and Sales Invoice.
Defined naming series in child table Beams Naming Rule of Beams Account Settings doctype and  the rule is made applicable for naming Quotation,Sales Order and Sales Invoice.

## Output
![image](https://github.com/user-attachments/assets/0797bf99-97c4-4cd1-8654-5801581ddeb5)
![image](https://github.com/user-attachments/assets/9caa9161-0b01-4be3-9fcf-252d0369e225)
![image](https://github.com/user-attachments/assets/3fc16f97-f0fb-4098-acc8-cf4b2b4e2566)
![image](https://github.com/user-attachments/assets/0a861e49-8de8-4802-8fd2-c0e7ad5a8f3e)
![image](https://github.com/user-attachments/assets/26bc76e1-c335-4c8f-88c1-f689ba3d3a2a)


## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox