### PR TITLE
feat: Create doctype Beams HR Settings

### DIFF
--- a/beams/beams/doctype/beams_hr_settings/beams_hr_settings.js
+++ b/beams/beams/doctype/beams_hr_settings/beams_hr_settings.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2024, efeone and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Beams HR Settings", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/beams/beams/doctype/beams_hr_settings/beams_hr_settings.json
+++ b/beams/beams/doctype/beams_hr_settings/beams_hr_settings.json
@@ -1,0 +1,89 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2024-11-02 12:43:07.245206",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "column_break_wgti",
+  "default_local_enquiry_duration",
+  "tab_2_tab",
+  "admin_department",
+  "admin_hod",
+  "column_break_nncm",
+  "it_department",
+  "it_hod"
+ ],
+ "fields": [
+  {
+   "description": "In Days",
+   "fieldname": "default_local_enquiry_duration",
+   "fieldtype": "Int",
+   "label": "Default Local Enquiry Duration"
+  },
+  {
+   "fieldname": "tab_2_tab",
+   "fieldtype": "Tab Break",
+   "label": "Department Settings"
+  },
+  {
+   "fieldname": "column_break_wgti",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "admin_department",
+   "fieldtype": "Link",
+   "label": "Admin Department ",
+   "options": "Department"
+  },
+  {
+   "fetch_from": "admin_department.head_of_department",
+   "fieldname": "admin_hod",
+   "fieldtype": "Link",
+   "label": "Admin HOD",
+   "options": "Employee",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_nncm",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "it_department",
+   "fieldtype": "Link",
+   "label": "IT Department",
+   "options": "Department"
+  },
+  {
+   "fetch_from": "it_department.head_of_department",
+   "fieldname": "it_hod",
+   "fieldtype": "Link",
+   "label": "IT HOD",
+   "options": "Employee",
+   "read_only": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "issingle": 1,
+ "links": [],
+ "modified": "2024-11-02 13:03:53.608882",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "Beams HR Settings",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/beams/beams/doctype/beams_hr_settings/beams_hr_settings.json
+++ b/beams/beams/doctype/beams_hr_settings/beams_hr_settings.json
@@ -33,7 +33,7 @@
   {
    "fieldname": "admin_department",
    "fieldtype": "Link",
-   "label": "Admin Department ",
+   "label": "Admin Department",
    "options": "Department"
   },
   {
@@ -66,7 +66,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-11-02 13:03:53.608882",
+ "modified": "2024-11-04 09:23:13.513846",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Beams HR Settings",
@@ -81,6 +81,13 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "All",
+   "share": 1
   }
  ],
  "sort_field": "modified",

--- a/beams/beams/doctype/beams_hr_settings/beams_hr_settings.py
+++ b/beams/beams/doctype/beams_hr_settings/beams_hr_settings.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class BeamsHRSettings(Document):
+	pass

--- a/beams/beams/doctype/beams_hr_settings/test_beams_hr_settings.py
+++ b/beams/beams/doctype/beams_hr_settings/test_beams_hr_settings.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, efeone and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestBeamsHRSettings(FrappeTestCase):
+	pass


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- Feat

## Clearly and concisely describe the feature, chore or bug.
- a docype is needed to manage default configurations for HR Settings.
- Add read permission for "All" in Beams HR Settings.
- Remove the whitespace from label Admin Department

## Solution description
- Created doctype named 'Beams HR Settings' with fields Default Local Enquiry Duration ,Admin Department, Admin HOD,IT Department ,IT HOD 
- Add read permission for "All" in Beams HR Settings and removed the whitespace from label Admin Department.

## Output Screenshots

![image](https://github.com/user-attachments/assets/9b40597b-a36a-4003-bc51-b39a078f5f16)
![image](https://github.com/user-attachments/assets/e5f42b59-ec51-428b-9e74-85e44dc1ec68)
![image](https://github.com/user-attachments/assets/04b2ae31-bac1-473b-8553-a7b9b2b433b7)

## Areas affected and ensured
- Beams HR Settings.
## Is there any existing behavior change of other features due to this code change?
No
