### PR TITLE
fix : Update Batta Claim and Sales Order

### DIFF
--- a/beams/beams/doctype/batta_claim/batta_claim.js
+++ b/beams/beams/doctype/batta_claim/batta_claim.js
@@ -84,6 +84,7 @@ frappe.ui.form.on('Batta Claim', {
         frm.refresh_field('work_detail');
         set_batta_based_on_options(frm);
         handle_designation_based_on_batta_type(frm);
+        frm.set_value('batta', 0);
     },
     employee: function (frm) {
         handle_designation_based_on_batta_type(frm);

--- a/beams/beams/doctype/batta_claim/batta_claim.json
+++ b/beams/beams/doctype/batta_claim/batta_claim.json
@@ -75,6 +75,7 @@
    "options": "Employee"
   },
   {
+   "depends_on": "eval:doc.batta_type == \"Internal\"",
    "fetch_from": "employee.employee_name",
    "fieldname": "employee_name",
    "fieldtype": "Data",
@@ -283,7 +284,7 @@
    "link_fieldname": "batta_claim_reference"
   }
  ],
- "modified": "2024-10-04 14:56:54.663716",
+ "modified": "2024-10-10 11:01:24.580594",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Batta Claim",

--- a/beams/beams/doctype/batta_claim/batta_claim.py
+++ b/beams/beams/doctype/batta_claim/batta_claim.py
@@ -94,10 +94,10 @@ class BattaClaim(Document):
         total_daily_batta = 0
         total_ot_batta = 0
 
-        # Loop through the work_detail child table
+        # Loop through the work_detail child table and ensure default values are integers
         for row in doc.get('work_detail', []):
-            total_daily_batta += row.get('daily_batta', 0)
-            total_ot_batta += row.get('ot_batta', 0)
+            total_daily_batta += row.get('daily_batta', 0) or 0
+            total_ot_batta += row.get('ot_batta', 0) or 0
 
         # Total batta is the sum of total_daily_batta and total_ot_batta
         total_driver_batta = total_daily_batta + total_ot_batta
@@ -212,4 +212,4 @@ def calculate_batta_allowance(designation, is_travelling_outside_kerala, is_over
 @frappe.whitelist()
 def get_batta_policy_values():
     result = frappe.db.get_value('Batta Policy', {}, ['is_actual', 'is_actual_', 'is_actual__', 'is_actual___'], as_dict=True)
-    return result    
+    return result

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -137,8 +137,8 @@ before_uninstall = "beams.uninstall.before_uninstall"
 doc_events = {
     "Sales Invoice": {
         "on_update_after_submit":"beams.beams.custom_scripts.sales_invoice.sales_invoice.on_update_after_submit",
-        "autoname": "beams.beams.custom_scripts.sales_invoice.sales_invoice.autoname"
-
+        "autoname": "beams.beams.custom_scripts.sales_invoice.sales_invoice.autoname",
+        "before_save": "beams.beams.custom_scripts.sales_invoice.sales_invoice.validate_sales_invoice_for_barter"
     },
     "Quotation": {
         "validate": "beams.beams.custom_scripts.quotation.quotation.validate_is_barter",

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -138,7 +138,7 @@ doc_events = {
     "Sales Invoice": {
         "on_update_after_submit":"beams.beams.custom_scripts.sales_invoice.sales_invoice.on_update_after_submit",
         "autoname": "beams.beams.custom_scripts.sales_invoice.sales_invoice.autoname",
-        "before_save": "beams.beams.custom_scripts.sales_invoice.sales_invoice.validate_sales_invoice_for_barter"
+        "validate": "beams.beams.custom_scripts.sales_invoice.sales_invoice.validate_sales_invoice_for_barter"
     },
     "Quotation": {
         "validate": "beams.beams.custom_scripts.quotation.quotation.validate_is_barter",

--- a/beams/public/js/sales_order.js
+++ b/beams/public/js/sales_order.js
@@ -12,9 +12,24 @@ frappe.ui.form.on('Sales Order', {
             callback: function(r) {
                 if (r.message && r.message.length > 0) {
                     let overdue_invoices = r.message;
-                    let message = "<b>Overdue Sales Invoices found:</b><br>";
-                    overdue_invoices.forEach(invoice => {
-                        message += `<a href="/app/sales-invoice/${invoice.name}" style="color:red;">${invoice.name}</a> - ${invoice.due_date}<br>`;
+                    let message = "<b>Overdue Sales Invoices found:</b>";
+
+                    overdue_invoices.forEach((invoice, index) => {
+                        // Convert the due date to a proper date object
+                        let due_date = new Date(invoice.due_date);
+
+                        // Manually format the date as dd-mm-yy
+                        let day = ("0" + due_date.getDate()).slice(-2);
+                        let month = ("0" + (due_date.getMonth() + 1)).slice(-2);
+                        let year = due_date.getFullYear().toString().slice(-2);
+
+                        let formatted_due_date = `${day}-${month}-${year}`;
+
+                        // Add comma after each sales invoice except the last one
+                        message += `<a href="/app/sales-invoice/${invoice.name}" style="color:red;">${invoice.name}</a> - (${formatted_due_date})`;
+                        if (index < overdue_invoices.length - 1) {
+                            message += ", ";
+                        }
                     });
 
                     frm.dashboard.set_headline_alert(message, 'red');
@@ -22,7 +37,6 @@ frappe.ui.form.on('Sales Order', {
             }
         });
     }
-
     // Check if the Sales Order is being created from a Quotation (i.e., reference_id is set)
     if (frm.doc.reference_id) {
       frm.set_df_property('customer', 'read_only', 1);


### PR DESCRIPTION
 ## Feature description
-Update Batta claim Doctype and sales order.

## Solution Description
-Added validation for barter Sales Invoice to ensure corresponding Purchase Invoice exists
-Set batta to 0 upon changing batta_type in Batta Claim doctype
-Hide Employee name in batta claim when the batta type is external.
-Updated Overdue Invoice Alert in sales order.

## Output
![image](https://github.com/user-attachments/assets/b920709e-4a95-41f9-a4c8-2acd8ec1412f)
![image](https://github.com/user-attachments/assets/40733fc7-5529-4caa-a209-dd1c006e81e6)
![image](https://github.com/user-attachments/assets/4dcf8de8-2d1e-4e40-bd53-2246a70f70e8)

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
- Mozilla Firefox