### PR TITLE
    TASK-2024-00987 : Create Custom Button Job Proposal In Job Applicant when the status is Selected

### DIFF
--- a/beams/beams/custom_scripts/job_applicant/job_applicant.js
+++ b/beams/beams/custom_scripts/job_applicant/job_applicant.js
@@ -9,11 +9,29 @@ frappe.ui.form.on('Job Applicant', {
                 frm.save();
             }, __('Set Status'));
         }
-    },
-    status: function(frm) {
-        frm.trigger('refresh');
-    }
-});
+
+        if (frappe.user.has_role("HR Manager")) {
+                // Check if the status is "Selected"
+                if (frm.doc.status === "Selected") {
+                    // Check if there's no existing Job Proposal linked to this Job Applicant
+                    frappe.db.get_value('Job Proposal', { 'job_applicant': frm.doc.name }, 'name', function(result) {
+                        if (!result || !result.name) {
+                            // Add the "Job Proposal" button
+                            frm.add_custom_button(__('Job Proposal'), function() {
+                                // Redirect to Job Proposal Doctype
+                                frappe.new_doc('Job Proposal', {
+                                    job_applicant: frm.doc.name
+                                });
+                            }, __('Create'));
+                        }
+                    });
+                }
+            }
+        },
+        status: function(frm) {
+            frm.trigger('refresh');
+        }
+    });
 
 function handle_custom_buttons(frm) {
     if (!frm.is_new()) {

--- a/beams/beams/custom_scripts/job_applicant/job_applicant.js
+++ b/beams/beams/custom_scripts/job_applicant/job_applicant.js
@@ -1,14 +1,37 @@
 frappe.ui.form.on('Job Applicant', {
-    refresh: function (frm) {
-        handle_custom_buttons(frm);
-        frm.toggle_display('applicant_interview_round', !frm.is_new());
-        // Add the "Set Status" group button with "Selected" option only if status is "Local Enquiry Approved"
-        if (frm.doc.status === 'Local Enquiry Approved') {
-            frm.add_custom_button(__('Selected'), function() {
-                frm.set_value('status', 'Selected');
-                frm.save();
-            }, __('Set Status'));
-        }
+  refresh: function (frm) {
+    handle_custom_buttons(frm);
+    frm.toggle_display('applicant_interview_round', !frm.is_new());
+    // Add the "Set Status" group button with "Selected" option only if status is "Local Enquiry Approved"
+    if (frm.doc.status === 'Local Enquiry Approved') {
+      frm.add_custom_button(__('Selected'), function() {
+        frm.set_value('status', 'Selected');
+        frm.save();
+      }, __('Set Status'));
+    }
+
+    if (frappe.user.has_role("HR Manager")) {
+      // Check if the status is "Selected"
+      if (frm.doc.status === "Selected") {
+        // Check if there's no existing Job Proposal linked to this Job Applicant
+        frappe.db.get_value('Job Proposal', { 'job_applicant': frm.doc.name }, 'name', function(result) {
+          if (!result || !result.name) {
+            // Add the "Job Proposal" button
+            frm.add_custom_button(__('Job Proposal'), function() {
+              // Redirect to Job Proposal Doctype
+              frappe.new_doc('Job Proposal', {
+                job_applicant: frm.doc.name
+              });
+            }, __('Create'));
+          }
+        });
+      }
+    }
+  },
+  status: function(frm) {
+    frm.trigger('refresh');
+  }
+});
 
         if (frappe.user.has_role("HR Manager")) {
                 // Check if the status is "Selected"


### PR DESCRIPTION
## Feature description
-Create Custom Button Job Proposal in Job Applicant when the status is Selected.

## Solution description
-Created Job Proposal button in Job Applicant when the status is "Selected".
-when clicking button it should be redirected to Job Proposal Doctype.
-Button will only show to HR Manager Role.
-Ensure that the button only appears if there is no existing Job Proposal for the Job Applicant."

## Output screenshots (optional)
[Screencast from 06-11-24 03:04:46 PM IST.webm](https://github.com/user-attachments/assets/47b60aa8-e006-4bc2-bcdc-beaa5951b0c0)
[Screencast from 06-11-24 03:06:39 PM IST.webm](https://github.com/user-attachments/assets/bd29945b-1096-4af4-a344-2504bbd13708)

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox
