### PR TITLE
feat: Restrict Job Applicant Visibility

### DIFF
--- a/beams/beams/custom_scripts/job_applicant/job_applicant.py
+++ b/beams/beams/custom_scripts/job_applicant/job_applicant.py
@@ -23,24 +23,4 @@ def get_permission_query_conditions(user):
     return None
 
 
-def has_permission(doc, user, ptype="read"):
-    user_roles = frappe.get_roles(user)
 
-    
-    if "Administrator" in user_roles:
-        return True
-
-    
-    if "Interviewer" in user_roles:
-        
-        if frappe.db.exists('ToDo', {
-            'reference_type': 'Job Applicant',
-            'reference_name': doc.name,
-            'allocated_to': user
-        }):
-            
-            if ptype in ["read", "write"]:
-                return True
-    
-    
-    return False

--- a/beams/beams/custom_scripts/job_applicant/job_applicant.py
+++ b/beams/beams/custom_scripts/job_applicant/job_applicant.py
@@ -1,0 +1,46 @@
+import frappe
+
+def get_permission_query_conditions(user):
+    if not user:
+        user = frappe.session.user
+    
+    user_roles = frappe.get_roles(user)
+    
+    
+    if "Administrator" in user_roles:
+        return ""
+
+    
+    if "Interviewer" in user_roles:
+        return f"""
+        `tabJob Applicant`.name IN (
+            SELECT reference_name 
+            FROM `tabToDo`
+            WHERE reference_type = 'Job Applicant'
+            AND allocated_to = '{user}'
+        )
+        """
+    return None
+
+
+def has_permission(doc, user, ptype="read"):
+    user_roles = frappe.get_roles(user)
+
+    
+    if "Administrator" in user_roles:
+        return True
+
+    
+    if "Interviewer" in user_roles:
+        
+        if frappe.db.exists('ToDo', {
+            'reference_type': 'Job Applicant',
+            'reference_name': doc.name,
+            'allocated_to': user
+        }):
+            
+            if ptype in ["read", "write"]:
+                return True
+    
+    
+    return False

--- a/beams/beams/doctype/local_enquiry_report/local_enquiry_report.js
+++ b/beams/beams/doctype/local_enquiry_report/local_enquiry_report.js
@@ -1,8 +1,9 @@
 // Copyright (c) 2024, efeone and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Local Enquiry Report", {
-// 	refresh(frm) {
+frappe.ui.form.on("Local Enquiry Report", {
+	onload(frm) {
+        frm.set_value('information_collected_by', frappe.session.user);
 
-// 	},
-// });
+	},
+});

--- a/beams/beams/doctype/local_enquiry_report/local_enquiry_report.json
+++ b/beams/beams/doctype/local_enquiry_report/local_enquiry_report.json
@@ -41,10 +41,12 @@
    "label": "Remarks"
   },
   {
+   "fetch_from": "job_applicant.applicant_name",
    "fieldname": "job_applicant_name",
    "fieldtype": "Link",
    "label": "Job Applicant Name",
-   "options": "Job Applicant"
+   "options": "Job Applicant",
+   "read_only": 1
   },
   {
    "fieldname": "designation",
@@ -82,7 +84,8 @@
    "fieldname": "information_collected_by",
    "fieldtype": "Link",
    "label": "Information Collected By",
-   "options": "Employee"
+   "options": "Employee",
+   "read_only": 1
   },
   {
    "fieldname": "section_break_2hnf",
@@ -95,7 +98,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-10-15 10:34:17.158722",
+ "modified": "2024-10-16 11:52:48.316033",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Local Enquiry Report",

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -120,7 +120,7 @@ permission_query_conditions = {
 }
 
 # has_permission = {
-# 	"Job Applicant": "beams.beams.custom_scripts.job_applicant.job_applicant.has_permission",
+# 	
 # }
 
 # DocType Class

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -115,12 +115,12 @@ before_uninstall = "beams.uninstall.before_uninstall"
 # -----------
 # Permissions evaluated in scripted ways
 
-# permission_query_conditions = {
-# 	"Event": "frappe.desk.doctype.event.event.get_permission_query_conditions",
-# }
-#
+permission_query_conditions = {
+	"Job Applicant": "beams.beams.custom_scripts.job_applicant.job_applicant.get_permission_query_conditions",
+}
+
 # has_permission = {
-# 	"Event": "frappe.desk.doctype.event.event.has_permission",
+# 	"Job Applicant": "beams.beams.custom_scripts.job_applicant.job_applicant.has_permission",
 # }
 
 # DocType Class


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
Feature

## Clearly and concisely describe the feature, chore or bug.

Restrict Job Applicant Visibility Using Permission Query Condition  
Only allow the interviewer to view and edit the job applicant , assigned to

## Solution description

Implemented the logic using permission query condition.
allowed only the job applicant to visible to interviewer that thay got assigned

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/57ff39c7-869d-470b-898e-459b4a6d176e)
 

## Areas affected and ensured
beams/hooks.py
beams/beams/custom_scripts/job_applicant/

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
Existing Data
New Data

## Is patch required?
No