### PR TITLE
feat:Reorganize fields in Work Detail Doctype and update wage mapping in Purchase Invoice

### DIFF
--- a/beams/beams/doctype/stringer_bill/stringer_bill.py
+++ b/beams/beams/doctype/stringer_bill/stringer_bill.py
@@ -39,7 +39,7 @@ class StringerBill(Document):
         purchase_invoice.append('items', {
             'item_code': item_code,
             'qty': 1,
-            'rate': self.total_wage
+            'rate': self.daily_wage
         })
 
         # Insert and submit the document

--- a/beams/beams/doctype/work_detail/work_detail.json
+++ b/beams/beams/doctype/work_detail/work_detail.json
@@ -6,19 +6,23 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "from_date_and_time",
-  "to_date_and_time",
   "origin",
   "destination",
   "distance_travelled_km",
-  "total_hours",
-  "ot_hours",
   "number_of_days",
-  "daily_batta",
-  "ot_batta",
   "batta_type",
+  "column_break_aerg",
+  "from_date_and_time",
+  "to_date_and_time",
+  "on_air_date",
+  "section_break_wigg",
+  "daily_batta",
+  "column_break_uihk",
+  "ot_batta",
+  "section_break_elqj",
   "purpose",
-  "on_air_date"
+  "total_hours",
+  "ot_hours"
  ],
  "fields": [
   {
@@ -109,12 +113,28 @@
    "fieldtype": "Date",
    "in_list_view": 1,
    "label": "On Air date"
+  },
+  {
+   "fieldname": "column_break_aerg",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_elqj",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "section_break_wigg",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_uihk",
+   "fieldtype": "Column Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-09-21 09:42:35.688083",
+ "modified": "2024-09-25 11:27:06.396834",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Work Detail",


### PR DESCRIPTION
## Feature description
-Reorganize the field layout in the Work Detail Doctype to include new fields like batta_type and on_air_date.
-Update the rate in Purchase Invoice creation from total_wage to daily_wage for more accurate calculations.

## Solution description
 -Reorganized fields in the Work Detail form
 -Changed Purchase Invoice item rate calculation from total_wage to daily_wage for more precise billing.

## Output
![image](https://github.com/user-attachments/assets/bd990da2-6b89-4ac1-93e4-c88688752d9c)
![image](https://github.com/user-attachments/assets/ff1f1a0f-578e-45ef-94e8-6d458f1af54f)
![image](https://github.com/user-attachments/assets/07cc50aa-3ce1-443e-b4ca-4f8808a2b64c)
![image](https://github.com/user-attachments/assets/22c4ba14-a4a0-41b3-97fe-6ed117fdcdcb)


## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox