### PR TITLE
feat:Customised Purchase Order

### DIFF
--- a/beams/beams/custom_scripts/quotation/quotation.py
+++ b/beams/beams/custom_scripts/quotation/quotation.py
@@ -30,7 +30,6 @@ def autoname(doc, method=None):
             else:
                 frappe.throw(_("No valid naming series found for Quotation doctype"))
 
-
 @frappe.whitelist()
 def make_sales_invoice(source_name, target_doc=None, ignore_permissions=False):
     """

--- a/beams/beams/custom_scripts/quotation/quotation.py
+++ b/beams/beams/custom_scripts/quotation/quotation.py
@@ -30,6 +30,7 @@ def autoname(doc, method=None):
             else:
                 frappe.throw(_("No valid naming series found for Quotation doctype"))
 
+
 @frappe.whitelist()
 def make_sales_invoice(source_name, target_doc=None, ignore_permissions=False):
     """

--- a/beams/public/js/quotation.js
+++ b/beams/public/js/quotation.js
@@ -24,13 +24,46 @@ frappe.ui.form.on('Quotation', {
     is_barter: function(frm) {
         if (frm.doc.is_barter) {
             frappe.db.get_single_value('Accounts Settings', 'enable_common_party_accounting')
-            .then(check => {
-              if (!check) {
-                  frm.set_value('is_barter', 0); // Uncheck the checkbox if validation fails
-                  frm.refresh_fields();
-                  frappe.msgprint("Please enable 'Common Party Accounting' in the Accounts Settings to proceed with barter transactions.");
-              }
-            })
+                .then(check => {
+                    if (!check) {
+                        frm.set_value('is_barter', 0); // Uncheck the checkbox if validation fails
+                        frm.refresh_fields();
+                        frappe.msgprint("Please enable 'Common Party Accounting' in the Accounts Settings to proceed with barter transactions.");
+                    }
+                });
         }
     },
+    is_barter: function(frm) {
+       if (frm.doc.is_barter) {
+           frappe.db.get_single_value('Accounts Settings', 'enable_common_party_accounting')
+               .then(check => {
+                   if (!check) {
+                       frm.set_value('is_barter', 0); // Uncheck the checkbox if validation fails
+                       frm.refresh_fields();
+                       frappe.msgprint("Please enable 'Common Party Accounting' in the Accounts Settings to proceed with barter transactions.");
+                   }
+               });
+       }
+   },
+
+    sales_type: function(frm) {
+        check_sales_type(frm);
+    }
 });
+
+function check_sales_type(frm) {
+    // Fetch  is_time_sales field value from the linked Sales Type doctype
+    if (frm.doc.sales_type) {
+        frappe.db.get_value('Sales Type', frm.doc.sales_type, 'is_time_sales')
+            .then(r => {
+                let is_time_sales = r.message.is_time_sales;
+                if (is_time_sales) {
+                    frm.set_df_property('albatross_ro_id', 'reqd', true);
+                } else {
+                    frm.set_df_property('albatross_ro_id', 'reqd', false);
+                }
+            });
+    } else {
+        frm.set_df_property('albatross_ro_id', 'reqd', false);
+    }
+}

--- a/beams/public/js/quotation.js
+++ b/beams/public/js/quotation.js
@@ -33,18 +33,6 @@ frappe.ui.form.on('Quotation', {
                 });
         }
     },
-    is_barter: function(frm) {
-       if (frm.doc.is_barter) {
-           frappe.db.get_single_value('Accounts Settings', 'enable_common_party_accounting')
-               .then(check => {
-                   if (!check) {
-                       frm.set_value('is_barter', 0); // Uncheck the checkbox if validation fails
-                       frm.refresh_fields();
-                       frappe.msgprint("Please enable 'Common Party Accounting' in the Accounts Settings to proceed with barter transactions.");
-                   }
-               });
-       }
-   },
 
     sales_type: function(frm) {
         check_sales_type(frm);

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -172,7 +172,7 @@ def get_quotation_custom_fields():
                 "fieldtype": "Data",
                 "label": "Albatross RO ID",
                 "in_standard_filter": 1,
-                "reqd":1,
+                "reqd":0,
                 "insert_after": "order_type"
             },
             {
@@ -180,6 +180,21 @@ def get_quotation_custom_fields():
                 "fieldtype": "Check",
                 "label": "Is Barter",
                 "insert_after": "albatross_ro_id"
+            },
+            {
+                "fieldname": "sales_type",
+                "fieldtype": "Link",
+                "label": "Sales Type",
+                "insert_after": "order_type",
+                "options": "Sales Type"
+            },
+            {
+                "fieldname": "purchase_order",
+                "fieldtype": "Link",
+                "label": "Purchase Order",
+                "insert_after": "valid_till",
+                "depends_on": "eval:doc.is_barter",
+                "options": "Purchase Order"
             }
 
         ]


### PR DESCRIPTION
## Feature description
Customise Purchase Order doctype by adding fields  Sales Type(Linked to Sales Type)and Purchase Order(Linked to Purchase Order).Display Purchase Order  only if Is Barter is checked.
Make Albatross RO ID imandatory only when  Is Time Sales  field of Sales Type is checked.

## Solution description
Purchase Order doctype is customised  by adding fields   Sales Type(Linked to Sales Type)and Purchase Order(Linked to Purchase Order). Order).Purchase Order is made visible only if Is Barter is checked.
Albatross RO ID is made mandatory only when  Is Time Sales  field of Sales Type is checked.

## Output
![image](https://github.com/user-attachments/assets/2d03bec5-116c-459f-82c3-740949a742a5)



## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
-Mozilla 