### PR TITLE
fix:  Close Job Opening on Job Requisition Cancellation

### DIFF
--- a/beams/beams/custom_scripts/job_applicant/job_applicant.py
+++ b/beams/beams/custom_scripts/job_applicant/job_applicant.py
@@ -1,20 +1,21 @@
 import frappe
+from frappe import _
 
 def get_permission_query_conditions(user):
     if not user:
         user = frappe.session.user
-    
+
     user_roles = frappe.get_roles(user)
-    
-    
+
+
     if "Administrator" in user_roles:
         return ""
 
-    
+
     if "Interviewer" in user_roles:
         return f"""
         `tabJob Applicant`.name IN (
-            SELECT reference_name 
+            SELECT reference_name
             FROM `tabToDo`
             WHERE reference_type = 'Job Applicant'
             AND allocated_to = '{user}'
@@ -22,5 +23,37 @@ def get_permission_query_conditions(user):
         """
     return None
 
+@frappe.whitelist()
+def validate(doc, method):
+    """
+    Method triggered before the documentaion saving .
+    Validate the Job Applicant against Job Opening requirements.
+    """
+    job_opening = frappe.get_doc('Job Opening', doc.job_title)
 
+    if doc.location != job_opening.location:
+        frappe.throw("Applicant's location does not match the Job Opening's location.")
 
+    applicant_qualifications = [qual.qualification for qual in doc.min_education_qual] if doc.min_education_qual else []
+    job_opening_qualifications = [qual.qualification for qual in job_opening.min_education_qual] if job_opening.min_education_qual else []
+    if not any(qual in job_opening_qualifications for qual in applicant_qualifications):
+        frappe.throw("Applicant's  does not meet the minimum qualification for the Job Opening")
+
+    if doc.min_experience < job_opening.min_experience:
+        frappe.throw("Applicant's does not meet the minimum experience  for the Job Opening.")
+
+    required_skills = {skill.skill: skill.proficiency for skill in job_opening.skill_proficiency}
+    applicant_skills = {skill.skill: skill.proficiency for skill in doc.skill_proficiency}
+    missing_skills = []
+    proficiency_mismatch = []
+    for required_skill, required_proficiency in required_skills.items():
+        if required_skill not in applicant_skills:
+            missing_skills.append(required_skill)
+        else:
+            applicant_proficiency = applicant_skills[required_skill]
+            if applicant_proficiency < required_proficiency:
+                proficiency_mismatch.append(f"{required_skill} (Required: {required_proficiency}, Provided: {applicant_proficiency})")
+    if missing_skills:
+        frappe.throw("The Applicant's does not meet the skill requirements for the Job Opening.")
+    if proficiency_mismatch:
+        frappe.throw("Applicant's does not meet the required proficiency levels for the following skills")

--- a/beams/beams/custom_scripts/job_requisition/job_requisition.py
+++ b/beams/beams/custom_scripts/job_requisition/job_requisition.py
@@ -27,11 +27,12 @@ def create_job_opening_from_job_requisition(doc, method):
         job_opening.min_education_qual = doc.min_education_qual
         job_opening.min_experience = doc.min_experience
         job_opening.expected_compensation = doc.expected_compensation
-        job_opening.job_title = doc.designation
+        job_opening.job_title = doc.job_title
         job_opening.no_of_positions = doc.no_of_positions
         job_opening.employment_type = doc.employment_type
         job_opening.department = doc.department
         job_opening.designation = doc.designation
+        job_opening.location = doc.location
 
         # Validation checks
         if not job_opening.employment_type:
@@ -48,6 +49,12 @@ def create_job_opening_from_job_requisition(doc, method):
             frappe.throw("Please specify the Expected Compensation in the Job Requisition.")
         if not job_opening.no_of_positions:
             frappe.throw("Please specify the Number of Positions in the Job Requisition.")
+
+        for skill in doc.skill_proficiency:
+            job_opening.append("skill_proficiency", {
+                "skill": skill.skill,
+                "proficiency": skill.proficiency
+            })
 
         # Insert and submit the Job Opening document
         job_opening.insert()

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -181,7 +181,8 @@ doc_events = {
         "onchange": "beams.beams.doctype.batta_claim.batta_claim.calculate_batta"
     },
     "Job Requisition": {
-        "on_update": "beams.beams.custom_scripts.job_requisition.job_requisition.create_job_opening_from_job_requisition",
+        "on_update": ["beams.beams.custom_scripts.job_requisition.job_requisition.create_job_opening_from_job_requisition",
+                      "beams.beams.custom_scripts.job_requisition.job_requisition.on_update"],
         "on_cancel": "beams.beams.custom_scripts.job_requisition.job_requisition.on_workflow_cancel",
         "validate":  "beams.beams.custom_scripts.job_requisition.job_requisition.validate_job_requisition"
     },

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -37,7 +37,8 @@ doctype_js = {
     "Voucher Entry": "public/js/voucher_entry.js",
     "Contract":"public/js/contract.js",
     "Department":"public/js/department.js",
-    "Job Requisition":"public/js/job_requisition.js"
+    "Job Requisition":"public/js/job_requisition.js",
+    "Job Applicant" :"public/js/job_applicant.js"
 }
 doctype_list_js = {
     "Sales Invoice" : "public/js/sales_invoice_list.js",
@@ -120,7 +121,7 @@ permission_query_conditions = {
 }
 
 # has_permission = {
-# 	
+#
 # }
 
 # DocType Class
@@ -186,9 +187,12 @@ doc_events = {
     },
     "Journal Entry": {
         "on_cancel": "beams.beams.custom_scripts.journal_entry.journal_entry.on_cancel"
-        }
-    }
+        },
+    "Job Applicant": {
+        "validate": "beams.beams.custom_scripts.job_applicant.job_applicant.validate"
+        },
 
+    }
 
 
 # Scheduled Tasks

--- a/beams/public/js/job_applicant.js
+++ b/beams/public/js/job_applicant.js
@@ -1,0 +1,63 @@
+
+frappe.ui.form.on('Job Applicant', {
+    /*
+     * Validate the Job Applicant against the requirements of the Job Opening.
+     * This function checks if the applicant's location, qualifications,
+     * experience, and skills meet the requirements specified in the Job Opening
+     */
+    validate: function(frm) {
+        frappe.db.get_doc('Job Opening', frm.doc.job_title).then((job_opening) => {
+            if (frm.doc.location !== job_opening.location) {
+                frappe.msgprint("Applicant's location does not match the Job Opening's location.");
+                frappe.validated = false;
+                return;
+            }
+            if (frm.doc.min_education_qual && job_opening.min_education_qual) {
+                let applicant_qualifications = frm.doc.min_education_qual.map(d => d.qualification);
+                let job_opening_qualifications = job_opening.min_education_qual.map(d => d.qualification);
+                let has_qualification = applicant_qualifications.some(qual => job_opening_qualifications.includes(qual));
+
+                if (!has_qualification) {
+                    frappe.msgprint("Applicant's does not meet the minimum qualification  for the Job Opening.");
+                    frappe.validated = false;
+                    return;
+                }
+            }
+            if (frm.doc.min_experience < job_opening.min_experience) {
+                frappe.msgprint("Applicant's does not meet the minimum experience  for the Job Opening.");
+                frappe.validated = false;
+                return;
+            }
+            if (job_opening.skill_proficiency && frm.doc.skill_proficiency) {
+                const requiredSkills = job_opening.skill_proficiency.map(skill => {
+                    return { skill: skill.skill, proficiency: skill.proficiency };
+                });
+                const applicantSkills = frm.doc.skill_proficiency.map(skill => {
+                    return { skill: skill.skill, proficiency: skill.proficiency };
+                });
+                let missingSkills = [];
+                let proficiencyMismatch = [];
+                requiredSkills.forEach(required => {
+                    const match = applicantSkills.find(applicant => applicant.skill === required.skill);
+                    if (!match) {
+                        // Skill is missing
+                        missingSkills.push(required.skill);
+                    } else if (match.proficiency < required.proficiency) {
+                        // Skill is present, but proficiency is not sufficient
+                        proficiencyMismatch.push(`${required.skill} (Required: ${required.proficiency}, Provided: ${match.proficiency})`);
+                    }
+                });
+                if (missingSkills.length > 0) {
+                    frappe.msgprint("The Applicant's does not meet the skill requirements for the Job Opening.");
+                    frappe.validated = false;
+                    return;
+                }
+                if (proficiencyMismatch.length > 0) {
+                    frappe.msgprint("Applicant's does not meet the required proficiency levels for the following skills");
+                    frappe.validated = false;
+                    return;
+                }
+            }
+        });
+    }
+});

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -560,10 +560,10 @@ def get_job_requisition_custom_fields():
                 "insert_after": "license_type"
             },
             {
-                "fieldname": "min_education_qual",
-                "fieldtype": "Link",
+               "fieldname": "min_education_qual",
+                "fieldtype": "Table MultiSelect",
                 "label": "Minimum Educational Qualification",
-                "options": "Educational Qualification",
+                'options':"Educational Qualifications",
                 "insert_after": "education"
             },
             {
@@ -818,6 +818,26 @@ def get_job_opening_custom_fields():
                 "fieldtype": "Link",
                 "options": "Location",
                 "insert_after": "no_of_days_off"
+            },
+             {
+                 "fieldname": "skill_proficiency_break",
+                 "fieldtype": "Section Break",
+                 "label": "",
+                 "insert_after": "job_details"
+             },
+             {
+                "fieldname": "skill_proficiency",
+                "fieldtype": "Table",
+                "options": "Skill Proficiency",
+                "label": "Skill Proficiency",
+                "insert_after": "skill_proficiency_break"
+            },
+            {
+                "fieldname": "skill_proficiency_description",
+                "fieldtype": "HTML",
+                "label": "",
+                "options": "<p style='margin-top: 5px; color: #6c757d; font-size: 0.9em;'>Proficiency selected here is the minimum proficiency needed.</p>",
+                "insert_after": "skill_proficiency"
             }
         ]
     }


### PR DESCRIPTION
## Issue description
-Need To Implement  Close Job Opening on Job Requisition Cancellation

## Solution description

- Implemented Cancel action on job requisition then the corresponding job opening status is changed to closed via job         requisition.py 

-job opening field closed on date set to current date

- changed the event on_cancel in to on_update hooks.py 


## Output
Uploading Screencast from 17-10-24 11:41:09 AM IST.webm…]()

## Areas affected and ensured
-status "open" in job opening is changed in to "closed"  via job requistion.py

## Is there any existing behavior change of other features due to this code change?
-hooks.py
-job Requisition.py

## Was this feature tested on the browsers?
  - Mozilla Firefox