### PR TITLE
fix : Replace frappe.call with frappe.db.get_value to fetch sales_type in Quotation Item

### DIFF
--- a/beams/public/js/quotation.js
+++ b/beams/public/js/quotation.js
@@ -68,24 +68,19 @@ frappe.ui.form.on('Quotation Item', {
 
         if (row.item_code) {
             // Fetch sales_type from Item doctype based on selected item_code
-            frappe.call({
-                method: 'frappe.client.get_value',
-                args: {
-                    'doctype': 'Item',
-                    'filters': {'item_code': row.item_code},
-                    'fieldname': ['sales_type']
-                },
-                callback: function(response) {
-                    var sales_type = response.message.sales_type;
+            frappe.db.get_value('Item', {'item_code': row.item_code}, 'sales_type')
+                .then(r => {
+                    if (r.message) {
+                        var sales_type = r.message.sales_type;
 
-                    if (sales_type) {
-                        // Set the sales_type in the child table row
-                        frappe.model.set_value(cdt, cdn, 'sales_type', sales_type);
-                    } else {
-                        frappe.model.set_value(cdt, cdn, 'sales_type', ''); // Clear if no sales_type in Item
+                        if (sales_type) {
+                            // Set the sales_type in the child table row
+                            frappe.model.set_value(cdt, cdn, 'sales_type', sales_type);
+                        } else {
+                            frappe.model.set_value(cdt, cdn, 'sales_type', ''); // Clear if no sales_type in Item
+                        }
                     }
-                }
-            });
+                });
         }
     }
 });


### PR DESCRIPTION
 ## Feature description
-Replace frappe.call with frappe.db.get_value to fetch sales_type in Quotation Item

## Solution Description
-Updated item_code trigger in Quotation Item doctype to use frappe.db.get_value for a cleaner, promise-based approach.

## Output
![image](https://github.com/user-attachments/assets/fd53542d-9f58-4f94-b9cb-9171603fbc4f)

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
- Mozilla Firefox