### PR TITLE
feat:Update Stringer Bill Doctype

### DIFF
--- a/beams/beams/doctype/stringer_bill/stringer_bill.json
+++ b/beams/beams/doctype/stringer_bill/stringer_bill.json
@@ -13,6 +13,7 @@
   "company",
   "column_break_byey",
   "bureau",
+  "cost_center",
   "daily_wage",
   "section_break_zcc8",
   "date",
@@ -105,12 +106,19 @@
    "fieldtype": "Link",
    "label": "Stringer Type",
    "options": "Stringer Type"
+  },
+  {
+   "fetch_from": "bureau.cost_center",
+   "fieldname": "cost_center",
+   "fieldtype": "Link",
+   "label": "Cost Center",
+   "options": "Cost Center"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-09-02 14:30:00.607845",
+ "modified": "2024-09-10 13:20:39.224545",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Stringer Bill",

--- a/beams/beams/doctype/stringer_bill/stringer_bill.py
+++ b/beams/beams/doctype/stringer_bill/stringer_bill.py
@@ -27,12 +27,20 @@ class StringerBill(Document):
             frappe.throw(f"No item found for Stringer Type: {self.stringer_type}")
             return
 
+
+
         # Create a new Purchase Invoice
         purchase_invoice = frappe.new_doc('Purchase Invoice')
         purchase_invoice.stringer_bill_reference = self.name
         purchase_invoice.supplier = self.supplier
         purchase_invoice.invoice_type = 'Stringer Bill'  # Set invoice type to "Stringer Bill"
         purchase_invoice.posting_date = frappe.utils.nowdate()
+
+        purchase_invoice.bureau = self.bureau  # Assuming bureau is a field in the Stringer Bill
+        if self.bureau:
+            bureau_doc = frappe.get_doc('Bureau', self.bureau)
+            purchase_invoice.cost_center = bureau_doc.cost_center
+
 
         # Populate Child Table
         purchase_invoice.append('items', {

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -269,6 +269,22 @@ def get_purchase_invoice_custom_fields():
                 "depends_on": "eval:doc.invoice_type == 'Stringer Bill' ",
                 "read_only": 1,
                 "insert_after": "purchase_order_id"
+            },
+            {
+                "fieldname": "bureau",
+                "fieldtype": "Link",
+                "label": "Bureau",
+                "read_only": 1,
+                "options": "Bureau",
+                "insert_after": "supplier"
+            },
+            {
+                "fieldname": "cost_center",
+                "fieldtype": "Link",
+                "label": "Cost Center",
+                "read_only": 1,
+                "options": "Cost Center",
+                "insert_after": "bureau"
             }
         ]
     }


### PR DESCRIPTION
## Feature description
-Link Cost Center to Bureau in Stringer Bill and auto-fetch in Purchase Invoice
-Add 'Cost Center' (Link) field in Stringer Bill, fetched automatically from selected Bureau
-Allow manual selection of 'Cost Center' if Bureau is not specified
-Customize Purchase Invoice to auto-fetch 'Bureau' and 'Cost Center' upon Stringer Bill approval

## Solution description
 -Added a Cost Center and Bureau (Link) field in the Stringer Bill doctype
 -Applied logic to auto-fetch the Cost Center from the selected Bureau in the Stringer Bill
- If no Bureau is selected, the Cost Center field can be manually set
- Upon approval of the Stringer Bill, the Bureau and Cost Center values are automatically fetched and set in the Purchase Invoice
- 
## Output
![image](https://github.com/user-attachments/assets/eb985e1d-b4df-408a-a1b9-c2ba7fe30e0a)
![image](https://github.com/user-attachments/assets/80e8e708-4943-4695-8811-b35153196945)
![image](https://github.com/user-attachments/assets/bafcaa8f-927f-411c-825a-23e581a292ac)
![image](https://github.com/user-attachments/assets/9909458e-4715-4853-9256-69a10c8218e4)

## Areas affected and ensured
-Ensured consistency between Stringer Bill and Purchase Invoice by auto-fetching relevant fields, reducing the chance of manual data entry errors

## Is there any existing behavior change of other features due to this code change?
-no

## Was this feature tested on the browsers?
  - Mozilla Firefox