### PR TITLE
feat:Created Child table Interview rounds

### DIFF
--- a/beams/beams/doctype/interview_rounds/interview_rounds.json
+++ b/beams/beams/doctype/interview_rounds/interview_rounds.json
@@ -1,0 +1,33 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2024-10-18 15:22:48.625362",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "interview_round"
+ ],
+ "fields": [
+  {
+   "fieldname": "interview_round",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Interview Round",
+   "options": "Interview Round",
+   "reqd": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2024-10-18 15:23:44.414944",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "Interview Rounds",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/beams/beams/doctype/interview_rounds/interview_rounds.py
+++ b/beams/beams/doctype/interview_rounds/interview_rounds.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class InterviewRounds(Document):
+	pass

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -727,6 +727,20 @@ def get_job_requisition_custom_fields():
                 "options": "Employee",
                 "insert_after": "staffing_plan",
             },
+            {
+                "fieldname": "interview",
+                "fieldtype": "Section Break",
+                "label": "",
+                "insert_after": "requested_by"
+            },
+            {
+                "fieldname": "interview_rounds",
+                "fieldtype": "Table MultiSelect",
+                "options": "Interview Rounds",
+                "label": "Interview Rounds",
+                "insert_after": "interview"
+            },
+            
              {
                 "fieldname": "location",
                 "label": "Location",


### PR DESCRIPTION
## Feature description
Add a multiselect field in Job Requisition.

## Solution description
Added child Interview Round(Link,option-Interview Round)
Add this child table in to Job Requisition as 'Interview Rounds'
This is a  Multi select field (Option-Interview Rounds)

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/ab067ae8-4d54-4a3e-8f49-3da531a52ff5)

## Areas affected and ensured
Job Requisition.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari