### PR TITLE
TASK-2024-00896: Added status options in Job Requisition through Property Setter

### DIFF
--- a/beams/setup.py
+++ b/beams/setup.py
@@ -1184,6 +1184,13 @@ def get_property_setters():
             "doc_type": "Job Requisition",
             "property": "field_order",
             "value": "[\"workflow_state\", \"naming_series\", \"request_for\", \"employee_left\", \"staffing_plan\", \"designation\", \"column_break_qkna\", \"department\", \"no_of_positions\", \"expected_compensation\", \"column_break_4\", \"company\", \"status\", \"section_break_7\", \"requested_by\", \"requested_by_name\", \"column_break_10\", \"requested_by_dept\", \"requested_by_designation\", \"work_details\", \"employment_type\", \"no_of_days_off\", \"location\", \"work_details_column_break\", \"travel_required\", \"driving_license_needed\", \"is_work_shift_needed\", \"license_type\", \"education\", \"min_education_qual\", \"education_column_break\", \"min_experience\", \"reset_column\", \"language_proficiency\", \"skill_proficiency\", \"timelines_tab\", \"posting_date\", \"completed_on\", \"column_break_15\", \"expected_by\", \"time_to_fill\", \"job_description_tab\", \"job_description_template\", \"job_title\", \"description\", \"reason_for_requesting\", \"connections_tab\"]"
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Job Requisition",
+            "field_name": "status",
+            "property": "options",
+            "value": "Pending\nOpen & Approved\nRejected\nFilled\nOn Hold\nCancelled"
         }
 
     ]


### PR DESCRIPTION
## Feature description
 status options ("Pending,Open & Approved,Rejected,Filled,On Hold,Cancelled") should be added through Property Setter in Job Requisition.

## Solution description
Added required option in status field of job requisition using property setter.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/2dd74782-51c5-49e8-88a2-7befa4837999)

## Areas affected and ensured
Job Requisition.

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox
  
