### PR TITLE
fix:Update autoname format for Division doctype

### DIFF
--- a/beams/beams/doctype/division/division.json
+++ b/beams/beams/doctype/division/division.json
@@ -1,7 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
- "autoname": "format:Division-{department_abbreviation}",
+ "autoname": "format:{division}-{department_abbreviation}",
  "creation": "2024-10-01 10:39:21.831573",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -35,7 +35,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-10-02 09:33:19.901503",
+ "modified": "2024-10-11 08:58:05.387867",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Division",


### PR DESCRIPTION
## Feature description
 -Update autoname format in Division doctype

## Solution description
 - Changed autoname to "{division}-{department_abbreviation}" for improved naming clarity and consistency.
 
## Output
![image](https://github.com/user-attachments/assets/9db1c445-0749-4ac2-a7f6-b7af20f49624)
![image](https://github.com/user-attachments/assets/ba627360-3abf-4a1a-860c-1ee8f0c36e95)

## Is there any existing behavior change of other features due to this code change?
-yes.

## Was this feature tested on the browsers?
  - Mozilla Firefox