### PR TITLE
feat:Created a doctype Albatross Settings and Customized Quotation nd Customer doctype

### DIFF
--- a/beams/beams/doctype/albatross_settings/albatross_settings.js
+++ b/beams/beams/doctype/albatross_settings/albatross_settings.js
@@ -1,0 +1,40 @@
+// Copyright (c) 2024, efeone and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('Albatross Settings', {
+   /*
+   *  Applies a filter on `albatross_service_item` where is_stock_item'checkbox is unchecked in item doctype.
+   * Applies a filter to the `albatross_service_item` field based on the fetched Sales Types where is_time_sales
+    checkbox is checked in item doctype.
+   */
+    onload: function (frm) {
+        // Initialize the list for filtering
+        frm.albatross_service_item_sales_types = [];
+        // Fetch Sales Types where is_time_sales is checked
+        frappe.call({
+            method: 'frappe.client.get_list',
+            args: {
+                doctype: 'Sales Type',
+                filters: {
+                    'is_time_sales': 1
+                },
+                fields: ['name']
+            },
+            callback: function (data) {
+                if (data.message) {
+                    frm.albatross_service_item_sales_types = data.message.map(sales_type => sales_type.name);
+                    // Set query for the albatross_service_item field
+                    frm.fields_dict['albatross_service_item'].get_query = function () {
+                        return {
+                            filters: {
+                                'is_stock_item': 0, // Filter for is_stock_item being unchecked
+                                'sales_type': ['in', frm.albatross_service_item_sales_types] // Filter based on sales types
+                            }
+                        };
+                    };
+                    frm.refresh_field('albatross_service_item');
+                }
+            }
+        });
+    }
+});

--- a/beams/beams/doctype/albatross_settings/albatross_settings.js
+++ b/beams/beams/doctype/albatross_settings/albatross_settings.js
@@ -2,39 +2,34 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Albatross Settings', {
-   /*
-   *  Applies a filter on `albatross_service_item` where is_stock_item'checkbox is unchecked in item doctype.
-   * Applies a filter to the `albatross_service_item` field based on the fetched Sales Types where is_time_sales
-    checkbox is checked in item doctype.
-   */
+    /*
+     * Applies a filter on `albatross_service_item` where is_stock_item checkbox is unchecked in item doctype.
+     * Applies a filter to the `albatross_service_item` field based on the fetched Sales Types where is_time_sales
+     * checkbox is checked in item doctype.
+     */
     onload: function (frm) {
-        // Initialize the list for filtering
-        frm.albatross_service_item_sales_types = [];
+        let albatross_service_item_sales_types = [];
+
         // Fetch Sales Types where is_time_sales is checked
-        frappe.call({
-            method: 'frappe.client.get_list',
-            args: {
-                doctype: 'Sales Type',
-                filters: {
-                    'is_time_sales': 1
-                },
-                fields: ['name']
+        frappe.db.get_list('Sales Type', {
+            filters: {
+                'is_time_sales': 1
             },
-            callback: function (data) {
-                if (data.message) {
-                    frm.albatross_service_item_sales_types = data.message.map(sales_type => sales_type.name);
-                    // Set query for the albatross_service_item field
-                    frm.fields_dict['albatross_service_item'].get_query = function () {
-                        return {
-                            filters: {
-                                'is_stock_item': 0, // Filter for is_stock_item being unchecked
-                                'sales_type': ['in', frm.albatross_service_item_sales_types] // Filter based on sales types
-                            }
-                        };
+            fields: ['name']
+        }).then(data => {
+            if (data && data.length > 0) {
+                albatross_service_item_sales_types = data.map(sales_type => sales_type.name);
+                // Set query for the albatross_service_item field
+                frm.fields_dict['albatross_service_item'].get_query = function () {
+                    return {
+                        filters: {
+                            'is_stock_item': 0, // Filter for is_stock_item being unchecked
+                            'sales_type': ['in', albatross_service_item_sales_types] // Filter based on sales types
+                        }
                     };
-                    frm.refresh_field('albatross_service_item');
-                }
+                };
+                frm.refresh_field('albatross_service_item');
             }
-        });
+        })
     }
 });

--- a/beams/beams/doctype/albatross_settings/albatross_settings.json
+++ b/beams/beams/doctype/albatross_settings/albatross_settings.json
@@ -1,0 +1,41 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2024-09-19 10:36:36.024839",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "albatross_service_item"
+ ],
+ "fields": [
+  {
+   "fieldname": "albatross_service_item",
+   "fieldtype": "Link",
+   "label": "Albatross Service Item",
+   "options": "Item"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "issingle": 1,
+ "links": [],
+ "modified": "2024-09-19 10:37:42.276246",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "Albatross Settings",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/beams/beams/doctype/albatross_settings/albatross_settings.py
+++ b/beams/beams/doctype/albatross_settings/albatross_settings.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class AlbatrossSettings(Document):
+	pass

--- a/beams/beams/doctype/albatross_settings/test_albatross_settings.py
+++ b/beams/beams/doctype/albatross_settings/test_albatross_settings.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, efeone and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestAlbatrossSettings(FrappeTestCase):
+	pass

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -76,6 +76,12 @@ def get_customer_custom_fields():
                 "label": "Is Agent",
                 "insert_after": "msme_status"
             },
+            {
+                "fieldname": "albatross_customer_id",
+                "fieldtype": "Data",
+                "label": "Albatross Customer ID",
+                "insert_after": "is_agent"
+            }
 
         ]
     }
@@ -194,18 +200,10 @@ def get_quotation_custom_fields():
                 "insert_after": "valid_till"
             },
             {
-                "fieldname": "albatross_ro_id",
-                "fieldtype": "Data",
-                "label": "Albatross RO ID",
-                "in_standard_filter": 1,
-                "reqd":0,
-                "insert_after": "order_type"
-            },
-            {
                 "fieldname": "is_barter",
                 "fieldtype": "Check",
                 "label": "Is Barter",
-                "insert_after": "albatross_ro_id"
+                "insert_after": "sales_type"
             },
             {
                 "fieldname": "sales_type",
@@ -221,6 +219,56 @@ def get_quotation_custom_fields():
                 "insert_after": "valid_till",
                 "depends_on": "eval:doc.is_barter",
                 "options": "Purchase Order"
+            },
+            {
+                "fieldname": "region",
+                "fieldtype": "Link",
+                "label": "Region",
+                "insert_after": "party_name",
+                "options": "Region"
+
+            },
+            {
+                "fieldname": "albatross_details_section",
+                "fieldtype": "Section Break",
+                "label": "Albatross Details",
+                "insert_after": "sales_type"
+            },
+            {
+                "fieldname": "albatross_ro_id",
+                "fieldtype": "Data",
+                "label": "Albatross RO ID",
+                "insert_after": "albatross_details_section"
+            },
+            {
+                "fieldname": "albatross_invoice_number",
+                "fieldtype": "Data",
+                "label": "Albatross Invoice Number",
+                "insert_after": "albatross_ro_id"
+            },
+            {
+                "fieldname": "albatross_ref_number",
+                "fieldtype": "Data",
+                "label": "Albatross Ref Number",
+                "insert_after": "albatross_invoice_number"
+            },
+            {
+                "fieldname": "albatross_column_break",
+                "fieldtype": "Column Break",
+                "label": "",
+                "insert_after": "albatross_ref_number"
+            },
+            {
+                "fieldname": "client_name",
+                "fieldtype": "Data",
+                "label": "Client Name",
+                "insert_after": "albatross_column_break"
+            },
+            {
+                "fieldname": "executive_name",
+                "fieldtype": "Data",
+                "label": "Executive Name",
+                "insert_after": "client_name"
             }
 
         ]


### PR DESCRIPTION
## Feature description

 Need to Add a new Custom Field 'Albatross Customer ID' to the Customer doctype .
also add a new Custom Fields  in Quotation doctype.
create a new single doctype Albatross settings need to filter where maintain stock is zero and Sales type is Time Sales.

## Solution description

Added ''Albatross Customer ID'' custom field in Customer via setup.py.
Added 'Region' custom field in Quotation via setup.py
Added  a new section break Albatross Details includes 'Albatross Invoice Number','Albatross Ref  Number','Client Name','Executive Name' custom fields in Quotation via setup.py. 
deleted Albatross RO ID custom field in Quotation  and added in section break Albatross Details .also is barter checkbox insert after the sale type field in via setup.py.
Created a single doctype Albatross settings with field  'Albatross Service Item'  also filter to get items in item doctype checkbox  maintain stock is unchecked  and Sales type is contain is_time_sales is checked .

## Output
![image](https://github.com/user-attachments/assets/cda7ef01-0c84-4e26-8553-17cf7848b851)

![image](https://github.com/user-attachments/assets/0f8adc93-0be2-432e-8de7-502148a6cc59)

![image](https://github.com/user-attachments/assets/881aa64f-7602-460b-8534-ad4d27849619)

![image](https://github.com/user-attachments/assets/0ea8edd6-1892-40bc-b467-f5b49085d43c)

## Areas affected and ensured
New feature

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox