### PR TITLE
feat: added fields and created child doctype and fetched the data from interview round to interview feedback

### DIFF
--- a/beams/beams/doctype/interview_question_result/interview_question_result.json
+++ b/beams/beams/doctype/interview_question_result/interview_question_result.json
@@ -1,0 +1,50 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2024-10-21 11:25:25.082840",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "question",
+  "weight",
+  "answer",
+  "score"
+ ],
+ "fields": [
+  {
+   "fieldname": "question",
+   "fieldtype": "Small Text",
+   "in_list_view": 1,
+   "label": "Question",
+   "reqd": 1
+  },
+  {
+   "fieldname": "weight",
+   "fieldtype": "Float",
+   "label": "Weight"
+  },
+  {
+   "fieldname": "answer",
+   "fieldtype": "Small Text",
+   "label": "Answer"
+  },
+  {
+   "fieldname": "score",
+   "fieldtype": "Float",
+   "label": "Score"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2024-10-21 11:26:25.124663",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "Interview Question Result",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/beams/beams/doctype/interview_question_result/interview_question_result.py
+++ b/beams/beams/doctype/interview_question_result/interview_question_result.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class InterviewQuestionResult(Document):
+	pass

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -39,7 +39,8 @@ doctype_js = {
     "Department":"public/js/department.js",
     "Job Requisition":"public/js/job_requisition.js",
     "Job Applicant" :"public/js/job_applicant.js",
-    "Budget":"public/js/budget.js"
+    "Budget":"public/js/budget.js",
+    "Interview Feedback":"public/js/interview_feedback.js"
 }
 doctype_list_js = {
     "Sales Invoice" : "public/js/sales_invoice_list.js",

--- a/beams/public/js/interview_feedback.js
+++ b/beams/public/js/interview_feedback.js
@@ -2,21 +2,21 @@ frappe.ui.form.on('Interview Feedback', {
     // The code fetches both expected_skill_set and expected_question_set_in_interview_round
     // from the selected "Interview Round" and dynamically updates the respective tables
     interview_round: function(frm) {
-        const interviewRoundName = frm.doc.interview_round;
-        if (interviewRoundName) {
+        const interview_round_name = frm.doc.interview_round;
+        if (interview_round_name) {
             frappe.call({
                 method: 'frappe.client.get',
                 args: {
                     doctype: 'Interview Round',
-                    name: interviewRoundName
+                    name: interview_round_name
                 },
                 callback: function(response) {
-                    const interviewRound = response.message;
+                    const interview_round = response.message;
 
-                    if (interviewRound && Array.isArray(interviewRound.expected_skill_set)) {
+                    if (interview_round && Array.isArray(interview_round.expected_skill_set)) {
                         frm.clear_table('skill_assessment');
                         
-                        interviewRound.expected_skill_set.forEach(skill => {
+                        interview_round.expected_skill_set.forEach(skill => {
                             const row = frm.add_child('skill_assessment');
                             row.weight = skill.weight;
                         });
@@ -26,10 +26,10 @@ frappe.ui.form.on('Interview Feedback', {
                         frappe.msgprint(__('No expected skill set found for the selected interview round.'));
                     }
 
-                    if (interviewRound && Array.isArray(interviewRound.expected_question_set_in_interview_round)) {
+                    if (interview_round && Array.isArray(interview_round.expected_question_set_in_interview_round)) {
                         frm.clear_table('interview_question_result');
                         
-                        interviewRound.expected_question_set_in_interview_round.forEach(question => {
+                        interview_round.expected_question_set_in_interview_round.forEach(question => {
                             const row = frm.add_child('interview_question_result');
                             row.weight = question.weight;
                         });

--- a/beams/public/js/interview_feedback.js
+++ b/beams/public/js/interview_feedback.js
@@ -1,0 +1,48 @@
+frappe.ui.form.on('Interview Feedback', {
+    // The code fetches both expected_skill_set and expected_question_set_in_interview_round
+    // from the selected "Interview Round" and dynamically updates the respective tables
+    interview_round: function(frm) {
+        const interviewRoundName = frm.doc.interview_round;
+        if (interviewRoundName) {
+            frappe.call({
+                method: 'frappe.client.get',
+                args: {
+                    doctype: 'Interview Round',
+                    name: interviewRoundName
+                },
+                callback: function(response) {
+                    const interviewRound = response.message;
+
+                    if (interviewRound && Array.isArray(interviewRound.expected_skill_set)) {
+                        frm.clear_table('skill_assessment');
+                        
+                        interviewRound.expected_skill_set.forEach(skill => {
+                            const row = frm.add_child('skill_assessment');
+                            row.weight = skill.weight;
+                        });
+
+                        frm.refresh_field('skill_assessment');
+                    } else {
+                        frappe.msgprint(__('No expected skill set found for the selected interview round.'));
+                    }
+
+                    if (interviewRound && Array.isArray(interviewRound.expected_question_set_in_interview_round)) {
+                        frm.clear_table('interview_question_result');
+                        
+                        interviewRound.expected_question_set_in_interview_round.forEach(question => {
+                            const row = frm.add_child('interview_question_result');
+                            row.weight = question.weight;
+                        });
+
+                        frm.refresh_field('interview_question_result');
+                    } else {
+                        frappe.msgprint(__('No expected question set found for the selected interview round.'));
+                    }
+                },
+                error: function(error) {
+                    frappe.msgprint(__('Failed to fetch Interview Round details. Please try again.'));
+                }
+            });
+        }
+    }
+});

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -31,6 +31,7 @@ def after_install():
     create_custom_fields(get_job_applicant_custom_fields(),ignore_validate=True)
     create_custom_fields(get_budget_custom_fields(),ignore_validate=True)
     create_custom_fields(get_budget_account_custom_fields(),ignore_validate=True)
+    create_custom_fields(get_interview_feedback_custom_fields(),ignore_validate=True)
 
 
 def after_migrate():
@@ -1301,3 +1302,35 @@ def create_translation_quotation_to():
     frappe.db.commit()
 
 create_translation_quotation_to()
+
+
+
+def get_interview_feedback_custom_fields():
+    '''
+    Custom fields that need to be added to the Interview Feedback
+    '''
+    return {
+        "Interview Feedback": [
+            {
+                "fieldname": "skill_assessment_section",
+                "label": "Skill Assessment",
+                "fieldtype": "Section Break",
+                "insert_after": "section_break_4"  
+            },
+            {
+                "fieldname": "skill_assessment",
+                "label": "Skill Assessment",
+                "fieldtype": "Table",
+                "options": "Skill Assessment",
+                "insert_after": "skill_assessment_section"
+            },
+            {
+                "fieldname": "interview_question_result",
+                "label": "Interview Question Result",
+                "fieldtype": "Table",
+                "options": "Interview Question Result",
+                "insert_after": "section_break_4"
+            }
+        ]
+    }
+


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
Feature

## Clearly and concisely describe the feature, chore or bug.
=>  Add new fields to Skill Assessment child table 
* Score(Float, Mandatory, In list view) 
* Remarks(Small Text) 
* Weight(Fetch from Expected Skill Set child table in interview round doctype)

=> Create child table - Interview Question Result 
* Fields are: 
* Question(Small Text, Mandatory, In list view),
* Weight(Fetch from Expected Question Set in interview round doctype)
 * Answer(Small Text, Mandatory)
* Score(Float)

## Solution description
Created all the neccessary fields and child doctype .

updates the "Interview Feedback" form by populating the skill_assessment and interview_question_result tables with data fetched from the selected "Interview Round."

## Output screenshots (optional)
![Screenshot from 2024-10-21 15-11-04](https://github.com/user-attachments/assets/7eaece49-87e2-4418-aa28-be356020b817)
![Screenshot from 2024-10-21 15-10-52](https://github.com/user-attachments/assets/83ee3ba7-ebca-4df7-8b4e-541fd1d15b0d)


## Areas affected and ensured
   beams/beams/doctype/interview_question_result/__init__.py
   beams/beams/doctype/interview_question_result/interview_question_result.json
   beams/beams/doctype/interview_question_result/interview_question_result.py
   beams/hooks.py
   beams/public/js/interview_feedback.js
  beams/setup.py


## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
Existing Data
New Data

## Is patch required?
No