### PR TITLE
 TASK-2024-00938:  Fixed the Creation of Local Enquiry Report From Job Applicant 

### DIFF
--- a/beams/beams/custom_scripts/job_applicant/job_applicant.js
+++ b/beams/beams/custom_scripts/job_applicant/job_applicant.js
@@ -38,11 +38,11 @@ function handle_custom_buttons(frm) {
                                 }
                             }
                         });
-            }, __('Create'));
-        } else if (response.message) {
-            frappe.db.get_doc("Local Enquiry Report", response.message).then(report => {
-                frm.add_custom_button(__('Local Enquiry Report'), function() {
-                    frappe.set_route('Form', 'Local Enquiry Report', report.name);
+                }, __('Create'));
+              } else if (response.message) {
+                  frappe.db.get_doc("Local Enquiry Report", response.message).then(report => {
+                      frm.add_custom_button(__('Local Enquiry Report'), function() {
+                          frappe.set_route('Form', 'Local Enquiry Report', report.name);
                 }, __('View'));
             });
         }

--- a/beams/beams/custom_scripts/job_applicant/job_applicant.js
+++ b/beams/beams/custom_scripts/job_applicant/job_applicant.js
@@ -18,41 +18,36 @@ frappe.ui.form.on('Job Applicant', {
 function handle_custom_buttons(frm) {
     if (!frm.is_new()) {
       frappe.call({
-             method: "beams.beams.custom_scripts.job_applicant.job_applicant.get_existing_local_enquiry_report",
-             args: {
-                 doc_name: frm.doc.name
-             },
-             callback: function(r) {
-                 if (r.message === "no_report") {
-               // Case 1: No report exists; show the "Create" button to create a new report
-               frm.add_custom_button(__(' Local Enquiry Report'), function() {
-                   // Automatically create the Local Enquiry Report
-                   frappe.call({
-                   method: "beams.beams.custom_scripts.job_applicant.job_applicant.create_and_return_report",
-                   args: {
-                       job_applicant: frm.doc.name
-                   },
-                   callback: function(r) {
-                       if (r.message) {
-                           frm.add_custom_button(__(' Local Enquiry Report'), function() {
-                               frappe.set_route('Form', 'Local Enquiry Report', r.message);
-                           }, __('View'));
-                       }
-                   }
-               });
-
-               }, __('Create'));
-                 } else if (r.message) {
-               // Case 2: Report exists, get the report document
-               frappe.db.get_doc("Local Enquiry Report", r.message).then(report => {
-                   // Add a button to view the report, regardless of its docstatus
-                   frm.add_custom_button(__('Local Enquiry Report'), function() {
-                 frappe.set_route('Form', 'Local Enquiry Report', report.name);
-                   }, __('View'));
-               });
-            }
-          }
-      });
+            method: "beams.beams.custom_scripts.job_applicant.job_applicant.get_existing_local_enquiry_report",
+            args: {
+                doc_name: frm.doc.name
+            },
+            callback: function(response) {
+                if (response.message === "no_report") {
+                    frm.add_custom_button(__('Local Enquiry Report'), function() {
+                        frappe.call({
+                            method: "beams.beams.custom_scripts.job_applicant.job_applicant.create_and_return_report",
+                            args: {
+                                job_applicant: frm.doc.name
+                            },
+                            callback: function(createResponse) {
+                                if (createResponse.message) {
+                                    frm.add_custom_button(__('Local Enquiry Report'), function() {
+                                        frappe.set_route('Form', 'Local Enquiry Report', createResponse.message);
+                                    }, __('View'));
+                                }
+                            }
+                        });
+            }, __('Create'));
+        } else if (response.message) {
+            frappe.db.get_doc("Local Enquiry Report", response.message).then(report => {
+                frm.add_custom_button(__('Local Enquiry Report'), function() {
+                    frappe.set_route('Form', 'Local Enquiry Report', report.name);
+                }, __('View'));
+            });
+        }
+    }
+});
         // Button for Sending Magic Link
         frm.add_custom_button(__('Send Magic Link'), function () {
             frappe.confirm(

--- a/beams/beams/doctype/local_enquiry_checklist/local_enquiry_checklist.json
+++ b/beams/beams/doctype/local_enquiry_checklist/local_enquiry_checklist.json
@@ -16,8 +16,7 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Parameter",
-   "options": "Local Enquiry Parameter",
-   "reqd": 1
+   "options": "Local Enquiry Parameter"
   },
   {
    "fieldname": "value",
@@ -34,7 +33,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-10-24 10:54:30.030785",
+ "modified": "2024-11-06 10:26:01.870601",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Local Enquiry Checklist",

--- a/beams/beams/doctype/local_enquiry_report/local_enquiry_report.json
+++ b/beams/beams/doctype/local_enquiry_report/local_enquiry_report.json
@@ -39,8 +39,7 @@
    "fieldname": "enquiry_report",
    "fieldtype": "Table",
    "label": "Enquiry Report",
-   "options": "Local Enquiry Checklist",
-   "reqd": 1
+   "options": "Local Enquiry Checklist"
   },
   {
    "fieldname": "remarks",
@@ -145,7 +144,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-11-05 14:47:51.525123",
+ "modified": "2024-11-06 10:41:50.514086",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Local Enquiry Report",


### PR DESCRIPTION
## Issue  description

1.Make 'Enquiry Report' field optional  in Local Enquiry Report 
2.Need  to Implement the creation Button Local Enquiry Report in Job apaplicant 


## Solution description

1.Make 'Enquiry Report' field optional  in Local Enquiry Report 

 -Removed  the mandatory in enquiry_report field(option-table) in local enquiry report.
 -Removed  the mandatory in Parameter field(option-data) in  child table local enquiry checklist .
 
 2.Need  to Implement the creation Button Local Enquiry Report in Job apaplicant 

  -Added a check to call get_existing_local_enquiry_report and conditionally display the "Create" or "View" button for the Local     Enquiry Report.
-implement the logic that create button only when if not exists and if clicked the button alert message created and viewed from the button view buttonvia job applicant.py and job applicant .js
-provided alert message while creating with link.
## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/cab027dc-1327-43e1-97d5-e8f90188c595)
![image](https://github.com/user-attachments/assets/8d547587-8843-4dbc-9c4a-23def729d16e)
[Screencast from 06-11-24 11:33:54 AM IST.webm](https://github.com/user-attachments/assets/1e23af83-edaf-4f03-b9c0-a92893631d2d)


## Areas affected and ensured
job applicant 
local enquiry report

## Is there any existing behavior change of other features due to this code change?
yes . changed the logic creation of button in job applicant 

## Was this feature tested on the browsers?

  - Mozilla Firefox
 
