### PR TITLE
feat:Created custom button to view leave details in Substitute Booking doctype

### DIFF
--- a/beams/beams/doctype/substitute_booking/substitute_booking.js
+++ b/beams/beams/doctype/substitute_booking/substitute_booking.js
@@ -1,8 +1,19 @@
-// Copyright (c) 2024, efeone and contributors
-// For license information, please see license.txt
+//  Copyright (c) 2024, efeone and contributors
+//  For license information, please see license.txt
 
-// frappe.ui.form.on("Substitute Booking", {
-// 	refresh(frm) {
 
-// 	},
-// });
+frappe.ui.form.on('Substitute Booking', {
+    refresh: function(frm) {
+        // Add "Leave Application" button under "View"
+        frm.add_custom_button(__('Leave Application List'), function () {
+            const employee = frm.doc.substituting_for;
+            if (employee) {
+                // Navigate to the Leave Application doctype for the specified employee
+                frappe.set_route('Form', 'Leave Application', { employee: employee });
+                }
+            else {
+                frappe.msgprint(__('Please specify an employee in the "Substituting For" field.'));
+              }
+            }, __("View"));
+          }
+        });


### PR DESCRIPTION
## Feature description
Create custom button to view leave details in Substitute Booking doctype.

## Solution description
 Created  custom button labelled View and a dropdown Leave Application List.On clicking Leave Application List  leave details of the employee can be viewed.

## Output
![image](https://github.com/user-attachments/assets/63051bea-a19e-4cbb-80b7-635fa4d9fd34)
![image](https://github.com/user-attachments/assets/8eb5f666-1825-49a0-814c-f08af89e8a01)


## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox