### PR TITLE
fix : Total distance automatically fetch through backend

### DIFF
--- a/beams/beams/doctype/batta_claim/batta_claim.py
+++ b/beams/beams/doctype/batta_claim/batta_claim.py
@@ -13,6 +13,23 @@ class BattaClaim(Document):
             elif self.batta_type == 'Internal':
                 self.create_journal_entry_from_batta_claim()
 
+    def validate(self):
+        # Call the method to calculate the total distance travelled
+        self.calculate_total_distance_travelled()
+
+    def calculate_total_distance_travelled(self):
+        total_distance = 0
+
+        # Loop through the rows in the 'work_detail' child table
+        if self.work_detail:
+            for row in self.work_detail:
+                if row.distance_travelled_km:
+                    total_distance += row.distance_travelled_km
+
+        # Set the 'total_distance_travelled_km' field with the calculated sum
+        self.total_distance_travelled_km = total_distance
+
+
     def create_purchase_invoice_from_batta_claim(self):
         '''
             Creation of Purchase Invoice on The Approval Of the Batta Claim.

--- a/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.json
+++ b/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.json
@@ -69,6 +69,7 @@
   },
   {
    "default": "0",
+   "description": "Only a single Sales Invoice can be created from a Quotation.",
    "fieldname": "single_sales_invoice",
    "fieldtype": "Check",
    "label": "Single Sales Invoice"
@@ -112,7 +113,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-09-17 10:09:31.090372",
+ "modified": "2024-09-19 09:43:58.471970",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Beams Accounts Settings",


### PR DESCRIPTION
Issue Description:
- Total distance should automatically fetch through back-end
- Add Description to single sales checkbox in beams settings

Solution Description:
- Total distance automatically fetched from the child table workdetails
- Added Description to single sales checkbox in beams settings

Output
[Screencast from 19-09-24 12:31:22 PM IST.webm](https://github.com/user-attachments/assets/4b78fb57-8aaa-42d7-a634-16d732ff17e6)
![image](https://github.com/user-attachments/assets/254cc3fa-9c2b-4385-a799-dd254ee8105c)
