### PR TITLE
fix:Updated Stringer Bill Doctype

### DIFF
--- a/beams/beams/doctype/batta_claim/batta_claim.py
+++ b/beams/beams/doctype/batta_claim/batta_claim.py
@@ -69,10 +69,11 @@ class BattaClaim(Document):
         journal_entry.insert()
         journal_entry.submit()
 
-    '''Function to calculate the Total Daily Batta based on data in work detail child table
-        and batta'''
     @frappe.whitelist()
     def calculate_total_batta(doc):
+        '''Function to calculate the Total Daily Batta based on data in work detail child table
+            and batta
+        '''
         total_daily_batta = 0
         total_ot_batta = 0
 

--- a/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.js
+++ b/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.js
@@ -20,5 +20,13 @@ frappe.ui.form.on('Beams Accounts Settings', {
                 }
             };
         });
+
+        frm.set_query('stringer_service_item', function() {
+          return {
+                filters: {
+                    'is_stock_item' : 0
+                  }
+                };
+              });
     },
 });

--- a/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.json
+++ b/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.json
@@ -12,6 +12,7 @@
   "tab_break_4hid",
   "default_working_hours",
   "batta_claim_service_item",
+  "stringer_service_item",
   "naming_rule_tab",
   "beams_naming_rule"
  ],
@@ -66,12 +67,18 @@
    "fieldname": "single_sales_invoice",
    "fieldtype": "Check",
    "label": "Single Sales Invoice"
+  },
+  {
+   "fieldname": "stringer_service_item",
+   "fieldtype": "Link",
+   "label": "Stringer Service Item",
+   "options": "Item"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-09-10 11:51:50.626726",
+ "modified": "2024-09-12 16:02:32.392538",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Beams Accounts Settings",

--- a/beams/beams/doctype/stringer_bill/stringer_bill.js
+++ b/beams/beams/doctype/stringer_bill/stringer_bill.js
@@ -10,38 +10,7 @@ frappe.ui.form.on('Stringer Bill', {
                 }
             };
         });
-        /*
-        *  Set a query filter for the 'substituting_for' field to only show records where 'bureau' is not empty
-        */
-        frm.set_query('substituting_for', function() {
-            return {
-                filters: {
-                    'bureau': ['!=', '']
-                }
-            };
-        });
     },
-    daily_wage: function(frm) {
-       update_total_wage(frm);
-   },
-   no_of_days: function(frm) {
-       update_total_wage(frm);
-   },
-   bureau: function(frm) {
-        if (frm.doc.bureau) {
-            frm.set_query('substituting_for', function() {
-                return {
-                    filters: {
-                        'bureau': frm.doc.bureau
-                    }
-                };
-            });
-        } else {
-            frm.set_query('substituting_for', function() {
-                return {};
-            });
-        }
-   }
 });
 frappe.ui.form.on('Stringer Bill Date', {
     date: function(frm, cdt, cdn) {
@@ -74,14 +43,4 @@ function update_no_of_days(frm) {
     let dates = frm.doc.date.map(row => row.date);
     let unique_dates = [...new Set(dates)];
     frm.set_value('no_of_days', unique_dates.length);
-}
-/*
-*  Function to check when daily_wage or no_of_days fields are updated to ensure total_wage is always current.
-*/
-function update_total_wage(frm) {
-    if (frm.doc.daily_wage && frm.doc.no_of_days) {
-        frm.set_value('total_wage', frm.doc.daily_wage * frm.doc.no_of_days);
-    } else {
-        frm.set_value('total_wage', 0); // Set to 0 if either field is missing
-    }
 }

--- a/beams/beams/doctype/stringer_bill/stringer_bill.js
+++ b/beams/beams/doctype/stringer_bill/stringer_bill.js
@@ -12,35 +12,3 @@ frappe.ui.form.on('Stringer Bill', {
         });
     },
 });
-frappe.ui.form.on('Stringer Bill Date', {
-    date: function(frm, cdt, cdn) {
-        let child = locals[cdt][cdn];
-        // Get the list of dates from the child table
-        let dates = frm.doc.date.map(row => row.date);
-        // Check for duplicate dates
-        if (dates.filter(d => d === child.date).length > 1) {
-            frappe.msgprint({
-                title: __('Message'),
-                message: __('{0} Date should be Unique', [child.date]),
-                indicator: 'red'
-            });
-            frappe.model.set_value(cdt, cdn, 'date', '');
-            return;
-        }
-        // Calculate the number of unique dates and update the no_of_days field
-        update_no_of_days(frm);
-    },
-    date_remove: function(frm) {
-        // Recalculate no_of_days when a row is removed
-        update_no_of_days(frm);
-    }
-});
-
-/*
-* Helper function to update the no_of_days field
-*/
-function update_no_of_days(frm) {
-    let dates = frm.doc.date.map(row => row.date);
-    let unique_dates = [...new Set(dates)];
-    frm.set_value('no_of_days', unique_dates.length);
-}

--- a/beams/beams/doctype/stringer_bill/stringer_bill.json
+++ b/beams/beams/doctype/stringer_bill/stringer_bill.json
@@ -7,17 +7,17 @@
  "engine": "InnoDB",
  "field_order": [
   "section_break_vh0v",
-  "stringer_type",
   "supplier",
-  "substituting_for",
   "company",
   "column_break_byey",
+  "date",
   "bureau",
   "cost_center",
-  "daily_wage",
   "section_break_zcc8",
-  "date",
+  "on_air_date_and_time",
+  "news_remarks",
   "column_break_cgfc",
+  "daily_wage",
   "no_of_days",
   "total_wage",
   "amended_from"
@@ -33,14 +33,6 @@
    "in_list_view": 1,
    "label": "Supplier",
    "options": "Supplier",
-   "reqd": 1
-  },
-  {
-   "fieldname": "substituting_for",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "label": "Substituting For",
-   "options": "Employee",
    "reqd": 1
   },
   {
@@ -60,7 +52,7 @@
   {
    "fieldname": "daily_wage",
    "fieldtype": "Currency",
-   "label": "Daily Wage"
+   "label": "Stringer Amount"
   },
   {
    "fieldname": "no_of_days",
@@ -83,10 +75,10 @@
    "fieldtype": "Column Break"
   },
   {
+   "default": "Today",
    "fieldname": "date",
-   "fieldtype": "Table",
-   "label": "Stringer Bill Date",
-   "options": "Stringer Bill Date"
+   "fieldtype": "Date",
+   "label": "Date"
   },
   {
    "fieldname": "column_break_cgfc",
@@ -103,23 +95,27 @@
    "search_index": 1
   },
   {
-   "fieldname": "stringer_type",
-   "fieldtype": "Link",
-   "label": "Stringer Type",
-   "options": "Stringer Type"
-  },
-  {
    "fetch_from": "bureau.cost_center",
    "fieldname": "cost_center",
    "fieldtype": "Link",
    "label": "Cost Center",
    "options": "Cost Center"
+  },
+  {
+   "fieldname": "news_remarks",
+   "fieldtype": "Small Text",
+   "label": "News Remarks"
+  },
+  {
+   "fieldname": "on_air_date_and_time",
+   "fieldtype": "Datetime",
+   "label": "On Air Date and Time"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-09-10 14:53:10.745984",
+ "modified": "2024-09-12 16:39:04.551473",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Stringer Bill",

--- a/beams/beams/doctype/stringer_bill/stringer_bill.json
+++ b/beams/beams/doctype/stringer_bill/stringer_bill.json
@@ -17,8 +17,7 @@
   "on_air_date_and_time",
   "news_remarks",
   "column_break_cgfc",
-  "daily_wage",
-  "no_of_days",
+  "stringer_amount",
   "total_wage",
   "amended_from"
  ],
@@ -48,17 +47,6 @@
    "fieldtype": "Link",
    "label": "Bureau",
    "options": "Bureau"
-  },
-  {
-   "fieldname": "daily_wage",
-   "fieldtype": "Currency",
-   "label": "Stringer Amount"
-  },
-  {
-   "fieldname": "no_of_days",
-   "fieldtype": "Int",
-   "label": "No Of Days",
-   "read_only": 1
   },
   {
    "fieldname": "total_wage",
@@ -110,12 +98,17 @@
    "fieldname": "on_air_date_and_time",
    "fieldtype": "Datetime",
    "label": "On Air Date and Time"
+  },
+  {
+   "fieldname": "stringer_amount",
+   "fieldtype": "Currency",
+   "label": "Stringer Amount"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-09-12 16:39:04.551473",
+ "modified": "2024-09-13 11:21:57.140738",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Stringer Bill",

--- a/beams/beams/doctype/stringer_bill/stringer_bill.py
+++ b/beams/beams/doctype/stringer_bill/stringer_bill.py
@@ -37,7 +37,7 @@ class StringerBill(Document):
         purchase_invoice.append('items', {
             'item_code': item_code,
             'qty': 1,
-            'rate': self.total_wage
+            'rate': self.stringer_amount
         })
 
         # Insert and submit the document

--- a/beams/beams/doctype/stringer_bill/stringer_bill.py
+++ b/beams/beams/doctype/stringer_bill/stringer_bill.py
@@ -9,22 +9,13 @@ class StringerBill(Document):
     def on_submit(self):
         if self.workflow_state == 'Approved':
             self.create_purchase_invoice_from_stringer_bill()
-    def before_save(self):
-        old_doc = self.get_doc_before_save()
-
-        if old_doc and old_doc.workflow_state != self.workflow_state and self.workflow_state == "Pending Approval":
-            self.check_employee_leave()
-    def validate(self):
-        self.validate_unique_dates()
-        self.update_total_wage()
-
 
     def create_purchase_invoice_from_stringer_bill(self):
         """
         Creation of Purchase Invoice On The Approval Of the Stringer Bill.
         """
         # Fetch the item code from the Stringer Type
-        item_code = frappe.get_value("Stringer Type", self.stringer_type, "item")
+        item_code = frappe.db.get_single_value('Beams Accounts Settings', 'stringer_service_item')
 
         if not item_code:
             frappe.throw(f"No item found for Stringer Type: {self.stringer_type}")
@@ -55,51 +46,3 @@ class StringerBill(Document):
 
         # Confirm success
         frappe.msgprint(f"Purchase Invoice {purchase_invoice.name} created successfully with Stringer Bill reference {self.name}.", alert=True, indicator="green")
-
-    def check_employee_leave(self):
-        '''
-            Method to verifies if the employee is on  leave for each specified date.
-        '''
-        employee = self.substituting_for
-
-        if self.date and employee:
-            for date_entry in self.date:
-                leave_exists = frappe.db.exists('Leave Application', {
-                    'employee': employee,
-                    'status': 'Approved',
-                    'from_date': ('<=', date_entry.date),
-                    'to_date': ('>=', date_entry.date)
-                })
-
-                if not leave_exists:
-                    formatted_date = date_entry.date.strftime("%d/%m/%Y")
-                    frappe.throw(f"Employee {employee} is not on leave on {formatted_date}.")
-
-
-    def validate_unique_dates(self):
-        '''
-            Validate that each date in the Stringer Bill Date table is unique.
-        '''
-        dates = [row.date for row in self.date]
-
-        if len(dates) != len(set(dates)):
-            frappe.throw(_('Each Date should be unique.'))
-
-        self.update_no_of_days()
-
-    def update_no_of_days(self):
-        '''
-            Update the number of unique days based on the dates in the Stringer Bill Date table.
-        '''
-        unique_dates = set([row.date for row in self.date])
-
-        self.no_of_days = len(unique_dates)
-
-    def update_total_wage(self):
-        '''
-            Calculate and update the total wage based on daily wage and the number of days.
-        '''
-        if self.daily_wage and self.no_of_days:
-            self.total_wage = self.daily_wage * self.no_of_days
-        else:
-            self.total_wage = 0


### PR DESCRIPTION
## Feature description
Update Stringer Bill doctype.

## Solution description
The Stringer Bill doctype is updated with following features:
-      Stringer Type,Substituting For fields were  removed.
-       Daily Wage field was renamed as Stringer Amount.
-      Stringer Bill Date child table was removed.
-      Added  Field  Date(set Default=Today).
-      Added DateTime field 'On Air Date and Time'.
-      Added Field News Remarks(Small Text).

 Updated Beams Account Settings:
                -Add Link Field Stringer Service Item(Options=ItemDoctype)(Applied Filter Maintain Stock=0)
On creating Purchase Invoice up on the Approval Of Stringer Bill, Service Items was fetched from Stringer Service Item Of Beams Account Settings.

## Output
![image](https://github.com/user-attachments/assets/01da7c2a-0411-41f1-9d5f-0bd7028aa21c)
![image](https://github.com/user-attachments/assets/e7834a94-ec2e-4a5e-968d-a82b8275d93b)


## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox