### PR TITLE
fix: Resolve inconsistent filter for employee_left field based on status

### DIFF
--- a/beams/public/js/job_requisition.js
+++ b/beams/public/js/job_requisition.js
@@ -41,14 +41,14 @@ frappe.ui.form.on('Job Requisition', {
      * It fetches the employee who's status is Left
      */
 
-    employee_left: function(frm) {
-        frm.set_query('employee_left', function() {
-            return {
-                filters: {
-                    status: 'Left'
-                }
-            };
-        });
+    refresh: function(frm) {
+         frm.set_query('employee_left', function() {
+             return {
+                 filters: {
+                     status: 'Left'
+                 }
+             };
+         });
     },
     onload: function(frm) {
       if (!frm.doc.requested_by) {


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- Fix
## Clearly and concisely describe the feature, chore or bug.
- The employee_left field in job requisition did not always filter employees with status "Left".
## Solution Description
- Moved the set_query call to refresh event.
## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/6f6d7e96-467c-4705-b759-6b34b60c691b)

## Areas affected and ensured
Job Requisition
## Did you test with the following dataset?
- Existing Data
- New Data