### PR TITLE
TASK-2024-00986: Add Department field in Job Applicant and create Job Proposal doctype

### DIFF
--- a/beams/beams/doctype/job_proposal/job_proposal.js
+++ b/beams/beams/doctype/job_proposal/job_proposal.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2024, efeone and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Job Proposal", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/beams/beams/doctype/job_proposal/job_proposal.json
+++ b/beams/beams/doctype/job_proposal/job_proposal.json
@@ -1,0 +1,102 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "HR-PRO-.YYYY.-.#####",
+ "creation": "2024-11-04 14:43:16.307310",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "section_break_ha0t",
+  "job_applicant",
+  "applicant_name",
+  "department",
+  "column_break_bavx",
+  "designation",
+  "proposed_ctc",
+  "amended_from"
+ ],
+ "fields": [
+  {
+   "fieldname": "section_break_ha0t",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "job_applicant",
+   "fieldtype": "Link",
+   "label": "Job Applicant",
+   "options": "Job Applicant"
+  },
+  {
+   "fetch_from": "job_applicant.applicant_name",
+   "fieldname": "applicant_name",
+   "fieldtype": "Data",
+   "label": "Applicant Name ",
+   "read_only": 1,
+   "unique": 1
+  },
+  {
+   "fetch_from": "job_applicant.designation",
+   "fieldname": "designation",
+   "fieldtype": "Link",
+   "label": "Designation",
+   "options": "Designation",
+   "read_only": 1
+  },
+  {
+   "fieldname": "proposed_ctc",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Proposed CTC ",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_bavx",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "job_applicant.department",
+   "fieldname": "department",
+   "fieldtype": "Link",
+   "label": "Department",
+   "options": "Department",
+   "read_only": 1
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "Job Proposal",
+   "print_hide": 1,
+   "read_only": 1,
+   "search_index": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "is_submittable": 1,
+ "links": [],
+ "modified": "2024-11-04 16:01:48.128975",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "Job Proposal",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "title_field": "applicant_name"
+}

--- a/beams/beams/doctype/job_proposal/job_proposal.json
+++ b/beams/beams/doctype/job_proposal/job_proposal.json
@@ -75,7 +75,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-11-04 16:01:48.128975",
+ "modified": "2024-11-05 09:49:20.360151",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Job Proposal",
@@ -90,6 +90,19 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "HR Manager",
    "share": 1,
    "submit": 1,
    "write": 1

--- a/beams/beams/doctype/job_proposal/job_proposal.py
+++ b/beams/beams/doctype/job_proposal/job_proposal.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class JobProposal(Document):
+	pass

--- a/beams/beams/doctype/job_proposal/test_job_proposal.py
+++ b/beams/beams/doctype/job_proposal/test_job_proposal.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, efeone and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestJobProposal(FrappeTestCase):
+	pass

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -776,11 +776,20 @@ def get_job_applicant_custom_fields():
             },
 
             {
+                "fieldname": "department",
+                "fieldtype": "Link",
+                "label": "Department",
+                "options": "Department",
+                "insert_after": "designation"
+            },
+
+            {
                 "fieldname": "min_experience",
                 "fieldtype": "Float",
                 "label": "Work Experience(in years)",
                 "insert_after": "details_column_break"
             },
+
             {
                 "fieldname": "details_column_break",
                 "fieldtype": "Column Break",


### PR DESCRIPTION
## Feature description
Update Job Applicant with Department field and introduce Job Proposal doctype

## Solution description
- Added 'Department' field (Link to Department) in the Job Applicant doctype.
- Created a new  doctype 'Job Proposal' with the following fields:
  - Job Applicant: Link (select from Job Applicant)
  - Applicant Name: Data (Read-Only, auto-fetch from Job Applicant)
  - Designation: Link (select from Designation, Read-Only, auto-fetch from Job Applicant)
  - Department: Link (select from Department, Read-Only, auto-fetch from Job Applicant)
  - Proposed CTC: Currency (mandatory field)

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/8596dba8-945e-45db-96de-76e1ad6d0bf1)
![image](https://github.com/user-attachments/assets/358bb9b5-bdb8-4ae2-a8ad-610fde4eecc5)
![image](https://github.com/user-attachments/assets/d0ec6150-f686-47d3-8111-b48343354b5f)
![image](https://github.com/user-attachments/assets/c31b4e3b-e7e4-4150-920c-110589af0b70)

[Screencast from 04-11-24 04:43:29 PM IST.webm](https://github.com/user-attachments/assets/4a717e0c-bfdf-4477-8721-575b0a0ec0ac)

## Areas affected and ensured
Job Applicant Doctype 
Job Proposal Doctype

## Is there any existing behavior change of other features due to this code change?
no

## Was this feature tested on the browsers?
  - Mozilla Firefox
 