### PR TITLE
feat :  Added dynamic read-only field handling for Batta Claim form based on Batta Policy

### DIFF
--- a/beams/beams/doctype/batta_claim/batta_claim.js
+++ b/beams/beams/doctype/batta_claim/batta_claim.js
@@ -51,6 +51,35 @@ frappe.ui.form.on('Batta Claim', {
         calculate_totals(frm);
         calculate_total_distance_travelled(frm);
         calculate_batta_totals(frm);
+
+        frappe.call({
+            method: "frappe.client.get_value",
+            args: {
+                doctype: "Batta Policy",
+                filters: {},
+                fieldname: ["is_actual", "is_actual_", "is_actual__", "is_actual___"]  
+            },
+            callback: function(response) {
+                if (response.message) {
+                    let is_actual_daily_batta_without_overnight_stay = response.message.is_actual___;
+                    let is_actual_daily_batta_with_overnight_stay = response.message.is_actual_;
+                    let is_actual_room_rent_batta = response.message.is_actual;
+                    let is_actual_food_allowance = response.message.is_actual___;
+
+                    // Set read-only based on conditions
+                    frm.set_df_property('daily_batta_without_overnight_stay', 'read_only', is_actual_daily_batta_without_overnight_stay == 0);
+                    frm.set_df_property('daily_batta_with_overnight_stay', 'read_only', is_actual_daily_batta_with_overnight_stay == 0);
+                    frm.set_df_property('room_rent_batta', 'read_only', is_actual_room_rent_batta == 0);
+                    frm.set_df_property('food_allowance', 'read_only', is_actual_food_allowance == 0);
+
+                    // Refresh the fields to reflect the changes
+                    frm.refresh_field('daily_batta_without_overnight_stay');
+                    frm.refresh_field('daily_batta_with_overnight_stay');
+                    frm.refresh_field('room_rent_batta');
+                    frm.refresh_field('food_allowance');
+                }
+            }
+        });
     },
     batta_type: function(frm) {
         set_batta_based_on_options(frm);

--- a/beams/beams/doctype/batta_claim/batta_claim.js
+++ b/beams/beams/doctype/batta_claim/batta_claim.js
@@ -53,15 +53,10 @@ frappe.ui.form.on('Batta Claim', {
         calculate_batta_totals(frm);
 
         frappe.call({
-            method: "frappe.client.get_value",
-            args: {
-                doctype: "Batta Policy",
-                filters: {},
-                fieldname: ["is_actual", "is_actual_", "is_actual__", "is_actual___"]  
-            },
+            method: "beams.beams.doctype.batta_claim.batta_claim.get_batta_policy_values",
             callback: function(response) {
                 if (response.message) {
-                    let is_actual_daily_batta_without_overnight_stay = response.message.is_actual___;
+                    let is_actual_daily_batta_without_overnight_stay = response.message.is_actual__;
                     let is_actual_daily_batta_with_overnight_stay = response.message.is_actual_;
                     let is_actual_room_rent_batta = response.message.is_actual;
                     let is_actual_food_allowance = response.message.is_actual___;

--- a/beams/beams/doctype/batta_claim/batta_claim.py
+++ b/beams/beams/doctype/batta_claim/batta_claim.py
@@ -208,3 +208,8 @@ def calculate_batta_allowance(designation, is_travelling_outside_kerala, is_over
         "food_allowance": food_allowance,
         "batta": total_batta
     }
+
+@frappe.whitelist()
+def get_batta_policy_values():
+    result = frappe.db.get_value('Batta Policy', {}, ['is_actual', 'is_actual_', 'is_actual__', 'is_actual___'], as_dict=True)
+    return result    


### PR DESCRIPTION
 ## Feature description
-Set Read Only to Batta claim fields based on checkbox of Batta Policy.

## Solution Description
-Updated the Batta Claim form to dynamically set fields as read-only based on values from the "is_actual"     checkboxes in the Batta Policy.

## Output
![image](https://github.com/user-attachments/assets/60fa385c-549b-4887-88e7-fb58eb400cb1)
![image](https://github.com/user-attachments/assets/2d9f2a00-24d2-465e-9af9-c95ed90378fb)

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?

  - Mozilla Firefox