### PR TITLE
TASK-2024-00985:Set Expected Completion Date in Local Enquiry Report on Enquiry Officer assignment

### DIFF
--- a/beams/beams/doctype/beams_hr_settings/beams_hr_settings.json
+++ b/beams/beams/doctype/beams_hr_settings/beams_hr_settings.json
@@ -5,7 +5,6 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
-  "column_break_wgti",
   "default_local_enquiry_duration",
   "tab_2_tab",
   "admin_department",
@@ -25,10 +24,6 @@
    "fieldname": "tab_2_tab",
    "fieldtype": "Tab Break",
    "label": "Department Settings"
-  },
-  {
-   "fieldname": "column_break_wgti",
-   "fieldtype": "Column Break"
   },
   {
    "fieldname": "admin_department",
@@ -66,7 +61,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-11-04 09:23:13.513846",
+ "modified": "2024-11-05 14:55:50.765755",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Beams HR Settings",

--- a/beams/beams/doctype/local_enquiry_report/local_enquiry_report.json
+++ b/beams/beams/doctype/local_enquiry_report/local_enquiry_report.json
@@ -23,7 +23,8 @@
   "enquiry_officer",
   "section_break_2hnf",
   "enquiry_report",
-  "remarks"
+  "remarks",
+  "amended_from"
  ],
  "fields": [
   {
@@ -121,19 +122,30 @@
   {
    "fieldname": "expected_completion_date",
    "fieldtype": "Date",
-   "label": "Expected Completion Date "
+   "label": "Expected Completion Date ",
+   "read_only": 1
   },
   {
    "fieldname": "enquiry_officer",
    "fieldtype": "Link",
    "label": "Enquiry Officer",
    "options": "Employee"
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "Local Enquiry Report",
+   "print_hide": 1,
+   "read_only": 1,
+   "search_index": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-11-05 10:53:30.537685",
+ "modified": "2024-11-05 14:47:51.525123",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Local Enquiry Report",


### PR DESCRIPTION
## Feature description

-Set Expected Completion Date on Enquiry Officer assignment
-Remove unused "column_break  from Beams HR Settings Doctype

## Solution description

-Removed unused "column_break_wgti" field from Beams HR Settings Doctype.
- On "Assign to Enquiry Officer" action, automatically set the Expected Completion Date in Local Enquiry Report by adding the Default Local Enquiry Duration (from Beams HR Settings) to the current date.
- Set Expected Completion Date field as read-only to prevent manual edits.

## Output screenshots (optional)

![image](https://github.com/user-attachments/assets/21c6a6e1-1ada-436c-983c-f519bb9cbfaa)

[Screencast from 05-11-24 03:20:02 PM IST.webm](https://github.com/user-attachments/assets/f44d09f1-3930-4256-9924-abf7b326fef1)



## Areas affected and ensured

Beams HR Settings Doctype 
Local Enquiry Report Doctype

## Is there any existing behavior change of other features due to this code change?
no

## Was this feature tested on the browsers?
  - Mozilla Firefox
 