### PR TITLE
fix: Update Purchase Invoice & Sales Invoice

### DIFF
--- a/beams/public/js/purchase_invoice.js
+++ b/beams/public/js/purchase_invoice.js
@@ -2,6 +2,18 @@ frappe.ui.form.on('Purchase Invoice', {
   setup: function(frm) {
       handle_workflow_button(frm);
   },
+  refresh: function (frm) {
+        // Trim spaces from selecbox invoice type
+        const options = frm.fields_dict['invoice_type'].df.options;
+        if (options) {
+            frm.fields_dict['invoice_type'].df.options = options
+                .split('\n')
+                .map(option => option.trim())
+                .filter(option => option)
+                .join('\n');
+            frm.refresh_field('invoice_type');
+        }
+  },
   invoice_type: function(frm) {
     if (frm.doc.invoice_type === 'Stringer Bill') {
       frm.fields_dict['items'].grid.get_field('item_code').get_query = function(doc, cdt, cdn) {
@@ -18,7 +30,16 @@ frappe.ui.form.on('Purchase Invoice', {
           }
         };
       });
+    }else if (frm.doc.invoice_type === 'General') {
+      // Clear filters when 'General' is selected
+      frm.fields_dict['items'].grid.get_field('item_code').get_query = function(doc, cdt, cdn) {
+        return {};
+      };
+      frm.set_query('supplier', function() {
+        return {};
+      });
     }
+
     frm.clear_table('stringer_work_details');
     frm.clear_table('items');
     frm.refresh_field('stringer_work_details');

--- a/beams/public/js/purchase_invoice.js
+++ b/beams/public/js/purchase_invoice.js
@@ -2,18 +2,6 @@ frappe.ui.form.on('Purchase Invoice', {
   setup: function(frm) {
       handle_workflow_button(frm);
   },
-  refresh: function (frm) {
-        // Trim spaces from selecbox invoice type
-        const options = frm.fields_dict['invoice_type'].df.options;
-        if (options) {
-            frm.fields_dict['invoice_type'].df.options = options
-                .split('\n')
-                .map(option => option.trim())
-                .filter(option => option)
-                .join('\n');
-            frm.refresh_field('invoice_type');
-        }
-  },
   invoice_type: function(frm) {
     if (frm.doc.invoice_type === 'Stringer Bill') {
       frm.fields_dict['items'].grid.get_field('item_code').get_query = function(doc, cdt, cdn) {

--- a/beams/public/js/sales_invoice.js
+++ b/beams/public/js/sales_invoice.js
@@ -9,31 +9,40 @@ frappe.ui.form.on('Sales Invoice', {
     });
   },
   sales_type: function(frm) {
-      if (frm.doc.sales_type) {
-        frm.fields_dict['items'].grid.get_field('item_code').get_query = function(doc, cdt, cdn) {
-          return {
-            filters: {
-              'sales_type': frm.doc.sales_type
-            }
-         };
+    if (frm.doc.sales_type) {
+      frm.fields_dict['items'].grid.get_field('item_code').get_query = function(doc, cdt, cdn) {
+        return {
+          filters: {
+            'sales_type': frm.doc.sales_type
+          }
+        };
       };
     }
+    check_include_in_ibf(frm);
     frm.clear_table('items');
     frm.refresh_field('items');
   },
-  customer: function(frm) {
-    if (frm.doc.customer) {
-      if (!frm.doc.is_barter_invoice) {
-        frm.set_value('include_in_ibf', 1);
-      } else {
-        frm.set_value('include_in_ibf', 0);
-      }
+  is_barter_invoice: function(frm) {
+    check_include_in_ibf(frm);
+  },
+  is_agent: function(frm) {
+    check_include_in_ibf(frm);
+  },
+  onload: function(frm) {
+    if (frm.is_new) {
+      check_include_in_ibf(frm);
+    }
+  },
+
+});
+
+let check_include_in_ibf = function(frm) {
+  frappe.db.get_value('Sales Type', frm.doc.sales_type, 'is_time_sales', function(value) {
+    if (value && value.is_time_sales && !frm.doc.is_barter_invoice && frm.doc.is_agent) {
+      frm.set_value('include_in_ibf', 1);
     } else {
       frm.set_value('include_in_ibf', 0);
     }
-  },
-  is_barter_invoice: function(frm) {
-    frm.set_value('include_in_ibf', 0);
-    frm.trigger('customer');
-  }
-});
+    frm.refresh_field('include_in_ibf');
+  });
+}

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -212,7 +212,7 @@ def get_purchase_invoice_custom_fields():
             {
                 "fieldname": "invoice_type",
                 "fieldtype": "Select",
-                "options": "\nGeneral\nStringer Bill",
+                "options": "General\nStringer Bill",
                 "default": "General",
                 "label": "Invoice Type",
                 "insert_after": "naming_series"

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -218,11 +218,17 @@ def get_purchase_invoice_custom_fields():
                 "insert_after": "naming_series"
             },
             {
+			    "fieldname": "stringer_work_details_sb",
+			    "fieldtype": "Section Break",
+			    "label": "",
+			    "insert_after": "is_reverse_charge"
+			},
+            {
                 "fieldname": "stringer_work_details",
                 "fieldtype": "Table",
                 "label": "Stringer Work Details",
                 "options": "Stringer Work Details",
-                "insert_after": "items",
+                "insert_after": "stringer_work_details_sb",
                 "depends_on": "eval:doc.invoice_type == 'Stringer Bill'"
             },
             {
@@ -373,6 +379,30 @@ def get_property_setters():
             "property": "hidden",
             "property_type": "Small Text",
             "value":1
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Purchase Invoice",
+            "field_name": "update_stock",
+            "property": "hidden",
+            "property_type": "Check",
+            "value": 1
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Purchase Invoice",
+            "field_name": "is_subcontracted",
+            "property": "hidden",
+            "property_type": "Check",
+            "value": 1
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Purchase Invoice",
+            "field_name": "scan_barcode",
+            "property": "hidden",
+            "property_type": "Data",
+            "value": 1
         }
     ]
 def get_material_request_custom_fields():


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- chore

## Solution description
- Removed space from selectbox Invoice Type in Purchase Invoice.
- Clear filters for Item table and Supplier field in Purchase Invoice when Invoice Type is General.
- Set 'include_in_ibf' field based on Sales Type, 'is_barter_invoice' and 'is_agent' in  Sales Invoice.
- Hid 'Is Subcontracted', Scan Barcode, Update Stock  fields in Sales Invoice.

## Output screenshots (optional)
[Screencast from 09-02-2024 02:23:12 PM.webm](https://github.com/user-attachments/assets/80a62b71-92ae-4081-94af-648af3ece09a)
[Screencast from 09-02-2024 02:25:29 PM.webm](https://github.com/user-attachments/assets/dc509897-9b29-4e7b-925e-bc19237c15e2)
![image](https://github.com/user-attachments/assets/8ad89ce5-d0b8-441b-a15f-d654ac9d1b06)

## Areas affected and ensured
Sales Invoice.
Purchase Invoice.

## Did you test with the following dataset?
- Existing Data
- New Data
