### PR TITLE
fix:Hide Series field, make Purpose mandatory in Employee Advance, and set String Type Doctype as not submittable

### DIFF
--- a/beams/beams/doctype/stringer_type/stringer_type.json
+++ b/beams/beams/doctype/stringer_type/stringer_type.json
@@ -40,9 +40,8 @@
   }
  ],
  "index_web_pages_for_search": 1,
- "is_submittable": 1,
  "links": [],
- "modified": "2024-09-02 15:03:24.710987",
+ "modified": "2024-09-05 10:15:15.842517",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Stringer Type",
@@ -59,7 +58,6 @@
    "report": 1,
    "role": "System Manager",
    "share": 1,
-   "submit": 1,
    "write": 1
   }
  ],

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -436,6 +436,14 @@ def get_property_setters():
             "property": "hidden",
             "property_type": "Data",
             "value": 1
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Employee Advance",
+            "field_name": "naming_series",
+            "property": "hidden",
+            "property_type": "Data",
+            "value": 1
         }
     ]
 def get_material_request_custom_fields():
@@ -481,6 +489,15 @@ def get_employee_advance_custom_fields():
                 "label": "Purpose",
                 "options": "Employee Advance Purpose",
                 "insert_after":"currency"
+            },
+            {
+                "fieldname": "purpose",
+                "fieldtype": "Link",
+                "label": "Purpose",
+                "options": "Employee Advance Purpose",
+                "insert_after": "currency",
+                "reqd": 1
             }
+
         ]
     }


### PR DESCRIPTION
## Feature description
- Hide the Series field in the Employee Advance doctype 
- Add a mandatory Purpose field in Employee Advance
- Set the String Type doctype as not submittable to prevent unnecessary submission workflow for this document type.

## Solution description
 -Hid Series field in Employee Advance to simplify the form.
 -Added mandatory Purpose field in Employee Advance
 -Configured String Type doctype as not submittable to prevent submission errors.

## Output
![image](https://github.com/user-attachments/assets/b92957d0-f8c8-428d-87cd-19c1bd2664d5)
![image](https://github.com/user-attachments/assets/b684a42f-2a82-493c-9e47-506586e830ca)
![image](https://github.com/user-attachments/assets/65c72d32-5218-4f83-b8a5-aca5fe7d0740)


## Is there any existing behavior change of other features due to this code change?
-no

## Was this feature tested on the browsers?
  - Mozilla Firefox