### PR TITLE
feat : Validate Sales Invoice Amount

### DIFF
--- a/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.json
+++ b/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.json
@@ -7,6 +7,7 @@
  "field_order": [
   "adhoc_budget_threshold",
   "equalize_purchase_and_quotation_amounts",
+  "single_sales_invoice",
   "tab_break_4hid",
   "default_working_hours",
   "batta_claim_service_item",
@@ -52,12 +53,19 @@
    "fieldtype": "Link",
    "label": "Batta Claim Service Item",
    "options": "Item"
+ },
+ {
+   "default": "0",
+   "fieldname": "single_sales_invoice",
+   "fieldtype": "Check",
+   "label": "Single Sales Invoice"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
  "modified": "2024-09-05 16:52:17.585822",
+ "modified": "2024-09-07 09:17:24.229429",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Beams Accounts Settings",

--- a/beams/public/js/purchase_invoice.js
+++ b/beams/public/js/purchase_invoice.js
@@ -1,6 +1,6 @@
 frappe.ui.form.on('Purchase Invoice', {
   setup: function(frm) {
-      handle_workflow_button(frm);
+    handle_workflow_button(frm);
   },
   invoice_type: function(frm) {
     if (frm.doc.invoice_type === 'Stringer Bill') {
@@ -13,12 +13,12 @@ frappe.ui.form.on('Purchase Invoice', {
       };
       frm.set_query('supplier', function() {
         return {
-          "filters": {
+          filters: {
             is_stringer: 1
           }
         };
       });
-    }else if (frm.doc.invoice_type === 'General') {
+    } else if (frm.doc.invoice_type === 'General') {
       // Clear filters when 'General' is selected
       frm.fields_dict['items'].grid.get_field('item_code').get_query = function(doc, cdt, cdn) {
         return {};
@@ -32,7 +32,7 @@ frappe.ui.form.on('Purchase Invoice', {
     frm.clear_table('items');
     frm.refresh_field('stringer_work_details');
     frm.refresh_field('items');
-    frm.set_value('supplier','');
+    frm.set_value('supplier', '');
   },
   supplier: function(frm) {
     if (frm.doc.supplier) {
@@ -49,15 +49,21 @@ frappe.ui.form.on('Purchase Invoice', {
         frm.refresh_field('stringer_work_details');
       });
     }
+  },
+  onload: function(frm) {
+    // Set the supplier as read-only when reference_id is present (e.g., from Quotation)
+    if (frm.doc.quotation) {
+      frm.set_df_property('supplier', 'read_only', 1);
+    }
   }
 });
 
 frappe.ui.form.on('Stringer Work Details', {
-  from_time: function (frm, cdt, cdn) {
+  from_time: function(frm, cdt, cdn) {
     validate_time_and_calculate_hours(frm, cdt, cdn);
     validate_row_dates(frm, cdt, cdn);
   },
-  to_time: function (frm, cdt, cdn) {
+  to_time: function(frm, cdt, cdn) {
     validate_time_and_calculate_hours(frm, cdt, cdn);
     validate_row_dates(frm, cdt, cdn);
   },
@@ -71,9 +77,6 @@ frappe.ui.form.on('Stringer Work Details', {
 });
 
 function validate_time_and_calculate_hours(frm, cdt, cdn) {
-  /**
-   * Function for validating from_time and to_time and calculating hours.
-   */
   var row = locals[cdt][cdn];
   if (row.from_time && row.to_time) {
     var from_time = new Date(row.from_time);
@@ -93,9 +96,6 @@ function validate_time_and_calculate_hours(frm, cdt, cdn) {
 }
 
 function validate_row_dates(frm, cdt, cdn) {
-  /**
-    Ensures that all rows in the 'stringer_work_details' table have the same date.
-   */
   var row = locals[cdt][cdn];
 
   if (row.from_time) {
@@ -119,15 +119,13 @@ function validate_row_dates(frm, cdt, cdn) {
 function handle_workflow_button(frm) {
   //Function to handle the visibility or behavior of workflow buttons
   if (frm.doc.purchase_order_id) {
-    // Check if the current document contains a Purchase Order ID
     $(document).ready(function () {
-        var workflow_button = $(".btn.btn-primary.btn-sm[data-toggle='dropdown']");
-           workflow_button
-           .html('<span>S<span class="alt-underline">u</span>bmit</span>');
-        workflow_button.find("svg").remove();
-        workflow_button.on("click", function () {
-          frm.savesubmit();
-        });
+      var workflow_button = $(".btn.btn-primary.btn-sm[data-toggle='dropdown']");
+      workflow_button.html('<span>S<span class="alt-underline">u</span>bmit</span>');
+      workflow_button.find("svg").remove();
+      workflow_button.on("click", function () {
+        frm.savesubmit();
+      });
     });
   }
 }

--- a/beams/public/js/sales_invoice.js
+++ b/beams/public/js/sales_invoice.js
@@ -1,48 +1,78 @@
 frappe.ui.form.on('Sales Invoice', {
   refresh: function(frm) {
-    frm.set_query('actual_customer', function() {
-      return {
-        filters: {
-          'is_agent': 0
-        }
-      };
-    });
+    set_actual_customer_query(frm);
+
+    // Check if the Sales Invoice is being created from a Quotation (i.e., reference_id is set)
+    if (frm.doc.reference_id) {
+      // Make the customer field read-only
+      frm.set_df_property('customer', 'read_only', 1);
+    }
   },
+
   sales_type: function(frm) {
     if (frm.doc.sales_type) {
-      frm.fields_dict['items'].grid.get_field('item_code').get_query = function(doc, cdt, cdn) {
-        return {
-          filters: {
-            'sales_type': frm.doc.sales_type
-          }
-        };
-      };
+      set_item_code_query(frm);
     }
+
+    // Check and update 'include_in_ibf' based on the current state of the form
     check_include_in_ibf(frm);
+
+    // Clear and refresh the items table
     frm.clear_table('items');
     frm.refresh_field('items');
   },
+
   is_barter_invoice: function(frm) {
     check_include_in_ibf(frm);
   },
+
   is_agent: function(frm) {
     check_include_in_ibf(frm);
   },
+
   onload: function(frm) {
     if (frm.is_new) {
       check_include_in_ibf(frm);
     }
-  },
 
+    // Check if the Sales Invoice is being created from a Quotation (i.e., reference_id is set)
+    if (frm.doc.reference_id) {
+      // Make the customer field read-only
+      frm.set_df_property('customer', 'read_only', 1);
+    }
+  }
 });
 
-let check_include_in_ibf = function(frm) {
+// Function to set query for the 'actual_customer' field
+function set_actual_customer_query(frm) {
+  frm.set_query('actual_customer', function() {
+    return {
+      filters: {
+        'is_agent': 0
+      }
+    };
+  });
+}
+
+// Function to set query for 'item_code' field in the 'items' child table based on 'sales_type'
+function set_item_code_query(frm) {
+  frm.fields_dict['items'].grid.get_field('item_code').get_query = function(doc, cdt, cdn) {
+    return {
+      filters: {
+        'sales_type': frm.doc.sales_type
+      }
+    };
+  };
+}
+
+// Function to check and set the value of 'include_in_ibf'
+function check_include_in_ibf(frm) {
   frappe.db.get_value('Sales Type', frm.doc.sales_type, 'is_time_sales', function(value) {
     if (value && value.is_time_sales && !frm.doc.is_barter_invoice && frm.doc.is_agent) {
-      frm.set_value('include_in_ibf', 1);
+      frm.set_value('include_in_ibf', 1);  // Set 'include_in_ibf' to 1 (true)
     } else {
-      frm.set_value('include_in_ibf', 0);
+      frm.set_value('include_in_ibf', 0);  // Set 'include_in_ibf' to 0 (false)
     }
-    frm.refresh_field('include_in_ibf');
+    frm.refresh_field('include_in_ibf');  // Refresh the field to reflect the change
   });
 }


### PR DESCRIPTION
## Feature Description 
- Add a checkbox single sales invoice in beams account settings
- Sales invoice amount validation only on condition checkbox single sales invoice
- Set customer in sales invoice while fetching from quotation as read only
- Set supplier in purchase invoice while fetching from quotation as read only

## Solution Description 
- Checkbox added to the beams account settings
- On checking the checkbox the validation alert is triggered
- Cannot change customer and supplier while creating from quotation

## Output
[Screencast from 09-09-24 10:12:12 AM IST.webm](https://github.com/user-attachments/assets/f1c20293-2025-46bf-a770-3c4c5bc90833)
