### PR TITLE
fix:updated no_of_days and total_wage based on child table changes in Substitute Booking

### DIFF
--- a/beams/beams/doctype/substitute_booking/substitute_booking.js
+++ b/beams/beams/doctype/substitute_booking/substitute_booking.js
@@ -51,6 +51,9 @@ frappe.ui.form.on('Substitution Bill Date', {
 	date: function(frm, cdt, cdn) {
 		// Validate dates and update no_of_days when a date is entered or changed
 		validate_dates(frm);
+	},
+	substitution_bill_date_remove: function(frm) {
+			validate_dates(frm);
 	}
 });
 


### PR DESCRIPTION
 ## Issue  description

-Implemented to  Fix  issue where the   No of days and Total Wage was not updating after row deletions Substitute Bill Date  child table in  Substitute Booking Doctype

## Solution description

 Fixed issue where the No of days and Total Wage was not updating after row  deletions in Substitute Bill Date child table in a Substitute Booking  Doctype.

## Output

[Screencast from 27-09-24 11:49:28 AM IST.webm](https://github.com/user-attachments/assets/d33389f5-6f08-4a10-b3b9-4fe25bad732e)

## Areas affected and ensured

-fixed issue in the update No of days and Total Wage  in Substitute booking  Doctype

## Is there any existing behavior change of other features due to this code change?

-Substitute Booking .js

## Was this feature tested on the browsers?

  - Mozilla Firefox