### PR TITLE
feat:Update document status based on workflow state in Job Requisition Doctype

### DIFF
--- a/beams/beams/custom_scripts/job_requisition/job_requisition.py
+++ b/beams/beams/custom_scripts/job_requisition/job_requisition.py
@@ -1,0 +1,23 @@
+import frappe
+from frappe import _
+
+def before_save(doc, method):
+    """
+    Updates the document status based on its workflow state.
+    Allows changes unless the document is in a final state, with "Cancelled" as an exception.
+    """
+    workflow_to_status = {
+        "Draft": "Pending",
+        "Pending Approval": "Pending",
+        "Approved": "Open & Approved",
+        "Rejected": "Rejected",
+        "On Hold": "On Hold",
+        "Cancelled": "Cancelled"
+    }
+    final_statuses = ["Open & Approved", "Rejected", "Filled", "On Hold"]
+
+    if doc.workflow_state == "Cancelled":
+        doc.status = "Cancelled"
+    # Update status only if not in a final state
+    elif doc.status not in final_statuses:
+        doc.status = workflow_to_status.get(doc.workflow_state, doc.status)

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -178,6 +178,10 @@ doc_events = {
     "Batta Claim": {
         "onchange": "beams.beams.doctype.batta_claim.batta_claim.calculate_batta_allowance",
         "onchange": "beams.beams.doctype.batta_claim.batta_claim.calculate_batta"
+    },
+    "Job Requisition": {
+        "before_save": "beams.beams.custom_scripts.job_requisition.job_requisition.before_save"
+
     }
 }
 

--- a/beams/public/js/job_requisition.js
+++ b/beams/public/js/job_requisition.js
@@ -1,6 +1,9 @@
 
 frappe.ui.form.on('Job Requisition', {
-    /*
+  refresh: function(frm) {
+        frm.set_df_property('status', 'read_only', 1);
+    },
+     /*
      * This function triggers when the designation field is changed.
      * It sets a filter for the Job Description Template based on the selected designation.
      */


### PR DESCRIPTION
## Feature description
-Update status based on workflow state 
-set status field to read-only
## Solution description
-Implemented automatic updates to the `status` field based on the current workflow state
-Handled workflow states such as "Draft", "Pending Approval", "Approved", "Rejected", "On Hold", and "Cancelled"
-Made the `status` field read-only on the form
## Output
[Screencast from 05-10-24 10:10:13 AM IST.webm](https://github.com/user-attachments/assets/fcb01b4d-444a-495a-9b69-bf2814344515)

## Is there any existing behavior change of other features due to this code change?
-no

## Was this feature tested on the browsers?
  - Mozilla Firefox