### PR TITLE
feat:Filter and reset Quotation items by Sales Type

### DIFF
--- a/beams/public/js/quotation.js
+++ b/beams/public/js/quotation.js
@@ -36,10 +36,11 @@ frappe.ui.form.on('Quotation', {
 
     sales_type: function(frm) {
         check_sales_type(frm);
-
+        // function to check the selected Sales Type
         frm.clear_table('items');
         frm.refresh_field('items');
 
+        //function to check the selected Sales Type
         if (frm.doc.sales_type) {
             frm.fields_dict['items'].grid.get_field('item_code').get_query = function(doc, cdt, cdn) {
                 return {

--- a/beams/public/js/quotation.js
+++ b/beams/public/js/quotation.js
@@ -36,6 +36,19 @@ frappe.ui.form.on('Quotation', {
 
     sales_type: function(frm) {
         check_sales_type(frm);
+
+        frm.clear_table('items');
+        frm.refresh_field('items');
+
+        if (frm.doc.sales_type) {
+            frm.fields_dict['items'].grid.get_field('item_code').get_query = function(doc, cdt, cdn) {
+                return {
+                    filters: {
+                        'sales_type': frm.doc.sales_type
+                    }
+                };
+            };
+        }
     }
 });
 


### PR DESCRIPTION
## Feature description
-Apply a filter to the items child table in the Quotation doctype so that only items matching the selected Sales Type are displayed

## Solution description
 -Implemented a filter on the items child table based on the selected Sales Type in the Quotation doctype. This ensures that only      relevant items are shown according to the selected Sales Type
-Added functionality to clear the items child table whenever the Sales Type is updated to maintain data consistency and relevance.

## Output
[Screencast from 02-09-24 04:36:20 PM IST.webm](https://github.com/user-attachments/assets/e676ed8c-1ff9-4ba6-a01e-8f57cc34ab4c)

## Is there any existing behavior change of other features due to this code change?
-no

## Was this feature tested on the browsers?
  - Mozilla Firefox