### PR TITLE
fix: Added field in Beams Accounts Settings, enabled print format attachment  in Sales Invoice emails

### DIFF
--- a/beams/beams/custom_scripts/sales_invoice/sales_invoice.py
+++ b/beams/beams/custom_scripts/sales_invoice/sales_invoice.py
@@ -96,10 +96,20 @@ def validate_sales_invoice_amount_with_quotation(doc, method):
 
 
 @frappe.whitelist()
-def send_email_to_party(doc, method=None):
+def on_update_after_submit(doc, method=None):
     """
-    Method to Send an Email with a PDF attachment of the given document (Sales Invoice) to the contact associated with the customer.
-    Also validate the existence of the contact for customer and its Email ID.
+    Method triggered after the document is updated and submitted.
+    It checks if the workflow state has changed to "Completed".
+    """
+    if doc.workflow_state == "Completed":
+        send_email_to_party(doc)
+
+
+@frappe.whitelist()
+def send_email_to_party(doc):
+    """
+    Method to send an email with a PDF attachment of the given document (Sales Invoice) to the contact associated with the customer.
+    Also validate the existence of the contact for the customer and its Email ID.
     """
     customer_name = doc.customer
     contact_name = frappe.db.get_value("Dynamic Link", {
@@ -107,28 +117,46 @@ def send_email_to_party(doc, method=None):
         "link_name": customer_name,
         "parenttype": "Contact"
     }, "parent")
+
     if not contact_name:
-        frappe.throw(f"Email id is not found for the {customer_name}")
+        frappe.msgprint(f"please Configure contact for Customer")
+
     contact = frappe.get_doc("Contact", contact_name)
+
     if not contact.email_id:
-        frappe.throw(f"Email id is not found {contact_name} linked to {customer_name}")
+        frappe.msgprint("Please configure an email address for the contact.")
+        return
+
     email_id = contact.email_id
     subject = f"{doc.doctype} {doc.name}"
     message = f"Dear {contact.first_name or 'Customer'},<br><br>Please find the attached {doc.doctype} {doc.name}.<br><br>Thank you."
 
-    # Generate PDF for the Sales Invoice
-    pdf_data = frappe.attach_print('Sales Invoice', doc.name)
+    # Fetch the print format from Beam Account Settings
+    print_format = frappe.db.get_single_value("Beams Accounts Settings", "default_sales_invoice_print_format")
 
-    # Attach the PDF and send the email
-    frappe.sendmail(
-        recipients=[email_id],
-        subject=subject,
-        message=message,
-        reference_doctype=doc.doctype,
-        reference_name=doc.name,
-        attachments=[{
-            'fname': pdf_data['fname'],
-            'fcontent': pdf_data['fcontent'],
-        }]
-    )
-    frappe.msgprint(f"Email sent to {email_id} successfully.")
+    if not print_format:
+        frappe.msgprint("Please configure a default print format for Sales Invoice in Beam Account Settings.")
+        return
+
+    try:
+        # Try to generate PDF using the selected print format
+        pdf_data = frappe.attach_print('Sales Invoice', doc.name, print_format=print_format)
+
+        # Send the email with the PDF attachment
+        frappe.sendmail(
+            recipients=[email_id],
+            subject=subject,
+            message=message,
+            reference_doctype=doc.doctype,
+            reference_name=doc.name,
+            attachments=[{
+                'fname': pdf_data['fname'],
+                'fcontent': pdf_data['fcontent'],
+            }]
+        )
+        frappe.msgprint(f"Email sent to {email_id} successfully.")
+
+    except Exception as e:
+        # Log the error and notify the user
+        frappe.log_error(f"Failed to generate PDF or send email for {doc.doctype} {doc.name}: {str(e)}", "PDF/Email Failure")
+        frappe.msgprint("Failed to generate PDF or send email. Please check the system logs for more details.")

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -130,7 +130,7 @@ before_uninstall = "beams.uninstall.before_uninstall"
 doc_events = {
     "Sales Invoice": {
         "before_save": "beams.beams.custom_scripts.sales_invoice.sales_invoice.validate_sales_invoice_amount_with_quotation",
-        "on_submit":  "beams.beams.custom_scripts.sales_invoice.sales_invoice.send_email_to_party",
+        "on_update_after_submit":"beams.beams.custom_scripts.sales_invoice.sales_invoice.on_update_after_submit",
         "autoname": "beams.beams.custom_scripts.sales_invoice.sales_invoice.autoname"
 
     },


### PR DESCRIPTION
## Issue description
-Need to add New Field in Beams Accounts Settings and  enabled print formats is attached in email in Sales Invoice doctype.

## Solution description
 Added new field in Beams Accounts Settings 
Applied filter to enabled print formats in Beams Accounts Settings for attaching for sending email
updated the workflow Docstatus.
changed the controller event in hooks.

## Output
![image](https://github.com/user-attachments/assets/8a1ec926-d2a8-4718-9a1e-dca3001bca26)
![image](https://github.com/user-attachments/assets/fa97397b-f896-4b05-8683-b1acefb87ff5)


## Is there any existing behavior change of other features due to this code change?
-Sales Invoice doctype

## Was this feature tested on the browsers?
  - Mozilla Firefox