### PR TITLE
fix:On updating Batta field Total Daily Batta is updated.

### DIFF
--- a/beams/beams/doctype/batta_claim/batta_claim.js
+++ b/beams/beams/doctype/batta_claim/batta_claim.js
@@ -1,17 +1,12 @@
-// Copyright (c) 2024, efeone and contributors
-// For license information, please see license.txt
-
 frappe.ui.form.on('Batta Claim', {
     onload: function (frm) {
         set_batta_based_on_options(frm);
-        calculate_totals(frm);
     },
     refresh: function (frm) {
         set_batta_based_on_options(frm);
-        calculate_totals(frm);
     },
     batta_type: function(frm) {
-        set_batta_based_on_options(frm)
+        set_batta_based_on_options(frm);
         frm.doc.work_detail.forEach(function(row) {
             frappe.model.set_value(row.doctype, row.name, 'batta_type', frm.doc.batta_type);
         });
@@ -21,6 +16,25 @@ frappe.ui.form.on('Batta Claim', {
     },
     employee: function (frm) {
         handle_designation_based_on_batta_type(frm);
+    },
+    batta: function (frm) {
+        // Loop through each row in the work_detail child table to calculate the row values based on the updated batta
+        frm.doc.work_detail.forEach(function(row) {
+            if (frm.doc.batta_based_on === 'Daily') {
+                row.number_of_days = Math.ceil(row.total_hours / 24); 
+                row.daily_batta = row.number_of_days * frm.doc.batta;
+            } else if (frm.doc.batta_based_on === 'Hours') {
+                row.daily_batta = (row.total_hours - row.ot_hours) * frm.doc.batta;
+            }
+
+            row.ot_batta = row.ot_hours * frm.doc.ot_batta;
+
+            // Refresh the fields for each row in the child table
+            frm.refresh_field('work_detail');
+        });
+
+        // After updating all the rows, recalculate the total values
+        calculate_totals(frm);
     }
 });
 

--- a/beams/beams/doctype/batta_claim/batta_claim.json
+++ b/beams/beams/doctype/batta_claim/batta_claim.json
@@ -14,9 +14,10 @@
   "employee_name",
   "supplier",
   "designation",
+  "company",
   "column_break_lgjy",
   "bureau",
-  "company",
+  "cost_centre",
   "orgin",
   "destination",
   "distance_travelledkm",
@@ -196,12 +197,19 @@
    "fieldtype": "Link",
    "label": "Batta Claim Type",
    "options": "Batta Claim Type"
+  },
+  {
+   "fetch_from": "bureau.cost_center",
+   "fieldname": "cost_centre",
+   "fieldtype": "Link",
+   "label": "Cost Centre",
+   "options": "Cost Center"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-09-10 11:47:56.950837",
+ "modified": "2024-09-10 14:39:48.355394",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Batta Claim",


### PR DESCRIPTION
## Fix:
Update  Total daily batta field when  Batta field is changed.

## Solution description
 Total Daily Batta is calculated based on days and Batta  and updated when either one is changed.

## Output
![image](https://github.com/user-attachments/assets/0551651e-3bf4-4806-8a95-02f159769f92)


## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox