### PR TITLE
fix: Apply Filters On Budget Expense Type Based On Comapany

### DIFF
--- a/beams/beams/doctype/adhoc_budget/adhoc_budget.js
+++ b/beams/beams/doctype/adhoc_budget/adhoc_budget.js
@@ -34,6 +34,24 @@
 
           frm.refresh_fields()
 
+      },
+      company: function (frm) {
+          // Fetch the selected company
+          let selected_company = frm.doc.company;
+          frm.clear_table('budget_expense');
+          frm.refresh_field('budget_expense');
+
+          // Apply filter on the child table's 'budget_expense_type' field
+          frm.fields_dict['budget_expense'].grid.get_field('budget_expense_type').get_query = function () {
+              return {
+                  filters: {
+                      company: selected_company
+                  }
+              };
+          };
+
+          // Refresh the field to apply the filter
+          frm.fields_dict['budget_expense'].grid.refresh_field('budget_expense_type');
       }
   });
 

--- a/beams/beams/doctype/adhoc_budget/adhoc_budget.json
+++ b/beams/beams/doctype/adhoc_budget/adhoc_budget.json
@@ -8,6 +8,7 @@
  "field_order": [
   "project",
   "fiscal_year",
+  "company",
   "expected_revenue",
   "expected_revenue_reached",
   "column_break_zhmw",
@@ -139,12 +140,19 @@
   {
    "fieldname": "section_break_qooy",
    "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "label": "Company",
+   "options": "Company",
+   "reqd": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-08-24 16:07:56.125636",
+ "modified": "2024-09-03 17:22:50.245140",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Adhoc Budget",

--- a/beams/beams/doctype/adhoc_budget/adhoc_budget.py
+++ b/beams/beams/doctype/adhoc_budget/adhoc_budget.py
@@ -72,6 +72,7 @@ class AdhocBudget(Document):
         budget.budget_against = 'Project'
         budget.project = self.project
         budget.fiscal_year = self.fiscal_year
+        budget.company = self.company
 
         budget.applicable_on_material_request = 1
         budget.applicable_on_booking_actual_expenses = 1


### PR DESCRIPTION
## Feature description
-Add Company Field In Adhoc  Budget Doctype
-Apply Filters On Budget Expense Type based On Company.

## Solution description
-Added Company Field In Adhoc Budget Doctype
-Applied Filters On Budget Expense Type Based On Company.

## Output
![image](https://github.com/user-attachments/assets/05ea94b3-c17a-48ce-a2bd-f5b984aef646)


## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
-Mozilla 