### PR TITLE
feat: Add Fields In Batta Claim Doctype

### DIFF
--- a/beams/beams/doctype/batta_claim/batta_claim.json
+++ b/beams/beams/doctype/batta_claim/batta_claim.json
@@ -14,6 +14,7 @@
   "employee_name",
   "supplier",
   "designation",
+  "purpose",
   "column_break_lgjy",
   "bureau",
   "company",
@@ -196,12 +197,17 @@
    "fieldtype": "Link",
    "label": "Batta Claim Type",
    "options": "Batta Claim Type"
+  },
+  {
+   "fieldname": "purpose",
+   "fieldtype": "Small Text",
+   "label": "Purpose"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-09-10 11:47:56.950837",
+ "modified": "2024-09-10 14:56:56.241561",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Batta Claim",

--- a/beams/beams/doctype/batta_claim_type/batta_claim_type.json
+++ b/beams/beams/doctype/batta_claim_type/batta_claim_type.json
@@ -42,9 +42,8 @@
   }
  ],
  "index_web_pages_for_search": 1,
- "is_submittable": 1,
  "links": [],
- "modified": "2024-09-10 11:48:47.491015",
+ "modified": "2024-09-10 14:54:27.730657",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Batta Claim Type",
@@ -61,7 +60,6 @@
    "report": 1,
    "role": "System Manager",
    "share": 1,
-   "submit": 1,
    "write": 1
   }
  ],

--- a/beams/beams/doctype/budget_expense_type/budget_expense_type.json
+++ b/beams/beams/doctype/budget_expense_type/budget_expense_type.json
@@ -37,9 +37,8 @@
   }
  ],
  "index_web_pages_for_search": 1,
- "is_submittable": 1,
  "links": [],
- "modified": "2024-08-21 10:13:22.241024",
+ "modified": "2024-09-10 14:54:55.322266",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Budget Expense Type",
@@ -56,7 +55,6 @@
    "report": 1,
    "role": "System Manager",
    "share": 1,
-   "submit": 1,
    "write": 1
   }
  ],

--- a/beams/beams/doctype/work_detail/work_detail.json
+++ b/beams/beams/doctype/work_detail/work_detail.json
@@ -13,7 +13,8 @@
   "number_of_days",
   "daily_batta",
   "ot_batta",
-  "batta_type"
+  "batta_type",
+  "purpose"
  ],
  "fields": [
   {
@@ -73,12 +74,17 @@
    "label": "Batta Type",
    "options": "External\nInternal",
    "read_only": 1
+  },
+  {
+   "fieldname": "purpose",
+   "fieldtype": "Small Text",
+   "label": "Purpose"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-09-09 13:21:49.716310",
+ "modified": "2024-09-10 14:57:29.355620",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Work Detail",


### PR DESCRIPTION
## Feature description
-Add purpose Field In Batta Claim Doctype and its child table Work Detail.
-Make Batta Claim Type Doctype as Non-submittable.
-Make Budget Expense Type Doctype as Non-submittable.

## Solution description
 -Added Purpose field in Batta Claim Doctype and Its Child table Work detail.
-Make Batta Claim Type doctype and Budget expense Doctype as non-submittable.

## Output
![image](https://github.com/user-attachments/assets/7e72419a-b28a-4733-9f54-02f4954ccc00)
![image](https://github.com/user-attachments/assets/a0ed5a65-d04f-4b7e-9da7-bef49e247c46)


## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox