### PR TITLE
feat: Create Purchase Invoice & Journal Entry on the Approval of Batta Claim

### DIFF
--- a/beams/beams/doctype/batta_claim/batta_claim.json
+++ b/beams/beams/doctype/batta_claim/batta_claim.json
@@ -9,12 +9,13 @@
   "section_break_twbt",
   "amended_from",
   "batta_type",
+  "batta_claim_type",
   "employee",
   "employee_name",
-  "designation",
   "supplier",
-  "bureau",
+  "designation",
   "column_break_lgjy",
+  "bureau",
   "company",
   "orgin",
   "destination",
@@ -25,7 +26,6 @@
   "batta",
   "column_break_jwtq",
   "ot_batta",
-  "section_break_gksm",
   "section_break_osak",
   "work_detail",
   "section_break_nsff",
@@ -167,8 +167,6 @@
    "fieldtype": "Column Break"
   },
   {
-   "fieldname": "section_break_gksm",
-   "fieldtype": "Section Break",
    "fieldname": "column_break_jwtq",
    "fieldtype": "Column Break"
   },
@@ -192,12 +190,18 @@
    "fieldtype": "Link",
    "label": "Company",
    "options": "Company"
+  },
+  {
+   "fieldname": "batta_claim_type",
+   "fieldtype": "Link",
+   "label": "Batta Claim Type",
+   "options": "Batta Claim Type"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-09-09 12:55:59.610599",
+ "modified": "2024-09-10 11:47:56.950837",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Batta Claim",

--- a/beams/beams/doctype/batta_claim/batta_claim.py
+++ b/beams/beams/doctype/batta_claim/batta_claim.py
@@ -20,8 +20,7 @@ class BattaClaim(Document):
         purchase_invoice.supplier = self.supplier
         purchase_invoice.posting_date = frappe.utils.nowdate()
         purchase_invoice.due_date = frappe.utils.add_days(purchase_invoice.posting_date, 30)
-        beams_account_settings = frappe.get_doc('Beams Accounts Settings')
-        batta_claim_service_item = beams_account_settings.batta_claim_service_item
+        batta_claim_service_item = frappe.db.get_single_value('Beams Accounts Settings', 'batta_claim_service_item')
         purchase_invoice.append('items', {
             'item_code': batta_claim_service_item,
             'rate': self.total_driver_batta,
@@ -38,10 +37,8 @@ class BattaClaim(Document):
 
         journal_entry = frappe.new_doc('Journal Entry')
         journal_entry.posting_date = frappe.utils.nowdate()
-        beams_account_settings = frappe.get_doc('Beams Accounts Settings')
-
-        batta_payable_account = beams_account_settings.batta_payable_account
-        batta_expense_account = beams_account_settings.batta_expense_account
+        batta_payable_account = frappe.db.get_single_value('Beams Accounts Settings', 'batta_payable_account')
+        batta_expense_account = frappe.db.get_single_value('Beams Accounts Settings', 'batta_expense_account')
 
         journal_entry.append('accounts', {
             'account': batta_payable_account,

--- a/beams/beams/doctype/batta_claim/batta_claim.py
+++ b/beams/beams/doctype/batta_claim/batta_claim.py
@@ -1,9 +1,63 @@
 # Copyright (c) 2024, efeone and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
 
-
 class BattaClaim(Document):
-	pass
+    def on_submit(self):
+        if self.workflow_state == 'Approved':
+            if self.batta_type == 'External':
+                self.create_purchase_invoice_from_batta_claim()
+            elif self.batta_type == 'Internal':
+                self.create_journal_entry_from_batta_claim()
+
+    def create_purchase_invoice_from_batta_claim(self):
+        '''
+            Creation of Purchase Invoice on The Approval Of the Batta Claim.
+        '''
+        purchase_invoice = frappe.new_doc('Purchase Invoice')
+        purchase_invoice.supplier = self.supplier
+        purchase_invoice.posting_date = frappe.utils.nowdate()
+        purchase_invoice.due_date = frappe.utils.add_days(purchase_invoice.posting_date, 30)
+        beams_account_settings = frappe.get_doc('Beams Accounts Settings')
+        batta_claim_service_item = beams_account_settings.batta_claim_service_item
+        purchase_invoice.append('items', {
+            'item_code': batta_claim_service_item,
+            'rate': self.total_driver_batta,
+            'qty': 1
+        })
+
+        purchase_invoice.insert()
+        purchase_invoice.submit()
+
+    def create_journal_entry_from_batta_claim(self):
+        '''
+            Creation of Journal Entry on the Approval of the Batta Claim.
+        '''
+
+        journal_entry = frappe.new_doc('Journal Entry')
+        journal_entry.posting_date = frappe.utils.nowdate()
+        beams_account_settings = frappe.get_doc('Beams Accounts Settings')
+
+        batta_payable_account = beams_account_settings.batta_payable_account
+        batta_expense_account = beams_account_settings.batta_expense_account
+
+        journal_entry.append('accounts', {
+            'account': batta_payable_account,
+            'party_type': 'Employee',
+            'party': self.employee,
+            'debit_in_account_currency': 0,
+            'credit_in_account_currency': self.total_driver_batta,
+        })
+
+        journal_entry.append('accounts', {
+            'account': batta_expense_account,
+            'party_type': 'Employee',
+            'party': self.employee,
+            'debit_in_account_currency': self.total_driver_batta,
+            'credit_in_account_currency': 0,
+        })
+
+        journal_entry.insert()
+        journal_entry.submit()

--- a/beams/beams/doctype/batta_claim/batta_claim.py
+++ b/beams/beams/doctype/batta_claim/batta_claim.py
@@ -38,7 +38,6 @@ class BattaClaim(Document):
         journal_entry = frappe.new_doc('Journal Entry')
         journal_entry.posting_date = frappe.utils.nowdate()
         batta_payable_account = frappe.db.get_single_value('Beams Accounts Settings', 'batta_payable_account')
-        batta_expense_account = frappe.db.get_single_value('Beams Accounts Settings', 'batta_expense_account')
 
         journal_entry.append('accounts', {
             'account': batta_payable_account,
@@ -48,6 +47,18 @@ class BattaClaim(Document):
             'credit_in_account_currency': self.total_driver_batta,
         })
 
+        batta_claim_type = frappe.get_doc('Batta Claim Type', self.batta_claim_type)
+
+        batta_expense_account = None
+
+        for row in batta_claim_type.accounts:
+            if row.company == self.company:
+                batta_expense_account = row.default_account
+                break
+
+        if not batta_expense_account:
+            frappe.throw(_("Batta expense account not found for the company {0}").format(self.company))
+
         journal_entry.append('accounts', {
             'account': batta_expense_account,
             'party_type': 'Employee',
@@ -55,6 +66,5 @@ class BattaClaim(Document):
             'debit_in_account_currency': self.total_driver_batta,
             'credit_in_account_currency': 0,
         })
-
         journal_entry.insert()
         journal_entry.submit()

--- a/beams/beams/doctype/batta_claim_type/batta_claim_type.js
+++ b/beams/beams/doctype/batta_claim_type/batta_claim_type.js
@@ -1,0 +1,20 @@
+// Copyright (c) 2024, efeone and contributors
+// For license information, please see license.txt
+frappe.ui.form.on('Accounts', {
+    company: function(frm, cdt, cdn) {
+        set_account_query(frm);
+    },
+    accounts_add: function(frm, cdt, cdn) {
+        set_account_query(frm);
+    }
+});
+
+// Set query to filter 'default_account' based on the selected company
+function set_account_query(frm) {
+    frm.fields_dict['accounts'].grid.get_field("default_account").get_query = function(doc, cdt, cdn) {
+        let row = locals[cdt][cdn];
+        return {
+            filters: {'company': row.company}
+        };
+    };
+}

--- a/beams/beams/doctype/batta_claim_type/batta_claim_type.json
+++ b/beams/beams/doctype/batta_claim_type/batta_claim_type.json
@@ -1,0 +1,71 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:batta_claim_type",
+ "creation": "2024-09-10 11:43:06.991558",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "section_break_hilt",
+  "batta_claim_type",
+  "accounts",
+  "amended_from"
+ ],
+ "fields": [
+  {
+   "fieldname": "section_break_hilt",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "batta_claim_type",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Batta Claim Type",
+   "reqd": 1,
+   "unique": 1
+  },
+  {
+   "fieldname": "accounts",
+   "fieldtype": "Table",
+   "label": "Accounts",
+   "options": "Accounts"
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "Batta Claim Type",
+   "print_hide": 1,
+   "read_only": 1,
+   "search_index": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "is_submittable": 1,
+ "links": [],
+ "modified": "2024-09-10 11:48:47.491015",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "Batta Claim Type",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/beams/beams/doctype/batta_claim_type/batta_claim_type.py
+++ b/beams/beams/doctype/batta_claim_type/batta_claim_type.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class BattaClaimType(Document):
+	pass

--- a/beams/beams/doctype/batta_claim_type/test_batta_claim_type.py
+++ b/beams/beams/doctype/batta_claim_type/test_batta_claim_type.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, efeone and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestBattaClaimType(FrappeTestCase):
+	pass

--- a/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.json
+++ b/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.json
@@ -8,7 +8,6 @@
   "adhoc_budget_threshold",
   "equalize_purchase_and_quotation_amounts",
   "batta_payable_account",
-  "batta_expense_account",
   "single_sales_invoice",
   "tab_break_4hid",
   "default_working_hours",
@@ -63,12 +62,6 @@
    "options": "Account"
   },
   {
-   "fieldname": "batta_expense_account",
-   "fieldtype": "Link",
-   "label": "Batta Expense Account",
-   "options": "Account"
- },
- {
    "default": "0",
    "fieldname": "single_sales_invoice",
    "fieldtype": "Check",
@@ -78,7 +71,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-09-09 15:37:38.356341",
+ "modified": "2024-09-10 11:51:50.626726",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Beams Accounts Settings",

--- a/beams/beams/doctype/stringer_bill/stringer_bill.json
+++ b/beams/beams/doctype/stringer_bill/stringer_bill.json
@@ -50,6 +50,7 @@
    "read_only": 1
   },
   {
+   "fetch_from": "substituting_for.Bureau",
    "fieldname": "bureau",
    "fieldtype": "Link",
    "label": "Bureau",
@@ -110,7 +111,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-09-02 14:30:00.607845",
+ "modified": "2024-09-10 14:53:10.745984",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Stringer Bill",


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- Feature

## Clearly and concisely describe the feature, chore or bug.
- This feature Automatically create a Purchase Invoice when the  Batta Claim is approved, but only if the Batta Type is External.
- This feature Automatically create a Journal Entry when the  Batta Claim is approved, but only if the Batta Type is Internal.

## Output screenshots (optional)
- Purchase Invoice

![image](https://github.com/user-attachments/assets/1ec96f74-c89d-41cb-b1e6-86fae6109782)
![image](https://github.com/user-attachments/assets/2dd41744-6928-41a6-81cb-2e1c46292cf2)
![image](https://github.com/user-attachments/assets/dab8892c-db19-42b1-87f1-95d7c32b7a89)

- Journal Entry

![image](https://github.com/user-attachments/assets/802818ed-d610-4562-8169-26b83f8cb123)
![image](https://github.com/user-attachments/assets/a0fdea30-df9b-4ee2-84e3-018256f5322d)
![image](https://github.com/user-attachments/assets/e83e7230-f3d1-43c8-aa51-52f9d35a5cc2)

## Areas affected and ensured
- Batta Claim.
- Purchase Invoice.
- Journal Entry
 
## Did you test with the following dataset?
- Existing Data
- New Data
