### PR TITLE
feat: Update Local Enquiry Report doctype

### DIFF
--- a/beams/beams/doctype/local_enquiry_checklist/local_enquiry_checklist.json
+++ b/beams/beams/doctype/local_enquiry_checklist/local_enquiry_checklist.json
@@ -22,6 +22,7 @@
   {
    "fieldname": "value",
    "fieldtype": "Data",
+   "in_list_view": 1,
    "label": "Value"
   },
   {
@@ -33,7 +34,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-10-14 10:18:42.099351",
+ "modified": "2024-10-19 12:10:30.910044",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Local Enquiry Checklist",

--- a/beams/beams/doctype/local_enquiry_report/local_enquiry_report.json
+++ b/beams/beams/doctype/local_enquiry_report/local_enquiry_report.json
@@ -15,6 +15,12 @@
   "information_given_by",
   "information_collected_by",
   "status",
+  "section_break_gnwp",
+  "enquiry_start_date",
+  "enquiry_completion_date",
+  "column_break_yfct",
+  "expected_completion_date",
+  "enquiry_officer",
   "section_break_2hnf",
   "enquiry_report",
   "remarks"
@@ -64,7 +70,7 @@
    "fieldname": "status",
    "fieldtype": "Select",
    "label": "Status",
-   "options": "Open\nOngoing\nHold\nCompleted"
+   "options": "Open\nOngoing\nHold\nCompleted\nOverdue"
   },
   {
    "fieldname": "information_given_by",
@@ -94,11 +100,40 @@
   {
    "fieldname": "column_break_xtgz",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_gnwp",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "enquiry_start_date",
+   "fieldtype": "Date",
+   "label": "Enquiry Start Date"
+  },
+  {
+   "fieldname": "column_break_yfct",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "enquiry_completion_date",
+   "fieldtype": "Date",
+   "label": " Enquiry Completion Date"
+  },
+  {
+   "fieldname": "expected_completion_date",
+   "fieldtype": "Date",
+   "label": "Expected Completion Date "
+  },
+  {
+   "fieldname": "enquiry_officer",
+   "fieldtype": "Link",
+   "label": "Enquiry Officer",
+   "options": "Employee"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-10-17 10:06:49.714988",
+ "modified": "2024-10-19 13:14:11.101690",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Local Enquiry Report",

--- a/beams/beams/doctype/local_enquiry_report/local_enquiry_report.py
+++ b/beams/beams/doctype/local_enquiry_report/local_enquiry_report.py
@@ -1,9 +1,32 @@
 # Copyright (c) 2024, efeone and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
+from frappe.utils import getdate
 
 
 class LocalEnquiryReport(Document):
-	pass
+    pass
+
+
+@frappe.whitelist()
+def update_local_enquiry_status():
+    '''
+    This function updates the status of Local Enquiry Reports. It sets the status to 'Overdue'for reports where the expected completion date is today or earlier,
+    the enquiry completion date is not set or is later than the expected completion date, and the current status is not already 'Overdue'.
+    '''
+    today = getdate()
+    enquiries = frappe.get_all('Local Enquiry Report', filters={
+        'expected_completion_date': ['<=', today],
+        'status': ['!=', 'Overdue']
+    })
+    for enquiry in enquiries:
+        if frappe.db.exists("Local Enquiry Report", enquiry.name):
+            doc = frappe.get_doc('Local Enquiry Report', enquiry.name)
+            if not doc.enquiry_completion_date or doc.enquiry_completion_date > doc.expected_completion_date:
+                doc.status = 'Overdue'  # Set status to 'Overdue'
+                doc.save()  # Save the document
+
+    # Commit the changes to the database
+    frappe.db.commit()

--- a/beams/beams/doctype/local_enquiry_report/local_enquiry_report.py
+++ b/beams/beams/doctype/local_enquiry_report/local_enquiry_report.py
@@ -27,6 +27,3 @@ def update_local_enquiry_status():
             if not doc.enquiry_completion_date or doc.enquiry_completion_date > doc.expected_completion_date:
                 doc.status = 'Overdue'  # Set status to 'Overdue'
                 doc.save()  # Save the document
-
-    # Commit the changes to the database
-    frappe.db.commit()

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -202,7 +202,10 @@ doc_events = {
 # Scheduled Tasks
 # ---------------
 
-# scheduler_events = {
+scheduler_events = {
+    "daily": [
+        "beams.beams.doctype.local_enquiry_report.local_enquiry_report.update_local_enquiry_status"
+    ],
 # 	"all": [
 # 		"beams.tasks.all"
 # 	],
@@ -218,7 +221,7 @@ doc_events = {
 # 	"monthly": [
 # 		"beams.tasks.monthly"
 # 	],
-# }
+  }
 
 # Testing
 # -------


### PR DESCRIPTION
## Feature description
->Need to update the Local Enquiry Report 

 - Need to Add the field in Local Enquiry Report
 
 - Need to Add option in select field in Local Enquiry Report
 
 - Need to add list view in a field in the Local enquiry checklist child table

-  need to set if the Expected Completion Date passed change the status in Local Enquiry Report.

## Solution description

1.  Added the fields
  Enquiry Start Date(Date),
  Enquiry Completion Date(Date) ,
  Expected Completion Date(Date),
  Enquiry Officer(Link, option-Employee)  in the Local Enquiry Report doctype

2. Added  new status 'Overdue' in status field(it is a select field) in the Local Enquiry Report doctype

3.  4.Added the list view for value field in Local enquiry checklist child table.

 4.updated the status "open" to "overdue" in status field when enquiry_completion_date is after expected_completion_date using 
scheduler_events via Local Enquiry Report .py

 5.added the scheduler_events in via hooks.py

## Output
![Screenshot from 2024-10-22 12-27-37](https://github.com/user-attachments/assets/23b26f85-535c-4dea-b71e-01d4a2af8eb3)
![image](https://github.com/user-attachments/assets/0e853be3-553e-4e0f-ad55-edf823a1ac15)

## Areas affected and ensured
-new feature

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox