### PR TITLE
feat: Added new field Batta Claim Service Item and applied fiter

### DIFF
--- a/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.js
+++ b/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.js
@@ -1,18 +1,22 @@
 // Copyright (c) 2024, efeone and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Beams Accounts Settings", {
-// 	refresh(frm) {
-
-// 	},
-// });
-
 frappe.ui.form.on('Beams Accounts Settings', {
     setup: function(frm) {
+        // Set query filter for 'doc_type' field in the 'beams_naming_rule' child table
         frm.set_query('doc_type', 'beams_naming_rule', function() {
             return {
                 filters: {
-                    name: ['in', ['Quotation', 'Sales Order', 'Sales Invoice']]
+                    name: ['in', ['Quotation', 'Sales Order', 'Sales Invoice']]  // Filter for specific doctypes
+                }
+            };
+        });
+
+        // Set query filter for the 'batta_claim_service_item' field
+        frm.set_query('batta_claim_service_item', function() {
+            return {
+                filters: {
+                    'is_stock_item': 0  // Filter items where 'maintain_stock' is 1
                 }
             };
         });

--- a/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.json
+++ b/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.json
@@ -9,6 +9,7 @@
   "equalize_purchase_and_quotation_amounts",
   "tab_break_4hid",
   "default_working_hours",
+  "batta_claim_service_item",
   "naming_rule_tab",
   "beams_naming_rule"
  ],
@@ -45,12 +46,18 @@
    "fieldtype": "Table",
    "label": "Beams Naming Rule",
    "options": "Beams Naming Rule"
+  },
+  {
+   "fieldname": "batta_claim_service_item",
+   "fieldtype": "Link",
+   "label": "Batta Claim Service Item",
+   "options": "Item"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-08-29 10:14:41.594535",
+ "modified": "2024-09-05 16:52:17.585822",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Beams Accounts Settings",


### PR DESCRIPTION
## Feature description
Add a new field Batta Claim Service Item in Beams Accounts Settings linked to item doctype and applied filter as maintain stock is false.

## Solution description
Applied filter to field Batta Claim Service Item in Beams Accounts Settings  as maintain stock is false. 

## Output
![image](https://github.com/user-attachments/assets/39d7d1b6-d6b9-4e89-b453-62b422cb9032)


## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox