### PR TITLE
fix: improve Job Applicant validation based on Job Opening fields

### DIFF
--- a/beams/beams/doctype/language_proficiency/language_proficiency.json
+++ b/beams/beams/doctype/language_proficiency/language_proficiency.json
@@ -17,8 +17,7 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Language",
-   "options": "Language",
-   "reqd": 1
+   "options": "Language"
   },
   {
    "fieldname": "speak",
@@ -42,7 +41,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-10-03 10:03:18.480483",
+ "modified": "2024-11-04 14:40:00.168283",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Language Proficiency",

--- a/beams/beams/doctype/skill_proficiency/skill_proficiency.json
+++ b/beams/beams/doctype/skill_proficiency/skill_proficiency.json
@@ -15,21 +15,19 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Skill",
-   "options": "Skill",
-   "reqd": 1
+   "options": "Skill"
   },
   {
    "fieldname": "proficiency",
    "fieldtype": "Rating",
    "in_list_view": 1,
-   "label": "Proficiency",
-   "reqd": 1
+   "label": "Proficiency"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-10-03 10:03:29.247027",
+ "modified": "2024-11-04 14:40:13.262941",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Skill Proficiency",

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -798,7 +798,6 @@ def get_job_applicant_custom_fields():
                 "fieldname": "language_proficiency",
                 "fieldtype": "Table",
                 "options": "Language Proficiency",
-                "reqd":1,
                 "label": "Language Proficiency",
                 "insert_after": "min_experience"
             },
@@ -807,7 +806,6 @@ def get_job_applicant_custom_fields():
                 "fieldtype": "Table",
                 "options": "Skill Proficiency",
                 "label": "Skill Proficiency",
-                "reqd":1,
                 "insert_after": "language_proficiency"
             },
             {


### PR DESCRIPTION
## Feature description

- fix.

## Analysis and design (optional)
- Removed Validation errors that occur unnecessarily when creating a Job Applicant without a linked Job Opening.
- Validation for location, qualifications, experience, and skills is applied only when these fields are specified in the Job Opening.

## Solution description
- Added checks to validate only filled fields in the Job Applicant against those in the Job Opening.
- Included error handling to avoid validation errors when creating a Job Applicant without a linked Job Opening.
- Made skill proficiency and language proficiency table not mandatory in Job Applicant.
- Made Skill and Proficiency fields in Skill proficiency table not mandatory
- Made Language field in Language proficiency table not mandatory.

## Output screenshots (optional)
[Screencast from 11-04-2024 04:06:42 PM.webm](https://github.com/user-attachments/assets/5240ad95-4184-435d-a6a5-4643f11780f4)
[Screencast from 11-04-2024 04:08:17 PM.webm](https://github.com/user-attachments/assets/e5b989d2-9955-45cd-b97f-c376474f6b05)



## Areas affected and ensured
Job Applicant.

## Was this feature tested on the browsers?
  - Mozilla Firefox
 
