### PR TITLE
TASK-2024-00932: Set information_collected_by on Pending Approval of Local Enquiry Report

### DIFF
--- a/beams/beams/doctype/local_enquiry_report/local_enquiry_report.js
+++ b/beams/beams/doctype/local_enquiry_report/local_enquiry_report.js
@@ -1,9 +1,7 @@
 // Copyright (c) 2024, efeone and contributors
 // For license information, please see license.txt
 
-frappe.ui.form.on("Local Enquiry Report", {
-	onload(frm) {
-        frm.set_value('information_collected_by', frappe.session.user);
-
-	},
-});
+// frappe.ui.form.on("Local Enquiry Report", {
+// 	onload(frm) {
+// 	},
+// });

--- a/beams/beams/doctype/local_enquiry_report/local_enquiry_report.py
+++ b/beams/beams/doctype/local_enquiry_report/local_enquiry_report.py
@@ -15,6 +15,9 @@ class LocalEnquiryReport(Document):
         Validation for the missing fields -> information_given_by and information_given_by_designation
         """
         if self.workflow_state == "Pending Approval":
+            if frappe.session.user:
+                self.information_collected_by = frappe.session.user
+
             missing_fields = []
 
             if not self.information_given_by:
@@ -24,6 +27,7 @@ class LocalEnquiryReport(Document):
 
             if len(missing_fields) == 2:
                 frappe.throw("Please provide 'Information given by' and 'Information given by Designation' before completing the report.")
+
             elif missing_fields:
                 frappe.throw(f"Please provide '{', '.join(missing_fields)}' before completing the report.")
 
@@ -37,7 +41,6 @@ class LocalEnquiryReport(Document):
 
             # Set Expected Completion Date as today’s date plus the default duration
             self.expected_completion_date = add_days(today(), int(default_duration))
-
 
 @frappe.whitelist()
 def set_status_to_overdue():


### PR DESCRIPTION
## Feature description

-  The information_collected_by field  in Local Enquiry Report was previously being set to the current user every time the form loaded.
- The information_collected_by field in the Local Enquiry Report is now set to the current user only when the workflow state transitions to "Pending Approval."
- Local Enquiry is done by Assigned Enquiry Officer mentioned in Local Enquiry Report.

## Solution description
- The client-side code that previously set the information_collected_by field on form load was removed.
-  Instead, the field is now updated on the server-side during the validation phase of the Local Enquiry Report. When the workflow_state changes to "Pending Approval," the field is assigned the value of the current user 
- the information_collected_by field in Local Enquiry Report is assigned the id of Enquiry Officer who completed the enquiry.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/93ee6856-8609-433f-ac60-4ac3e9fdfd64)

## Areas affected and ensured
- Local Enquiry Report DocType
- Workflow for the Local Enquiry Report

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox
  