### PR TITLE
fix: Remove tax template assignment from quotation API

### DIFF
--- a/beams/beams/api/api.py
+++ b/beams/beams/api/api.py
@@ -121,14 +121,9 @@ def create_release_order():
             'rate': input_data.get('taxable_value')
         })
 
-        template_name = input_data.get('template_name')
-        quotation_doc.taxes_and_charges = template_name
-        quotation_doc.set_missing_values()
-
         quotation_doc.save(ignore_permissions=True)
         frappe.clear_messages()
         return response('Created Release Order Successfully', quotation_doc.as_dict(), True, 201)
-
 
     except frappe.exceptions.CharacterLengthExceededError as e:
         frappe.log_error("Character Length Exceeded", "Error in Release Order creation: " + str(e)[:120])


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- Fix
## Clearly and concisely describe the feature, chore or bug.
- There is no need for tax template assignment in quotation API .
##Solution description
Removed tax template assignment.
## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/e6f58c6d-db46-47f2-a1d4-a0f3fb75c092)
![image](https://github.com/user-attachments/assets/5f783723-7b8c-44aa-a4f9-05c0c3ae3915)

## Areas affected and ensured
Release Order.
## Did you test with the following dataset?
- Existing Data
- New Data