### PR TITLE
fix : Existing Interview feedback fetched back

### DIFF
--- a/beams/beams/custom_scripts/interview/interview.js
+++ b/beams/beams/custom_scripts/interview/interview.js
@@ -21,7 +21,7 @@ frappe.ui.form.on('Interview', {
             if (!frm.is_dirty() && frm.doc.docstatus == 0) {
                 frm.page.clear_primary_action();
                 frm.page.set_primary_action(__('Submit'), function () {
-                    frm.submit(); // Use frm.submit() instead of frm.save_submit()
+                    frm.submit(); 
                 });
             } else if (frm.is_dirty() && frm.doc.docstatus == 0) {
                 frm.page.clear_primary_action();

--- a/beams/beams/custom_scripts/interview/interview.js
+++ b/beams/beams/custom_scripts/interview/interview.js
@@ -1,134 +1,151 @@
 frappe.ui.form.on('Interview', {
     refresh: function (frm) {
         setTimeout(function () {
-            if (!frm.is_dirty() && frm.doc.docstatus==0) {
+            // Remove the HR-provided 'Submit Feedback' button if it exists
+            frm.remove_custom_button('Submit Feedback');
+        }, 250);
+
+        // Add Interview Feedback button if the document is in draft state
+        frappe.db.get_value('Interview Feedback', {interview: frm.doc.name,docstatus:1}, 'name') .then(r => {
+         let values = r.message;
+         if (frm.doc.docstatus === 0&&!values.name) {
+             frm.add_custom_button(__('Interview Feedback'), function () {
+                 frm.events.show_feedback_dialog(frm);
+             });
+         }
+       })
+
+
+        // Manage primary action buttons
+        setTimeout(function () {
+            if (!frm.is_dirty() && frm.doc.docstatus == 0) {
                 frm.page.clear_primary_action();
                 frm.page.set_primary_action(__('Submit'), function () {
-                    frm.savesubmit();
+                    frm.submit(); // Use frm.submit() instead of frm.save_submit()
                 });
-                frm.add_custom_button(__('Interview Feedback'), function () {
-                    frm.events.show_feedback_dialog(frm);
-                });
-            } else if (frm.is_dirty() && frm.doc.docstatus==0) {
+            } else if (frm.is_dirty() && frm.doc.docstatus == 0) {
                 frm.page.clear_primary_action();
                 frm.page.set_primary_action(__('Save'), function () {
                     frm.save();
                 });
-            }
-            else if (frm.doc.docstatus==1){
-              frm.page.clear_primary_action();
+            } else if (frm.doc.docstatus == 1) {
+                frm.page.clear_primary_action();
             }
         }, 500);
     },
 
     show_feedback_dialog: function (frm) {
+        // Check for existing feedback
         frappe.call({
-            method: "hrms.hr.doctype.interview.interview.get_expected_skill_set",
+            method: "beams.beams.custom_scripts.interview.interview.get_interview_feedback",
             args: {
-                interview_round: frm.doc.interview_round,
+                interview_name: frm.doc.name
             },
             callback: function (r) {
-                if (r.message) {
-                    let skill_fields = frm.events.get_fields_for_feedback();
+                let existing_feedback = r.message || null;
 
-                    frappe.call({
-                        method: "beams.beams.custom_scripts.interview_round.interview_round.get_expected_question_set",
-                        args: {
-                            interview_round: frm.doc.interview_round,
-                        },
-                        callback: function (q) {
-                            let question_fields = frm.events.get_fields_for_question_assessment();
-                            let show_questions_section = q.message && q.message.length > 0;
+                // Fetch expected skill set
+                frappe.call({
+                    method: "hrms.hr.doctype.interview.interview.get_expected_skill_set",
+                    args: {
+                        interview_round: frm.doc.interview_round,
+                    },
+                    callback: function (skill_response) {
+                        let skill_fields = frm.events.get_fields_for_feedback();
 
-                            let d = new frappe.ui.Dialog({
-                                title: __("Submit Feedback"),
-                                fields: [
-                                    {
-                                        fieldname: "skill_set",
-                                        fieldtype: "Table",
-                                        label: __("Skill Assessment"),
-                                        cannot_add_rows: false,
-                                        in_editable_grid: true,
-                                        reqd: 1,
-                                        fields: skill_fields,
-                                        data: r.message,
-                                    },
-                                    ...(show_questions_section ? [
+                        // Fetch expected questions set
+                        frappe.call({
+                            method: "beams.beams.custom_scripts.interview_round.interview_round.get_expected_question_set",
+                            args: {
+                                interview_round: frm.doc.interview_round,
+                            },
+                            callback: function (question_response) {
+                                let question_fields = frm.events.get_fields_for_question_assessment();
+                                let show_questions_section = question_response.message && question_response.message.length > 0;
+                                let d = new frappe.ui.Dialog({
+                                    title: __("Submit Feedback"),
+                                    fields: [
                                         {
-                                            fieldname: "section_break_1",
-                                            fieldtype: "Section Break",
-                                            label: __("Interview Questions and Answers")
-                                        },
-                                        {
-                                            fieldname: "question_assessment",
+                                            fieldname: "skill_set",
                                             fieldtype: "Table",
-                                            label: __("Question Assessment"),
+                                            label: __("Skill Assessment"),
                                             cannot_add_rows: false,
                                             in_editable_grid: true,
                                             reqd: 1,
-                                            fields: question_fields,
-                                        }
-                                    ] : []),
-                                    {
-                                        fieldname: "remarks",
-                                        fieldtype: "Small Text",
-                                        label: __("Remarks"),
-                                        description: __("Additional comments or feedback.")
+                                            fields: skill_fields,
+                                            data: existing_feedback?existing_feedback.skill_set:skill_response.message,
+                                        },
+                                        ...(show_questions_section ? [
+                                            {
+                                                fieldname: "section_break_1",
+                                                fieldtype: "Section Break",
+                                                label: __("Interview Questions and Answers")
+                                            },
+                                            {
+                                                fieldname: "question_assessment",
+                                                fieldtype: "Table",
+                                                label: __("Question Assessment"),
+                                                cannot_add_rows: false,
+                                                in_editable_grid: true,
+                                                reqd: 1,
+                                                fields: question_fields,
+                                                data: existing_feedback?existing_feedback.question_assessment:question_response.message,
+                                            }
+                                        ] : []),
+                                        {
+                                            fieldname: "feedback",
+                                            fieldtype: "Small Text",
+                                            label: __("Feedback"),
+                                            description: __("Additional comments or feedback."),
+                                            default: existing_feedback ? existing_feedback.feedback : ""
+                                        },
+                                        {
+                                            fieldname: "result",
+                                            fieldtype: "Select",
+                                            options: ["", "Cleared", "Rejected"],
+                                            label: __("Result"),
+                                            reqd: 1,
+                                            default: existing_feedback ? existing_feedback.result : ""
+                                        },
+                                    ],
+                                    size: "large",
+                                    minimizable: true,
+                                    static: true,
+                                    primary_action_label: __("Save"),
+                                    primary_action: function (values) {
+                                        frm.events.save_feedback(frm, values, d,0); // Save as draft
                                     },
-                                    {
-                                        fieldname: "result",
-                                        fieldtype: "Select",
-                                        options: ["", "Cleared", "Rejected"],
-                                        label: __("Result"),
-                                        reqd: 1,
-                                    },
-                                ],
-                                size: "large",
-                                minimizable: true,
-                                static: true,
-                                primary_action_label: __("Submit"),
-                                primary_action: function (values) {
-                                    const isValid = values.skill_set.every(skill => skill.skill && skill.score != null && skill.score !== '' && !isNaN(skill.score));
-
-                                    if (!isValid) {
-                                        frappe.msgprint(__('Each skill must have a Skill and a valid Score.'));
-                                        return;
+                                    secondary_action_label: __("Save and Submit"),
+                                    secondary_action: function () {
+                                        frm.events.save_feedback(frm, d.get_values(), d,1); // Submit
                                     }
+                                });
 
-                                    frappe.call({
-                                        method: "beams.beams.custom_scripts.interview.interview.create_interview_feedback",
-                                        args: {
-                                            data: values,
-                                            interview_name: frm.doc.name,
-                                            interviewer: frappe.session.user,
-                                            job_applicant: frm.doc.job_applicant,
-                                        },
-                                        callback: function () {
-                                            frappe.msgprint(__('Feedback submitted successfully.'));
-                                            frm.refresh();
-                                        },
-                                        error: function (err) {
-                                            frappe.msgprint(__('Error submitting feedback: {0}', [err.message]));
-                                        }
+                                // If existing feedback, populate the fields
+                                if (existing_feedback) {
+                                    d.set_values({
+                                        skill_set: existing_feedback.skill_set || [],
+                                        question_assessment: existing_feedback.question_assessment || [],
+                                        feedback: existing_feedback.feedback,
+                                        result: existing_feedback.result
                                     });
-
-                                    d.hide();
                                 }
-                            });
 
-                            d.show();
-                            d.get_close_btn().show();
-                        },
-                        error: function (err) {
-                            frappe.msgprint(__('Error fetching expected questions: {0}', [err.message]));
-                        }
-                    });
-                } else {
-                    frappe.msgprint(__('No skill set found.'));
-                }
+                                d.show();
+                                d.get_close_btn().show();
+                            },
+                            error: function (err) {
+                                frappe.msgprint(__('Error fetching expected questions: {0}', [err.message]));
+                            }
+                        });
+                    },
+                    error: function (err) {
+                        frappe.msgprint(__('Error fetching skill set: {0}', [err.message]));
+                    }
+                });
             },
             error: function (err) {
-                frappe.msgprint(__('Error fetching skill set: {0}', [err.message]));
+                frappe.msgprint(__('Error fetching existing feedback: {0}', [err.message]));
             }
         });
     },
@@ -163,8 +180,8 @@ frappe.ui.form.on('Interview', {
             },
             {
                 fieldtype: "Data",
-                fieldname: "applicant_answer",
-                label: __("Applicant's Answer"),
+                fieldname: "answer",
+                label: __("Answer"),
                 in_list_view: 1,
                 reqd: 1
             },
@@ -176,5 +193,33 @@ frappe.ui.form.on('Interview', {
                 reqd: 1
             }
         ];
+    },
+
+    save_feedback: function (frm, values, dialog, isSubmit) {
+        const isValid = values.skill_set.every(skill => skill.skill && skill.score != null && skill.score !== '' && !isNaN(skill.score));
+        if (!isValid) {
+            frappe.msgprint(__('Each skill must have a Skill and a valid Score.'));
+            return;
+        }
+
+        // Call the backend method to save feedback
+        frappe.call({
+            method: "beams.beams.custom_scripts.interview.interview.create_interview_feedback",
+            args: {
+                data: values,
+                interview_name: frm.doc.name,
+                interviewer: frappe.session.user,
+                job_applicant: frm.doc.job_applicant,
+                submit: isSubmit // Pass the submit flag to Python
+            },
+            callback: function () {
+                frappe.msgprint(__('Feedback saved successfully.'));
+                frm.refresh(); // Refresh the form to show changes
+                dialog.hide(); // Hide the dialog
+            },
+            error: function (err) {
+                frappe.msgprint(__('Error saving feedback: {0}', [err.message]));
+            }
+        });
     },
 });

--- a/beams/beams/custom_scripts/interview/interview.py
+++ b/beams/beams/custom_scripts/interview/interview.py
@@ -2,9 +2,10 @@ import frappe
 from frappe import _
 
 @frappe.whitelist()
-def create_interview_feedback(data, interview_name, interviewer, job_applicant):
+def create_interview_feedback(data, interview_name, interviewer, job_applicant, submit=0):
     """
-    method: Creates and submits an Interview Feedback document for a job applicant, ensuring the user is the interviewer, validates skills and their scores, and appends them to the feedback.
+    Creates an Interview Feedback document for a job applicant,
+    allowing for draft saves and submission.
     """
     import json
 
@@ -17,7 +18,13 @@ def create_interview_feedback(data, interview_name, interviewer, job_applicant):
         frappe.throw(_("Only Interviewers are allowed to submit Interview Feedback"))
 
     # Create a new Interview Feedback document
-    interview_feedback = frappe.new_doc("Interview Feedback")
+    interview_feedback_name = frappe.db.exists('Interview Feedback',{'interview':interview_name,'docstatus':0})
+
+    if interview_feedback_name:
+        interview_feedback = frappe.get_doc("Interview Feedback",interview_feedback_name)
+    else:
+        interview_feedback = frappe.new_doc("Interview Feedback")
+
     interview_feedback.interview = interview_name
     interview_feedback.interviewer = interviewer
     interview_feedback.job_applicant = job_applicant
@@ -26,6 +33,8 @@ def create_interview_feedback(data, interview_name, interviewer, job_applicant):
     if not hasattr(data, 'skill_set') or not data.skill_set:
         frappe.throw(_("No skills found in the feedback data."))
 
+    if interview_feedback_name:
+        interview_feedback.skill_assessment = []
     # Append skills directly with the score as the rating
     for d in data.skill_set:
         d = frappe._dict(d)
@@ -34,27 +43,113 @@ def create_interview_feedback(data, interview_name, interviewer, job_applicant):
         if d.score is None or d.score == '':
             frappe.throw(_("Score for skill {0} is missing or invalid.").format(d.skill))
 
-        try:
-            # Convert score to integer
-            rating = int(d.score)/10
-        except ValueError:
-            frappe.throw(_("Invalid score for skill {0}. Please enter a valid number.").format(d.skill))
+        # Check if score is a number (int or float) and validate
+        if not isinstance(d.score, (int, float)) or d.score < 0 or d.score > 100:
+            frappe.throw(_("Score for skill {0} must be a number between 0 and 100.").format(d.skill))
 
-
+        # Convert score to a float and calculate rating
+        rating = float(d.score) / 10
         # Append the validated skill and rating to the Interview Feedback
-        interview_feedback.append("skill_assessment", {"skill": d.skill, "rating": rating, "score":d.score})
+        interview_feedback.append("skill_assessment", {
+            "skill": d.skill,
+            "rating": rating,
+            "score": d.score
+        })
+
+    # Process question assessments if provided
+    if hasattr(data, 'question_assessment') and data.question_assessment:
+        if interview_feedback_name:
+            interview_feedback.interview_question_result = []
+        for q in data.question_assessment:
+            q = frappe._dict(q)
+
+            # Ensure the score is not None and is a valid number
+            if q.score is None or q.score == '':
+                frappe.throw(_("Score for question '{0}' is missing or invalid.").format(q.question))
+
+            # Check if score is a number (int or float) and validate
+            if not isinstance(q.score, (int, float)) or q.score < 0 or q.score > 100:
+                frappe.throw(_("Score for question '{0}' must be a number between 0 and 100.").format(q.question))
+
+            # Append the validated question, answer, and score to the Interview Feedback
+            interview_feedback.append("interview_question_result", {
+                "question": q.question,
+                "answer": q.answer,
+                "score": q.score  # Directly use the score
+            })
 
     # Set feedback and result
-    interview_feedback.remarks = data.remarks
+    interview_feedback.feedback = data.feedback
     interview_feedback.result = data.result
-
-    # Save and submit the feedback document
-    interview_feedback.save()
-    interview_feedback.submit()
+    if int(submit):
+        interview_feedback.submit()  # Submit if the submit flag is True
+    else:
+        interview_feedback.save()
 
     # Show success message with a link to the created feedback
     frappe.msgprint(
-        _("Interview Feedback {0} submitted successfully").format(
-            frappe.utils.get_link_to_form("Interview Feedback", interview_feedback.name)
+        _("Interview Feedback {0} {1} successfully").format(
+            frappe.utils.get_link_to_form("Interview Feedback", interview_feedback.name),
+            _("submitted") if int(submit) else _("saved")
         )
     )
+
+
+@frappe.whitelist()
+def get_interview_feedback(interview_name):
+    """
+    Fetch the existing Interview Feedback for the specified interview.
+
+    :param interview_name: Name of the interview to fetch feedback for
+    :return: Feedback data including skill assessments and question assessments, or None if not found
+    """
+    # Fetch the existing Interview Feedback
+    feedback = frappe.get_all("Interview Feedback",
+        filters={"interview": interview_name},
+        fields=["name", "feedback", "result"])  # Ensure 'feedback' and 'result' are the correct fields
+
+    if feedback:
+        feedback = feedback[0]  # Get the first feedback if it exists
+
+        # Fetching the skill assessments from the child table 'Skill Assessment'
+        skill_set = frappe.get_all("Skill Assessment",
+            filters={"parent": feedback.name},
+            fields=["skill", "score"])  # Fetching skill and score fields
+
+        # Fetching the question assessments from the child table 'Interview Question Result'
+        question_assessments = frappe.get_all("Interview Question Result",
+            filters={"parent": feedback.name},
+            fields=["question", "answer", "score"])  # Fetching question, _answer, and score fields
+
+        # Map the feedback to include all relevant fields
+        feedback_data = {
+            "name": feedback.name,
+            "feedback": feedback.feedback,  # Mapping  to feedback
+            "result": feedback.result,      # Mapping result
+            "skill_set": [
+                {"skill": set.skill, "score": set.score} for set in skill_set
+            ],  # Including skill assessments with score mapped to rating
+            "question_assessment": [
+                {"question": assessment.question, "answer": assessment.answer, "score": assessment.score} for assessment in question_assessments
+            ]  # Including question assessments with _answer mapped to answer
+        }
+
+        return feedback_data
+    else:
+        return None
+
+@frappe.whitelist()
+def get_interview_skill_and_question_set(interview_round, interviewer=False, interview_name=False):
+    feedback_exists = False
+    if interviewer and interview_name:
+        feedback_exists = frappe.db.exists(
+            "Interview Feedback",
+            {"interviewer": interviewer, "interview": interview_name, "docstatus": 0},
+        )
+    if feedback_exists:
+        interview_feedback = frappe.get_doc('Interview Feedback', feedback_exists)
+        return interview_feedback.interview_question_result, interview_feedback.skill_assessment, feedback_exists
+    else:
+        question = frappe.get_all('Expected Question Set', filters ={'parent': interview_round}, fields=['questions'], order_by='idx')
+        skill = frappe.get_all('Expected Skill Set', filters ={'parent': interview_round}, fields=['skill'])
+        return question, skill, False

--- a/beams/beams/custom_scripts/interview/interview.py
+++ b/beams/beams/custom_scripts/interview/interview.py
@@ -137,19 +137,3 @@ def get_interview_feedback(interview_name):
         return feedback_data
     else:
         return None
-
-@frappe.whitelist()
-def get_interview_skill_and_question_set(interview_round, interviewer=False, interview_name=False):
-    feedback_exists = False
-    if interviewer and interview_name:
-        feedback_exists = frappe.db.exists(
-            "Interview Feedback",
-            {"interviewer": interviewer, "interview": interview_name, "docstatus": 0},
-        )
-    if feedback_exists:
-        interview_feedback = frappe.get_doc('Interview Feedback', feedback_exists)
-        return interview_feedback.interview_question_result, interview_feedback.skill_assessment, feedback_exists
-    else:
-        question = frappe.get_all('Expected Question Set', filters ={'parent': interview_round}, fields=['questions'], order_by='idx')
-        skill = frappe.get_all('Expected Skill Set', filters ={'parent': interview_round}, fields=['skill'])
-        return question, skill, False

--- a/beams/beams/custom_scripts/interview_round/interview_round.py
+++ b/beams/beams/custom_scripts/interview_round/interview_round.py
@@ -1,4 +1,3 @@
-
 import frappe
 
 @frappe.whitelist()
@@ -9,8 +8,14 @@ def get_expected_question_set(interview_round):
     # Fetch the Interview Round document
     interview_round_doc = frappe.get_doc("Interview Round", interview_round)
 
-    # Assuming 'expected_questions' is the child table name in Interview Round Doctype
+    # Assuming 'expected_question_set' is the child table name in Interview Round DocType
     if interview_round_doc and interview_round_doc.expected_question_set:
-        # Return the list of expected questions
-        return interview_round_doc.expected_question_set
-    return []
+        # Extract the expected questions
+        expected_questions = [
+            {
+                'question': question.question  # Access the 'question' field from the child table
+            }
+            for question in interview_round_doc.expected_question_set
+        ]
+        return expected_questions  # Return the list of expected questions
+    return []  # Return an empty list if no questions found


### PR DESCRIPTION
## Issue description

- Questions should be fetched from interview round to Question assessment table in dialog
- Hide 'Submit feedback' Button
- Check exist of feedback and   fetch it while reloading the dialog button.
- Save,save and submit buttons should be shown in that dialog
- If an interview feedback is submitted for an interview hide dialog button.

## Solution description

- Questions automatically fetch from interview round to dialog box and can also additionally add.
- Hided Already existing submit feedback button from erp.
- Fetched the existing feedback once if it is in draft.
- Both Save and submit actions are available in dialog.
- Once the interview feedback for an interview is submitted then the dialog button is hided

## Output screenshots (optional)

[Screencast from 06-11-24 12:34:38 PM IST.webm](https://github.com/user-attachments/assets/bff71ca0-dbc8-4339-bb1f-3dd83130959c)

## Task ID : [TASK-2024-00947]

