### PR TITLE
fix : Remove duplicate custom field definition.

### DIFF
--- a/beams/setup.py
+++ b/beams/setup.py
@@ -590,6 +590,13 @@ def get_job_requisition_custom_fields():
                 "options": "Skill Proficiency",
                 "label": "Skill Proficiency",
                 "insert_after": "language_proficiency"
+            },
+            {
+                "fieldname": "job_description_template",
+                "fieldtype": "Link",
+                "label": "Job Description Template",
+                "options": "Job Description Template",
+                "insert_after": "job_description_tab"
             }
         ]
 }
@@ -876,22 +883,6 @@ def get_journal_entry_custom_fields():
         ]
     }
 
-def get_job_requisition_custom_fields():
-    '''
-    Custom fields that need to be added to the Job Requisition Doctype
-    '''
-    return {
-        "Job Requisition": [
-            {
-                "fieldname": "job_description_template",
-                "fieldtype": "Link",
-                "label": "Job Description Template",
-                "options": "Job Description Template",
-                "insert_after": "job_description_tab"
-            }
-
-        ]
-    }
 
 def create_custom_roles(role_name):
     """
@@ -909,5 +900,3 @@ def create_custom_roles(role_name):
             print(f"Role already exists: {role_name}")
 
     frappe.db.commit()
- 
- 


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- Fix

## Clearly and concisely describe the feature, chore or bug.

- There was a duplicate custom fields definition for "Job Requisition" in the setup.py file, which led to redundant code.


## Solution description

- Removed the duplicate get_job_requisition_custom_fields() function from setup.py, ensuring only one definition remains for the custom fields setup.

## Output screenshots (optional)
![Screenshot from 2024-10-04 15-29-18](https://github.com/user-attachments/assets/87259220-8718-4a17-8697-f40758d18699)
![Screenshot from 2024-10-04 13-12-38](https://github.com/user-attachments/assets/ce5dff75-83b9-4214-a7c2-816c6943cdd7)


## Areas affected and ensured
- `beams/setup.py`

## Is there any existing behavior change of other features due to this code change?
- No

## Did you test with the following dataset?
- Existing Data
- New Data

## Is patch required?
- No
