### PR TITLE
feat: Set overdue status for Local Enquiry Reports(TASK-2024-00945)

### DIFF
--- a/beams/beams/doctype/local_enquiry_report/local_enquiry_report.py
+++ b/beams/beams/doctype/local_enquiry_report/local_enquiry_report.py
@@ -11,10 +11,10 @@ class LocalEnquiryReport(Document):
 
 @frappe.whitelist()
 def set_status_to_overdue():
-    """
+    '''
      This function updates the status of Local Enquiry Reports. It sets the status to 'Overdue'for reports where the expected completion date is today or earlier,
      the enquiry completion date is not set or is later than the expected completion date, and the current status is not already 'Overdue'.
-    """
+    '''
     today = getdate(frappe.utils.today())
 
     # Fetch Local Enquiry Reports with expected completion date on or before today and status not set to 'Overdue'
@@ -25,9 +25,8 @@ def set_status_to_overdue():
 
     if enquiries:
         for enquiry in enquiries:
-            doc = frappe.get_doc('Local Enquiry Report', enquiry.name)
             # Check if 'Enquiry Completion Date' is not set or is later than 'Expected Completion Date'
-            if not doc.enquiry_completion_date or getdate(doc.enquiry_completion_date) > getdate(doc.expected_completion_date):
+            if not enquiry.enquiry_completion_date or getdate(enquiry.enquiry_completion_date) > getdate(enquiry.expected_completion_date):
                 frappe.db.set_value('Local Enquiry Report', enquiry.name, 'status', 'Overdue')
 
         frappe.db.commit()

--- a/beams/beams/doctype/local_enquiry_report/local_enquiry_report.py
+++ b/beams/beams/doctype/local_enquiry_report/local_enquiry_report.py
@@ -9,21 +9,25 @@ from frappe.utils import getdate
 class LocalEnquiryReport(Document):
     pass
 
-
 @frappe.whitelist()
-def update_local_enquiry_status():
-    '''
-    This function updates the status of Local Enquiry Reports. It sets the status to 'Overdue'for reports where the expected completion date is today or earlier,
-    the enquiry completion date is not set or is later than the expected completion date, and the current status is not already 'Overdue'.
-    '''
-    today = getdate()
+def set_status_to_overdue():
+    """
+     This function updates the status of Local Enquiry Reports. It sets the status to 'Overdue'for reports where the expected completion date is today or earlier,
+     the enquiry completion date is not set or is later than the expected completion date, and the current status is not already 'Overdue'.
+    """
+    today = getdate(frappe.utils.today())
+
+    # Fetch Local Enquiry Reports with expected completion date on or before today and status not set to 'Overdue'
     enquiries = frappe.get_all('Local Enquiry Report', filters={
         'expected_completion_date': ['<=', today],
         'status': ['!=', 'Overdue']
-    })
-    for enquiry in enquiries:
-        if frappe.db.exists("Local Enquiry Report", enquiry.name):
+    }, fields=['name', 'expected_completion_date', 'enquiry_completion_date'])
+
+    if enquiries:
+        for enquiry in enquiries:
             doc = frappe.get_doc('Local Enquiry Report', enquiry.name)
-            if not doc.enquiry_completion_date or doc.enquiry_completion_date > doc.expected_completion_date:
-                doc.status = 'Overdue'  # Set status to 'Overdue'
-                doc.save()  # Save the document
+            # Check if 'Enquiry Completion Date' is not set or is later than 'Expected Completion Date'
+            if not doc.enquiry_completion_date or getdate(doc.enquiry_completion_date) > getdate(doc.expected_completion_date):
+                frappe.db.set_value('Local Enquiry Report', enquiry.name, 'status', 'Overdue')
+
+        frappe.db.commit()

--- a/beams/beams/doctype/local_enquiry_report/local_enquiry_report_list.js
+++ b/beams/beams/doctype/local_enquiry_report/local_enquiry_report_list.js
@@ -1,0 +1,26 @@
+frappe.listview_settings["Local Enquiry Report"] = {
+    has_indicator_for_draft: 1,
+    add_fields: ["status", "workflow_state"],
+    get_indicator: function (doc) {
+        if (doc.status === "Overdue") {
+            return [__("Overdue"), "red", "status,=,Overdue"];
+        }
+        else {
+            if (doc.workflow_state === "Pending Approval") {
+                return [__("Pending Approval"), "orange", "status,=,Pending Approval"];
+            } else if (doc.workflow_state === "Draft") {
+                return [__("Draft"), "blue", "status,=,Draft"];
+            } else if (doc.workflow_state === "Assigned to Admin") {
+                return [__("Assigned to Admin"), "purple", "status,=,Assigned to Admin"];
+            } else if (doc.workflow_state === "Assigned to Enquiry Officer") {
+                return [__("Assigned to Enquiry Officer"), "cyan", "status,=,Assigned to Enquiry Officer"];
+            } else if (doc.workflow_state === "Enquiry on Progress") {
+                return [__("Enquiry on Progress"), "yellow", "status,=,Enquiry on Progress"];
+            } else if (doc.workflow_state === "Approved") {
+                return [__("Approved"), "green", "status,=,Approved"];
+            } else if (doc.workflow_state === "Rejected") {
+                return [__("Rejected"), "red", "status,=,Rejected"];
+            }
+        }
+    }
+};

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -208,7 +208,7 @@ doc_events = {
 
 scheduler_events = {
     "daily": [
-        "beams.beams.doctype.local_enquiry_report.local_enquiry_report.update_local_enquiry_status"
+        "beams.beams.doctype.local_enquiry_report.local_enquiry_report.set_status_to_overdue"
     ],
 # 	"all": [
 # 		"beams.tasks.all"


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- Feat

## Clearly and concisely describe the feature, chore or bug.
- Update Local Enquiry Report status to 'Overdue' when enquiry completion date exceeds expected completion date.
- Introduced a feature to enhance the Local Enquiry Report list view  with color-coded status indicators,

## Solution description
- Added functionality to update the status of Local Enquiry Report records to 'Overdue' based on the enquiry completion date and expected completion date.
- Added color-coded status indicators to the Local Enquiry Report list view.

## Areas affected and ensured
- Local Enquiry Report-status updates for overdue reports
- Local Enquiry Report List View: Enhanced with color-coded indicators

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
Existing Data
New Data
