### PR TITLE
feat: Added custom status indicators to Purchase Invoice and Sales Invoice List View.

### DIFF
--- a/beams/fixtures/workflow.json
+++ b/beams/fixtures/workflow.json
@@ -347,9 +347,9 @@
   "doctype": "Workflow",
   "document_type": "Sales Invoice",
   "is_active": 1,
-  "modified": "2024-09-10 12:54:41.490051",
+  "modified": "2024-09-19 17:18:48.437823",
   "name": "Sales Invoice Approval",
-  "override_status": 0,
+  "override_status": 1,
   "send_email_alert": 0,
   "states": [
    {
@@ -1650,9 +1650,9 @@
   "doctype": "Workflow",
   "document_type": "Purchase Invoice",
   "is_active": 1,
-  "modified": "2024-08-29 10:32:28.384697",
+  "modified": "2024-09-20 09:43:23.468116",
   "name": "Purchase Invoice Workflow",
-  "override_status": 0,
+  "override_status": 1,
   "send_email_alert": 0,
   "states": [
    {

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -36,7 +36,10 @@ doctype_js = {
     "Sales Order": "public/js/sales_order.js",
     "Voucher Entry": "public/js/voucher_entry.js"
 }
-# doctype_list_js = {"doctype" : "public/js/doctype_list.js"}
+doctype_list_js = {
+    "Sales Invoice" : "public/js/sales_invoice_list.js",
+    "Purchase Invoice":"public/js/purchase_invoice_list.js"
+}
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}
 # doctype_calendar_js = {"doctype" : "public/js/doctype_calendar.js"}
 

--- a/beams/public/js/purchase_invoice_list.js
+++ b/beams/public/js/purchase_invoice_list.js
@@ -1,10 +1,10 @@
 frappe.listview_settings["Purchase Invoice"] = {
-  /*
-   * The code sets the list view settings for the Purchase Invoice doctype, adding custom status indicators based on
-   * the invoice's status and workflow state. These indicators visually distinguish invoices as Paid, Unpaid,
-   * Partly Paid, Overdue, etc.
-   */
-  has_indicator_for_draft: 1,
+    /*
+    * The code sets the list view settings for the Purchase Invoice doctype, adding custom status indicators based on
+    * the invoice's status and workflow state. These indicators visually distinguish invoices as Paid, Unpaid,
+    * Partly Paid, Overdue, etc.
+    */
+    has_indicator_for_draft: 1,
     add_fields: ["status", "workflow_state"],
     get_indicator: function (doc) {
         if (doc.workflow_state === "Approved"|| doc.workflow_state == "Submitted") {

--- a/beams/public/js/purchase_invoice_list.js
+++ b/beams/public/js/purchase_invoice_list.js
@@ -1,0 +1,34 @@
+frappe.listview_settings["Purchase Invoice"] = {
+  /*
+   * The code sets the list view settings for the Purchase Invoice doctype, adding custom status indicators based on
+   * the invoice's status and workflow state. These indicators visually distinguish invoices as Paid, Unpaid,
+   * Partly Paid, Overdue, etc.
+   */
+  has_indicator_for_draft: 1,
+    add_fields: ["status", "workflow_state"],
+    get_indicator: function (doc) {
+        if (doc.workflow_state === "Approved"|| doc.workflow_state == "Submitted") {
+            if (doc.status === "Paid") {
+                return [__("Paid"), "green", "status,=,Paid"];
+            } else if (doc.status === "Unpaid") {
+                return [__("Unpaid"), "orange", "status,=,Unpaid"];
+            } else if (doc.status === "Partly Paid") {
+                return [__("Partly Paid"), "yellow", "status,=,Partly Paid"];
+            } else if (doc.status === "Overdue") {
+                return [__("Overdue"), "red", "status,=,Overdue"];
+            }
+        }
+        else {
+            if (doc.workflow_state === "Pending Approval") {
+                return [__("Pending Approval"), "orange", "status,=,Pending Approval"];
+            } else if (doc.workflow_state === "Draft") {
+                return [__("Draft"), "blue", "status,=,Draft"];
+            } else if (doc.workflow_state === "Rejected") {
+                return [__("Rejected"), "red", "status,=,Rejected"];
+            } else if (doc.workflow_state === "Cancelled") {
+                return [__("Cancelled"), "red", "status,=,Cancelled"];
+            }
+        }
+        return [__("No Status"), "gray", ""];
+    }
+};

--- a/beams/public/js/sales_invoice_list.js
+++ b/beams/public/js/sales_invoice_list.js
@@ -1,0 +1,36 @@
+frappe.listview_settings["Sales Invoice"] = {
+  /*
+   * The code sets the list view settings for the Sales Invoice doctype, adding custom status indicators based on
+   * the invoice's status and workflow state. These indicators visually distinguish invoices as Paid, Unpaid,
+   * Partly Paid, Overdue, etc.
+   */
+  has_indicator_for_draft: 1,
+    add_fields: ["status", "workflow_state"],
+    get_indicator: function (doc) {
+        if (doc.workflow_state === "Completed") {
+            if (doc.status === "Paid") {
+                return [__("Paid"), "green", "status,=,Paid"];
+            } else if (doc.status === "Unpaid") {
+                return [__("Unpaid"), "orange", "status,=,Unpaid"];
+            } else if (doc.status === "Partly Paid") {
+                return [__("Partly Paid"), "yellow", "status,=,Partly Paid"];
+            } else if (doc.status === "Overdue") {
+                return [__("Overdue"), "red", "status,=,Overdue"];
+            }
+        }
+        else {
+            if (doc.workflow_state === "Approved") {
+                return [__("Approved"), "green", "status,=,Approved"];
+            } else if (doc.workflow_state === "Pending Approval") {
+                return [__("Pending Approval"), "orange", "status,=,Pending Approval"];
+            } else if (doc.workflow_state === "Draft") {
+                return [__("Draft"), "blue", "status,=,Draft"];
+            } else if (doc.workflow_state === "Rejected") {
+                return [__("Rejected"), "red", "status,=,Rejected"];
+            } else if (doc.workflow_state === "Cancelled") {
+                return [__("Cancelled"), "red", "status,=,Cancelled"];
+            }
+        }
+        return [__("No Status"), "gray", ""];
+    }
+};

--- a/beams/public/js/sales_invoice_list.js
+++ b/beams/public/js/sales_invoice_list.js
@@ -1,10 +1,10 @@
 frappe.listview_settings["Sales Invoice"] = {
-  /*
-   * The code sets the list view settings for the Sales Invoice doctype, adding custom status indicators based on
-   * the invoice's status and workflow state. These indicators visually distinguish invoices as Paid, Unpaid,
-   * Partly Paid, Overdue, etc.
-   */
-  has_indicator_for_draft: 1,
+    /*
+    * The code sets the list view settings for the Sales Invoice doctype, adding custom status indicators based on
+    * the invoice's status and workflow state. These indicators visually distinguish invoices as Paid, Unpaid,
+    * Partly Paid, Overdue, etc.
+    */
+    has_indicator_for_draft: 1,
     add_fields: ["status", "workflow_state"],
     get_indicator: function (doc) {
         if (doc.workflow_state === "Completed") {


### PR DESCRIPTION
# Feature description

-Implemented custom status indicators in the Sales Invoice and Purchase Invoice  List Views based on both the status and workflow_state and need to ensure workflow state does not override the status in the list view.

## Solution description

 Purchase Invoice  and Sales Invoice list view, particularly the display of invoices based on their status and workflow state.
Displayed  purchase invoice and sales invoice in list view based on the status and workflow state.
Ensured that the workflow state does not override the status in the list view when both are present.
Added  logic to display visual indicators for invoice status.

## Output

![image](https://github.com/user-attachments/assets/3b0d4113-82a3-4850-becc-dd1dcf1aca48)
![image](https://github.com/user-attachments/assets/f20d55d6-1e1b-42f7-b574-89344c1aee99)
![image](https://github.com/user-attachments/assets/d5961389-306d-48b8-939c-d07b3e84710d)
![image](https://github.com/user-attachments/assets/5b4cbb78-01d1-4793-bdab-656f3fa7142c)
[Screencast from 20-09-24 01:29:45 PM IST.webm](https://github.com/user-attachments/assets/2dc75312-ef5a-4c1d-b06d-f6500c84566a)

# Areas affected and ensured
new feature 

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox