### PR TITLE
fix:Added payment details in Substitute Booking

### DIFF
--- a/beams/beams/doctype/substitute_booking/substitute_booking.json
+++ b/beams/beams/doctype/substitute_booking/substitute_booking.json
@@ -35,7 +35,9 @@
   "column_break_sbia",
   "mode_of_payment",
   "column_break_rqau",
-  "paid_amount"
+  "is_paid",
+  "paid_amount",
+  "amended_from"
  ],
  "fields": [
   {
@@ -86,7 +88,8 @@
   {
    "fieldname": "daily_wage",
    "fieldtype": "Currency",
-   "label": "Daily Wage"
+   "label": "Daily Wage",
+   "reqd": 1
   },
   {
    "fieldname": "no_of_days",
@@ -119,7 +122,8 @@
    "fieldname": "substitution_bill_date",
    "fieldtype": "Table",
    "label": "Substitution Bill Date",
-   "options": "Substitution Bill Date"
+   "options": "Substitution Bill Date",
+   "reqd": 1
   },
   {
    "fieldname": "section_break_l0sx",
@@ -199,19 +203,35 @@
    "fieldname": "paid_amount",
    "fieldtype": "Currency",
    "label": "Paid Amount"
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "Substitute Booking",
+   "print_hide": 1,
+   "read_only": 1,
+   "search_index": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "default": "0",
+   "fieldname": "is_paid",
+   "fieldtype": "Check",
+   "label": "Is Paid",
+   "mandatory_depends_on": "eval:doc.workflow_state === \"Pending Approval\";"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
- "links": [],
- "modified": "2024-09-23 15:19:21.887973",
  "links": [
   {
    "link_doctype": "Journal Entry",
    "link_fieldname": "substitute_booking_reference"
   }
  ],
- "modified": "2024-09-24 10:15:40.605043",
+ "modified": "2024-09-27 13:30:44.924183",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Substitute Booking",


### PR DESCRIPTION
## Feature description
Add some logic to mark payment details before making journal entry.

## Solution description
- Added new fields Is Paid(checkbox) and Paid Amount.
- If Is Paid is checked,Paid Amount is populated with value fetched from  Total Wage.
- If unchecked a custom button labelled 'Make Payment' appears on approval of workflow.On action of this button payment is completed and Journal Entry is made.

## Output
![image](https://github.com/user-attachments/assets/df55fe61-2a3b-4705-be86-8b9f197ada3e)
![image](https://github.com/user-attachments/assets/94cd2a27-0303-4ed2-9d3c-7710fd4f0a21)
![image](https://github.com/user-attachments/assets/3226777e-b7de-409c-9d88-ba2e24ed2f04)
![image](https://github.com/user-attachments/assets/517061bd-ee00-4cc0-9170-38cd5bb143da)


## Areas affected and ensured
-Task form UI, including the navbar where the timer is displayed.

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox