### PR TITLE
fix:Update work_detail rows with parent values and fix label casing

### DIFF
--- a/beams/beams/doctype/batta_claim/batta_claim.js
+++ b/beams/beams/doctype/batta_claim/batta_claim.js
@@ -171,22 +171,17 @@ function calculate_totals(frm) {
     });
 }
 
-function update_work_detail(frm) {
-const { origin, destination, work_detail } = frm.doc;
-
-    // Update child table rows
-work_detail.forEach(row => {
-    frappe.model.set_value(row.doctype, row.name, 'origin', origin);
-    frappe.model.set_value(row.doctype, row.name, 'destination', destination);
-});
-
-frm.refresh_field('work_detail');
-    // Refresh child table to reflect changes
-}
-
 frappe.ui.form.on('Work Detail', {
     distance_travelled_km: function(frm, cdt, cdn) {
         calculate_total_distance_travelled(frm);
+    },
+
+    work_detail_add: function(frm, cdt, cdn) {
+        const { origin, destination } = frm.doc;
+
+           // Set initial values for the new row
+        frappe.model.set_value(cdt, cdn, 'origin', origin);
+        frappe.model.set_value(cdt, cdn, 'destination', destination);
     }
 });
 
@@ -200,4 +195,20 @@ function calculate_total_distance_travelled(frm) {
     });
        // Set the total_distance_travelled_km field with the calculated sum
     frm.set_value('total_distance_travelled_km', totalDistance);
+}
+
+function update_work_detail(frm) {
+    const { origin, destination, work_detail } = frm.doc;
+
+    // Update existing child rows with parent values
+    work_detail.forEach((row, index) => {
+        if (index >= 0) {
+            if (!row.origin || !row.destination) {
+                frappe.model.set_value(row.doctype, row.name, 'origin', origin);
+                frappe.model.set_value(row.doctype, row.name, 'destination', destination);
+            }
+        }
+    });
+
+    frm.refresh_field('work_detail');
 }

--- a/beams/beams/doctype/work_detail/work_detail.json
+++ b/beams/beams/doctype/work_detail/work_detail.json
@@ -95,7 +95,7 @@
    "fieldname": "destination",
    "fieldtype": "Link",
    "in_list_view": 1,
-   "label": "destination ",
+   "label": "Destination ",
    "options": "Location"
   },
   {
@@ -114,7 +114,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-09-17 10:51:24.673435",
+ "modified": "2024-09-21 09:42:35.688083",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Work Detail",


### PR DESCRIPTION
## Feature description
-Add logic to populate  `origin` and `destination` fields in the `work_detail` child table from the parent form.

## Solution description
 -Implemented logic to fill  `origin` and `destination` fields in the `work_detail` child table using parent form values.
 -Corrected label casing for the `Destination` field in `work_detail`

## Output

[Screencast from 23-09-24 09:39:54 AM IST.webm](https://github.com/user-attachments/assets/8a52a03a-8aaf-4e4a-90d8-e649a3b8e724)

## Is there any existing behavior change of other features due to this code change?
-no

## Was this feature tested on the browsers?
  - Mozilla Firefox