### PR TITLE
fix: Fixed the alignment of is_barter checkbox in Quotation doctype

### DIFF
--- a/beams/setup.py
+++ b/beams/setup.py
@@ -232,7 +232,7 @@ def get_quotation_custom_fields():
                 "fieldname": "albatross_details_section",
                 "fieldtype": "Section Break",
                 "label": "Albatross Details",
-                "insert_after": "sales_type"
+                "insert_after": "is_barter"
             },
             {
                 "fieldname": "albatross_ro_id",


### PR DESCRIPTION
## Issue  description

- Need to Fix the Alignment is_barter checkbox in quotation doctype.

## Solution description

added the section break insert after the is_barter checkbox  via setup.py 

## Output

![image](https://github.com/user-attachments/assets/fdade445-386a-41ac-bd53-f06dae7863f5)


## Areas affected and ensured
-added the changes in setup.py

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox