### PR TITLE
Added field in Beams Accounts Settings, enabled print format attachment in Sales Invoice emails 

### DIFF
--- a/beams/beams/custom_scripts/sales_invoice/sales_invoice.py
+++ b/beams/beams/custom_scripts/sales_invoice/sales_invoice.py
@@ -122,12 +122,12 @@ def send_email_to_party(doc):
     }, "parent")
 
     if not contact_name:
-        frappe.msgprint(f"please Configure contact for Customer")
+        frappe.msgprint(f"please configure contact for customer")
 
     contact = frappe.get_doc("Contact", contact_name)
 
     if not contact.email_id:
-        frappe.msgprint("Please configure an email address for the contact.")
+        frappe.msgprint("please configure an email address for the contact.")
         return
 
     email_id = contact.email_id
@@ -138,7 +138,7 @@ def send_email_to_party(doc):
     print_format = frappe.db.get_single_value("Beams Accounts Settings", "default_sales_invoice_print_format")
 
     if not print_format:
-        frappe.msgprint("Please configure a default print format for Sales Invoice in Beam Account Settings.")
+        frappe.msgprint("please configure a default print format for Sales Invoice in Beam Account Settings.")
         return
 
     try:

--- a/beams/beams/custom_scripts/sales_invoice/sales_invoice.py
+++ b/beams/beams/custom_scripts/sales_invoice/sales_invoice.py
@@ -97,7 +97,7 @@ def validate_sales_invoice_amount_with_quotation(doc, method):
 
 
 @frappe.whitelist()
-def on_update_after_submit(doc, method=None):
+def si_on_update_after_submit_custom(doc, method=None):
     """
     Method triggered after the document is updated and submitted. It checks if the workflow state
     has changed to "Send Email to Party".

--- a/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.js
+++ b/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.js
@@ -21,4 +21,14 @@ frappe.ui.form.on('Beams Accounts Settings', {
             };
         });
     },
+    onload: function(frm) {
+        frm.set_query('default_sales_invoice_print_format', function() {
+            return {
+                filters: {
+                    'doc_type': 'Sales Invoice',
+                    'disabled': 0  
+                }
+            };
+        });
+    }
 });

--- a/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.js
+++ b/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.js
@@ -22,11 +22,14 @@ frappe.ui.form.on('Beams Accounts Settings', {
         });
     },
     onload: function(frm) {
+      /*
+      * Set a query filter for the 'default_sales_invoice_print_format' field only the enabled print formats for Sales Invoice is show
+      */
         frm.set_query('default_sales_invoice_print_format', function() {
             return {
                 filters: {
                     'doc_type': 'Sales Invoice',
-                    'disabled': 0  
+                    'disabled': 0
                 }
             };
         });

--- a/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.json
+++ b/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.json
@@ -9,6 +9,8 @@
   "equalize_purchase_and_quotation_amounts",
   "batta_payable_account",
   "single_sales_invoice",
+  "batta_expense_account",
+  "default_sales_invoice_print_format",
   "tab_break_4hid",
   "default_working_hours",
   "batta_claim_service_item",
@@ -66,12 +68,24 @@
    "fieldname": "single_sales_invoice",
    "fieldtype": "Check",
    "label": "Single Sales Invoice"
+ },
+ {
+   "fieldname": "batta_expense_account",
+   "fieldtype": "Link",
+   "label": "Batta Expense Account",
+   "options": "Account"
+ },
+ {
+   "fieldname": "default_sales_invoice_print_format",
+   "fieldtype": "Link",
+   "label": "Default Sales Invoice Print Format",
+   "options": "Print Format"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-09-10 11:51:50.626726",
+ "modified": "2024-09-05 15:59:09.254258",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Beams Accounts Settings",

--- a/beams/fixtures/workflow.json
+++ b/beams/fixtures/workflow.json
@@ -347,7 +347,7 @@
   "doctype": "Workflow",
   "document_type": "Sales Invoice",
   "is_active": 1,
-  "modified": "2024-08-27 10:51:28.351947",
+  "modified": "2024-09-10 12:54:41.490051",
   "name": "Sales Invoice Approval",
   "override_status": 0,
   "send_email_alert": 0,
@@ -400,7 +400,7 @@
    {
     "allow_edit": "Accounts Manager",
     "avoid_status_override": 0,
-    "doc_status": "0",
+    "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
     "next_action_email_template": null,
@@ -430,7 +430,7 @@
    {
     "allow_edit": "Accounts Manager",
     "avoid_status_override": 0,
-    "doc_status": "0",
+    "doc_status": "2",
     "is_optional_state": 0,
     "message": null,
     "next_action_email_template": null,

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -130,7 +130,7 @@ before_uninstall = "beams.uninstall.before_uninstall"
 doc_events = {
     "Sales Invoice": {
         "before_save": "beams.beams.custom_scripts.sales_invoice.sales_invoice.validate_sales_invoice_amount_with_quotation",
-        "on_update_after_submit":"beams.beams.custom_scripts.sales_invoice.sales_invoice.send_email_to_party",
+        "on_update_after_submit":"beams.beams.custom_scripts.sales_invoice.sales_invoice.si_on_update_after_submit_custom",
         "autoname": "beams.beams.custom_scripts.sales_invoice.sales_invoice.autoname"
 
     },

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -130,7 +130,7 @@ before_uninstall = "beams.uninstall.before_uninstall"
 doc_events = {
     "Sales Invoice": {
         "before_save": "beams.beams.custom_scripts.sales_invoice.sales_invoice.validate_sales_invoice_amount_with_quotation",
-        "on_submit":  "beams.beams.custom_scripts.sales_invoice.sales_invoice.send_email_to_party",
+        "on_update_after_submit":"beams.beams.custom_scripts.sales_invoice.sales_invoice.send_email_to_party",
         "autoname": "beams.beams.custom_scripts.sales_invoice.sales_invoice.autoname"
 
     },

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -130,7 +130,7 @@ before_uninstall = "beams.uninstall.before_uninstall"
 doc_events = {
     "Sales Invoice": {
         "before_save": "beams.beams.custom_scripts.sales_invoice.sales_invoice.validate_sales_invoice_amount_with_quotation",
-        "on_update_after_submit":"beams.beams.custom_scripts.sales_invoice.sales_invoice.si_on_update_after_submit_custom",
+        "on_update_after_submit":"beams.beams.custom_scripts.sales_invoice.sales_invoice.on_update_after_submit",
         "autoname": "beams.beams.custom_scripts.sales_invoice.sales_invoice.autoname"
 
     },


### PR DESCRIPTION
## Issue description
-Need to add New Field in Beams Accounts Settings and  enabled print formats is attached in email in Sales Invoice doctype.

## Solution description
 Added new field in Beams Accounts Settings 
Applied filter to enabled print formats in Beams Accounts Settings for attaching for sending email
updated the  Sales Invoice Approval Workflow  docstatus.
changed the controller event in hooks.

## Output
![image](https://github.com/user-attachments/assets/165655b6-00ca-47b9-84cd-521c9aae79af)
![image](https://github.com/user-attachments/assets/07b73ec4-cf08-4095-a45e-13ee49ca6ecb)

## Is there any existing behavior change of other features due to this code change?
-Sales Invoice doctype

## Was this feature tested on the browsers?
  - Mozilla Firefox