### PR TITLE
fix:Update Total daily batta field when Batta field is changed.

### DIFF
--- a/beams/beams/doctype/batta_claim/batta_claim.js
+++ b/beams/beams/doctype/batta_claim/batta_claim.js
@@ -1,17 +1,12 @@
-// Copyright (c) 2024, efeone and contributors
-// For license information, please see license.txt
-
 frappe.ui.form.on('Batta Claim', {
     onload: function (frm) {
         set_batta_based_on_options(frm);
-        calculate_totals(frm);
     },
     refresh: function (frm) {
         set_batta_based_on_options(frm);
-        calculate_totals(frm);
     },
     batta_type: function(frm) {
-        set_batta_based_on_options(frm)
+        set_batta_based_on_options(frm);
         frm.doc.work_detail.forEach(function(row) {
             frappe.model.set_value(row.doctype, row.name, 'batta_type', frm.doc.batta_type);
         });
@@ -21,6 +16,25 @@ frappe.ui.form.on('Batta Claim', {
     },
     employee: function (frm) {
         handle_designation_based_on_batta_type(frm);
+    },
+    batta: function (frm) {
+        // Loop through each row in the work_detail child table to calculate the row values based on the updated batta
+        frm.doc.work_detail.forEach(function(row) {
+            if (frm.doc.batta_based_on === 'Daily') {
+                row.number_of_days = Math.ceil(row.total_hours / 24); 
+                row.daily_batta = row.number_of_days * frm.doc.batta;
+            } else if (frm.doc.batta_based_on === 'Hours') {
+                row.daily_batta = (row.total_hours - row.ot_hours) * frm.doc.batta;
+            }
+
+            row.ot_batta = row.ot_hours * frm.doc.ot_batta;
+
+            // Refresh the fields for each row in the child table
+            frm.refresh_field('work_detail');
+        });
+
+        // After updating all the rows, recalculate the total values
+        calculate_totals(frm);
     }
 });
 

--- a/beams/beams/doctype/batta_claim/batta_claim.json
+++ b/beams/beams/doctype/batta_claim/batta_claim.json
@@ -15,6 +15,7 @@
   "supplier",
   "designation",
   "company",
+  "purpose",
   "column_break_lgjy",
   "bureau",
   "cost_centre",
@@ -204,12 +205,17 @@
    "fieldtype": "Link",
    "label": "Cost Centre",
    "options": "Cost Center"
+  },
+  {
+   "fieldname": "purpose",
+   "fieldtype": "Small Text",
+   "label": "Purpose"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-09-10 14:39:48.355394",
+ "modified": "2024-09-11 10:00:05.144516",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Batta Claim",

--- a/beams/beams/doctype/batta_claim/batta_claim.json
+++ b/beams/beams/doctype/batta_claim/batta_claim.json
@@ -14,10 +14,10 @@
   "employee_name",
   "supplier",
   "designation",
-  "purpose",
+  "company",
   "column_break_lgjy",
   "bureau",
-  "company",
+  "cost_centre",
   "orgin",
   "destination",
   "distance_travelledkm",
@@ -199,15 +199,17 @@
    "options": "Batta Claim Type"
   },
   {
-   "fieldname": "purpose",
-   "fieldtype": "Small Text",
-   "label": "Purpose"
+   "fetch_from": "bureau.cost_center",
+   "fieldname": "cost_centre",
+   "fieldtype": "Link",
+   "label": "Cost Centre",
+   "options": "Cost Center"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-09-10 14:56:56.241561",
+ "modified": "2024-09-10 14:39:48.355394",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Batta Claim",

--- a/beams/beams/doctype/batta_claim/batta_claim.py
+++ b/beams/beams/doctype/batta_claim/batta_claim.py
@@ -68,3 +68,24 @@ class BattaClaim(Document):
         })
         journal_entry.insert()
         journal_entry.submit()
+
+
+'''Function to calculate the Total Daily Batta based on data in work detail child table
+   and batta'''
+    @frappe.whitelist()
+    def calculate_total_batta(doc):
+        total_daily_batta = 0
+        total_ot_batta = 0
+
+        # Loop through the work_detail child table
+        for row in doc.get('work_detail', []):
+            total_daily_batta += row.get('daily_batta', 0)
+            total_ot_batta += row.get('ot_batta', 0)
+
+        # Total batta is the sum of total_daily_batta and total_ot_batta
+        total_driver_batta = total_daily_batta + total_ot_batta
+        return {
+            'total_daily_batta': total_daily_batta,
+            'total_ot_batta': total_ot_batta,
+            'total_driver_batta': total_driver_batta
+        }

--- a/beams/beams/doctype/batta_claim/batta_claim.py
+++ b/beams/beams/doctype/batta_claim/batta_claim.py
@@ -69,9 +69,8 @@ class BattaClaim(Document):
         journal_entry.insert()
         journal_entry.submit()
 
-
-'''Function to calculate the Total Daily Batta based on data in work detail child table
-   and batta'''
+    '''Function to calculate the Total Daily Batta based on data in work detail child table
+        and batta'''
     @frappe.whitelist()
     def calculate_total_batta(doc):
         total_daily_batta = 0


### PR DESCRIPTION
## Fix:
Update  Total daily batta field when  Batta field is changed.

## Solution description
 Total Daily Batta is calculated based on days and Batta  and updated when either one is changed.

## Output
![image](https://github.com/user-attachments/assets/7eaa3607-da52-4013-9cdc-e70aba46b1eb)


## Is there any existing behavior change of other features due to this code change?
      No


## Was this feature tested on the browsers?
  - Mozilla Firefox