### PR TITLE
chore:Set 'status' field in Job Requisition to read-only

### DIFF
--- a/beams/setup.py
+++ b/beams/setup.py
@@ -597,17 +597,9 @@ def get_job_requisition_custom_fields():
                 "label": "Job Description Template",
                 "options": "Job Description Template",
                 "insert_after": "job_description_tab"
-            },
-            {
-                "fieldname": "status",
-                "fieldtype": "Select",
-                "label": "Status",
-                "options": "\nDraft\nPending\nOpen & Approved\nRejected\nOn Hold\nCancelled",
-                "default": "Pending",
-                "read_only": 1
             }
         ]
-}
+    }
 
 def get_contract_custom_fields():
     '''
@@ -733,6 +725,13 @@ def get_property_setters():
         },
         {
             "doctype_or_field": "DocField",
+            "doc_type": "Job Requisition",
+            "field_name": "status",
+            "property": "read_only",
+            "value": 1
+        },
+        {
+            "doctype_or_field": "DocField",
             "doc_type": "Customer",
             "field_name": "disabled",
             "property": "read_only",
@@ -818,6 +817,7 @@ def get_property_setters():
             "property": "read_only",
             "value": 1
         },
+
     ]
 
 def get_material_request_custom_fields():
@@ -1016,19 +1016,5 @@ def get_job_requisition_custom_fields():
                 "options": "Employee",
                 "insert_after": "staffing_plan",
             },
-            {
-                "fieldname": "posting_date",
-                "label": "Posting Date",
-                "fieldtype": "Date",
-                "insert_after": "requested_by",
-                "read_only": 1
-            },
-            {
-                "fieldname": "status",
-                "label": "Status",
-                "fieldtype": "Select",
-                "options": "\nActive\nInactive\nLeft",
-                "insert_after": "posting_date",
-            }
         ]
    }

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -597,6 +597,36 @@ def get_job_requisition_custom_fields():
                 "label": "Job Description Template",
                 "options": "Job Description Template",
                 "insert_after": "job_description_tab"
+            },
+            {
+                "fieldname": "request_for",
+                "label": "Request For",
+                "fieldtype": "Select",
+                "options": "\nEmployee Exit\nStaffing Plan\nUnplanned",
+                "insert_after": "naming_series"
+            },
+            {
+                "fieldname": "employee_left",
+                "label": "Employees Who Left",
+                "fieldtype": "Table MultiSelect",
+                "options": "Employees Left",
+                "insert_after": "request_for",
+                "depends_on": "eval:doc.request_for == 'Employee Exit'"
+            },
+            {
+                "fieldname": "staffing_plan",
+                "label": "Staffing Plan",
+                "fieldtype": "Link",
+                "options": "Staffing Plan",
+                "insert_after": "employee_left",
+                "depends_on": "eval:doc.request_for == 'Staffing Plan'"
+            },
+            {
+                "fieldname": "requested_by",
+                "label": "Requested By",
+                "fieldtype": "Link",
+                "options": "Employee",
+                "insert_after": "staffing_plan",
             }
         ]
     }
@@ -979,42 +1009,3 @@ def create_custom_roles(role_name):
             print(f"Role already exists: {role_name}")
 
     frappe.db.commit()
-
-def get_job_requisition_custom_fields():
-    '''
-    Custom fields that need to be added to the Job Requisition Doctype.
-    '''
-    return {
-        "Job Requisition": [
-            {
-                "fieldname": "request_for",
-                "label": "Request For",
-                "fieldtype": "Select",
-                "options": "\nEmployee Exit\nStaffing Plan\nUnplanned",
-                "insert_after": "naming_series"
-            },
-            {
-                "fieldname": "employee_left",
-                "label": "Employees Who Left",
-                "fieldtype": "Table MultiSelect",
-                "options": "Employees Left",
-                "insert_after": "request_for",
-                "depends_on": "eval:doc.request_for == 'Employee Exit'"
-            },
-            {
-                "fieldname": "staffing_plan",
-                "label": "Staffing Plan",
-                "fieldtype": "Link",
-                "options": "Staffing Plan",
-                "insert_after": "employee_left",
-                "depends_on": "eval:doc.request_for == 'Staffing Plan'"
-            },
-            {
-                "fieldname": "requested_by",
-                "label": "Requested By",
-                "fieldtype": "Link",
-                "options": "Employee",
-                "insert_after": "staffing_plan",
-            },
-        ]
-   }


### PR DESCRIPTION
## Feature description
-Move 'status' field configuration to property setter in Job Requisition
-Add new fields to Job Requisition for employee exit, staffing plan, and unplanned requests

## Solution description
 -Removed 'status' field configuration from custom fields definition.
 -Added property setter to make 'status' field read-only in the Job Requisition doctype.
 -Added "Request For" field as a Select option with values: Employee Exit, Staffing Plan, and Unplanned.
- Introduced "Employees Who Left" as a Table MultiSelect, shown only when "Request For" is set to "Employee Exit."
- Added "Staffing Plan" Link field, displayed when "Request For" is set to "Staffing Plan."
- Included "Requested By" field after the Staffing Plan.

## Output
![image](https://github.com/user-attachments/assets/65ddb31c-4c7d-4904-8e75-a6f6886e62ed)
![image](https://github.com/user-attachments/assets/3d2b6310-c47e-485e-88ed-10d443c5ded1)
![image](https://github.com/user-attachments/assets/5459857e-f1c0-499a-933e-68e5efb54559)

## Is there any existing behavior change of other features due to this code change?
-no

## Was this feature tested on the browsers?
  - Mozilla Firefox