### PR TITLE
feat: Update job requisition

### DIFF
--- a/beams/beams/custom_scripts/job_requisition/job_requisition.py
+++ b/beams/beams/custom_scripts/job_requisition/job_requisition.py
@@ -16,6 +16,10 @@ def create_job_opening_from_job_requisition(doc, method):
         job_opening.expected_compensation = doc.expected_compensation
         job_opening.job_title = doc.designation
         job_opening.no_of_positions = doc.no_of_positions
+        job_opening.employment_type = doc.employment_type
+        job_opening.department = doc.department
+        job_opening.designation = doc.designation
+
 
         if not job_opening.employment_type:
             frappe.throw("Please specify the Employment Type in the Job Requisition.")

--- a/beams/public/js/job_requisition.js
+++ b/beams/public/js/job_requisition.js
@@ -34,5 +34,25 @@ frappe.ui.form.on('Job Requisition', {
                 }
             );
         }
-    }
+    },
+    onload: function(frm) {
+       if (!frm.doc.requested_by) {
+           // Fetch the Employee linked to the current User
+           frappe.call({
+               method: "frappe.client.get_value",
+               args: {
+                   doctype: "Employee",
+                   filters: {
+                       user_id: frappe.session.user
+                   },
+                   fieldname: "name"
+               },
+               callback: function(r) {
+                   if (r.message) {
+                       frm.set_value('requested_by', r.message.name);
+                   }
+               }
+           });
+       }
+   }
 });

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -549,7 +549,7 @@ def get_job_requisition_custom_fields():
                 "insert_after": "driving_license_needed"
             },
             {
-                "fieldname": "eduacation",
+                "fieldname": "education",
                 "fieldtype": "Section Break",
                 "label": "Education and Qualification Details",
                 "insert_after": "license_type"
@@ -559,7 +559,7 @@ def get_job_requisition_custom_fields():
                 "fieldtype": "Select",
                 "label": "Minimum Educational Qualification",
                 "options": "\nPost Graduate Diploma in Journalism/Media\nDiploma in Media/Journalism/Communication\nUndergraduate (BA/BSc/BCom in any field)\nPost graduate (BA/BSc/BCom in any field)\nBachelor's in Journalism/Mass Communication/Media Studies\nBachelor's in Film/Television Production\nMaster's in Journalism/Mass Communication/Media Studies\nMBA/PGDM (for management roles)\nPlus Two\nSSLC\nOthers",
-                "insert_after": "eduacation"
+                "insert_after": "education"
             },
             {
                 "fieldname": "education_column_break",
@@ -643,7 +643,7 @@ def get_job_opening_custom_fields():
             {
                 "fieldname": "qualification_details",
                 "fieldtype": "Section Break",
-                "label": "Qualification Deatils",
+                "label": "Qualification Details",
                 "insert_after": "location"
             },
             {
@@ -668,7 +668,7 @@ def get_job_opening_custom_fields():
             {
                 "fieldname": "job_details",
                 "fieldtype": "Section Break",
-                "label": "Job Deatils",
+                "label": "Job Details",
                 "insert_after": "min_experience"
             },
             {
@@ -804,8 +804,16 @@ def get_property_setters():
             "property": "hidden",
             "property_type": "Data",
             "value": 1
-        }
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Job Requisition",
+            "field_name": "posting_date",
+            "property": "read_only",
+            "value": 1
+        },
     ]
+
 def get_material_request_custom_fields():
     '''
     Custom fields that need to be added to the Material Request Doctype


### PR DESCRIPTION
## Feature description
- Feature
## Solution Description
- Automatically set requested by field in job requisition to the employee who created the request.
- set posting date read only.
- fetch the employment type,designation from job requisition to job opening,

## Output
![image](https://github.com/user-attachments/assets/f7ea74d6-2894-4724-85b4-76cfbacddd66)
![image](https://github.com/user-attachments/assets/1effdddc-922d-4133-802c-9b9d30eae3ef)

## Is there any existing behavior change of other features due to this code change?
- No
## Was this feature tested on the browsers?
  - Mozilla Firefox