### PR TITLE
chore:Set 'status' field in Job Requisition to read-only

### DIFF
--- a/beams/setup.py
+++ b/beams/setup.py
@@ -599,17 +599,9 @@ def get_job_requisition_custom_fields():
                 "label": "Job Description Template",
                 "options": "Job Description Template",
                 "insert_after": "job_description_tab"
-            },
-            {
-                "fieldname": "status",
-                "fieldtype": "Select",
-                "label": "Status",
-                "options": "\nDraft\nPending\nOpen & Approved\nRejected\nOn Hold\nCancelled",
-                "default": "Pending",
-                "read_only": 1
             }
         ]
-}
+    }
 
 def get_contract_custom_fields():
     '''
@@ -735,6 +727,13 @@ def get_property_setters():
         },
         {
             "doctype_or_field": "DocField",
+            "doc_type": "Job Requisition",
+            "field_name": "status",
+            "property": "read_only",
+            "value": 1
+        },
+        {
+            "doctype_or_field": "DocField",
             "doc_type": "Customer",
             "field_name": "disabled",
             "property": "read_only",
@@ -820,6 +819,7 @@ def get_property_setters():
             "property": "read_only",
             "value": 1
         },
+
     ]
 
 def get_material_request_custom_fields():
@@ -983,8 +983,8 @@ def create_custom_roles(role_name):
 
     frappe.db.commit()
 
- 
- 
+
+
 def get_job_requisition_custom_fields():
     '''
     Custom fields that need to be added to the Job Requisition Doctype.
@@ -1002,7 +1002,7 @@ def get_job_requisition_custom_fields():
                 "fieldname": "employee_left",
                 "label": "Employees Who Left",
                 "fieldtype": "Table MultiSelect",
-                "options": "Employees Left", 
+                "options": "Employees Left",
                 "insert_after": "request_for",
                 "depends_on": "eval:doc.request_for == 'Employee Exit'"
             },
@@ -1021,19 +1021,5 @@ def get_job_requisition_custom_fields():
                 "options": "Employee",
                 "insert_after": "staffing_plan",
             },
-            {
-                "fieldname": "posting_date",
-                "label": "Posting Date",
-                "fieldtype": "Date",
-                "insert_after": "requested_by",
-                "read_only": 1
-            },
-            {
-                "fieldname": "status",
-                "label": "Status",
-                "fieldtype": "Select",
-                "options": "\nActive\nInactive\nLeft",
-                "insert_after": "posting_date",
-            }
         ]
    }


### PR DESCRIPTION
## Feature description
-Move 'status' field configuration to property setter in Job Requisition
## Solution description
 -Removed 'status' field configuration from custom fields definition.
 -Added property setter to make 'status' field read-only in the Job Requisition doctype.

## Output
![image](https://github.com/user-attachments/assets/65ddb31c-4c7d-4904-8e75-a6f6886e62ed)
![image](https://github.com/user-attachments/assets/3d2b6310-c47e-485e-88ed-10d443c5ded1)

## Is there any existing behavior change of other features due to this code change?
-no

## Was this feature tested on the browsers?
  - Mozilla Firefox