### PR TITLE
fix: Fixed the filter for Job Description Template in Job Requisition doctype

### DIFF
--- a/beams/public/js/job_requisition.js
+++ b/beams/public/js/job_requisition.js
@@ -17,19 +17,10 @@ frappe.ui.form.on('Job Requisition', {
                 };
             }
         });
-    },
-
-    request_for: function(frm) {
-        // When request_for changes, reset the employee_left field
-        frm.set_value('employee_left', []);
-        frm.refresh_field('employee_left');  // Refresh the field to apply the new query
-    },
-
-    /*
-     * This function triggers when the designation field is changed.
-     * It sets a filter for the Job Description Template based on the selected designation.
-     */
-    designation: function(frm) {
+        /*
+         * Sets a filter on the Job Description Template field based on the Designation .
+         * Clears the Job Description Template field when the form is refreshed,
+         */
         frm.set_query('job_description_template', function() {
             return {
                 filters: {
@@ -37,11 +28,12 @@ frappe.ui.form.on('Job Requisition', {
                 }
             };
         });
-        // Refresh the Job Description Template field to apply the new filter
-        frm.refresh_field('job_description_template');
+    },
 
-        // Clear the current selection in Job Description Template if designation changes
-        frm.set_value('job_description_template', null);
+    request_for: function(frm) {
+        // When request_for changes, reset the employee_left field
+        frm.set_value('employee_left', []);
+        frm.refresh_field('employee_left');  // Refresh the field to apply the new query
     },
 
     /*
@@ -60,7 +52,6 @@ frappe.ui.form.on('Job Requisition', {
             );
         }
     },
-
     onload: function(frm) {
       if (!frm.doc.requested_by) {
         // Fetch the Employee linked to the current User


### PR DESCRIPTION
## Issue description

- Fixed the Implementation of filter for Job Description Template in Job Requisition doctype

-  Need to Clears the Job Description Template field when the form is refreshed in Job Requistion doctype.

## Solution description

1. Changed the event for filter the job description template in the job Requisition Doctype
 
 -  Sets a filter on the Job Description Template field based on the Designation in refresh event via job requisition.js
 
 -   Clears the Job Description Template field when the form is refreshed via job requisition.js
 
2. Added a docstring to describe the function purpose in Job Requisiton .js

## Output

[Screencast from 14-10-24 12:02:44 PM IST.webm](https://github.com/user-attachments/assets/801f9017-b8d7-431e-91c9-8f2183ee4dd7)

[Screencast from 14-10-24 11:47:39 AM IST.webm](https://github.com/user-attachments/assets/6ba442f7-ec76-442d-9051-8f37bb5033d5)

## Areas affected and ensured

-Filter the job description template in the Job Requisition Doctype

## Is there any existing behavior change of other features due to this code change?

- Job Requisition .js

## Was this feature tested on the browsers?

  - Mozilla Firefox