### PR TITLE
feat:Add Expected Question Set child table to Interview Round and enhance 

### DIFF
--- a/beams/beams/doctype/expected_question_set_in_interview_round/expected_question_set_in_interview_round.json
+++ b/beams/beams/doctype/expected_question_set_in_interview_round/expected_question_set_in_interview_round.json
@@ -1,0 +1,38 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2024-10-18 12:28:30.691639",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "question",
+  "weight"
+ ],
+ "fields": [
+  {
+   "fieldname": "question",
+   "fieldtype": "Small Text",
+   "in_list_view": 1,
+   "label": "Question",
+   "reqd": 1
+  },
+  {
+   "fieldname": "weight",
+   "fieldtype": "Float",
+   "label": "Weight"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2024-10-18 12:29:30.802263",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "Expected Question Set In Interview Round",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/beams/beams/doctype/expected_question_set_in_interview_round/expected_question_set_in_interview_round.py
+++ b/beams/beams/doctype/expected_question_set_in_interview_round/expected_question_set_in_interview_round.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class ExpectedQuestionSetInInterviewRound(Document):
+	pass

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -25,6 +25,8 @@ def after_install():
     create_custom_fields(get_job_requisition_custom_fields(),ignore_validate=True)
     create_custom_fields(get_quotation_item_custom_fields(),ignore_validate=True)
     create_custom_fields(get_job_opening_custom_fields(),ignore_validate=True)
+    create_custom_fields(get_expected_skill_set_custom_fields(),ignore_validate=True)
+    create_custom_fields(get_interview_round_custom_fields(),ignore_validate=True)
     # create_custom_roles('')
     create_custom_fields(get_job_applicant_custom_fields(),ignore_validate=True)
     create_custom_fields(get_budget_custom_fields(),ignore_validate=True)
@@ -57,7 +59,8 @@ def before_uninstall():
     delete_custom_fields(get_job_applicant_custom_field())
     delete_custom_fields(get_budget_custom_fields())
     delete_custom_fields(get_budget_account_custom_fields())
-
+    delete_custom_fields(get_expected_skill_set_custom_fields())
+    delete_custom_fields(get_interview_round_custom_fields())
 
 def delete_custom_fields(custom_fields: dict):
     '''
@@ -549,6 +552,37 @@ def get_voucher_entry_custom_fields():
         ]
     }
 
+
+def get_expected_skill_set_custom_fields():
+    '''
+    Custom fields that need to be added to the Expected Skill Set Doctype
+    '''
+    return {
+        "Expected Skill Set": [
+            {
+                "fieldname": "weight",
+                "fieldtype": "Float",
+                "label": "Weight",
+                "insert_after": "description"
+            }
+        ]
+    }
+
+def get_interview_round_custom_fields():
+    '''
+    Custom fields that need to be added to the Interview Round Child Table
+    '''
+    return {
+        "Interview Round": [
+            {
+                "fieldname": "expected_question_set_in_interview_round",
+                "fieldtype": "Table",
+                "label": "Expected Questions Set",
+                "options":"Expected Question Set In Interview Round",
+                "insert_after":"expected_skill_set"
+            }
+        ]
+    }
 
 def get_job_requisition_custom_fields():
     '''


### PR DESCRIPTION
## Feature description
-Introduce "Expected Question Set" Child Table In Interview Round and update related fields

## Solution description
-Created "Expected Question Set In Interview Round" child table with:
      - "Question" (Small Text, Mandatory)
      - "Weight" (Float)
- Enhanced "Expected Skill Set" in "Interview Round" by adding a "Weight" (Float) field.
- Integrated "Expected Question Set In Interview Round" as a child table in the "Interview Round" doctype.

## Output
![image](https://github.com/user-attachments/assets/a9488bb3-f0c5-4895-b349-a832cca236a2)

## Is there any existing behavior change of other features due to this code change?
-no

## Was this feature tested on the browsers?
  - Mozilla Firefox