### PR TITLE
feat:Customize Bureau Doctype

### DIFF
--- a/beams/beams/doctype/bureau/bureau.json
+++ b/beams/beams/doctype/bureau/bureau.json
@@ -9,7 +9,8 @@
   "section_break_zaao",
   "bureau_name",
   "cost_center",
-  "amended_from"
+  "amended_from",
+  "company"
  ],
  "fields": [
   {
@@ -39,11 +40,17 @@
    "fieldtype": "Link",
    "label": "Cost Center",
    "options": "Cost Center"
+  },
+  {
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "label": "Company",
+   "options": "Company"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-08-20 16:55:16.556657",
+ "modified": "2024-09-03 10:30:55.280684",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Bureau",


### PR DESCRIPTION
## Feature description
-Add 'Company' link field to Bureau doctype

## Solution description
 -Added 'Company' link field to Bureau doctype.

## Output
![image](https://github.com/user-attachments/assets/4d215c10-439d-4512-90fa-59731c800086)

## Is there any existing behavior change of other features due to this code change?
-no

## Was this feature tested on the browsers?
  - Mozilla Firefox