### PR TITLE
feat : Sync across Batta Claim and Work Detail.

### DIFF
--- a/beams/beams/doctype/batta_claim/batta_claim.js
+++ b/beams/beams/doctype/batta_claim/batta_claim.js
@@ -14,6 +14,10 @@ frappe.ui.form.on('Batta Claim', {
     },
     batta_type: function(frm) {
         set_batta_based_on_options(frm)
+        frm.doc.work_detail.forEach(function(row) {
+            frappe.model.set_value(row.doctype, row.name, 'batta_type', frm.doc.batta_type);
+        });
+        frm.refresh_field('work_detail');
     }
 });
 

--- a/beams/beams/doctype/batta_claim/batta_claim.json
+++ b/beams/beams/doctype/batta_claim/batta_claim.json
@@ -1,6 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
+ "autoname": "format:BC-{YY}-{####}",
  "creation": "2024-09-02 10:37:13.367643",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -18,8 +19,10 @@
   "km_travelled",
   "section_break_bkxb",
   "batta_based_on",
+  "column_break_gbiv",
   "batta",
   "ot_batta",
+  "section_break_gksm",
   "work_detail",
   "section_break_nsff",
   "total_daily_batta",
@@ -47,7 +50,7 @@
    "fieldname": "batta_type",
    "fieldtype": "Select",
    "label": "Batta Type",
-   "options": "Internal\nExternal"
+   "options": "External\nInternal"
   },
   {
    "depends_on": "eval:doc.batta_type == \"Internal\"\n",
@@ -55,6 +58,7 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Employee",
+   "mandatory_depends_on": "eval:doc.batta_type == 'Internal'",
    "options": "Employee"
   },
   {
@@ -76,6 +80,7 @@
    "fieldname": "supplier",
    "fieldtype": "Link",
    "label": "Supplier",
+   "mandatory_depends_on": "eval:doc.batta_type == 'External'",
    "options": "Supplier"
   },
   {
@@ -155,15 +160,24 @@
    "fieldtype": "Table",
    "label": "Work Detail",
    "options": "Work Detail"
+  },
+  {
+   "fieldname": "column_break_gbiv",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_gksm",
+   "fieldtype": "Section Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-09-02 14:59:16.574156",
+ "modified": "2024-09-04 10:27:14.695663",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Batta Claim",
+ "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [
   {

--- a/beams/beams/doctype/work_detail/work_detail.json
+++ b/beams/beams/doctype/work_detail/work_detail.json
@@ -12,7 +12,8 @@
   "ot_hours",
   "number_of_days",
   "daily_batta",
-  "ot_batta"
+  "ot_batta",
+  "batta_type"
  ],
  "fields": [
   {
@@ -35,6 +36,7 @@
    "read_only": 1
   },
   {
+   "depends_on": "eval:doc.batta_type == 'External'",
    "fieldname": "ot_hours",
    "fieldtype": "Float",
    "in_list_view": 1,
@@ -49,6 +51,7 @@
    "read_only": 1
   },
   {
+   "depends_on": "eval:doc.batta_type == 'External'",
    "fieldname": "ot_batta",
    "fieldtype": "Currency",
    "in_list_view": 1,
@@ -61,12 +64,21 @@
    "in_list_view": 1,
    "label": "Number of Days",
    "read_only": 1
+  },
+  {
+   "fieldname": "batta_type",
+   "fieldtype": "Select",
+   "hidden": 1,
+   "in_list_view": 1,
+   "label": "Batta Type",
+   "options": "External\nInternal",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-09-02 14:25:58.478678",
+ "modified": "2024-09-09 13:21:49.716310",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Work Detail",


### PR DESCRIPTION
## Feature description
- Added functionality to automatically sync the batta_type field between the parent Batta Claim doctype and the child Work Detail table.
- Improved field visibility and behavior based on the selected batta_type in Work Detail.

## Solution description
- Added logic to update the `batta_type` field in the child table when the parent `Batta Type` is changed.
- Set `batta_type` as a hidden and read-only field in the `Work Detail` doctype, ensuring it reflects the parent's value.
- Added necessary UI dependencies to display fields like `ot_hours` and `ot_batta` based on the `batta_type` being 'External.'
- Modified the Batta Claim doctype to include autonaming as 'BC-{YY}-{####}'.

## Output
[Screencast from 09-09-2024 04:18:52 PM.webm](https://github.com/user-attachments/assets/afee0961-6e3a-434d-8469-0518c6dfe8a1)
[Screencast from 09-09-2024 04:22:12 PM.webm](https://github.com/user-attachments/assets/c2dee86f-733d-4bf4-b478-8174bec4618b)


## Is there any existing behavior change of other features due to this code change?
-no

## Was this feature tested on the browsers?
  - Mozilla Firefox