### PR TITLE
feat:Created ToDo in Stringer Bill and Substitute booking

### DIFF
--- a/beams/beams/doctype/substitute_booking/substitute_booking.json
+++ b/beams/beams/doctype/substitute_booking/substitute_booking.json
@@ -202,8 +202,9 @@
   }
  ],
  "index_web_pages_for_search": 1,
+ "is_submittable": 1,
  "links": [],
- "modified": "2024-09-21 13:16:44.225429",
+ "modified": "2024-09-23 15:19:21.887973",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Substitute Booking",


### PR DESCRIPTION
## Feature description

-Implement the automatic creation of ToDo while creating the Stringer Bill and Substitute Booking.
-Make Substitute Booking   Doctype Submittable

## Solution description
-created ToDo while creating the stringer bill ,TodO Created to Account Manager
-created ToDo While Creating the Subtitute Booking , ToDo Created to Account Manager
-Modified the Substitute Booking  doctype to be submittable

## Output
![image](https://github.com/user-attachments/assets/1ca12798-d53b-4d63-99c3-4c987c52f185)

stringer bill:

[Screencast from 23-09-24 04:59:32 PM IST.webm](https://github.com/user-attachments/assets/1fe70cb2-c553-4423-9e12-bed57406ec1e)

substitute Booking:

[Screencast from 23-09-24 05:02:43 PM IST.webm](https://github.com/user-attachments/assets/3dd9d785-f005-4bac-8abb-b7f577c8289c)


## Areas affected and ensured

-New Feature

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox