### PR TITLE
feat: Create Purchase Invoice and Journal Entry on the Approval of Batta Claim

### DIFF
--- a/beams/beams/doctype/batta_claim/batta_claim.py
+++ b/beams/beams/doctype/batta_claim/batta_claim.py
@@ -1,9 +1,58 @@
 # Copyright (c) 2024, efeone and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
 
-
 class BattaClaim(Document):
-	pass
+    def on_submit(self):
+        if self.workflow_state == 'Approved':
+            if self.batta_type == 'External':
+                self.create_purchase_invoice_from_batta_claim()
+            elif self.batta_type == 'Internal':
+                self.create_journal_entry_from_batta_claim()
+
+    def create_purchase_invoice_from_batta_claim(self):
+        """
+        	Creation of Purchase Invoice On The Approval Of the Batta Claim.
+        """
+        purchase_invoice = frappe.new_doc('Purchase Invoice')
+        purchase_invoice.supplier = self.supplier
+        purchase_invoice.posting_date = frappe.utils.nowdate()
+        purchase_invoice.due_date = frappe.utils.add_days(purchase_invoice.posting_date, 30)
+
+        purchase_invoice.append('items', {
+            'item_code': 'Batta Claim',
+            'rate': self.total_driver_batta,
+            'qty': 1
+        })
+
+        purchase_invoice.insert()
+        purchase_invoice.submit()
+
+    def create_journal_entry_from_batta_claim(self):
+        """
+        	Creation of Journal Entry On The Approval Of the Batta Claim.
+        """
+        journal_entry = frappe.new_doc('Journal Entry')
+        journal_entry.posting_date = frappe.utils.nowdate()
+        journal_entry.party_type = 'Employee'
+
+        journal_entry.append('accounts', {
+            'account': 'Payroll Payable - E',
+            'party_type': 'Employee',
+            'party': self.employee,
+            'debit_in_account_currency': self.total_driver_batta,
+            'credit_in_account_currency': 0,
+        })
+
+        journal_entry.append('accounts', {
+            'account': 'Payroll Payable - E',
+            'party_type': 'Employee',
+            'party': self.employee,
+            'debit_in_account_currency': 0,
+            'credit_in_account_currency': self.total_driver_batta,
+        })
+
+        journal_entry.insert()
+        journal_entry.submit()


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- Feature

## Clearly and concisely describe the feature, chore or bug.
-  This feature Auto create Purchase Invoice when the Driver Batta Claim is Approved only if Batta Type is External.
-  This feature Auto create Journal Entry when the Driver Batta Claim is Approved only if Batta Type is Internal.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/74318cb9-350a-4055-88bf-d332d5fb103b)
![image](https://github.com/user-attachments/assets/417eede1-1c4c-4d02-bbbe-f0d07c8f8d13)
![image](https://github.com/user-attachments/assets/2fff409f-0b37-4ffa-b390-0a76b0abbd90)
![image](https://github.com/user-attachments/assets/a4d8350b-9850-409f-925f-e83545b9ecde)


## Areas affected and ensured
Purchase Invoice.
Driver Batta Claim.
Journal Entry

## Did you test with the following dataset?
- Existing Data
- New Data
