### PR TITLE
fix: Set Stringer Type doctype as non-submitable

### DIFF
--- a/beams/beams/doctype/stringer_type/stringer_type.json
+++ b/beams/beams/doctype/stringer_type/stringer_type.json
@@ -41,7 +41,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-09-05 10:15:15.842517",
+ "modified": "2024-09-06 10:11:58.478642",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Stringer Type",


### PR DESCRIPTION
## Issue description
Make Stringer Type  Doctype Non-Submittable

## Solution description
-Modified the Sales Type doctype to be non-submittable
 removed submittable from the doctype

## Output
![image](https://github.com/user-attachments/assets/ea638021-cc52-4927-95ea-28707abbd517)

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Mozilla Firefox
