### PR TITLE
feat: Add Connections In Batta Claim Doctype

### DIFF
--- a/beams/beams/doctype/batta_claim/batta_claim.json
+++ b/beams/beams/doctype/batta_claim/batta_claim.json
@@ -241,8 +241,17 @@
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
- "links": [],
- "modified": "2024-09-17 17:18:42.829235",
+ "links": [
+  {
+   "link_doctype": "Purchase Invoice",
+   "link_fieldname": "batta_claim_reference"
+  },
+  {
+   "link_doctype": "Journal Entry",
+   "link_fieldname": "batta_claim_reference"
+  }
+ ],
+ "modified": "2024-09-19 10:55:19.767891",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Batta Claim",

--- a/beams/beams/doctype/batta_claim/batta_claim.py
+++ b/beams/beams/doctype/batta_claim/batta_claim.py
@@ -19,6 +19,7 @@ class BattaClaim(Document):
         '''
         purchase_invoice = frappe.new_doc('Purchase Invoice')
         purchase_invoice.supplier = self.supplier
+        purchase_invoice.batta_claim_reference = self.name
         purchase_invoice.posting_date = frappe.utils.nowdate()
         purchase_invoice.due_date = frappe.utils.add_days(purchase_invoice.posting_date, 30)
         batta_claim_service_item = frappe.db.get_single_value('Beams Accounts Settings', 'batta_claim_service_item')
@@ -36,6 +37,7 @@ class BattaClaim(Document):
             Creation of Journal Entry on the Approval of the Batta Claim.
         '''
         journal_entry = frappe.new_doc('Journal Entry')
+        journal_entry.batta_claim_reference = self.name
         journal_entry.posting_date = frappe.utils.nowdate()
         batta_payable_account = frappe.db.get_single_value('Beams Accounts Settings', 'batta_payable_account')
         batta_expense_account = frappe.db.get_single_value('Beams Accounts Settings', 'batta_expense_account')

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -275,6 +275,14 @@ def get_purchase_invoice_custom_fields():
                 "insert_after": "purchase_order_id"
             },
             {
+                "fieldname": "batta_claim_reference",
+                "fieldtype": "Link",
+                "label": "Batta Claim Reference",
+                "read_only": 1,
+                "options": "Batta Claim",
+                "insert_after": "stringer_bill_reference"
+            },
+            {
                 "fieldname": "bureau",
                 "fieldtype": "Link",
                 "label": "Bureau",
@@ -560,6 +568,15 @@ def get_journal_entry_custom_fields():
                 "read_only": 1,
                 "options": "Cost Center",
                 "insert_after": "naming_series"
+            },
+            {
+                "fieldname": "batta_claim_reference",
+                "fieldtype": "Link",
+                "label": "Batta Claim Reference",
+                "read_only": 1,
+                "options": "Batta Claim",
+                "insert_after": "voucher_type"
             }
+
         ]
     }


### PR DESCRIPTION
## Feature description
-Update Batta Claim Doctype.

## Solution description
-Added Field batta Claim Reference in both purchase invoice and journal entry.
-Added Purchase Invoice and journal entry connections in Batta Claim Doctype.

## Output
![image](https://github.com/user-attachments/assets/19c8e2a0-f49a-40fa-920a-7b6d47916d18)
![image](https://github.com/user-attachments/assets/10e56e83-5e27-4797-ac3b-d204e7f82a21)
![image](https://github.com/user-attachments/assets/0c9b678d-8f66-48cf-af43-a984f0dbfd62)


## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox