### PR TITLE
fix : Added Custom Fields in Release Order and Changed the label of Cost Sub Head In Budget

### DIFF
--- a/beams/beams/report/budget_report/budget_report.py
+++ b/beams/beams/report/budget_report/budget_report.py
@@ -15,7 +15,7 @@ def get_columns(filters):
     columns = [
         {"label": _("Budget"), "fieldname": "budget_link", "fieldtype": "Link", "options": "Budget", "width": 230},
         {"label": _("Cost Description"), "fieldname": "cost_description", "fieldtype": "Data", "width": 230},
-        {"label": _("Cost Subhead"), "fieldname": "cost_subhead", "fieldtype": "Data", "width": 230},
+        {"label": _("Cost Sub Head"), "fieldname": "cost_subhead", "fieldtype": "Data", "width": 230},
         {"label": _("Cost Category"), "fieldname": "cost_category", "fieldtype": "Data", "width": 170},
         {"label": _("Account"), "fieldname": "account", "fieldtype": "Link", "options": "Account", "width": 230},
         {"label": _("Department"), "fieldname": "department", "fieldtype": "Link", "options": "Department", "width": 170},

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -202,7 +202,7 @@ def get_budget_custom_fields():
             {
                 "fieldname": "cost_subhead",
                 "fieldtype": "Link",
-                "label": "Cost Subhead",
+                "label": "Cost Sub Head",
                 "options":"Cost Subhead",
                 "insert_after": "cost_description"
             },
@@ -324,7 +324,7 @@ def get_quotation_custom_fields():
                 "fieldname": "region",
                 "fieldtype": "Link",
                 "label": "Region",
-                "insert_after": "party_name",
+                "insert_after": "customer_name",
                 "options": "Region"
 
             },
@@ -367,6 +367,32 @@ def get_quotation_custom_fields():
                 "label": "Client Name",
                 "insert_after": "albatross_column_break",
                 "read_only":1
+            },
+            {
+                "fieldname": "actual_customer",
+                "fieldtype": "Link",
+                "label": "Actual Customer",
+                "options": "Customer",
+                "depends_on": "eval:doc.is_agent == 1",
+                "insert_after": "is_agent"
+            },
+            {
+                "fieldname": "is_agent",
+                "fieldtype": "Check",
+                "label": "Is Agency",
+                "read_only":1,
+                "fetch_from": "party_name.is_agent",
+                "depends_on": "eval:doc.is_agent",
+                "insert_after": "party_name"
+            },
+            {
+                "fieldname": "actual_customer_group",
+                "fieldtype": "Link",
+                "label": "Actual Customer Group",
+                "options": "Customer Group",
+                "read_only": 1,
+                "fetch_from": "actual_customer.customer_group",
+                "insert_after": "actual_customer"
             },
             {
                 "fieldname": "executive_name",
@@ -1131,6 +1157,13 @@ def get_property_setters():
             "property": "depends_on",
             "property_type": "TabBreak",
             "value": "eval:doc.is_stock_item == 0"
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Job Applicant",
+            "field_name": "status",
+            "property": "options",
+            "value": "Open\nReplied\nRejected\nLocal Enquiry Approved\nSelected\nHold\nAccepted"
         },
         {
             "doctype_or_field": "DocType",


### PR DESCRIPTION
## Feature description
-Add Custom Fields in Release Order and change the label of Cost Subhead in Budget.
-Add Local Enquiry Approved and Selected options in status of the Job Applicant.

## Solution description
-Added Is Agency,Actual Customer and Actual customer group custom fields in Release Order.
-Changed the label of Cost Sub Head in Budget Report and its child table.
-Added Local Enquiry Approved and Selected Options in status of the Job Applicant.

## Output screenshots (optional)
[Screencast from 05-11-24 01:45:14 PM IST.webm](https://github.com/user-attachments/assets/b2463a74-3e36-4bfc-ad55-ec0d160afdfa)
![image](https://github.com/user-attachments/assets/634c1ed7-9802-437e-bc5d-b56aad2aad96)
![image](https://github.com/user-attachments/assets/f51c8d14-f670-4554-b1f5-be374bfa041c)
![image](https://github.com/user-attachments/assets/478124fe-4174-400d-983f-8bc390b84282)

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox
