### PR TITLE
chore:Made designation field editable

### DIFF
--- a/beams/beams/doctype/batta_claim/batta_claim.js
+++ b/beams/beams/doctype/batta_claim/batta_claim.js
@@ -55,7 +55,7 @@ frappe.ui.form.on('Batta Claim', {
         });
         // After updating all the rows, recalculate the total values
         calculate_totals(frm);
-    },
+    }
 });
 
 frappe.ui.form.on('Work Detail', {
@@ -88,20 +88,19 @@ function set_batta_based_on_options(frm) {
 function handle_designation_based_on_batta_type(frm) {
     if (frm.doc.batta_type === 'Internal' && frm.doc.employee) {
         // Fetch and set designation when batta_type is Internal
-        frappe.db.get_value('Employee', frm.doc.employee, 'designation', function (r) {
+        designation = frappe.db.get_value('Employee', frm.doc.employee, 'designation', function (r) {
             if (r && r.designation) {
                 frm.set_value('designation', r.designation);
-                frm.set_df_property('designation', 'read_only', 1);
             } else {
                 frappe.msgprint(__('Designation not found for the selected employee.'));
             }
         });
+        // Clear designation for External
     } else if (frm.doc.batta_type === 'External') {
-        // Allow designation to be selectable for External
-        frm.set_df_property('designation', 'read_only', 0);
         frm.set_value('designation', '');
     }
 }
+
 
 /* Function to validate dates and perform calculations */
 function validate_dates_and_calculate(frm, cdt, cdn) {

--- a/beams/beams/doctype/batta_claim/batta_claim.json
+++ b/beams/beams/doctype/batta_claim/batta_claim.json
@@ -79,7 +79,6 @@
   },
   {
    "depends_on": "eval:doc.batta_type !== 'External'",
-   "fetch_from": "employee.designation",
    "fieldname": "designation",
    "fieldtype": "Link",
    "label": "Designation",
@@ -251,7 +250,7 @@
    "link_fieldname": "batta_claim_reference"
   }
  ],
- "modified": "2024-09-19 10:55:19.767891",
+ "modified": "2024-09-25 09:30:19.697103",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Batta Claim",


### PR DESCRIPTION
Feature description
In Subsitute Booking doctype if employee is set then designation is fetched from Employee.The designation field is made editable.

## Solution description
Designation made editable. Fetch from expression  is removed from json file and is implemented through code.
Now one can edit designation as per his preference.

## Output
![image](https://github.com/user-attachments/assets/ec86f1fb-a7b5-41c5-99c1-0ce8c3c09c36)


## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox