### PR TITLE
chore:Adjust field order in Beams Accounts Settings

### DIFF
--- a/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.json
+++ b/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.json
@@ -113,7 +113,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-09-23 15:17:21.814582",
+ "modified": "2024-09-23 16:37:34.377456",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Beams Accounts Settings",

--- a/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.json
+++ b/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.json
@@ -7,8 +7,8 @@
  "field_order": [
   "adhoc_budget_threshold",
   "equalize_purchase_and_quotation_amounts",
-  "batta_payable_account",
   "single_sales_invoice",
+  "batta_payable_account",
   "batta_expense_account",
   "default_sales_invoice_print_format",
   "tab_break_4hid",
@@ -113,7 +113,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-09-19 09:43:58.471970",
+ "modified": "2024-09-23 15:17:21.814582",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Beams Accounts Settings",


### PR DESCRIPTION
## Feature description
-Reorganize field order in Beams Accounts Settings

## Solution description
 -.Reordered fields to move `batta_payable_account` after `single_sales_invoice`.

## Output
![image](https://github.com/user-attachments/assets/7803749d-e991-428d-93dd-61b62dbac3c1)

## Is there any existing behavior change of other features due to this code change?
-no

## Was this feature tested on the browsers?
  - Mozilla Firefox