### PR TITLE
feat:Secondary action button in Job Requisition was recreated

### DIFF
--- a/beams/beams/custom_scripts/job_requisition/job_requisition.py
+++ b/beams/beams/custom_scripts/job_requisition/job_requisition.py
@@ -120,7 +120,30 @@ def display_template_content(template_name, doc):
 
 @frappe.whitelist()
 def make_job_opening(source_name, target_doc=None):
+       """
+    Create a Job Opening from a Job Requisition.
+
+    This function maps fields from a Job Requisition to a new Job Opening.
+    It retrieves the Job Requisition by its name and sets relevant fields
+    in the Job Opening based on the information in the Job Requisition.
+
+    Parameters:
+    - source_name: str, the name of the Job Requisition document to be converted.
+    - target_doc: Document, optional; an existing Job Opening document to update.
+                  If not provided, a new Job Opening will be created.
+
+    Returns:
+    - Document: The newly created or updated Job Opening document.
+    """
     def set_missing_values(source, target):
+         """
+        Set default values in the target Job Opening document
+        that are missing from the source Job Requisition.
+
+        Parameters:
+        - source: Document, the source Job Requisition document.
+        - target: Document, the target Job Opening document to update.
+        """
         target.job_title = source.designation
         target.status = "Open"
         target.currency = frappe.db.get_value("Company", source.company, "default_currency")
@@ -152,4 +175,3 @@ def associate_job_opening(job_requisition, job_opening):
     job_requisition_doc = frappe.get_doc("Job Requisition", job_requisition)
     job_requisition_doc.job_opening = job_opening
     job_requisition_doc.save()
-    frappe.msgprint(f"Job Opening {job_opening} has been successfully associated.")

--- a/beams/public/js/job_requisition.js
+++ b/beams/public/js/job_requisition.js
@@ -17,11 +17,13 @@ frappe.ui.form.on('Job Requisition', {
             }
         });
 
+        // Check if the Job Requisition status is "Approved"
         if(frm.doc.status =="Approved") {
           // Create Job Opening Button
           frm.add_custom_button(
               __("Create Job Opening"),
               () => {
+                // Open a mapped document to create a Job Opening
                   frappe.model.open_mapped_doc({
                       method: "beams.beams.custom_scripts.job_requisition.job_requisition.make_job_opening",
                       source_name: frm.doc.name,  // Pass the current Job Requisition ID
@@ -43,6 +45,8 @@ frappe.ui.form.on('Job Requisition', {
                           options: "Job Opening",
                           reqd: 1,
                           get_query: () => {
+
+                            // Define query filters for the Job Opening link
                               const filters = {
                                   company: frm.doc.company,
                                   status: "Open",

--- a/beams/public/js/job_requisition.js
+++ b/beams/public/js/job_requisition.js
@@ -17,6 +17,81 @@ frappe.ui.form.on('Job Requisition', {
             }
         });
 
+        if(frm.doc.status =="Approved") {
+          // Create Job Opening Button
+          frm.add_custom_button(
+              __("Create Job Opening"),
+              () => {
+                  frappe.model.open_mapped_doc({
+                      method: "beams.beams.custom_scripts.job_requisition.job_requisition.make_job_opening",
+                      source_name: frm.doc.name,  // Pass the current Job Requisition ID
+                  });
+              },
+              __("Create"),
+              "btn-secondary"  // Set as a secondary button
+          );
+
+          // Associate Job Opening Button
+          frm.add_custom_button(
+              __("Associate Job Opening"),
+              () => {
+                  frappe.prompt(
+                      {
+                          label: __("Job Opening"),
+                          fieldname: "job_opening",
+                          fieldtype: "Link",
+                          options: "Job Opening",
+                          reqd: 1,
+                          get_query: () => {
+                              const filters = {
+                                  company: frm.doc.company,
+                                  status: "Open",
+                                  designation: frm.doc.designation,
+                              };
+
+                              if (frm.doc.department) {
+                                  filters.department = frm.doc.department;
+                              }
+
+                              return { filters: filters };
+                          },
+                      },
+                      (values) => {
+                          frm.call({
+                              method: "beams.beams.custom_scripts.job_requisition.job_requisition.associate_job_opening",
+                              args: {
+                                  job_opening: values.job_opening,
+                                  job_requisition: frm.doc.name  // Pass the current Job Requisition ID if needed
+                              },
+                              callback: function (r) {
+                                  if (!r.exc) {
+                                      frappe.msgprint(
+                                          __("Job Opening associated successfully."),
+                                          __("Success")
+                                      );
+                                      frm.reload_doc(); // Reload the form to reflect changes
+                                  }
+                              },
+                              error: function (err) {
+                                  console.error(err);
+                                  frappe.msgprint(
+                                      __("There was an issue associating the Job Opening."),
+                                      __("Error")
+                                  );
+                              },
+                          });
+                      },
+                      __("Associate Job Opening"),
+                      __("Submit")
+                  );
+              },
+              __("Create"),
+              "btn-secondary"  // Set as a secondary button
+          );
+        }
+
+
+
         /*
          * Sets a filter on the Job Description Template field based on the Designation.
          * Clears the Job Description Template field when the form is refreshed.
@@ -46,10 +121,23 @@ frappe.ui.form.on('Job Requisition', {
                 }
             });
         }
+
+// Rename Actions Button  as 'Create'  not primary action button
+     $(document).ready(function () {
+          // Find the specific custom "Actions" button dropdown using the parent or group
+          var dropdownActions = frm.page.inner_toolbar
+              .find('button:contains("Actions")')
+              .first();
+
+          // Rename this specific "Actions" button to "Create"
+          if (dropdownActions.length) {
+              dropdownActions.text("Create");
+          }
+      });
     },
 
     /*
-     * This script automatically fills the job description in the Job Requisition form based on 
+     * This script automatically fills the job description in the Job Requisition form based on
      * the selected Job Description Template and the current form details.
      */
     job_description_template: function (frm) {
@@ -58,7 +146,7 @@ frappe.ui.form.on('Job Requisition', {
                 method: "beams.beams.custom_scripts.job_requisition.job_requisition.display_template_content",
                 args: {
                     template_name: frm.doc.job_description_template,
-                    doc: frm.doc, 
+                    doc: frm.doc,
                 },
                 callback: function (r) {
                     if (r.message) {


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
Feature

## Clearly and concisely describe the feature, chore or bug.
In Job Requisition doctype two buttons labelled Actions is seen.One of them should be  renamed as Create.

## Solution description
The secondary action button is renamed as Create. The primary action button which follows a workflow  is remained as such.
The create button has two dropdown:Create Job Opening and Associate Job Opening.when these buttons are clicked they are mapped to Job Opening and associated with Job OPening respectevely. 

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/ee2f3a35-dc97-4675-9e76-46e6c89321c2)


## Areas affected and ensured
beams/beams/custom_scripts/job_requsition/job_requsition

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
Existing Data
New Data

## Is patch required?
No