### PR TITLE
fix: Remove fields from doctype Voucher entry type

### DIFF
--- a/beams/beams/doctype/voucher_entry_type/voucher_entry_type.json
+++ b/beams/beams/doctype/voucher_entry_type/voucher_entry_type.json
@@ -7,9 +7,7 @@
  "engine": "InnoDB",
  "field_order": [
   "voucher_entry_type",
-  "description",
-  "accounts",
-  "attachements"
+  "accounts"
  ],
  "fields": [
   {
@@ -23,21 +21,11 @@
    "fieldtype": "Table",
    "label": "Accounts",
    "options": "Accounts"
-  },
-  {
-   "fieldname": "description",
-   "fieldtype": "Small Text",
-   "label": "Description"
-  },
-  {
-   "fieldname": "attachements",
-   "fieldtype": "Attach Image",
-   "label": "Attachments"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-09-17 15:23:34.049378",
+ "modified": "2024-09-18 10:06:24.063798",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Voucher Entry Type",

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -18,7 +18,7 @@ def after_install():
     create_custom_fields(get_material_request_custom_fields(), ignore_validate=True)
     create_custom_fields(get_sales_order_custom_fields(), ignore_validate=True)
     create_custom_fields(get_employee_advance_custom_fields(), ignore_validate=True)
-
+    create_custom_fields(get_journal_entry_custom_fields(), ignore_validate=True)
 
 def after_migrate():
     after_install()
@@ -36,6 +36,7 @@ def before_uninstall():
     delete_custom_fields(get_sales_order_custom_fields())
     delete_custom_fields(get_employee_advance_custom_fields())
     delete_custom_fields(get_employee_custom_fields())
+    delete_custom_fields(get_journal_entry_custom_fields())
 
 
 def delete_custom_fields(custom_fields: dict):
@@ -525,5 +526,22 @@ def get_employee_advance_custom_fields():
                 "reqd": 1
             }
 
+        ]
+    }
+
+def get_journal_entry_custom_fields():
+    '''
+    Custom fields that need to be added to the Journal Entry Doctype.
+    '''
+    return {
+        "Journal Entry": [
+            {
+                "fieldname": "cost_center",
+                "fieldtype": "Link",
+                "label": "Cost Center",
+                "read_only": 1,
+                "options": "Cost Center",
+                "insert_after": "naming_series"
+            }
         ]
     }


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- fix

## Solution description 
- Remove fields 'Description' and 'Attachment' from the doctype Voucher Entry Type.
- Add custom field 'cost center' in the doctype Journal Entry.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/07a87f35-a6b7-4317-9f2e-e05b2f56592b)

## Areas affected and ensured
Journal Entry.
Voucher Entry Type
