### PR TITLE
feat:Validated  'Employees who Left field' in Job Requisition

### DIFF
--- a/beams/beams/custom_scripts/job_requisition/job_requisition.py
+++ b/beams/beams/custom_scripts/job_requisition/job_requisition.py
@@ -1,11 +1,23 @@
 import frappe
 from frappe.utils import nowdate
+from frappe import ValidationError
+
+
+def validate_job_requisition(doc, method):
+    # Adjusted to use request_for instead of request_type
+    if doc.request_for == 'Employee Exit':
+        if not doc.employee_left:
+            raise ValidationError("Please select at least one employee who has left.")
+    else:
+        doc.employee_left = []
+
+
 
 @frappe.whitelist()
 def create_job_opening_from_job_requisition(doc, method):
     '''
     Create a Job Opening when the Job Requisition is approved.
-    
+
     '''
     if doc.workflow_state == "Approved":
         job_opening = frappe.new_doc('Job Opening')

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -181,7 +181,8 @@ doc_events = {
     },
     "Job Requisition": {
         "on_update": "beams.beams.custom_scripts.job_requisition.job_requisition.create_job_opening_from_job_requisition",
-        "on_cancel": "beams.beams.custom_scripts.job_requisition.job_requisition.on_workflow_cancel"
+        "on_cancel": "beams.beams.custom_scripts.job_requisition.job_requisition.on_workflow_cancel",
+        "validate":  "beams.beams.custom_scripts.job_requisition.job_requisition.validate_job_requisition"
     },
     "Journal Entry": {
         "on_cancel": "beams.beams.custom_scripts.journal_entry.journal_entry.on_cancel"

--- a/beams/public/js/job_requisition.js
+++ b/beams/public/js/job_requisition.js
@@ -1,5 +1,30 @@
 
 frappe.ui.form.on('Job Requisition', {
+    refresh: function(frm) {
+        // Set the query for employee_left based on request_for
+        frm.set_query('employee_left', function() {
+            if (frm.doc.request_for === 'Employee Exit') {
+                return {
+                    filters: {
+                        status: 'Left'  // Assuming 'status' is the field that indicates the employee's status
+                    }
+                };
+            } else {
+                return {
+                    filters: {
+                        // No filter if it's not Employee Exit
+                    }
+                };
+            }
+        });
+    },
+
+    request_for: function(frm) {
+        // When request_for changes, reset the employee_left field
+        frm.set_value('employee_left', []);
+        frm.refresh_field('employee_left');  // Refresh the field to apply the new query
+    },
+
     /*
      * This function triggers when the designation field is changed.
      * It sets a filter for the Job Description Template based on the selected designation.
@@ -36,20 +61,6 @@ frappe.ui.form.on('Job Requisition', {
         }
     },
 
-    /*
-     * This function triggers when the Job Description Template field is changed.
-     * It fetches the employee who's status is Left
-     */
-
-    refresh: function(frm) {
-         frm.set_query('employee_left', function() {
-             return {
-                 filters: {
-                     status: 'Left'
-                 }
-             };
-         });
-    },
     onload: function(frm) {
       if (!frm.doc.requested_by) {
         // Fetch the Employee linked to the current User

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -511,6 +511,7 @@ def get_job_requisition_custom_fields():
                 "fieldname": "no_of_days_off",
                 "fieldtype": "Int",
                 "label": "Number of Days Off",
+                "description": "Number of days off in 30 days.",
                 "insert_after": "employment_type"
             },
             {
@@ -589,6 +590,7 @@ def get_job_requisition_custom_fields():
                 "fieldtype": "Table",
                 "options": "Skill Proficiency",
                 "label": "Skill Proficiency",
+                "description": "Proficency selected here is the minimum proficency needed.",
                 "insert_after": "language_proficiency"
             },
             {
@@ -627,7 +629,14 @@ def get_job_requisition_custom_fields():
                 "fieldtype": "Link",
                 "options": "Employee",
                 "insert_after": "staffing_plan",
-            }
+            },
+             {
+                "fieldname": "location",
+                "label": "Location",
+                "fieldtype": "Link",
+                "options": "Location",
+                "insert_after": "no_of_days_off",  # Adjust based on your form layout
+            },
         ]
     }
 


### PR DESCRIPTION
## Feature description

1. Apply validation for 'Employees who Left field' in Job Requisition(in Server side and Client side).
2. Customise Job Requisition Doctype:Add fields in Job Requisition

 - Location(Link,Options-Locations)
 - Add Description for Skill Field-"Proficiency selected here is the minimum proficiency needed".
 - Add description Number of days off in 30 days for No of Days off field.

## Solution description

Server-Side Validation Logic:
The employee_left field will be reset to an empty list to ensure the field is not populated in non-exit cases.
Client-side: When the request_for field is updated, the employee_left field is reset to an empty list.

New Fields Added:
 - Location(Link,Options-Locations)
 - Added Description for Skill Field-"Proficency selected here is the minimum proficency needed".
 -  Added  description Number of days off in 30 days for No of Days off field.


## Output
![image](https://github.com/user-attachments/assets/b8ac1b3c-92b2-45c2-94dd-740e0873b4a7)
![image](https://github.com/user-attachments/assets/06345ce7-8aff-4975-a5a6-856484dd42aa)
![image](https://github.com/user-attachments/assets/a6bf3536-140e-4999-b0ce-75a6e24fc9e2)
![image](https://github.com/user-attachments/assets/8e09bdc8-7800-4b32-af89-7764b6adbc75)


## Areas affected and ensured
-Task form UI, including the navbar where the timer is displayed.

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox