### PR TITLE
feat : Created doc-type Batta Claim Type

### DIFF
--- a/beams/beams/doctype/batta_claim/batta_claim.json
+++ b/beams/beams/doctype/batta_claim/batta_claim.json
@@ -9,12 +9,13 @@
   "section_break_twbt",
   "amended_from",
   "batta_type",
+  "batta_claim_type",
   "employee",
   "employee_name",
-  "designation",
   "supplier",
-  "bureau",
+  "designation",
   "column_break_lgjy",
+  "bureau",
   "company",
   "orgin",
   "destination",
@@ -25,7 +26,6 @@
   "batta",
   "column_break_jwtq",
   "ot_batta",
-  "section_break_gksm",
   "section_break_osak",
   "work_detail",
   "section_break_nsff",
@@ -167,8 +167,6 @@
    "fieldtype": "Column Break"
   },
   {
-   "fieldname": "section_break_gksm",
-   "fieldtype": "Section Break",
    "fieldname": "column_break_jwtq",
    "fieldtype": "Column Break"
   },
@@ -192,12 +190,18 @@
    "fieldtype": "Link",
    "label": "Company",
    "options": "Company"
+  },
+  {
+   "fieldname": "batta_claim_type",
+   "fieldtype": "Link",
+   "label": "Batta Claim Type",
+   "options": "Batta Claim Type"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-09-09 12:55:59.610599",
+ "modified": "2024-09-10 11:47:56.950837",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Batta Claim",

--- a/beams/beams/doctype/batta_claim_type/batta_claim_type.js
+++ b/beams/beams/doctype/batta_claim_type/batta_claim_type.js
@@ -1,0 +1,20 @@
+// Copyright (c) 2024, efeone and contributors
+// For license information, please see license.txt
+frappe.ui.form.on('Accounts', {
+    company: function(frm, cdt, cdn) {
+        set_account_query(frm);
+    },
+    accounts_add: function(frm, cdt, cdn) {
+        set_account_query(frm);
+    }
+});
+
+// Set query to filter 'default_account' based on the selected company
+function set_account_query(frm) {
+    frm.fields_dict['accounts'].grid.get_field("default_account").get_query = function(doc, cdt, cdn) {
+        let row = locals[cdt][cdn];
+        return {
+            filters: {'company': row.company}
+        };
+    };
+}

--- a/beams/beams/doctype/batta_claim_type/batta_claim_type.json
+++ b/beams/beams/doctype/batta_claim_type/batta_claim_type.json
@@ -1,0 +1,71 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:batta_claim_type",
+ "creation": "2024-09-10 11:43:06.991558",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "section_break_hilt",
+  "batta_claim_type",
+  "accounts",
+  "amended_from"
+ ],
+ "fields": [
+  {
+   "fieldname": "section_break_hilt",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "batta_claim_type",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Batta Claim Type",
+   "reqd": 1,
+   "unique": 1
+  },
+  {
+   "fieldname": "accounts",
+   "fieldtype": "Table",
+   "label": "Accounts",
+   "options": "Accounts"
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "Batta Claim Type",
+   "print_hide": 1,
+   "read_only": 1,
+   "search_index": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "is_submittable": 1,
+ "links": [],
+ "modified": "2024-09-10 11:48:47.491015",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "Batta Claim Type",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/beams/beams/doctype/batta_claim_type/batta_claim_type.py
+++ b/beams/beams/doctype/batta_claim_type/batta_claim_type.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class BattaClaimType(Document):
+	pass

--- a/beams/beams/doctype/batta_claim_type/test_batta_claim_type.py
+++ b/beams/beams/doctype/batta_claim_type/test_batta_claim_type.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, efeone and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestBattaClaimType(FrappeTestCase):
+	pass

--- a/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.json
+++ b/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.json
@@ -8,7 +8,6 @@
   "adhoc_budget_threshold",
   "equalize_purchase_and_quotation_amounts",
   "batta_payable_account",
-  "batta_expense_account",
   "single_sales_invoice",
   "tab_break_4hid",
   "default_working_hours",
@@ -63,12 +62,6 @@
    "options": "Account"
   },
   {
-   "fieldname": "batta_expense_account",
-   "fieldtype": "Link",
-   "label": "Batta Expense Account",
-   "options": "Account"
- },
- {
    "default": "0",
    "fieldname": "single_sales_invoice",
    "fieldtype": "Check",
@@ -78,7 +71,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-09-09 15:37:38.356341",
+ "modified": "2024-09-10 11:51:50.626726",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Beams Accounts Settings",


### PR DESCRIPTION
## Feature Description
- Create Doctype Batta Claim Type.
- Add the doctype as link in Batta Claim
- Remove Batta Expense Account From Beams Account Settings

## Solution Description
- Created Batta Claim Type
- Linked the batta claim type to the batta claim
- Removed the batta expense account field in beams account settings

Output
![image](https://github.com/user-attachments/assets/854c3ff1-e906-4ac4-8463-a92cf0bc0ebc)
![image](https://github.com/user-attachments/assets/ab2fc67b-8edd-492b-9115-11f37088ddd0)
![image](https://github.com/user-attachments/assets/f31aaa10-9e34-459c-af97-f8609a7b9284)

