### PR TITLE
feat : Create Job Opening on the Approval of Job Requistion

### DIFF
--- a/beams/beams/custom_scripts/job_requisition/job_requisition.py
+++ b/beams/beams/custom_scripts/job_requisition/job_requisition.py
@@ -1,0 +1,37 @@
+import frappe
+@frappe.whitelist()
+def create_job_opening_from_job_requisition(doc, method):
+    '''
+        Creation of Job Opening on the Approval of the Job Requisition.
+    '''
+    if doc.workflow_state == "Approved":
+        job_opening = frappe.new_doc('Job Opening')
+        job_opening.job_requisition = doc.name
+        job_opening.posting_date = frappe.utils.nowdate()
+        job_opening.employment_type = doc.employment_type
+        job_opening.no_of_days_off = doc.no_of_days_off
+        job_opening.designation = doc.designation
+        job_opening.min_education_qual = doc.min_education_qual
+        job_opening.min_experience= doc.min_experience
+        job_opening.expected_compensation = doc.expected_compensation
+        job_opening.job_title = doc.designation
+        job_opening.no_of_positions = doc.no_of_positions
+
+        if not job_opening.employment_type:
+            frappe.throw("Please specify the Employment Type in the Job Requisition.")
+        if not job_opening.no_of_days_off :
+            frappe.throw("Please specify the Number of Days Off in the Job Requisition.")
+        if not job_opening.designation :
+            frappe.throw("Please specify the Designation in the Job Requisition.")
+        if not job_opening.min_education_qual:
+            frappe.throw("Please specify the Minimum Education Qualification in the Job Requisition.")
+        if not job_opening.min_education_qual:
+            frappe.throw("Please specify the Minimum Experience in the Job Requisition.")
+        if not job_opening.expected_compensation:
+            frappe.throw("Please specify the Expected Compensation in the Job Requisition.")
+        if not job_opening.no_of_positions:
+            frappe.throw("Please specify the Number of Position in the Job Requisition.")
+
+        job_opening.insert()
+        job_opening.submit()
+        frappe.msgprint(f"Job Opening {job_opening.name} has been created successfully.", alert=True, indicator="green")

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -178,6 +178,9 @@ doc_events = {
     "Batta Claim": {
         "onchange": "beams.beams.doctype.batta_claim.batta_claim.calculate_batta_allowance",
         "onchange": "beams.beams.doctype.batta_claim.batta_claim.calculate_batta"
+    },
+    "Job Requisition": {
+        "on_update": "beams.beams.custom_scripts.job_requisition.job_requisition.create_job_opening_from_job_requisition"
     }
 }
 

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -24,6 +24,7 @@ def after_install():
     create_custom_fields(get_department_custom_fields(),ignore_validate=True)
     create_custom_fields(get_job_requisition_custom_fields(),ignore_validate=True)
     create_custom_fields(get_quotation_item_custom_fields(),ignore_validate=True)
+    create_custom_fields(get_job_opening_custom_fields(),ignore_validate=True)
     # create_custom_roles('')
 
 def after_migrate():
@@ -48,6 +49,7 @@ def before_uninstall():
     delete_custom_fields(get_department_custom_fields())
     delete_custom_fields(get_job_requisition_custom_fields())
     delete_custom_fields(get_quotation_item_custom_fields())
+    delete_custom_fields(get_job_opening_custom_fields())
 
 
 
@@ -553,7 +555,7 @@ def get_job_requisition_custom_fields():
                 "insert_after": "license_type"
             },
             {
-                "fieldname": "min_eduction_qual",
+                "fieldname": "min_education_qual",
                 "fieldtype": "Select",
                 "label": "Minimum Educational Qualification",
                 "options": "\nPost Graduate Diploma in Journalism/Media\nDiploma in Media/Journalism/Communication\nUndergraduate (BA/BSc/BCom in any field)\nPost graduate (BA/BSc/BCom in any field)\nBachelor's in Journalism/Mass Communication/Media Studies\nBachelor's in Film/Television Production\nMaster's in Journalism/Mass Communication/Media Studies\nMBA/PGDM (for management roles)\nPlus Two\nSSLC\nOthers",
@@ -563,7 +565,7 @@ def get_job_requisition_custom_fields():
                 "fieldname": "education_column_break",
                 "fieldtype": "Column Break",
                 "label": "",
-                "insert_after": "min_eduction_qual"
+                "insert_after": "min_education_qual"
             },
             {
                 "fieldname": "min_experience",
@@ -628,6 +630,70 @@ def get_contract_custom_fields():
                 "insert_after": "services",
                 "read_only":1,
                 "no_copy":1
+            }
+        ]
+    }
+
+def get_job_opening_custom_fields():
+    '''
+    Custom fields that need to be added to the Contract Doctype
+    '''
+    return {
+        "Job Opening": [
+            {
+                "fieldname": "qualification_details",
+                "fieldtype": "Section Break",
+                "label": "Qualification Deatils",
+                "insert_after": "location"
+            },
+            {
+                "fieldname": "min_education_qual",
+                "fieldtype": "Select",
+                "label": "Minimum Educational Qualification",
+                "options": "\nPost Graduate Diploma in Journalism/Media\nDiploma in Media/Journalism/Communication\nUndergraduate (BA/BSc/BCom in any field)\nPost graduate (BA/BSc/BCom in any field)\nBachelor's in Journalism/Mass Communication/Media Studies\nBachelor's in Film/Television Production\nMaster's in Journalism/Mass Communication/Media Studies\nMBA/PGDM (for management roles)\nPlus Two\nSSLC\nOthers",
+                "insert_after": "qualification_details"
+            },
+            {
+                "fieldname": "qualification_details_column_break",
+                "fieldtype": "Column Break",
+                "label": "",
+                "insert_after": "min_education_qual"
+            },
+            {
+                "fieldname": "min_experience",
+                "fieldtype": "Float",
+                "label": "Minimum Experience Required",
+                "insert_after": "qualification_details_column_break"
+            },
+            {
+                "fieldname": "job_details",
+                "fieldtype": "Section Break",
+                "label": "Job Deatils",
+                "insert_after": "min_experience"
+            },
+            {
+                "fieldname": "no_of_positions",
+                "fieldtype": "Float",
+                "label": "Number of Positions",
+                "insert_after": "job_details"
+            },
+            {
+                "fieldname": "expected_compensation",
+                "fieldtype": "Currency",
+                "label": "Expected Compensation",
+                "insert_after": "no_of_positions"
+            },
+            {
+                "fieldname": "job_details_column_break",
+                "fieldtype": "Column Break",
+                "label": "",
+                "insert_after": "expected_compensation"
+            },
+            {
+                "fieldname": "no_of_days_off",
+                "fieldtype": "Int",
+                "label": "Number of Days Off",
+                "insert_after": "job_details_column_break"
             }
         ]
     }


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- Feature

## Clearly and concisely describe the feature, chore or bug.

- Automatically create a Job Opening document when a Job Requisition is approved.
- Populate Job Opening fields with data from the approved Job Requisition.

  **Fields** : 
      1. Minimum Educational Qualification
      2. Add Minimum Experience Required
      3. No of Positions
      4. Expected Compensation
      5. Number of Days Off
      6. Designation
      7. Department
      8. Employment Type

## Solution description

1. Trigger the creation of a Job Opening when the workflow state of a Job Requisition changes to "**Approved**."
2. Validate essential fields in the Job Requisition before creating the Job Opening.
3. Populate relevant fields from the Job Requisition into the Job Opening document.
4. Display a success message upon successful creation.


## Output screenshots (optional)
[Screencast from 10-07-2024 10:41:28 AM.webm](https://github.com/user-attachments/assets/5587cf6d-c15b-444b-8a55-30679daa473c)


## Areas affected and ensured
- `beams/setup.py`
- `beams/hooks.py`
- `beams/beams/custom_scripts/job_requisition/`

## Is there any existing behavior change of other features due to this code change?
- No

## Did you test with the following dataset?
- Existing Data
- New Data

## Is patch required?
- No
