### PR TITLE
fix: Update Journal Entry Creation

### DIFF
--- a/beams/beams/doctype/batta_claim/batta_claim.py
+++ b/beams/beams/doctype/batta_claim/batta_claim.py
@@ -1,9 +1,70 @@
 # Copyright (c) 2024, efeone and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
 
 
 class BattaClaim(Document):
-	pass
+    def on_submit(self):
+        if self.workflow_state == 'Approved':
+            if self.batta_type == 'External':
+                self.create_purchase_invoice_from_batta_claim()
+            elif self.batta_type == 'Internal':
+                self.create_journal_entry_from_batta_claim()
+
+    def create_purchase_invoice_from_batta_claim(self):
+        '''
+            Creation of Purchase Invoice on The Approval Of the Batta Claim.
+        '''
+        purchase_invoice = frappe.new_doc('Purchase Invoice')
+        purchase_invoice.supplier = self.supplier
+        purchase_invoice.posting_date = frappe.utils.nowdate()
+        purchase_invoice.due_date = frappe.utils.add_days(purchase_invoice.posting_date, 30)
+        batta_claim_service_item = frappe.db.get_single_value('Beams Accounts Settings', 'batta_claim_service_item')
+        purchase_invoice.append('items', {
+            'item_code': batta_claim_service_item,
+            'rate': self.total_driver_batta,
+            'qty': 1
+        })
+
+        purchase_invoice.insert()
+        purchase_invoice.submit()
+
+    def create_journal_entry_from_batta_claim(self):
+        '''
+            Creation of Journal Entry on the Approval of the Batta Claim.
+        '''
+        journal_entry = frappe.new_doc('Journal Entry')
+        journal_entry.posting_date = frappe.utils.nowdate()
+        batta_payable_account = frappe.db.get_single_value('Beams Accounts Settings', 'batta_payable_account')
+
+        journal_entry.append('accounts', {
+            'account': batta_payable_account,
+            'party_type': 'Employee',
+            'party': self.employee,
+            'debit_in_account_currency': 0,
+            'credit_in_account_currency': self.total_driver_batta,
+        })
+
+        batta_claim_type = frappe.get_doc('Batta Claim Type', self.batta_claim_type)
+
+        batta_expense_account = None
+
+        for row in batta_claim_type.accounts:
+            if row.company == self.company:
+                batta_expense_account = row.default_account
+                break
+
+        if not batta_expense_account:
+            frappe.throw(_("Batta expense account not found for the company {0}").format(self.company))
+
+        journal_entry.append('accounts', {
+            'account': batta_expense_account,
+            'party_type': 'Employee',
+            'party': self.employee,
+            'debit_in_account_currency': self.total_driver_batta,
+            'credit_in_account_currency': 0,
+        })
+        journal_entry.insert()
+        journal_entry.submit()

--- a/beams/beams/doctype/stringer_bill/stringer_bill.json
+++ b/beams/beams/doctype/stringer_bill/stringer_bill.json
@@ -50,6 +50,7 @@
    "read_only": 1
   },
   {
+   "fetch_from": "substituting_for.Bureau",
    "fieldname": "bureau",
    "fieldtype": "Link",
    "label": "Bureau",
@@ -110,7 +111,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-09-02 14:30:00.607845",
+ "modified": "2024-09-10 14:53:10.745984",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Stringer Bill",


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- Feature

## Clearly and concisely describe the feature, chore or bug.
- This feature Automatically create a Purchase Invoice when the  Batta Claim is approved, but only if the Batta Type is External.
- This feature Automatically create a Journal Entry when the  Batta Claim is approved, but only if the Batta Type is Internal.
- Fetch the bureau from the employee in the Stringer Bill when the Substituting for field is selected.

## Output screenshots (optional)
- Purchase Invoice

![image](https://github.com/user-attachments/assets/1ec96f74-c89d-41cb-b1e6-86fae6109782)
![image](https://github.com/user-attachments/assets/2dd41744-6928-41a6-81cb-2e1c46292cf2)
![image](https://github.com/user-attachments/assets/dab8892c-db19-42b1-87f1-95d7c32b7a89)

- Journal Entry

![image](https://github.com/user-attachments/assets/d1796e39-052b-4367-ae30-19e038cde01a)
![image](https://github.com/user-attachments/assets/f1c5766a-dd23-4b05-a547-b4484687461b)

## Areas affected and ensured
- Batta Claim.
- Purchase Invoice.
- Journal Entry
 
## Did you test with the following dataset?
- Existing Data
- New Data
