### PR TITLE
TASK-2024-00890: Update filter applied for Head of Department in Department doctype

### DIFF
--- a/beams/beams/custom_scripts/department/department.js
+++ b/beams/beams/custom_scripts/department/department.js
@@ -23,7 +23,7 @@ frappe.ui.form.on('Department', {
                         return {
                             filters: {
                                 department: frm.doc.name, // Adjust to match the Employee's department field
-                                user_id: ['in', r.message] // Filter for users with role 'HOD'
+                                user_id: ['in', r.message || []] // Filter for users with role 'HOD'
                             }
                         };
                     });

--- a/beams/beams/custom_scripts/department/department.py
+++ b/beams/beams/custom_scripts/department/department.py
@@ -23,8 +23,9 @@ def get_hod_users(department_name):
         SELECT emp.user_id
         FROM `tabEmployee` emp
         JOIN `tabUser` usr ON usr.name = emp.user_id
-        JOIN `tabHas Role` role ON role.parent = usr.name
-        WHERE emp.department = %s AND role.role = 'HOD'
+        JOIN `tabHas Role` role1 ON role1.parent = usr.name AND role1.role = 'HOD'
+        JOIN `tabHas Role` role2 ON role2.parent = usr.name AND role2.role = 'Employee'
+        WHERE emp.department = %s
     """, (department_name,))
 
     return [user[0] for user in users]  # Return a list of user IDs


### PR DESCRIPTION
## Fix description
Filtered the "Head of Department" field in Department to display only employees who have both the "HOD" and "Employee" roles in their respective department.

## Solution description
- Updated the get_hod_users function to join the tabHas Role table twice to ensure that only users who have both the "HOD" and "Employee" roles are included in the results.
- Adjusted the client-side code to handle the case where no users with the "HOD" role are found in the specified department

## Output screenshots (optional)
- Created two employees with the same department
![image](https://github.com/user-attachments/assets/9999043a-ac54-4d73-88ba-33494ada3ff5)
![image](https://github.com/user-attachments/assets/f29f8daa-2c48-45e4-a4c9-c888c5e06b1c)

- Assigned a user employee role only.
![image](https://github.com/user-attachments/assets/0e8c0d3e-0e24-4222-a176-dce9d2c48bd1)

- Assigned another user both roles 'HOD' and 'Employee'
- ![image](https://github.com/user-attachments/assets/7a320aa0-9173-48ae-9b0f-9df7f2da2b9b)

- filtered "Head of Department" to show employees with both "HOD" and "Employee" roles.
![image](https://github.com/user-attachments/assets/d7c837c8-d5ea-48b6-824f-b5add1e1048b)



## Areas affected and ensured

- The "Head of Department" field in the Department DocType.
- The user role validation in the system.

## Is there any existing behavior change of other features due to this code change?
No
## Was this feature tested on the browsers?
  - Mozilla Firefox
 