### PR TITLE
fix:  TASK-2024-00946: updated the workflow in local enquiry report

### DIFF
--- a/beams/fixtures/workflow.json
+++ b/beams/fixtures/workflow.json
@@ -2297,13 +2297,13 @@
   "doctype": "Workflow",
   "document_type": "Local Enquiry Report",
   "is_active": 1,
-  "modified": "2024-11-04 11:44:07.621677",
+  "modified": "2024-11-05 12:09:15.146788",
   "name": "Enquiry Workflow",
-  "override_status": 0,
+  "override_status": 1,
   "send_email_alert": 0,
   "states": [
    {
-    "allow_edit": "All",
+    "allow_edit": "HR Manager",
     "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
@@ -2318,7 +2318,7 @@
     "workflow_builder_id": null
    },
    {
-    "allow_edit": "HR Manager",
+    "allow_edit": "Enquiry Manager",
     "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,


### PR DESCRIPTION
## Issue  description
-  Set to  enable status overriding  local enquiry report workflow
- Modify the allow edit  permissions to specify roles for different states

## Solution description
 -Checked the `override_status` to 1 to enable status overriding.
 - Changed `allow_edit` from "All" to "HR Manager" for the first state.
 - Changed `allow_edit` from "HR Manager" to "Enquiry Manager" for the second state

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/8656e5dc-50d4-4486-9782-2cd24654c025)



## Areas affected and ensured
local enquiry report doctype

## Is there any existing behavior change of other features due to this code change?
no

## Was this feature tested on the browsers?
  - Mozilla Firefox
  
