### PR TITLE
fix : Update Accounts Module

### DIFF
--- a/beams/beams/custom_scripts/customer_dashboard/customer_dashboard.py
+++ b/beams/beams/custom_scripts/customer_dashboard/customer_dashboard.py
@@ -1,0 +1,22 @@
+from frappe import _
+
+
+def get_data(data=None):
+	return {
+		"fieldname": "customer",
+		"non_standard_fieldnames": {
+			"Payment Entry": "party",
+			"Quotation": "party_name",
+			"Opportunity": "party_name",
+			"Bank Account": "party",
+			"Subscription": "party",
+		},
+		"dynamic_links": {"party_name": ["Customer", "quotation_to"]},
+		"transactions": [
+			{"label": _("Pre Sales"), "items": ["Opportunity", "Quotation"]},
+			{"label": _("Orders"), "items": ["Sales Order", "Sales Invoice"]},
+			{"label": _("Payments"), "items": ["Payment Entry", "Bank Account"]},
+			{"label": _("Projects"), "items": ["Project"]},
+			{"label": _("Pricing"), "items": ["Pricing Rule"]},
+		],
+	}

--- a/beams/beams/custom_scripts/item_dashboard/item_dashboard.py
+++ b/beams/beams/custom_scripts/item_dashboard/item_dashboard.py
@@ -1,0 +1,35 @@
+from frappe import _
+
+
+def get_data(data=None):
+	return {
+		"heatmap": True,
+		"heatmap_message": _("This is based on stock movement. See {0} for details").format(
+			'<a href="/app/query-report/Stock Ledger">' + _("Stock Ledger") + "</a>"
+		),
+		"fieldname": "item_code",
+		"non_standard_fieldnames": {
+			"Work Order": "production_item",
+			"Product Bundle": "new_item_code",
+			"BOM": "item",
+			"Batch": "item",
+		},
+		"transactions": [
+			{"label": _("Groups"), "items": ["Item Alternative"]},
+			{"label": _("Pricing"), "items": ["Item Price", "Pricing Rule"]},
+			{"label": _("Sell"), "items": ["Quotation", "Sales Order", "Sales Invoice"]},
+			{
+				"label": _("Buy"),
+				"items": [
+					"Material Request",
+					"Supplier Quotation",
+					"Request for Quotation",
+					"Purchase Order",
+					"Purchase Receipt",
+					"Purchase Invoice",
+				],
+			},
+			{"label": _("Traceability"), "items": ["Serial No", "Batch"]},
+			{"label": _("Stock Movement"), "items": ["Stock Entry", "Stock Reconciliation"]},
+		],
+	}

--- a/beams/beams/custom_scripts/sales_invoice_dashboard/sales_invoice_dashboard.py
+++ b/beams/beams/custom_scripts/sales_invoice_dashboard/sales_invoice_dashboard.py
@@ -1,0 +1,38 @@
+from frappe import _
+
+def get_data(data=None):
+    return {
+        "fieldname": "sales_invoice",
+        "non_standard_fieldnames": {
+            "Delivery Note": "against_sales_invoice",
+            "Journal Entry": "reference_name",
+            "Payment Entry": "reference_name",
+            "Payment Request": "reference_name",
+            "Sales Invoice": "return_against",
+            "Auto Repeat": "reference_document",
+            "Purchase Invoice": "inter_company_invoice_reference",
+        },
+        "internal_links": {
+            "Sales Order": ["items", "sales_order"],
+            "Timesheet": ["timesheets", "time_sheet"],
+        },
+        "internal_and_external_links": {
+            "Delivery Note": ["items", "delivery_note"],
+        },
+        "transactions": [
+            {
+                "label": _("Payment"),
+                "items": [
+                    "Payment Entry",
+                    "Payment Request",
+                    "Journal Entry",
+                    "Invoice Discounting",
+                    "Dunning",
+                ],
+            },
+            {"label": _("Reference"), "items": ["Timesheet", "Sales Order"]},
+            {"label": _("Returns"), "items": ["Sales Invoice"]},
+            {"label": _("Subscription"), "items": ["Auto Repeat"]},
+            {"label": _("Internal Transfers"), "items": ["Purchase Invoice"]},
+        ],
+    }

--- a/beams/beams/custom_scripts/sales_order_dashboard/sales_order_dashboard.py
+++ b/beams/beams/custom_scripts/sales_order_dashboard/sales_order_dashboard.py
@@ -1,0 +1,30 @@
+from frappe import _
+
+
+def get_data(data=None):
+	return {
+		"fieldname": "sales_order",
+		"non_standard_fieldnames": {
+			"Delivery Note": "against_sales_order",
+			"Journal Entry": "reference_name",
+			"Payment Entry": "reference_name",
+			"Payment Request": "reference_name",
+			"Auto Repeat": "reference_document",
+			"Maintenance Visit": "prevdoc_docname",
+			"Stock Reservation Entry": "voucher_no",
+		},
+		"internal_links": {
+			"Quotation": ["items", "prevdoc_docname"],
+		},
+		"transactions": [
+			{
+				"label": _("Fulfillment"),
+				"items": ["Sales Invoice", "Pick List", "Maintenance Visit"],
+			},
+			{"label": _("Purchasing"), "items": ["Material Request", "Purchase Order"]},
+			{"label": _("Projects"), "items": ["Project"]},
+			{"label": _("Manufacturing"), "items": ["Work Order"]},
+			{"label": _("Reference"), "items": ["Quotation", "Auto Repeat", "Stock Reservation Entry"]},
+			{"label": _("Payment"), "items": ["Payment Entry", "Payment Request", "Journal Entry"]},
+		],
+	}

--- a/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.json
+++ b/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.json
@@ -6,20 +6,23 @@
  "engine": "InnoDB",
  "field_order": [
   "adhoc_budget_threshold",
+  "default_sales_invoice_print_format",
+  "column_break_eqou",
   "equalize_purchase_and_quotation_amounts",
   "single_sales_order",
-  "batta_payable_account",
-  "batta_expense_account",
-  "default_sales_invoice_print_format",
   "tab_break_4hid",
   "default_working_hours",
   "batta_claim_service_item",
-  "stringer_service_item",
+  "column_break_jaqb",
+  "batta_expense_account",
+  "batta_payable_account",
   "naming_rule_tab",
   "beams_naming_rule",
   "substitute_booking_tab",
   "default_credit_account",
-  "default_debit_account"
+  "default_debit_account",
+  "stringer_settings_tab",
+  "stringer_service_item"
  ],
  "fields": [
   {
@@ -37,7 +40,7 @@
   {
    "fieldname": "tab_break_4hid",
    "fieldtype": "Tab Break",
-   "label": "Work Settings"
+   "label": "Batta Settings"
   },
   {
    "fieldname": "default_working_hours",
@@ -108,12 +111,25 @@
    "fieldname": "single_sales_order",
    "fieldtype": "Check",
    "label": "Single Sales Order"
+  },
+  {
+   "fieldname": "stringer_settings_tab",
+   "fieldtype": "Tab Break",
+   "label": "Stringer Settings"
+  },
+  {
+   "fieldname": "column_break_eqou",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_jaqb",
+   "fieldtype": "Column Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-10-07 11:39:50.058277",
+ "modified": "2024-10-16 14:57:42.229657",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Beams Accounts Settings",

--- a/beams/beams/doctype/stringer_bill/stringer_bill.json
+++ b/beams/beams/doctype/stringer_bill/stringer_bill.json
@@ -14,11 +14,12 @@
   "bureau",
   "cost_center",
   "section_break_zcc8",
-  "on_air_date_and_time",
   "news_remarks",
   "column_break_cgfc",
   "daily_wage",
-  "amended_from"
+  "amended_from",
+  "section_break_njgm",
+  "stringer_bill_detail"
  ],
  "fields": [
   {
@@ -83,11 +84,6 @@
    "label": "News Remarks"
   },
   {
-   "fieldname": "on_air_date_and_time",
-   "fieldtype": "Datetime",
-   "label": "On Air Date and Time"
-  },
-  {
    "fieldname": "amended_from",
    "fieldtype": "Link",
    "label": "Amended From",
@@ -96,6 +92,16 @@
    "print_hide": 1,
    "read_only": 1,
    "search_index": 1
+  },
+  {
+   "fieldname": "section_break_njgm",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "stringer_bill_detail",
+   "fieldtype": "Table",
+   "label": "Stringer Bill Detail",
+   "options": "Stringer Bill Detail"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -106,7 +112,7 @@
    "link_fieldname": "stringer_bill_reference"
   }
  ],
- "modified": "2024-09-18 16:11:38.332043",
+ "modified": "2024-10-17 09:39:46.949991",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Stringer Bill",

--- a/beams/beams/doctype/stringer_bill_detail/stringer_bill_detail.json
+++ b/beams/beams/doctype/stringer_bill_detail/stringer_bill_detail.json
@@ -1,0 +1,52 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2024-10-17 09:32:44.266003",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "date",
+  "on_air_date_and_time",
+  "subject",
+  "title"
+ ],
+ "fields": [
+  {
+   "fieldname": "date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "Date"
+  },
+  {
+   "fieldname": "on_air_date_and_time",
+   "fieldtype": "Datetime",
+   "in_list_view": 1,
+   "label": "On Air Date and Time"
+  },
+  {
+   "fieldname": "subject",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Subject"
+  },
+  {
+   "fieldname": "title",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Title"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2024-10-17 09:37:30.537112",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "Stringer Bill Detail",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/beams/beams/doctype/stringer_bill_detail/stringer_bill_detail.py
+++ b/beams/beams/doctype/stringer_bill_detail/stringer_bill_detail.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class StringerBillDetail(Document):
+	pass

--- a/beams/beams/workspace/beams/beams.json
+++ b/beams/beams/workspace/beams/beams.json
@@ -5,7 +5,7 @@
    "label": "Quotation Is Barter"
   }
  ],
- "content": "[{\"id\":\"mM37igfJxh\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\">BEAMS</span>\",\"col\":12}},{\"id\":\"mYOrBb92TB\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Account\",\"col\":3}},{\"id\":\"WLO_tZBeIe\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Beams Accounts Settings\",\"col\":3}},{\"id\":\"OihJCscygq\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Budget\",\"col\":3}},{\"id\":\"KVIBfudYxi\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Adhoc Budget\",\"col\":3}},{\"id\":\"AU3IgQiL8w\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Batta Claim\",\"col\":3}},{\"id\":\"y1KpAUVh-r\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"Qf4-cjQ8K_\",\"type\":\"card\",\"data\":{\"card_name\":\"Employees\",\"col\":6}},{\"id\":\"CVVtbAAAyD\",\"type\":\"card\",\"data\":{\"card_name\":\"Selling & Buying\",\"col\":6}},{\"id\":\"gc6Nr4BsjN\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"jNk-0qCCN-\",\"type\":\"chart\",\"data\":{\"chart_name\":\"Quotation Is Barter\",\"col\":12}}]",
+ "content": "[{\"id\":\"mM37igfJxh\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\">BEAMS</span>\",\"col\":12}},{\"id\":\"mYOrBb92TB\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Account\",\"col\":3}},{\"id\":\"WLO_tZBeIe\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Beams Accounts Settings\",\"col\":3}},{\"id\":\"OihJCscygq\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Budget\",\"col\":3}},{\"id\":\"KVIBfudYxi\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Adhoc Budget\",\"col\":3}},{\"id\":\"AU3IgQiL8w\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Batta Claim\",\"col\":3}},{\"id\":\"97_E879z_e\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Batta Policy\",\"col\":3}},{\"id\":\"k4gKNeLbJK\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Albatross Settings\",\"col\":3}},{\"id\":\"7ww0mBjFgz\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Contract\",\"col\":3}},{\"id\":\"y1KpAUVh-r\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"Qf4-cjQ8K_\",\"type\":\"card\",\"data\":{\"card_name\":\"Employees\",\"col\":3}},{\"id\":\"rBG0GFGfuj\",\"type\":\"card\",\"data\":{\"card_name\":\"Stringer Billing & Substitues\",\"col\":4}},{\"id\":\"CVVtbAAAyD\",\"type\":\"card\",\"data\":{\"card_name\":\"Selling & Buying\",\"col\":5}},{\"id\":\"gc6Nr4BsjN\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"jNk-0qCCN-\",\"type\":\"chart\",\"data\":{\"chart_name\":\"Quotation Is Barter\",\"col\":12}}]",
  "creation": "2024-08-29 09:58:35.022181",
  "custom_blocks": [],
  "docstatus": 0,
@@ -61,7 +61,7 @@
    "hidden": 0,
    "is_query_report": 0,
    "label": "Selling & Buying",
-   "link_count": 3,
+   "link_count": 4,
    "link_type": "DocType",
    "onboard": 0,
    "type": "Card Break"
@@ -95,9 +95,48 @@
    "link_type": "DocType",
    "onboard": 0,
    "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Sales Order",
+   "link_count": 0,
+   "link_to": "Sales Order",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Stringer Billing & Substitues",
+   "link_count": 2,
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Card Break"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Stringer Bill",
+   "link_count": 0,
+   "link_to": "Stringer Bill",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Substitute Booking",
+   "link_count": 0,
+   "link_to": "Substitute Booking",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
   }
  ],
- "modified": "2024-09-24 09:35:44.221395",
+ "modified": "2024-10-17 09:52:43.979836",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "BEAMS",
@@ -125,8 +164,31 @@
   {
    "color": "Grey",
    "doc_view": "List",
+   "label": "Albatross Settings",
+   "link_to": "Albatross Settings",
+   "type": "DocType"
+  },
+  {
+   "color": "Grey",
+   "doc_view": "List",
+   "label": "Contract",
+   "link_to": "Contract",
+   "stats_filter": "[]",
+   "type": "DocType"
+  },
+  {
+   "color": "Grey",
+   "doc_view": "List",
    "label": "Beams Accounts Settings",
    "link_to": "Beams Accounts Settings",
+   "type": "DocType"
+  },
+  {
+   "color": "Grey",
+   "doc_view": "List",
+   "label": "Batta Policy",
+   "link_to": "Batta Policy",
+   "stats_filter": "[]",
    "type": "DocType"
   },
   {

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -227,9 +227,12 @@ doc_events = {
 # each overriding function accepts a `data` argument;
 # generated from the base implementation of the doctype dashboard,
 # along with any modifications made in other Frappe apps
-# override_doctype_dashboards = {
-# 	"Task": "beams.task.get_dashboard_data"
-# }
+override_doctype_dashboards = {
+	'Item': 'beams.beams.custom_scripts.item_dashboard.item_dashboard.get_data',
+    'Customer': 'beams.beams.custom_scripts.customer_dashboard.customer_dashboard.get_data',
+    'Sales Invoice': 'beams.beams.custom_scripts.sales_invoice_dashboard.sales_invoice_dashboard.get_data',
+    'Sales Order': 'beams.beams.custom_scripts.sales_order_dashboard.sales_order_dashboard.get_data'
+}
 
 # exempt linked doctypes from being automatically cancelled
 #

--- a/beams/public/js/sales_invoice.js
+++ b/beams/public/js/sales_invoice.js
@@ -1,5 +1,8 @@
 frappe.ui.form.on('Sales Invoice', {
   refresh: function(frm) {
+    setTimeout(() => {
+        frm.remove_custom_button('Delivery', 'Create');
+    }, 500);
     set_actual_customer_query(frm);
 
     // Check if the Sales Invoice is being created from a Quotation (i.e., reference_id is set)

--- a/beams/public/js/sales_order.js
+++ b/beams/public/js/sales_order.js
@@ -1,7 +1,11 @@
 frappe.ui.form.on('Sales Order', {
   refresh: function(frm) {
+    setTimeout(() => {
+        frm.remove_custom_button('Delivery Note', 'Create');
+    }, 500);
     set_actual_customer_query(frm);
     frm.dashboard.clear_headline();
+
     //Check Overdue Invoices
     if (frm.doc.customer) {
         frappe.call({

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -87,7 +87,7 @@ def get_customer_custom_fields():
             {
                 "fieldname": "is_agent",
                 "fieldtype": "Check",
-                "label": "Is Agent",
+                "label": "Is Agency",
                 "insert_after": "msme_status"
             },
             {
@@ -179,7 +179,7 @@ def get_sales_invoice_custom_fields():
             {
                 "fieldname": "is_agent",
                 "fieldtype": "Check",
-                "label": "Is Agent",
+                "label": "Is Agency",
                 "read_only":1,
                 "fetch_from": "customer.is_agent",
                 "depends_on": "eval:doc.is_agent",
@@ -914,6 +914,14 @@ def get_property_setters():
         },
         {
             "doctype_or_field": "DocField",
+            "doc_type": "Customer",
+            "field_name": "sales_team_tab",
+            "property": "hidden",
+            "property_type": "TabBreak",
+            "value": 1
+        },
+        {
+            "doctype_or_field": "DocField",
             "doc_type": "Purchase Invoice",
             "field_name": "is_subcontracted",
             "property": "hidden",
@@ -935,6 +943,53 @@ def get_property_setters():
             "property": "hidden",
             "property_type": "Data",
             "value": 1
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Item",
+            "field_name": "grant_commission",
+            "property": "hidden",
+            "property_type": "Check",
+            "value": 1
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Customer",
+            "field_name": "dn_required",
+            "property": "hidden",
+            "property_type": "Check",
+            "value": 1
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Item",
+            "field_name": "include_item_in_manufacturing",
+            "property": "default",
+            "property_type": "Check",
+            "value": 0
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Item",
+            "field_name": "inspection_required_before_delivery",
+            "property": "hidden",
+            "property_type": "Check",
+            "value": 1
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Item",
+            "field_name": "manufacturing",
+            "property": "depends_on",
+            "property_type": "TabBreak",
+            "value": "eval:doc.is_stock_item == 0"
+        },
+        {
+            "doctype_or_field": "DocType",
+            "doc_type": "Item",
+            "property": "quick_entry",
+            "property_type": "Check",
+            "value": 0
         },
         {
             "doctype_or_field": "DocField",
@@ -988,7 +1043,7 @@ def get_sales_order_custom_fields():
             {
                 "fieldname": "is_agent",
                 "fieldtype": "Check",
-                "label": "Is Agent",
+                "label": "Is Agency",
                 "read_only":1,
                 "fetch_from": "customer.is_agent",
                 "depends_on": "eval:doc.is_agent",
@@ -1104,3 +1159,27 @@ def create_custom_roles(role_name):
             print(f"Role already exists: {role_name}")
 
     frappe.db.commit()
+
+def create_translation_quotation():
+    translation = frappe.get_doc({
+        'doctype': 'Translation',
+        'source_text': 'Quotation',
+        'translated_text': 'Release Order',
+        'language': 'en'
+    })
+    translation.insert(ignore_permissions=True)
+    frappe.db.commit()
+
+create_translation_quotation()
+
+def create_translation_quotation_to():
+    translation = frappe.get_doc({
+        'doctype': 'Translation',
+        'source_text': 'Quotation To',
+        'translated_text': 'Release Order To',
+        'language': 'en'
+    })
+    translation.insert(ignore_permissions=True)
+    frappe.db.commit()
+
+create_translation_quotation_to()


### PR DESCRIPTION
 ## Feature description
-Update Accounts Module.

## Solution Description
-Removed Item  Quick creation 
-Removed Dashboard Unnecessary Links in  item
-Removed  Grant Commission Field in item
-Changed Is Agent to Agency
-Removed Sale Team in Customer and All Delivery Note References
-Removed Support,Subscriptions,Delivery Note  and Allowed Items Connections from Customer
-Renamed Quotation to Release order
-Removed BOM,Product Bundle,Manufacture and Delivery Note connections from Item
-Set Include Item in Manufacturing to default 0
-Removed Inspection required before purchase in Item
-Hide Manufacturing TabBreak in item when the maintain stock is checked
-Added Accounts new doctypes to dashboard
-Added Stringer Bill Detail Child table in Stringer Bill

## Output
[Screencast from 17-10-24 10:17:24 AM IST.webm](https://github.com/user-attachments/assets/c14aef96-9b7b-4541-a08d-ff603816fba4)
[Screencast from 17-10-24 10:20:17 AM IST.webm](https://github.com/user-attachments/assets/7e172d8b-3d38-45bf-b906-120d25744497)
![image](https://github.com/user-attachments/assets/6f3847b3-05a5-496c-badb-df17eb7b3b67)
![image](https://github.com/user-attachments/assets/73a13b2b-5e85-4d05-93a4-bb975e06b854)

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
- Mozilla Firefox