### PR TITLE
 Hide '+' icon in Connections in Substitute Booking

### DIFF
--- a/beams/beams/doctype/substitute_booking/substitute_booking.js
+++ b/beams/beams/doctype/substitute_booking/substitute_booking.js
@@ -54,8 +54,14 @@ frappe.ui.form.on("Substitute Booking", {
                 });
             });
         }
-    },
+        // disabled '+' icon in connections for creating journal entry manually
+        if (frm.doc.status === 'Approved') {
+            frm.fields_dict['connections'].grid.wrapper.find('.grid-add').hide();
+        } else {
+            frm.fields_dict['connections'].grid.wrapper.find('.grid-add').show(); 
+        }
 
+    },
     // Triggered when the 'substituting_for' field is changed
     substituting_for: function(frm) {
         // Ensure the button is only shown when the form is saved


### PR DESCRIPTION
## Feature description

-    Need Disable the '+' icon in the Connections for  journal entry  substitute booking doctype.

## Solution description

-If the status is 'Approved', the '+' icon is disabled in Connections for journal entry in substitute booking doctype 

-Implemented logic to disable the '+' icon  via Substitute Booking doctype .

-Added a Comment to describe the code  purpose in  Substitute Booking doctype.js

## Output

[Screencast from 04-10-24 09:59:37 AM IST.webm](https://github.com/user-attachments/assets/2ad534f7-75b6-41e1-a91a-5dcad4d2d398)

## Areas affected and ensured

New Feature

## Is there any existing behavior change of other features due to this code change?

-No

## Was this feature tested on the browsers?

  - Mozilla Firefox