### PR TITLE
feat:Added link from Substitute Booking to Journal Entry

### DIFF
--- a/beams/beams/doctype/substitute_booking/substitute_booking.json
+++ b/beams/beams/doctype/substitute_booking/substitute_booking.json
@@ -205,6 +205,13 @@
  "is_submittable": 1,
  "links": [],
  "modified": "2024-09-23 15:19:21.887973",
+ "links": [
+  {
+   "link_doctype": "Journal Entry",
+   "link_fieldname": "substitute_booking_reference"
+  }
+ ],
+ "modified": "2024-09-24 10:15:40.605043",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Substitute Booking",

--- a/beams/beams/doctype/substitute_booking/substitute_booking.py
+++ b/beams/beams/doctype/substitute_booking/substitute_booking.py
@@ -29,6 +29,7 @@ class SubstituteBooking(Document):
             frappe.throw("Please configure the Default Debit Account in the Beams Accounts Settings.")
         # Create a new Journal Entry
         journal_entry = frappe.new_doc('Journal Entry')
+        journal_entry.substitute_booking_reference = self.name
         journal_entry.posting_date = frappe.utils.nowdate()
         # Append credit entry
         journal_entry.append('accounts', {
@@ -49,7 +50,7 @@ class SubstituteBooking(Document):
         # Insert and submit the Journal Entry
         journal_entry.insert(ignore_permissions=True)
         journal_entry.submit()
-        frappe.msgprint(f"Journal Entry {journal_entry.name} has been created successfully.", alert=True)
+        frappe.msgprint(f"Journal Entry {journal_entry.name} with Substitute Booking Reference {self.name} has been created successfully.", alert=True)
 
     def before_save(self):
         self.calculate_no_of_days()

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -7,7 +7,7 @@ from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 def after_install():
     create_custom_fields(get_customer_custom_fields(), ignore_validate=True)
     create_custom_fields(get_sales_invoice_custom_fields(), ignore_validate=True)
-    create_custom_fields(get_quotation_custom_fields(), ignore_validate=True)
+    # create_custom_fields(get_quotation_custom_fields(), ignore_validate=True)
     create_custom_fields(get_purchase_invoice_custom_fields(), ignore_validate=True)
     create_custom_fields(get_supplier_custom_fields(), ignore_validate=True)
     create_custom_fields(get_item_custom_fields(), ignore_validate=True)
@@ -28,7 +28,7 @@ def after_migrate():
 def before_uninstall():
     delete_custom_fields(get_customer_custom_fields())
     delete_custom_fields(get_sales_invoice_custom_fields())
-    delete_custom_fields(get_quotation_custom_fields())
+    # delete_custom_fields(get_quotation_custom_fields())
     delete_custom_fields(get_purchase_invoice_custom_fields())
     delete_custom_fields(get_supplier_custom_fields())
     delete_custom_fields(get_item_custom_fields())
@@ -657,6 +657,14 @@ def get_journal_entry_custom_fields():
                 "read_only": 1,
                 "options": "Batta Claim",
                 "insert_after": "voucher_type"
+            },
+            {
+                "fieldname": "substitute_booking_reference",
+                "fieldtype": "Link",
+                "label": "Substitute Booking Reference",
+                "read_only": 1,
+                "options": "Substitute Booking",
+                "insert_after": "batta_claim_reference"
             }
 
         ]

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -7,7 +7,7 @@ from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 def after_install():
     create_custom_fields(get_customer_custom_fields(), ignore_validate=True)
     create_custom_fields(get_sales_invoice_custom_fields(), ignore_validate=True)
-    # create_custom_fields(get_quotation_custom_fields(), ignore_validate=True)
+    create_custom_fields(get_quotation_custom_fields(), ignore_validate=True)
     create_custom_fields(get_purchase_invoice_custom_fields(), ignore_validate=True)
     create_custom_fields(get_supplier_custom_fields(), ignore_validate=True)
     create_custom_fields(get_item_custom_fields(), ignore_validate=True)
@@ -28,7 +28,7 @@ def after_migrate():
 def before_uninstall():
     delete_custom_fields(get_customer_custom_fields())
     delete_custom_fields(get_sales_invoice_custom_fields())
-    # delete_custom_fields(get_quotation_custom_fields())
+    delete_custom_fields(get_quotation_custom_fields())
     delete_custom_fields(get_purchase_invoice_custom_fields())
     delete_custom_fields(get_supplier_custom_fields())
     delete_custom_fields(get_item_custom_fields())


### PR DESCRIPTION
## Feature description
Create a field for Substitute Booking Reference in Journal Entry and with that  add connection from Substitute Booking to Journal Entry.

## Solution description
Created customised field Substitute Booking Reference in Journal Entry linked to Substitute Booking doctype.
The field was populated with  unique Id.Link was added from Substitute Booking to journal entry.


## Output
![image](https://github.com/user-attachments/assets/8faa9330-20ea-4f13-928b-21fc80c38756)


## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox