### PR TITLE
feat:Create Employee Advance Purpose Doctype and update Employee Advance form

### DIFF
--- a/beams/beams/doctype/employee_advance_purpose/employee_advance_purpose.js
+++ b/beams/beams/doctype/employee_advance_purpose/employee_advance_purpose.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2024, efeone and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Employee Advance Purpose", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/beams/beams/doctype/employee_advance_purpose/employee_advance_purpose.json
+++ b/beams/beams/doctype/employee_advance_purpose/employee_advance_purpose.json
@@ -1,0 +1,59 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2024-08-31 13:00:47.514140",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "section_break_sqoj",
+  "amended_from",
+  "purpose"
+ ],
+ "fields": [
+  {
+   "fieldname": "section_break_sqoj",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "Employee Advance Purpose",
+   "print_hide": 1,
+   "read_only": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "purpose",
+   "fieldtype": "Small Text",
+   "label": "Purpose"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "is_submittable": 1,
+ "links": [],
+ "modified": "2024-08-31 13:02:54.413046",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "Employee Advance Purpose",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/beams/beams/doctype/employee_advance_purpose/employee_advance_purpose.json
+++ b/beams/beams/doctype/employee_advance_purpose/employee_advance_purpose.json
@@ -1,6 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
+ "autoname": "field:purpose",
  "creation": "2024-08-31 13:00:47.514140",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -26,17 +27,19 @@
   },
   {
    "fieldname": "purpose",
-   "fieldtype": "Small Text",
-   "label": "Purpose"
+   "fieldtype": "Data",
+   "label": "Purpose",
+   "unique": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-08-31 13:02:54.413046",
+ "modified": "2024-08-31 15:38:33.528621",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Employee Advance Purpose",
+ "naming_rule": "By fieldname",
  "owner": "Administrator",
  "permissions": [
   {

--- a/beams/beams/doctype/employee_advance_purpose/employee_advance_purpose.py
+++ b/beams/beams/doctype/employee_advance_purpose/employee_advance_purpose.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class EmployeeAdvancePurpose(Document):
+	pass

--- a/beams/beams/doctype/employee_advance_purpose/test_employee_advance_purpose.py
+++ b/beams/beams/doctype/employee_advance_purpose/test_employee_advance_purpose.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, efeone and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestEmployeeAdvancePurpose(FrappeTestCase):
+	pass

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -16,6 +16,8 @@ def after_install():
     create_property_setters(get_property_setters())
     create_custom_fields(get_material_request_custom_fields(), ignore_validate=True)
     create_custom_fields(get_sales_order_custom_fields(), ignore_validate=True)
+    create_custom_fields(get_employee_advance_custom_fields(), ignore_validate=True)
+
 
 
 def after_migrate():
@@ -31,6 +33,7 @@ def before_uninstall():
     delete_custom_fields(get_driver_custom_fields())
     delete_custom_fields(get_material_request_custom_fields())
     delete_custom_fields(get_sales_order_custom_fields())
+    delete_custom_fields(get_employee_advance_custom_fields())
 
 
 def delete_custom_fields(custom_fields: dict):
@@ -363,6 +366,14 @@ def get_property_setters():
             "property": "read_only",
             "property_type": "Check",
             "value": 1
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Employee Advance",
+            "field_name": "purpose",
+            "property": "hidden",
+            "property_type": "Small Text",
+            "value":1
         }
     ]
 def get_material_request_custom_fields():
@@ -392,6 +403,22 @@ def get_sales_order_custom_fields():
                 "label": "Sales Type",
                 "insert_after": "naming_series",
                 "options": "Sales Type"
+            }
+        ]
+    }
+
+def get_employee_advance_custom_fields():
+    '''
+    Custom fields that need to be added to the Employee Advance  Doctype
+    '''
+    return {
+        "Employee Advance": [
+            {
+                "fieldname": "purpose",
+                "fieldtype": "Link",
+                "label": "Purpose",
+                "options": "Employee Advance Purpose",
+                "insert_after":"currency"
             }
         ]
     }


### PR DESCRIPTION
## Feature description
-Add "Employee Advance Purpose" Doctype and link field to "Employee Advance". Hide existing "Purpose" field in "Employee Advance".

## Solution description
  -    Added a new "Employee Advance Purpose" Doctype with a "Purpose" field (Small Text).
  -   Updated the "Employee Advance" Doctype to include a "Purpose" field (Link to "Employee Advance Purpose").
  - Hid the existing "Purpose" field in the "Employee Advance" Doctype.

## Output
![image](https://github.com/user-attachments/assets/5a73ce5e-150f-44ee-8e8f-2644793f86f2)
![image](https://github.com/user-attachments/assets/9b2237ff-bfb2-4e47-92bb-42d86e5ac681)
![image](https://github.com/user-attachments/assets/d7180088-405c-454d-9b37-3532401e4395)
![image](https://github.com/user-attachments/assets/965c0e52-fc6a-4b43-8d64-de7555f77578)
![image](https://github.com/user-attachments/assets/f146e394-25db-4f2f-86d3-a4c4df12ac83)



## Is there any existing behavior change of other features due to this code change?
-yes.

## Was this feature tested on the browsers?
  - Mozilla Firefox