### PR TITLE
feat : Create ToDos for Admin and HR Departments upon Job Offer Creation

### DIFF
--- a/beams/beams/custom_scripts/job_applicant/job_applicant.py
+++ b/beams/beams/custom_scripts/job_applicant/job_applicant.py
@@ -3,6 +3,8 @@ from frappe import _
 from frappe.utils import get_url, now_datetime
 from frappe.utils import nowdate
 from frappe.utils import get_url_to_form
+from frappe.utils.password import encrypt
+
 
 def get_permission_query_conditions(user):
     if not user:
@@ -158,16 +160,10 @@ def generate_magic_link(applicant_id):
     Returns:
         str: The generated magic link URL.
     """
-    token = frappe.generate_hash(length=10)
-    expiration_time = now_datetime()
-    link = f"{get_url()}/job_application_upload/upload_doc?applicant_id={applicant_id}&token={token}"
+    link = f"{get_url()}/job_application_upload/upload_doc?applicant_id="
     if frappe.db.exists('Job Applicant', applicant_id):
-        doc = frappe.get_doc('Job Applicant', applicant_id)
-        doc.magic_link_token = token
-        doc.magic_link_expiration = expiration_time
-        doc.save()
-    else:
-        frappe.msgprint(f'Job Applicant with ID {applicant_id} does not exist when generating magic link.', alert=True)
+        encrypted_link = encrypt(applicant_id)
+        link += encrypted_link
     return link
 
 

--- a/beams/beams/doctype/beams_hr_settings/beams_hr_settings.json
+++ b/beams/beams/doctype/beams_hr_settings/beams_hr_settings.json
@@ -11,7 +11,11 @@
   "admin_hod",
   "column_break_nncm",
   "it_department",
-  "it_hod"
+  "it_hod",
+  "notification_settings_tab",
+  "notification_to_admin",
+  "column_break_limx",
+  "notification_to_it"
  ],
  "fields": [
   {
@@ -56,12 +60,33 @@
    "label": "IT HOD",
    "options": "Employee",
    "read_only": 1
+  },
+  {
+   "fieldname": "notification_settings_tab",
+   "fieldtype": "Tab Break",
+   "label": "Notification Settings"
+  },
+  {
+   "description": "Based on Job Applicant you can apply jinja formatting like {{ doc.name }} ",
+   "fieldname": "notification_to_admin",
+   "fieldtype": "Small Text",
+   "label": "Notification to Admin on Job Offer Creation"
+  },
+  {
+   "description": " Based on Job Applicant you can apply jinja formatting like {{ doc.name }} ",
+   "fieldname": "notification_to_it",
+   "fieldtype": "Small Text",
+   "label": "Notification to IT on Job Offer Creation"
+  },
+  {
+   "fieldname": "column_break_limx",
+   "fieldtype": "Column Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-11-05 14:55:50.765755",
+ "modified": "2024-11-05 15:48:27.173873",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Beams HR Settings",

--- a/beams/beams/doctype/job_proposal/job_proposal.json
+++ b/beams/beams/doctype/job_proposal/job_proposal.json
@@ -31,8 +31,7 @@
    "fieldname": "applicant_name",
    "fieldtype": "Data",
    "label": "Applicant Name ",
-   "read_only": 1,
-   "unique": 1
+   "read_only": 1
   },
   {
    "fetch_from": "job_applicant.designation",
@@ -75,10 +74,11 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-11-05 09:49:20.360151",
+ "modified": "2024-11-05 16:54:19.670572",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Job Proposal",
+ "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [
   {
@@ -95,6 +95,7 @@
    "write": 1
   },
   {
+   "amend": 1,
    "create": 1,
    "delete": 1,
    "email": 1,
@@ -103,6 +104,20 @@
    "read": 1,
    "report": 1,
    "role": "HR Manager",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "CEO",
    "share": 1,
    "submit": 1,
    "write": 1

--- a/beams/beams/doctype/job_proposal/job_proposal.py
+++ b/beams/beams/doctype/job_proposal/job_proposal.py
@@ -1,9 +1,59 @@
 # Copyright (c) 2024, efeone and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
+from frappe.utils import today, getdate
+from frappe.utils import get_url_to_form
+from frappe.desk.form.assign_to import add as add_assign
+from frappe.email.doctype.notification.notification import get_context
 
 
 class JobProposal(Document):
-	pass
+	def on_update_after_submit(self):
+		self.create_offer_from_job_proposal()
+
+	def create_offer_from_job_proposal(self):
+		'''
+		Create a Job Offer when the Job Proposal is approved.
+
+		'''
+		if self.workflow_state == "Applicant Accepted":
+			job_offer = frappe.new_doc('Job Offer')
+			job_offer.job_applicant = self.job_applicant
+			job_offer.designation = self.designation
+			job_offer.offer_date = getdate(today())
+			job_offer.flags.ignore_mandatory = True
+			job_offer.flags.ignore_validate = True
+			job_offer.insert()
+			job_offer.submit()
+			frappe.msgprint('Job Offer Created: <a href="{0}">{1}</a>'.format(get_url_to_form(job_offer.doctype, job_offer.name), job_offer.name), alert=True, indicator='green')
+
+			beams_hr_settings = frappe.get_doc("Beams HR Settings")
+			job_applicant_doc = frappe.get_doc('Job Applicant', self.job_applicant)
+			context = get_context(job_applicant_doc)
+			if beams_hr_settings.admin_hod and beams_hr_settings.notification_to_admin:
+				# Admin HOD Assignment
+				if frappe.db.exists('Employee', beams_hr_settings.admin_hod):
+					admin_user = frappe.db.get_value('Employee', beams_hr_settings.admin_hod, 'user_id')
+					print(admin_user)
+					if admin_user:
+						admin_message = frappe.render_template(beams_hr_settings.notification_to_admin, context)
+						add_assign({
+							"assign_to": [admin_user],
+							"doctype": "Job Applicant",
+							"name": self.job_applicant,
+							"description": admin_message
+						})
+				# IT HOD Assignment
+				if frappe.db.exists('Employee', beams_hr_settings.it_hod):
+					it_user = frappe.db.get_value('Employee', beams_hr_settings.it_hod, 'user_id')
+					print(it_user)
+					if it_user:
+						it_message = frappe.render_template(beams_hr_settings.notification_to_it, context)
+						add_assign({
+							"assign_to": [it_user],
+							"doctype": "Job Applicant",
+							"name": self.job_applicant,
+							"description": it_message
+						})

--- a/beams/beams/doctype/job_proposal/job_proposal.py
+++ b/beams/beams/doctype/job_proposal/job_proposal.py
@@ -36,7 +36,6 @@ class JobProposal(Document):
 				# Admin HOD Assignment
 				if frappe.db.exists('Employee', beams_hr_settings.admin_hod):
 					admin_user = frappe.db.get_value('Employee', beams_hr_settings.admin_hod, 'user_id')
-					print(admin_user)
 					if admin_user:
 						admin_message = frappe.render_template(beams_hr_settings.notification_to_admin, context)
 						add_assign({
@@ -48,7 +47,6 @@ class JobProposal(Document):
 				# IT HOD Assignment
 				if frappe.db.exists('Employee', beams_hr_settings.it_hod):
 					it_user = frappe.db.get_value('Employee', beams_hr_settings.it_hod, 'user_id')
-					print(it_user)
 					if it_user:
 						it_message = frappe.render_template(beams_hr_settings.notification_to_it, context)
 						add_assign({

--- a/beams/fixtures/workflow.json
+++ b/beams/fixtures/workflow.json
@@ -2503,7 +2503,7 @@
   "doctype": "Workflow",
   "document_type": "Job Proposal",
   "is_active": 1,
-  "modified": "2024-11-05 12:15:04.237828",
+  "modified": "2024-11-07 09:52:43.950169",
   "name": "Job Proposal Workflow",
   "override_status": 0,
   "send_email_alert": 0,
@@ -2554,7 +2554,7 @@
     "workflow_builder_id": null
    },
    {
-    "allow_edit": "CEO",
+    "allow_edit": "HR Manager",
     "avoid_status_override": 0,
     "doc_status": "2",
     "is_optional_state": 0,


### PR DESCRIPTION
## Feature description

- [ ] Job Offer Creation on Approval: Automatically creates a Job Offer when a Job Proposal reaches the "Applicant Accepted" workflow state.

- [ ] Notifications to HODs: Notifies Admin HOD and IT HOD upon Job Offer creation, with  templates defined in Beams HR Settings.

- [ ] If the workflow state is "Rejected (Cancel)," the HR Manager can amend the Job Proposal document and create a revised version, with an Amend button if not available.

## Solution description

- The on_update_after_submit method checks the workflow state, triggering the job offer creation if "Applicant Accepted."

- A new Job Offer document is created, pulling data from the Job Proposal.

- Beams HR Settings configures Admin HOD and IT HOD fields and provides notification templates for personalized messages.

- Notifications are assigned to Admin HOD and IT HOD with custom Jinja messages if both are defined.

- The HR Manager can amend the Job Proposal document and create a revised version, with an Amend button if not available.


## Output screenshots (optional)
[Screencast from 11-07-2024 09:59:21 AM.webm](https://github.com/user-attachments/assets/4125ed84-dc21-4d94-acbe-f9b829fed222)
[Screencast from 11-07-2024 09:23:21 AM.webm](https://github.com/user-attachments/assets/ef4f80b0-0e10-49be-a376-0c46b9ff136f)
![Screenshot from 2024-11-07 09-22-00](https://github.com/user-attachments/assets/c9acde15-952e-462e-ade3-0acbc5cdff2a)
![image](https://github.com/user-attachments/assets/0a564a64-7ffa-4669-af48-57b923a5ca3d)


## Areas affected and ensured
  `Job Proposal Doctype`
  `Job Applicant Doctype`
  `Beams HR Settings`
  `Job Proposal Workflow`

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome

