### PR TITLE
feat : Add button in Job Applicant to send magic link via email with confirmation.

### DIFF
--- a/beams/public/js/job_applicant.js
+++ b/beams/public/js/job_applicant.js
@@ -66,7 +66,28 @@ frappe.ui.form.on('Job Applicant', {
                         }
                     },
                 });
-            }, frappe._('Create')); // Set the label of the button
-        }
-    }
-});
+            }, frappe._('Create'));
+
+            // Add a custom button for sending a magic link
+            frm.add_custom_button(__('Send Magic Link'), function() {
+                frappe.confirm(
+                    'Are you sure you want to send the magic link to the candidate?',
+                     function() {
+                        let applicant_name_value = frm.doc.name;
+                        frappe.call({
+                            method: "beams.beams.custom_scripts.job_applicant.job_applicant.send_magic_link",
+                            args: {
+                                applicant_name: applicant_name_value
+                            },
+                            callback: function(r) {
+                                if (r.message) {
+                                    frappe.msgprint("Magic link has been sent to the candidate.");
+                                }
+                            }
+                        });
+                      }
+                  );
+              }, __('Create'));
+          }
+      }
+  });


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- Feature

## Clearly and concisely describe the feature, chore or bug.

1. A button is added in the Job Applicant DocType to send a magic link via email.
2. This button triggers a confirmation dialog before proceeding. 
3. Once confirmed, the system sends an email to the applicant with the magic link.

## Solution description

1. Added a button labeled "Send Magic Link" to the Job Applicant DocType.
2. Implemented a confirmation prompt before sending the email.
3. Upon confirmation, the system generates the magic link and sends an email to the candidate.


## Output screenshots (optional)
[Screencast from 10-21-2024 04:24:31 PM.webm](https://github.com/user-attachments/assets/0cc6208d-a47a-44cd-bff2-ce4df46ceadd)
[Screencast from 10-21-2024 04:26:10 PM.webm](https://github.com/user-attachments/assets/d968dba4-a2c8-4232-acb1-c0bd7fce5895)


## Areas affected and ensured
- `beams/public/js/job_applicant.js`

## Is there any existing behavior change of other features due to this code change?
- No

## Did you test with the following dataset?
- Existing Data
- New Data

## Is patch required?
- No
