### PR TITLE
fix:Made Educational Qualification field as MultiSelect 

### DIFF
--- a/beams/setup.py
+++ b/beams/setup.py
@@ -651,14 +651,14 @@ def get_job_applicant_custom_fields():
     '''
     return {
         "Job Applicant": [
-
             {
-                "fieldname": "min_education_qual",
-                "fieldtype": "Link",
+               "fieldname": "min_education_qual",
+                "fieldtype": "Table MultiSelect",
                 "label": "Minimum Educational Qualification",
-                "options": "Educational Qualification",
-                "insert_after": "details_column_break"
+                'options':"Educational Qualifications",
+                "insert_after": "details"
             },
+
             {
                 "fieldname": "details",
                 "fieldtype": "Section Break",
@@ -670,11 +670,17 @@ def get_job_applicant_custom_fields():
                 "fieldname": "min_experience",
                 "fieldtype": "Float",
                 "label": "Minimum Experience Required",
-                "insert_after": "details"
+                "insert_after": "details_column_break"
             },
             {
                 "fieldname": "details_column_break",
                 "fieldtype": "Column Break",
+                "label": "",
+                "insert_after": "min_education_qual"
+            },
+            {
+                "fieldname": "reset_column",
+                "fieldtype": "Section Break",
                 "label": "",
                 "insert_after": "min_experience"
             },
@@ -693,7 +699,7 @@ def get_job_applicant_custom_fields():
                 "options": "Skill Proficiency",
                 "label": "Skill Proficiency",
                 "reqd":1,
-                "insert_after": "min_experience"
+                "insert_after": "language_proficiency"
             },
              {
                 "fieldname": "location",


### PR DESCRIPTION

## Feature description
Make Educational Qualification field as MultiSelect
 Rearrange child tables Skill Proficiency and Language Proficiency  in Job Applicant doctype

## Solution description
 The field Educational Qualification is made as a multiselect field which has link with Educational Qualifications childtable.

## Output
![image](https://github.com/user-attachments/assets/ebd51e52-7817-4a64-8c35-0cd61f8ff4af)

## Areas affected and ensured
-Task form UI, including the navbar where the timer is displayed.

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox