### PR TITLE
fix:  Added New Field Beams Accounts Settings and Filter the  enabled print formats for Sales Invoice to Send Email from Sales Invoice Doctype.

### DIFF
--- a/beams/beams/custom_scripts/sales_invoice/sales_invoice.py
+++ b/beams/beams/custom_scripts/sales_invoice/sales_invoice.py
@@ -2,8 +2,6 @@ import frappe
 from frappe import _
 from datetime import datetime
 from frappe.model.naming import make_autoname
-
-
 from beams.beams.custom_scripts.quotation.quotation import create_common_party_and_supplier
 from frappe.core.doctype.communication.email import make
 
@@ -90,31 +88,56 @@ def validate_sales_invoice_amount_with_quotation(doc, method):
                 ))
 
 
+
 @frappe.whitelist()
-def send_email_to_party(doc,method=None):
+def on_update_after_submit(doc, method=None):
     """
-      Method to Send an Email with a PDF attachment of the given document  Sales Invoice to the contact associated with the customer.
-      Also validate the existence of the contact for customer  and its Email ID.
+    Method triggered after the document is updated and submitted. It checks if the workflow state
+    has changed to "Send Email to Party".
+    """
+    old_doc = doc._doc_before_save
+    if old_doc.workflow_state != doc.workflow_state and doc.workflow_state == "Send Email to Party":
+        send_email_to_party(doc)
+
+
+@frappe.whitelist()
+def send_email_to_party(doc, method=None):
+    """
+    Method to send an email with a PDF attachment of the Sales Invoice to the contact associated with the customer.
+    Fetches the default Sales Invoice print format from Beam Account Settings. If not set, throws an error.
     """
     customer_name = doc.customer
+ 
+    # Fetch contact linked to the customer
     contact_name = frappe.db.get_value("Dynamic Link", {
         "link_doctype": "Customer",
         "link_name": customer_name,
         "parenttype": "Contact"
     }, "parent")
+
+
     if not contact_name:
-        frappe.throw(f"Email id is not found for the {customer_name}")
+        frappe.msgprint("Email ID is not configured. Please configure and send the email.")
+
     contact = frappe.get_doc("Contact", contact_name)
     if not contact.email_id:
-        frappe.throw(f"Email id is not found {contact_name} linked to {customer_name}")
+        frappe.msgprint(f"Email ID not found for contact {contact_name}")
+
     email_id = contact.email_id
     subject = f"{doc.doctype} {doc.name}"
     message = f"Dear {contact.first_name or 'Customer'},<br><br>Please find the attached {doc.doctype} {doc.name}.<br><br>Thank you."
 
-    # Generate PDF for the Sales Invoice
-    pdf_data = frappe.attach_print('Sales Invoice', doc.name)
+    # Fetch the print format from Beam Account Settings
+    print_format = frappe.db.get_single_value("Beams Accounts Settings", "default_sales_invoice_print_format")
 
-    # Attach the PDF and send the email
+
+    if not print_format:
+        frappe.msgprint(" Please configure a default print format for Sales Invoice.")
+
+    # Generate PDF using the selected print format
+    pdf_data = frappe.attach_print('Sales Invoice', doc.name, print_format=print_format)
+
+    # Send the email with the PDF attachment
     frappe.sendmail(
         recipients=[email_id],
         subject=subject,
@@ -126,4 +149,6 @@ def send_email_to_party(doc,method=None):
             'fcontent': pdf_data['fcontent'],
         }]
     )
+
+
     frappe.msgprint(f"Email sent to {email_id} successfully.")

--- a/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.js
+++ b/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.js
@@ -17,4 +17,14 @@ frappe.ui.form.on('Beams Accounts Settings', {
             };
         });
     },
+    onload: function(frm) {
+        frm.set_query('default_sales_invoice_print_format', function() {
+            return {
+                filters: {
+                    'doc_type': 'Sales Invoice',
+                    'disabled': 0  
+                }
+            };
+        });
+    }
 });

--- a/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.json
+++ b/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.json
@@ -7,6 +7,7 @@
  "field_order": [
   "adhoc_budget_threshold",
   "equalize_purchase_and_quotation_amounts",
+  "default_sales_invoice_print_format",
   "tab_break_4hid",
   "default_working_hours",
   "naming_rule_tab",
@@ -45,12 +46,18 @@
    "fieldtype": "Table",
    "label": "Beams Naming Rule",
    "options": "Beams Naming Rule"
+  },
+  {
+   "fieldname": "default_sales_invoice_print_format",
+   "fieldtype": "Link",
+   "label": "Default Sales Invoice Print Format",
+   "options": "Print Format"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-08-29 10:14:41.594535",
+ "modified": "2024-09-05 15:59:09.254258",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Beams Accounts Settings",

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -130,7 +130,7 @@ before_uninstall = "beams.uninstall.before_uninstall"
 doc_events = {
     "Sales Invoice": {
         "before_save": "beams.beams.custom_scripts.sales_invoice.sales_invoice.validate_sales_invoice_amount_with_quotation",
-        "on_submit":  "beams.beams.custom_scripts.sales_invoice.sales_invoice.send_email_to_party",
+        "on_update_after_submit":"beams.beams.custom_scripts.sales_invoice.sales_invoice.send_email_to_party",
         "autoname": "beams.beams.custom_scripts.sales_invoice.sales_invoice.autoname"
 
     },


### PR DESCRIPTION
## Issue description
Need to fix the Event  in hooks and add new Field Beams Accounts settings get the enabled print formats for Sales Invoice when Sending an email from Sales Invoice Doctype.
 
## Solution description
Fixed the Event in Hooks added new Field Beams Accounts Settings applied filter to enabled print format For Sales Invoice  Sending an email from Sales Invoice Doctype.

## Output
![image](https://github.com/user-attachments/assets/563bdb5e-765b-4f20-a877-601202ca3930)
![image](https://github.com/user-attachments/assets/866a1f85-19da-404a-979d-ae233da9925a)

## Areas affected and ensured
issue fixed in the Sales Invoice doctype

## Is there any existing behavior change of other features due to this code change?
Sales Invoice doctype

## Was this feature tested on the browsers?
  - Mozilla Firefox