### PR TITLE
feat: Created doctype Job Description Template

### DIFF
--- a/beams/beams/doctype/job_description_template/job_description_template.js
+++ b/beams/beams/doctype/job_description_template/job_description_template.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2024, efeone and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Job Description Template", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/beams/beams/doctype/job_description_template/job_description_template.json
+++ b/beams/beams/doctype/job_description_template/job_description_template.json
@@ -1,0 +1,61 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:job_description_template",
+ "creation": "2024-10-02 09:30:23.177786",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "job_description_template",
+  "description",
+  "designation"
+ ],
+ "fields": [
+  {
+   "fieldname": "job_description_template",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Job Description Template ",
+   "reqd": 1,
+   "unique": 1
+  },
+  {
+   "fieldname": "description",
+   "fieldtype": "Text Editor",
+   "label": "Description",
+   "reqd": 1
+  },
+  {
+   "fieldname": "designation",
+   "fieldtype": "Link",
+   "label": "Designation",
+   "options": "Designation",
+   "reqd": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2024-10-02 10:04:43.882045",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "Job Description Template",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/beams/beams/doctype/job_description_template/job_description_template.json
+++ b/beams/beams/doctype/job_description_template/job_description_template.json
@@ -15,7 +15,7 @@
    "fieldname": "job_description_template",
    "fieldtype": "Data",
    "in_list_view": 1,
-   "label": "Job Description Template ",
+   "label": "Job Description Template Name",
    "reqd": 1,
    "unique": 1
   },
@@ -35,7 +35,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-10-02 10:04:43.882045",
+ "modified": "2024-10-03 09:26:47.952327",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Job Description Template",

--- a/beams/beams/doctype/job_description_template/job_description_template.py
+++ b/beams/beams/doctype/job_description_template/job_description_template.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class JobDescriptionTemplate(Document):
+	pass

--- a/beams/beams/doctype/job_description_template/test_job_description_template.py
+++ b/beams/beams/doctype/job_description_template/test_job_description_template.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, efeone and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestJobDescriptionTemplate(FrappeTestCase):
+	pass

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -36,7 +36,8 @@ doctype_js = {
     "Sales Order": "public/js/sales_order.js",
     "Voucher Entry": "public/js/voucher_entry.js",
     "Contract":"public/js/contract.js",
-    "Department":"public/js/department.js"
+    "Department":"public/js/department.js",
+    "Job Requisition":"public/js/job_requisition.js"
 }
 doctype_list_js = {
     "Sales Invoice" : "public/js/sales_invoice_list.js",

--- a/beams/public/js/job_requisition.js
+++ b/beams/public/js/job_requisition.js
@@ -1,0 +1,38 @@
+
+frappe.ui.form.on('Job Requisition', {
+    /*
+     * This function triggers when the designation field is changed.
+     * It sets a filter for the Job Description Template based on the selected designation.
+     */
+    designation: function(frm) {
+        frm.set_query('job_description_template', function() {
+            return {
+                filters: {
+                    'designation': frm.doc.designation
+                }
+            };
+        });
+        // Refresh the Job Description Template field to apply the new filter
+        frm.refresh_field('job_description_template');
+
+        // Clear the current selection in Job Description Template if designation changes
+        frm.set_value('job_description_template', null);
+    },
+
+    /*
+     * This function triggers when the Job Description Template field is changed.
+     * It fetches the Job Description based on the selected Job Description Template.
+     */
+    job_description_template: function(frm) {
+        if (frm.doc.job_description_template) {
+            // Fetch Job Description from the selected Job Description Template
+            frappe.db.get_value('Job Description Template',{'name': frm.doc.job_description_template},'description',
+                function(r) {
+                    if (r && r.description) {
+                        frm.set_value('description', r.description);
+                    }
+                }
+            );
+        }
+    }
+});

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -22,6 +22,7 @@ def after_install():
     create_custom_fields(get_voucher_entry_custom_fields(), ignore_validate=True)
     create_custom_fields(get_contract_custom_fields(),ignore_validate=True)
     create_custom_fields(get_department_custom_fields(),ignore_validate=True)
+    create_custom_fields(get_job_requisition_custom_fields(),ignore_validate=True)
 
 def after_migrate():
     after_install()
@@ -43,6 +44,7 @@ def before_uninstall():
     delete_custom_fields(get_voucher_entry_custom_fields())
     delete_custom_fields(get_contract_custom_fields())
     delete_custom_fields(get_department_custom_fields())
+    delete_custom_fields(get_job_requisition_custom_fields())
 
 def delete_custom_fields(custom_fields: dict):
     '''
@@ -692,6 +694,23 @@ def get_journal_entry_custom_fields():
                 "read_only": 1,
                 "options": "Substitute Booking",
                 "insert_after": "batta_claim_reference"
+            }
+
+        ]
+    }
+
+def get_job_requisition_custom_fields():
+    '''
+    Custom fields that need to be added to the Job Requisition Doctype
+    '''
+    return {
+        "Job Requisition": [
+            {
+                "fieldname": "job_description_template",
+                "fieldtype": "Link",
+                "label": "Job Description Template",
+                "options": "Job Description Template",
+                "insert_after": "job_description_tab"
             }
 
         ]


### PR DESCRIPTION
## Feature description

-Need to create the Doctype Job Description Template and implement  dynamic filtering and data fetching for the Job Requisition 
doctype.

## Solution description

-Created  a new doctype Job Description Template with fields Job Description Template, Job Description and Designation.

-Added new field Job Description Template in Job Requisition doctype via setup.py.

-Applied  filter in field 'Job Description Template' by Designation in Job Requisition Doctype.

-Need to Map the  Job Description  in Job Description Template Doctype in to Job Requisition doctype.

-Configured Naming Series as  field name "Job Description Template" in Job Description Template

-Added a docstring to describe the function purpose in Job  Requisiton .js

-Added custom js job requisition.js via hooks.py

## Output

![image](https://github.com/user-attachments/assets/12c56c18-3f7e-4d27-9837-6c5011b65a8c)

[Screencast from 02-10-24 02:45:05 PM IST.webm](https://github.com/user-attachments/assets/b06fa8bf-c6f2-49f1-8c80-e5448d443c98)

![image](https://github.com/user-attachments/assets/a2319444-9ae9-43d5-bf81-80c2dab89194)

## Areas affected and ensured

-New Feature

## Is there any existing behavior change of other features due to this code change?

-No

## Was this feature tested on the browsers?

  - Mozilla Firefox