### PR TITLE
fix:Alignment of Job Requisition was done

### DIFF
--- a/beams/setup.py
+++ b/beams/setup.py
@@ -730,8 +730,8 @@ def get_job_requisition_custom_fields():
             {
                 "fieldname": "interview",
                 "fieldtype": "Section Break",
-                "label": "",
-                "insert_after": "requested_by"
+                "label": "Interview Details",
+                "insert_after": "requested_by_designation"
             },
             {
                 "fieldname": "interview_rounds",
@@ -740,7 +740,7 @@ def get_job_requisition_custom_fields():
                 "label": "Interview Rounds",
                 "insert_after": "interview"
             },
-            
+
              {
                 "fieldname": "location",
                 "label": "Location",


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
Feature

## Clearly and concisely describe the feature, chore or bug.
Interview rounds field was placed inside a section break named Interview Details.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/0c5365e6-6b90-43fe-862c-08410890d2a2)


## Areas affected and ensured
beams/setup.py

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
Existing Data
New Data

## Is patch required?
No