### PR TITLE
feat:Create Division Doctype

### DIFF
--- a/beams/beams/custom_scripts/department/department.py
+++ b/beams/beams/custom_scripts/department/department.py
@@ -1,10 +1,11 @@
 import frappe
+
+@frappe.whitelist()
+def get_hod_users(department_name):
     """
     Fetches the user IDs of employees who belong to a specific department and have the 'Hod' role.
     Returns a list of user IDs for filtering in the client-side code.
     """
-@frappe.whitelist()
-def get_hod_users(department_name):
     users = frappe.db.sql("""
         SELECT emp.user_id
         FROM `tabEmployee` emp

--- a/beams/beams/doctype/division/division.js
+++ b/beams/beams/doctype/division/division.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2024, efeone and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Division", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/beams/beams/doctype/division/division.json
+++ b/beams/beams/doctype/division/division.json
@@ -1,0 +1,61 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "format:Division-{department_abbreviation}",
+ "creation": "2024-10-01 10:39:21.831573",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "department",
+  "department_abbreviation",
+  "division"
+ ],
+ "fields": [
+  {
+   "fieldname": "department",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Department",
+   "options": "Department",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "department.abbreviation",
+   "fieldname": "department_abbreviation",
+   "fieldtype": "Data",
+   "label": "Department Abbreviation",
+   "options": "Department"
+  },
+  {
+   "fieldname": "division",
+   "fieldtype": "Data",
+   "label": "Division",
+   "reqd": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2024-10-02 09:33:19.901503",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "Division",
+ "naming_rule": "Expression",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/beams/beams/doctype/division/division.py
+++ b/beams/beams/doctype/division/division.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class Division(Document):
+	pass

--- a/beams/beams/doctype/division/test_division.py
+++ b/beams/beams/doctype/division/test_division.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, efeone and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestDivision(FrappeTestCase):
+	pass


### PR DESCRIPTION
## Feature description
-Add Division Doctype
-Add mandatory 'Department' Link field to associate with the Department Doctype
-Implement 'Department Abbreviation' field (Data) to auto-fetch from the selected department
-Add mandatory 'Division' field (Data) for specifying division names
-Set Naming Series

## Solution description
 -Added mandatory 'Department' Link field to associate with the Department Doctype
- Implemented 'Department Abbreviation' field (Data) to auto-fetch from the selected department
- Introduced mandatory 'Division' field (Data)
- Configured Naming Series as "Division-Department Abbreviation" 
- Added a docstring to describe the function purpose

## Output
![image](https://github.com/user-attachments/assets/9f55737f-9110-4479-b7fe-936ef113afba)
![image](https://github.com/user-attachments/assets/f30cfdd0-a5e5-4d61-8d01-e307414cb57a)

## Areas affected and ensured
-This filter enhances data accuracy by preventing agent customers from being selected where only non-agent customers are relevant.

## Is there any existing behavior change of other features due to this code change?
-yes.

## Was this feature tested on the browsers?
  - Mozilla Firefox