### PR TITLE
feat: Created child doctype Applicant Interview Round

### DIFF
--- a/beams/beams/custom_scripts/job_applicant/job_applicant.py
+++ b/beams/beams/custom_scripts/job_applicant/job_applicant.py
@@ -132,3 +132,25 @@ def generate_magic_link(applicant_id):
     doc.save()
 
     return link
+
+
+@frappe.whitelist()
+def fetch_interview_rounds(doc, method):
+    """
+    Fetch interview rounds for a job applicant based on the job title.
+    If the applicant has a job title and no interview rounds have been added,
+    this function retrieves the job requisition linked to the job opening
+    and populates the interview rounds in the applicant's document.
+    """
+    if doc.job_title and not doc.applicant_interview_round:  # Check if job title exists and rounds have not been added
+        if frappe.db.exists('Job Opening', doc.job_title):  # Check if the job opening exists
+            job_opening = frappe.get_doc('Job Opening', doc.job_title)
+            if job_opening.job_requisition and frappe.db.exists('Job Requisition', job_opening.job_requisition):
+                job_requisition = frappe.get_doc('Job Requisition', job_opening.job_requisition)
+                if job_requisition.interview_rounds:
+                    existing_rounds = {round.interview_round for round in doc.applicant_interview_round}
+                    for round in job_requisition.interview_rounds:
+                        if round.interview_round not in existing_rounds:
+                            doc.append('applicant_interview_round', {
+                                'interview_round': round.interview_round
+                            })

--- a/beams/beams/doctype/applicant_interview_round/applicant_interview_round.json
+++ b/beams/beams/doctype/applicant_interview_round/applicant_interview_round.json
@@ -1,0 +1,50 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2024-10-23 10:10:03.364538",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "interview_round",
+  "interview_reference",
+  "interview_status",
+  "create_interview"
+ ],
+ "fields": [
+  {
+   "fieldname": "interview_round",
+   "fieldtype": "Link",
+   "label": "Interview Round",
+   "options": "Interview Round"
+  },
+  {
+   "fieldname": "interview_reference",
+   "fieldtype": "Data",
+   "label": "Interview Reference"
+  },
+  {
+   "fieldname": "interview_status",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Interview Status"
+  },
+  {
+   "fieldname": "create_interview",
+   "fieldtype": "Button",
+   "label": "Create/View "
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2024-10-24 16:52:25.961612",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "Applicant Interview Round",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/beams/beams/doctype/applicant_interview_round/applicant_interview_round.py
+++ b/beams/beams/doctype/applicant_interview_round/applicant_interview_round.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class ApplicantInterviewRound(Document):
+	pass

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -193,7 +193,8 @@ doc_events = {
         "on_cancel": "beams.beams.custom_scripts.journal_entry.journal_entry.on_cancel"
         },
     "Job Applicant": {
-        "validate": "beams.beams.custom_scripts.job_applicant.job_applicant.validate"
+        "validate": "beams.beams.custom_scripts.job_applicant.job_applicant.validate",
+        "before_save":"beams.beams.custom_scripts.job_applicant.job_applicant.fetch_interview_rounds"
         },
     "Department": {
        "validate": "beams.beams.custom_scripts.department.department.validate"

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -821,6 +821,19 @@ def get_job_applicant_custom_fields():
                 "fieldtype": "Link",
                 "options": "Location",
                 "insert_after": "country"
+            },
+            {
+                "fieldname": "interview_process_break",
+                "fieldtype": "Section Break",
+                "label": "Interview Process",
+                "insert_after": "skill_proficiency"
+            },
+            {
+                "fieldname": "applicant_interview_round",
+                "fieldtype": "Table",
+                "options": "Applicant Interview Round",
+                "label": "Interview Rounds",
+                "insert_after": "interview_process_break"
             }
         ]
     }
@@ -945,6 +958,13 @@ def get_job_opening_custom_fields():
                 "label": "",
                 "options": "<p style='margin-top: 5px; color: #6c757d; font-size: 0.9em;'>Proficiency selected here is the minimum proficiency needed.</p>",
                 "insert_after": "skill_proficiency"
+            },
+            {
+                "fieldname": "job_requisition_id_",
+                "label": "job Requisition",
+                "fieldtype": "Link",
+                "options": "Job Requisition",
+                "insert_after": "designation"
             }
         ]
     }


### PR DESCRIPTION
## Feature description

-Need to create child table  'Applicant Interview Round
-Need to Add field Applicant Interview Round in to Job Applicant doctype .
-implement to fetch  the interview rounds from the Job Requisition and in the Applicant Interview Round child table.
-Need Add the Field job opening

## Solution description

1. created child table  'Applicant Interview Round 
 
     - Interview Round(Link, options: Interview Round)
     - Interview Reference (Data)
     - Interview Status (Data)
     - create/view(button)
 
2 . Added the child table applicant interview round in job appilicant via setup.py
       - added the section break via setup.py
       - added the field interview rounds (table,option-applicant interview round) via setup.py
       - also implemented that if the doctype job applicant doctype job title is selected and saved then only the
          Applicant Interview  Round is visible via job applicant.js 

3 . implemented to fetch  the interview rounds from the Job Requisition and in the Applicant Interview Round child table.
      -implement server side code fetching in via job applicant.py
      - implemented client side code for fetching in via job applicant.js
      - added event in hooks.py
 
 4.   added field jobrequisition(link,option-job requsition)
## Output

[Screencast from 29-10-24 01:23:17 PM IST.webm](https://github.com/user-attachments/assets/946ef0fe-c7fc-475e-b044-ccfedfc515e3)
![image](https://github.com/user-attachments/assets/7c163a6c-8194-4c20-b2a5-5ada9b8925a3)
![image](https://github.com/user-attachments/assets/bb0b2857-b823-4da0-9b19-9a32f5593e43)


## Areas affected and ensured
-job applicant doctype
-job Opening doctype 

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox