### PR TITLE
feat:Applied filter for Leave Application list.

### DIFF
--- a/beams/beams/custom_scripts/journal_entry/journal_entry.py
+++ b/beams/beams/custom_scripts/journal_entry/journal_entry.py
@@ -1,0 +1,24 @@
+import frappe
+from frappe import _
+
+def on_cancel(doc, method):
+    """
+    This method is called when the Journal Entry is canceled.
+    and updates the 'is_paid' field in the Substitute Booking.
+    """
+    # Check if the Journal Entry is linked to a Substitute Booking
+    substitute_booking_name = doc.substitute_booking_reference
+    if substitute_booking_name:
+        # Fetch the related Substitute Booking document
+        substitute_booking = frappe.get_doc('Substitute Booking', substitute_booking_name)
+
+        # Uncheck 'is_paid' in Substitute Booking
+        substitute_booking.db_set('is_paid', 0)
+        substitute_booking.save()
+
+        # Display success message
+        frappe.msgprint(_("Journal Entry cancelled, and Substitute Booking updated successfully."))
+
+    else:
+        # Handle case where no Substitute Booking is linked
+        frappe.msgprint(_("No Substitute Booking linked to this Journal Entry."))

--- a/beams/beams/doctype/substitute_booking/substitute_booking.js
+++ b/beams/beams/doctype/substitute_booking/substitute_booking.js
@@ -2,6 +2,24 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Substitute Booking", {
+  daily_wage: function(frm) {
+      calculate_total_wage(frm);
+  },
+
+  onload: function(frm) {
+    if (frm.is_new() && !frm.doc.expense_account) {  // Check if it's a new form and the field is empty
+    // Fetch the default debit account from Beams Account Settings
+      frappe.db.get_single_value('Beams Accounts Settings', 'default_debit_account')
+        .then(default_account => {
+          if (default_account) {
+            frm.set_value('expense_account', default_account);
+          } else {
+            frappe.msgprint(__('Default Debit Account is not set in Beams Account Settings.'));
+                  }
+             });
+    }
+},
+
     refresh: function(frm) {
         // Add custom button to view leave applications under "View"
         frm.add_custom_button(__('Leave Application List'), function() {
@@ -59,6 +77,7 @@ frappe.ui.form.on("Substitute Booking", {
             });
         }, __("View"));
 
+
         // Check for payment button visibility
         if (!frm.is_new() && !frm.doc.is_paid && frm.doc.workflow_state === "Approved") {
             frm.add_custom_button(__('Make Payment'), function() {
@@ -72,7 +91,7 @@ frappe.ui.form.on("Substitute Booking", {
             });
         }
 
-        // Disable '+' icon in connections for creating journal entry manually
+        // disabled '+' icon in connections for creating journal entry manually
         if (frm.doc.status === 'Approved') {
             frm.fields_dict['connections'].grid.wrapper.find('.grid-add').hide();
         } else {
@@ -83,8 +102,8 @@ frappe.ui.form.on("Substitute Booking", {
     // Triggered when the 'substituting_for' field is changed
     substituting_for: function(frm) {
         if (!frm.is_dirty() && frm.doc.substituting_for) {
-            frm.page.add_action_item(__('Leave Application List'), function() {
-                const employee = frm.doc.substituting_for;
+            frm.add_custom_button(__('Leave Application List'), function() {
+              const employee = frm.doc.substituting_for;
                 if (employee) {
                     frappe.set_route('List', 'Leave Application', { employee: employee });
                 } else {
@@ -102,42 +121,48 @@ frappe.ui.form.on("Substitute Booking", {
     }
 });
 
+
+
 frappe.ui.form.on('Substitution Bill Date', {
-    date: function(frm, cdt, cdn) {
-        validate_dates(frm);
-    },
-    substitution_bill_date_remove: function(frm) {
-        validate_dates(frm);
-    }
+	date: function(frm, cdt, cdn) {
+		// Validate dates and update no_of_days when a date is entered or changed
+		validate_dates(frm);
+	},
+	substitution_bill_date_remove: function(frm) {
+			validate_dates(frm);
+	}
 });
 
 function validate_dates(frm) {
-    let dates = frm.doc.substitution_bill_date.map(row => row.date).filter(date => date); // Get valid dates
+	let dates = frm.doc.substitution_bill_date.map(row => row.date).filter(date => date);
 
-    let unique_dates = [...new Set(dates)]; // Ensure unique dates
-    if (unique_dates.length !== dates.length) {
-        frappe.msgprint({
-            title: __('Message'),
-            message: __('Dates should be unique.'),
-            indicator: 'red'
-        });
-        frm.refresh_field('substitution_bill_date');
-        return;
-    }
+	// Check for duplicate dates
+	let unique_dates = [...new Set(dates)];
+	if (unique_dates.length !== dates.length) {
+		frappe.msgprint({
+			title: __('Message'),
+			message: __('Dates should be unique.'),
+			indicator: 'red'
+		});
+		frm.refresh_field('substitution_bill_date');
+		return;
+	}
 
-    // Set the number of unique days
-    let unique_dates_count = unique_dates.length;
-    frm.set_value('no_of_days', unique_dates_count);
+	let unique_dates_count = unique_dates.length;
+	frm.set_value('no_of_days', unique_dates_count);
 
-    calculate_total_wage(frm);
+	// Calculate the total wage after updating no_of_days
+	calculate_total_wage(frm);
 }
 
-function calculate_total_wage(frm) {
-    let no_of_days = frm.doc.no_of_days;
-    let daily_wage = frm.doc.daily_wage;
 
-    if (no_of_days && daily_wage) {
-        let total_wage = no_of_days * daily_wage;
-        frm.set_value('total_wage', total_wage); // Update total wage based on number of days and daily wage
-    }
+function calculate_total_wage(frm) {
+  let no_of_days = frm.doc.no_of_days;
+  let daily_wage = frm.doc.daily_wage;
+
+if (no_of_days && daily_wage) {
+  // Calculate total wage
+  let total_wage = no_of_days * daily_wage;
+  frm.set_value('total_wage', total_wage);
+}
 }

--- a/beams/beams/doctype/substitute_booking/substitute_booking.js
+++ b/beams/beams/doctype/substitute_booking/substitute_booking.js
@@ -1,72 +1,89 @@
-// Copyright (c) 2024, efeone and contributors
+//Copyright (c) 2024, efeone and contributors
 // For license information, please see license.txt
 
 frappe.ui.form.on("Substitute Booking", {
-    daily_wage: function(frm) {
-        calculate_total_wage(frm);
-    },
-
-    onload: function(frm) {
-      if (frm.is_new() && !frm.doc.expense_account) {  // Check if it's a new form and the field is empty
-      // Fetch the default debit account from Beams Account Settings
-        frappe.db.get_single_value('Beams Accounts Settings', 'default_debit_account')
-          .then(default_account => {
-            if (default_account) {
-              frm.set_value('expense_account', default_account);
-            } else {
-              frappe.msgprint(__('Default Debit Account is not set in Beams Account Settings.'));
-                    }
-               });
-      }
-},
-
     refresh: function(frm) {
-        // Remove the "Leave Application List" button if the form is dirty (unsaved changes)
-        if (frm.is_dirty()) {
-            frm.remove_custom_button(__('Leave Application List'), __("View"));
-        }
+        // Add custom button to view leave applications under "View"
+        frm.add_custom_button(__('Leave Application List'), function() {
+            if (!frm.doc.substitution_bill_date || frm.doc.substitution_bill_date.length === 0) {
+                frappe.msgprint(__('No dates found in Substitution Bill Date child table.'));
+                return;
+            }
 
-        // Add "Leave Application List" button only if the form is saved and "Substituting For" has a value
-        if (!frm.is_new() && frm.doc.substituting_for) {
-            frm.add_custom_button(__('Leave Application List'), function () {
-                const employee = frm.doc.substituting_for;
-                if (employee) {
-                    // Navigate to the Leave Application List filtered by the employee
-                    frappe.set_route('List', 'Leave Application', { employee: employee });
-                } else {
-                    frappe.msgprint(__('Please specify an employee in the "Substituting For" field.'));
+            // Collect dates from child table and convert them to JSON
+            let dates = frm.doc.substitution_bill_date.map(row => row.date);
+            if (dates.length === 0) {
+                frappe.msgprint(__('Please enter at least one date in the Substitution Bill Date table.'));
+                return;
+            }
+
+            // Call server-side method to check leave applications
+            frappe.call({
+                method: 'beams.beams.doctype.substitute_booking.substitute_booking.check_leave_application',
+                args: {
+                    employee: frm.doc.substituting_for,
+                    dates: JSON.stringify(dates) // Convert dates array to JSON string
+                },
+                callback: function(r) {
+                    if (r.message) {
+                        let { leave_applications, missing_dates } = r.message;
+
+                        // If there are missing dates, show a message
+                        if (missing_dates && missing_dates.length > 0) {
+                            frappe.msgprint(__('No Approved Leave Applications found for the following dates: {0}', [missing_dates.join(', ')]));
+                        }
+
+                        // If there are approved leave applications
+                        if (leave_applications && Object.keys(leave_applications).length > 0) {
+                            let leaveDetails = Object.entries(leave_applications).map(([date, applications]) => {
+                                return `For date ${date}: ` + applications.map(leave =>
+                                    `Leave Application ${leave.name} from ${leave.from_date} to ${leave.to_date}`
+                                ).join(', ');
+                            }).join('<br>');
+
+                            frappe.msgprint(__('Approved Leave Applications: <br>{0}', [leaveDetails]));
+
+                            // Redirect to Leave Application list with filters for approved leave dates
+                            frappe.set_route('List', 'Leave Application', {
+                                employee: frm.doc.substituting_for,
+                                from_date: ['in', Object.keys(leave_applications)],  // Dates with leave applications
+                                to_date: ['in', Object.keys(leave_applications)]
+                            });
+                        } else if (missing_dates.length === 0) {
+                            frappe.msgprint(__('No approved leave applications found for the provided dates.'));
+                        }
+                    } else {
+                        frappe.msgprint(__('No leave applications found.'));
+                    }
                 }
-            }, __("View"));
-        }
+            });
+        }, __("View"));
 
-        // Add "Make Payment" button if is_paid is not checked
+        // Check for payment button visibility
         if (!frm.is_new() && !frm.doc.is_paid && frm.doc.workflow_state === "Approved") {
             frm.add_custom_button(__('Make Payment'), function() {
-                // Mark the booking as paid
-                frm.set_value("is_paid", 1);
-                // Hide the "Make Payment" button
-                frm.remove_custom_button(__('Make Payment'));
+                frm.set_value("is_paid", 1); // Set payment status
+                frm.remove_custom_button(__('Make Payment')); // Remove button after setting paid
 
-                // Call the server-side method to create the journal entry
                 frm.call({
                     doc: frm.doc,
                     method: "create_journal_entry_from_substitute_booking",
                 });
             });
         }
-        // disabled '+' icon in connections for creating journal entry manually
+
+        // Disable '+' icon in connections for creating journal entry manually
         if (frm.doc.status === 'Approved') {
             frm.fields_dict['connections'].grid.wrapper.find('.grid-add').hide();
         } else {
-            frm.fields_dict['connections'].grid.wrapper.find('.grid-add').show(); 
+            frm.fields_dict['connections'].grid.wrapper.find('.grid-add').show();
         }
-
     },
+
     // Triggered when the 'substituting_for' field is changed
     substituting_for: function(frm) {
-        // Ensure the button is only shown when the form is saved
         if (!frm.is_dirty() && frm.doc.substituting_for) {
-            frm.add_custom_button(__('Leave Application List'), function() {
+            frm.page.add_action_item(__('Leave Application List'), function() {
                 const employee = frm.doc.substituting_for;
                 if (employee) {
                     frappe.set_route('List', 'Leave Application', { employee: employee });
@@ -74,60 +91,53 @@ frappe.ui.form.on("Substitute Booking", {
                     frappe.msgprint(__('Please specify an employee in the "Substituting For" field.'));
                 }
             }, __("View"));
-        } else {
-            frm.remove_custom_button(__('Leave Application List'), __("View"));
         }
     },
-		is_paid: function(frm) {
-		    if (frm.doc.is_paid) {
-		        frm.set_value('paid_amount', frm.doc.total_wage);
-		    } else {
-		        frm.set_value('paid_amount', null);  // Clear the field by setting it to null
-		    }
-		}
+    is_paid: function(frm) {
+        if (frm.doc.is_paid) {
+            frm.set_value('paid_amount', frm.doc.total_wage); // Set paid amount to total wage
+        } else {
+            frm.set_value('paid_amount', null); // Clear paid amount if not paid
+        }
+    }
 });
 
-
-
 frappe.ui.form.on('Substitution Bill Date', {
-	date: function(frm, cdt, cdn) {
-		// Validate dates and update no_of_days when a date is entered or changed
-		validate_dates(frm);
-	},
-	substitution_bill_date_remove: function(frm) {
-			validate_dates(frm);
-	}
+    date: function(frm, cdt, cdn) {
+        validate_dates(frm);
+    },
+    substitution_bill_date_remove: function(frm) {
+        validate_dates(frm);
+    }
 });
 
 function validate_dates(frm) {
-	let dates = frm.doc.substitution_bill_date.map(row => row.date).filter(date => date);
+    let dates = frm.doc.substitution_bill_date.map(row => row.date).filter(date => date); // Get valid dates
 
-	// Check for duplicate dates
-	let unique_dates = [...new Set(dates)];
-	if (unique_dates.length !== dates.length) {
-		frappe.msgprint({
-			title: __('Message'),
-			message: __('Dates should be unique.'),
-			indicator: 'red'
-		});
-		frm.refresh_field('substitution_bill_date');
-		return;
-	}
+    let unique_dates = [...new Set(dates)]; // Ensure unique dates
+    if (unique_dates.length !== dates.length) {
+        frappe.msgprint({
+            title: __('Message'),
+            message: __('Dates should be unique.'),
+            indicator: 'red'
+        });
+        frm.refresh_field('substitution_bill_date');
+        return;
+    }
 
-	let unique_dates_count = unique_dates.length;
-	frm.set_value('no_of_days', unique_dates_count);
+    // Set the number of unique days
+    let unique_dates_count = unique_dates.length;
+    frm.set_value('no_of_days', unique_dates_count);
 
-	// Calculate the total wage after updating no_of_days
-	calculate_total_wage(frm);
+    calculate_total_wage(frm);
 }
 
 function calculate_total_wage(frm) {
-	let no_of_days = frm.doc.no_of_days;
-	let daily_wage = frm.doc.daily_wage;
+    let no_of_days = frm.doc.no_of_days;
+    let daily_wage = frm.doc.daily_wage;
 
-	if (no_of_days && daily_wage) {
-		// Calculate total wage
-		let total_wage = no_of_days * daily_wage;
-		frm.set_value('total_wage', total_wage);
-	}
+    if (no_of_days && daily_wage) {
+        let total_wage = no_of_days * daily_wage;
+        frm.set_value('total_wage', total_wage); // Update total wage based on number of days and daily wage
+    }
 }

--- a/beams/beams/doctype/substitute_booking/substitute_booking.py
+++ b/beams/beams/doctype/substitute_booking/substitute_booking.py
@@ -2,9 +2,14 @@
 # For license information, please see license.txt
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
 from frappe.desk.form.assign_to import add as add_assign
 from frappe.utils.user import get_users_with_role
+from frappe.utils import getdate, add_days, date_diff
+import json
+from datetime import datetime, date, timedelta
+
 
 class SubstituteBooking(Document):
     def on_submit(self):
@@ -14,6 +19,22 @@ class SubstituteBooking(Document):
         """
         if self.workflow_state == 'Approved':
             self.create_journal_entry_from_substitute_booking()
+
+    def before_validate(self):
+        self.validate_duplicate_assignment()  # Call the method on self
+
+    def validate(self):
+        """
+        This method is called during validation before the document is saved.
+        It sets the 'paid_amount' field based on the 'is_paid' field.
+        """
+        # Check if 'is_paid' is true
+        if self.is_paid:
+            # Set 'paid_amount' to the value of 'total_wage'
+            self.paid_amount = self.total_wage
+        else:
+            # If 'is_paid' is not checked, set 'paid_amount' to None
+            self.paid_amount = None
 
 
     @frappe.whitelist()
@@ -26,40 +47,40 @@ class SubstituteBooking(Document):
         default_debit_account = frappe.db.get_single_value('Beams Accounts Settings', 'default_debit_account')
         # Validate that both debit and credit accounts are configured and different
         if not default_credit_account:
-           frappe.throw("Please configure the Default Credit Account in the Beams Accounts Settings.")
+            frappe.throw("Please configure the Default Credit Account in the Beams Accounts Settings.")
         if not default_debit_account:
             frappe.throw("Please configure the Default Debit Account in the Beams Accounts Settings.")
 
-
-        # Create Journal Entry only if no entry exists
-        journal_entry_exists = frappe.db.exists("Journal Entry", {"substitute_booking_reference": self.name})
+        # Check if a Journal Entry exists for this Substitute Booking, excluding canceled entries
+        journal_entry_exists = frappe.db.exists("Journal Entry", {"substitute_booking_reference": self.name,"docstatus": ["!=", 2] })
         if journal_entry_exists:
             frappe.throw("Journal Entry already exists for this Substitute Booking.")
+        else :
+            if self.is_paid:
+                journal_entry = frappe.new_doc('Journal Entry')
+                journal_entry.substitute_booking_reference = self.name
+                journal_entry.posting_date = frappe.utils.nowdate()
+                journal_entry.append('accounts', {
+                    'account': default_credit_account,
+                    'party_type': 'Employee',
+                    'party': self.substituting_for,
+                    'debit_in_account_currency': 0,
+                    'credit_in_account_currency': self.total_wage,
+                })
+                journal_entry.append('accounts', {
+                    'account': default_debit_account,
+                    'party_type': 'Employee',
+                    'party': self.substituting_for,
+                    'debit_in_account_currency': self.total_wage,
+                    'credit_in_account_currency': 0,
+                })
+                # Insert and submit the Journal Entry
+                journal_entry.insert(ignore_permissions=True)
+                journal_entry.submit()
+                frappe.msgprint(f"Journal Entry {journal_entry.name} has been created successfully.", alert=True)
+            else:
+                frappe.msgprint("Please make the payment to proceed.")
 
-        if self.is_paid:
-            journal_entry = frappe.new_doc('Journal Entry')
-            journal_entry.substitute_booking_reference = self.name
-            journal_entry.posting_date = frappe.utils.nowdate()
-            journal_entry.append('accounts', {
-                'account': default_credit_account,
-                'party_type': 'Employee',
-                'party': self.substituting_for,
-                'debit_in_account_currency': 0,
-                'credit_in_account_currency': self.total_wage,
-            })
-            journal_entry.append('accounts', {
-                'account': default_debit_account,
-                'party_type': 'Employee',
-                'party': self.substituting_for,
-                'debit_in_account_currency': self.total_wage,
-                'credit_in_account_currency': 0,
-            })
-              # Insert and submit the Journal Entry
-            journal_entry.insert(ignore_permissions=True)
-            journal_entry.submit()
-            frappe.msgprint(f"Journal Entry {journal_entry.name} has been created successfully.", alert=True)
-        else:
-            frappe.msgprint("Please make the payment to proceed.")
 
     def before_save(self):
         self.calculate_no_of_days()
@@ -105,18 +126,73 @@ class SubstituteBooking(Document):
                     frappe.throw(f"Employee {employee} is not on leave on {formatted_date}.")
 
     def after_insert(self):
-            self.create_todo_on_creation_for_substitute_booking()
+        self.create_todo_on_creation_for_substitute_booking()
 
     def create_todo_on_creation_for_substitute_booking(self):
-            """
-            Create a ToDo for Accounts Manager when a new Substitute Booking is created.
-            """
-            users = get_users_with_role("Accounts Manager")
-            if users:
-                description = f"New Substitute Booking Created for {self.substituted_by}.<br>Please Review and Update Details or take Necessary Actions."
-                add_assign({
-                    "assign_to": users,
-                    "doctype": "Substitute Booking",
-                    "name": self.name,
-                    "description": description
-                })
+        """
+        Create a ToDo for Accounts Manager when a new Substitute Booking is created.
+        """
+        users = get_users_with_role("Accounts Manager")
+        if users:
+            description = f"New Substitute Booking Created for {self.substituted_by}.<br>Please Review and Update Details or take Necessary Actions."
+            add_assign({
+                "assign_to": users,
+                "doctype": "Substitute Booking",
+                "name": self.name,
+                "description": description
+            })
+
+    def validate_duplicate_assignment(self):
+        # Iterate over each row in the child table 'substitution_bill_date'
+        for row in self.substitution_bill_date:
+            # Check if any other Substitute Booking exists for the same 'substituting_for' and 'date'
+            duplicate_exists = frappe.db.sql("""
+                SELECT
+                    parent
+                FROM
+                    `tabSubstitute Booking`
+                INNER JOIN
+                    `tabSubstitution Bill Date` as sbd
+                ON
+                    sbd.parent = `tabSubstitute Booking`.name
+                WHERE
+                    `tabSubstitute Booking`.substituting_for = %s
+                AND
+                    sbd.date = %s
+                AND
+                    `tabSubstitute Booking`.name != %s
+            """, (self.substituting_for, row.date, self.name))
+
+            # If a duplicate is found, raise an error
+            if duplicate_exists:
+                frappe.throw(_("A substitute is already assigned for {0} on {1}. No duplicate bookings are allowed.")
+                             .format(self.substituting_for, row.date))
+
+
+@frappe.whitelist()
+def check_leave_application(employee, dates):
+    dates = json.loads(dates)  # Parse JSON string into Python list of dates
+    leave_applications = {}
+    missing_dates = []
+
+    # Loop through the provided dates and check for approved leave applications
+    for date in dates:
+        approved_leaves = frappe.get_all("Leave Application",
+            filters={
+                "employee": employee,
+                "status": "Approved",
+                "from_date": ["<=", date],
+                "to_date": [">=", date]
+            },
+            fields=["name", "from_date", "to_date"]
+        )
+
+        if approved_leaves:
+            leave_applications[date] = approved_leaves  # Store approved leaves by date
+        else:
+            missing_dates.append(date)  # No approved leave found for this date
+
+    return {
+        "leave_applications": leave_applications,
+        "missing_dates": missing_dates
+    }

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -182,8 +182,12 @@ doc_events = {
     "Job Requisition": {
         "on_update": "beams.beams.custom_scripts.job_requisition.job_requisition.create_job_opening_from_job_requisition",
         "on_cancel": "beams.beams.custom_scripts.job_requisition.job_requisition.on_workflow_cancel"
+    },
+    "Journal Entry": {
+        "on_cancel": "beams.beams.custom_scripts.journal_entry.journal_entry.on_cancel"
+        }
     }
-}
+
 
 
 # Scheduled Tasks

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -22,6 +22,7 @@ def after_install():
     create_custom_fields(get_voucher_entry_custom_fields(), ignore_validate=True)
     create_custom_fields(get_contract_custom_fields(),ignore_validate=True)
     create_custom_fields(get_department_custom_fields(),ignore_validate=True)
+    create_custom_fields(get_job_requisition_custom_fields(),ignore_validate=True)
     create_custom_fields(get_quotation_item_custom_fields(),ignore_validate=True)
     create_custom_fields(get_job_opening_custom_fields(),ignore_validate=True)
     # create_custom_roles('')

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -22,7 +22,6 @@ def after_install():
     create_custom_fields(get_voucher_entry_custom_fields(), ignore_validate=True)
     create_custom_fields(get_contract_custom_fields(),ignore_validate=True)
     create_custom_fields(get_department_custom_fields(),ignore_validate=True)
-    create_custom_fields(get_job_requisition_custom_fields(),ignore_validate=True)
     create_custom_fields(get_quotation_item_custom_fields(),ignore_validate=True)
     create_custom_fields(get_job_opening_custom_fields(),ignore_validate=True)
     # create_custom_roles('')
@@ -50,8 +49,6 @@ def before_uninstall():
     delete_custom_fields(get_job_requisition_custom_fields())
     delete_custom_fields(get_quotation_item_custom_fields())
     delete_custom_fields(get_job_opening_custom_fields())
-
-
 
 def delete_custom_fields(custom_fields: dict):
     '''
@@ -965,7 +962,6 @@ def get_journal_entry_custom_fields():
         ]
     }
 
-
 def create_custom_roles(role_name):
     """
     Method to create Role , when argument is Passed
@@ -983,8 +979,6 @@ def create_custom_roles(role_name):
 
     frappe.db.commit()
 
- 
- 
 def get_job_requisition_custom_fields():
     '''
     Custom fields that need to be added to the Job Requisition Doctype.
@@ -1002,7 +996,7 @@ def get_job_requisition_custom_fields():
                 "fieldname": "employee_left",
                 "label": "Employees Who Left",
                 "fieldtype": "Table MultiSelect",
-                "options": "Employees Left", 
+                "options": "Employees Left",
                 "insert_after": "request_for",
                 "depends_on": "eval:doc.request_for == 'Employee Exit'"
             },


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- Feature

## Clearly and concisely describe the feature, chore or bug.
When a substitute is assigned for an employee on a specific date, the button must display a filtered list of approved leaves.Also validate Duplicate assignment of substitutes.


## Solution description
- This pull request adds a custom button "Leave Application List" under the "View" dropdown in the "Substitute Booking"     form. 
- The button allows users to view approved leave applications based on dates specified in the child table. 
   If no leave applications are found for the provided dates, an error message is displayed.
-  Also Journal Entry (that is created on approval of this Substitute Booking ) when cancelled updates Is Paid checkbox to    zero.
- Duplicate assignment of substitutes are validated.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/ca4bec0f-d8fe-4220-b406-6fabcfea54db)
/home/zakkiyath/Pictures/Screenshots/Screenshot from 2024-10-08 11-02-48.png
![Uploading image.png…]()

## Areas affected and ensured
- `beams/setup.py`
- `beams/hooks.py`
-beams/doctype/substitute_booking/substitute_booking.js
-beams/doctype/substitute_booking/substitute_booking.py
-beams/custom_scripts/journal_entry/journal_entry.py

## Is there any existing behavior change of other features due to this code change?
- No

## Did you test with the following dataset?
- Existing Data
- New Data

## Is patch required?
- No