### PR TITLE
feat: Update Substitute Booking doctype

### DIFF
--- a/beams/beams/doctype/substitute_booking/substitute_booking.js
+++ b/beams/beams/doctype/substitute_booking/substitute_booking.js
@@ -1,8 +1,48 @@
 // Copyright (c) 2024, efeone and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Substitute Booking", {
-// 	refresh(frm) {
+frappe.ui.form.on("Substitute Booking", {
+	daily_wage: function(frm) {
+			calculate_total_wage(frm);
+	}
+});
 
-// 	},
-// });
+frappe.ui.form.on('Substitution Bill Date', {
+    date: function(frm, cdt, cdn) {
+        // Validate dates and update no_of_days when a date is entered or changed
+        validate_dates(frm);
+    }
+});
+
+function validate_dates(frm) {
+    let dates = frm.doc.substitution_bill_date.map(row => row.date).filter(date => date);
+
+    // Check for duplicate dates
+    let unique_dates = [...new Set(dates)];
+    if (unique_dates.length !== dates.length) {
+        frappe.msgprint({
+            title: __('Message'),
+            message: __('Dates should be unique.'),
+            indicator: 'red'
+        });
+        frm.refresh_field('substitution_bill_date');
+        return;
+    }
+
+    let unique_dates_count = unique_dates.length;
+    frm.set_value('no_of_days', unique_dates_count);
+
+    // Calculate the total wage after updating no_of_days
+    calculate_total_wage(frm);
+}
+
+function calculate_total_wage(frm) {
+    let no_of_days = frm.doc.no_of_days;
+    let daily_wage = frm.doc.daily_wage;
+
+    if (no_of_days && daily_wage) {
+        // Calculate total wage
+        let total_wage = no_of_days * daily_wage;
+        frm.set_value('total_wage', total_wage);
+    }
+}

--- a/beams/beams/doctype/substitute_booking/substitute_booking.json
+++ b/beams/beams/doctype/substitute_booking/substitute_booking.json
@@ -33,6 +33,7 @@
    "options": "Employee"
   },
   {
+   "fetch_from": "substituting_for.stringer_type",
    "fieldname": "stringer_type",
    "fieldtype": "Link",
    "label": "Stringer Type",
@@ -61,6 +62,7 @@
    "options": "Bureau"
   },
   {
+   "fetch_from": "bureau.cost_center",
    "fieldname": "cost_center",
    "fieldtype": "Link",
    "label": "Cost Center",
@@ -121,7 +123,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-09-13 09:06:18.023171",
+ "modified": "2024-09-13 11:32:42.355552",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Substitute Booking",

--- a/beams/beams/doctype/substitute_booking/substitute_booking.json
+++ b/beams/beams/doctype/substitute_booking/substitute_booking.json
@@ -9,20 +9,17 @@
   "stringer_type",
   "substituting_for",
   "substituted_by",
-  "bureau",
-  "cost_center",
-  "column_break_rbcg",
   "phone_number",
   "email_id",
-  "column_break_jbgj",
+  "column_break_rbcg",
   "posting_date",
+  "bureau",
+  "cost_center",
+  "daily_wage",
   "section_break_igie",
   "substitution_bill_date",
-  "section_break_apfh",
-  "daily_wage",
-  "column_break_fdcd",
+  "column_break_bclp",
   "no_of_days",
-  "column_break_ymbh",
   "total_wage"
  ],
  "fields": [
@@ -86,28 +83,13 @@
    "read_only": 1
   },
   {
+   "default": "Today",
    "fieldname": "posting_date",
    "fieldtype": "Date",
    "label": "Posting Date"
   },
   {
    "fieldname": "column_break_rbcg",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "column_break_jbgj",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "section_break_apfh",
-   "fieldtype": "Section Break"
-  },
-  {
-   "fieldname": "column_break_fdcd",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "column_break_ymbh",
    "fieldtype": "Column Break"
   },
   {
@@ -119,11 +101,15 @@
    "fieldtype": "Table",
    "label": "Substitution Bill Date",
    "options": "Substitution Bill Date"
+  },
+  {
+   "fieldname": "column_break_bclp",
+   "fieldtype": "Column Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-09-13 11:32:42.355552",
+ "modified": "2024-09-17 16:09:40.484715",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Substitute Booking",

--- a/beams/beams/doctype/substitute_booking/substitute_booking.py
+++ b/beams/beams/doctype/substitute_booking/substitute_booking.py
@@ -1,9 +1,55 @@
 # Copyright (c) 2024, efeone and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
 
-
 class SubstituteBooking(Document):
-	pass
+    def before_save(self):
+        self.calculate_no_of_days()
+        self.calculate_total_wage()
+
+        old_doc = self.get_doc_before_save()
+        if old_doc and old_doc.workflow_state != self.workflow_state and self.workflow_state == "Pending Approval":
+            self.check_employee_leave()
+
+    def calculate_no_of_days(self):
+        '''
+            Method to calculate no of days based on dates specified in the child table Substitution Bill Date.
+        '''
+        dates = [row.date for row in self.substitution_bill_date if row.date]
+
+        unique_dates = list(set(dates))
+
+        if len(unique_dates) != len(dates):
+            frappe.throw(_("Dates should be unique."))
+
+        self.no_of_days = len(unique_dates)
+
+    def calculate_total_wage(self):
+        '''
+            Method to calculate total wage based on daily wage and no of days.
+        '''
+        if self.no_of_days and self.daily_wage:
+            self.total_wage = self.no_of_days * self.daily_wage
+        else:
+            self.total_wage = 0
+
+    def check_employee_leave(self):
+        '''
+            Method to verify whether the employee is on leave for each specified date in the child table Substitution Bill Date.
+        '''
+        employee = self.substituting_for
+
+        if self.substitution_bill_date and employee:
+            for date_entry in self.substitution_bill_date:
+                leave_exists = frappe.db.exists('Leave Application', {
+                    'employee': employee,
+                    'status': 'Approved',
+                    'from_date': ('<=', date_entry.date),
+                    'to_date': ('>=', date_entry.date)
+                })
+
+                if not leave_exists:
+                    formatted_date = date_entry.date.strftime("%d/%m/%Y")
+                    frappe.throw(f"Employee {employee} is not on leave on {formatted_date}.")


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- feat.

## Solution description 
- Calculate no of days based on dates specified in Substitution Bill Date child table.
- Compute total wage based on daily wage and no of days in Substitute Booking doctype.
- fetch cost center associated with  bureau when bureau is selected.
- Validation for employee leave on dates specified in Substitution Bill Date child table.

## Output screenshots (optional)
[Screencast from 09-17-2024 12:54:36 PM.webm](https://github.com/user-attachments/assets/cdb86050-22c0-444a-924a-0501e5aaa0dc)

## Areas affected and ensured
Substitute Booking.

## Did you test with the following dataset?
- Existing Data
- New Data
