### PR TITLE
feat:  TASK-2024-00938:Added custum button depend on status updates

### DIFF
--- a/beams/beams/custom_scripts/job_applicant/job_applicant.js
+++ b/beams/beams/custom_scripts/job_applicant/job_applicant.js
@@ -3,52 +3,7 @@ frappe.ui.form.on('Job Applicant', {
     handle_custom_buttons(frm);
     frm.toggle_display('applicant_interview_round', !frm.is_new());
     // Add the "Set Status" group button with "Selected" option only if status is "Local Enquiry Approved"
-    if (frm.doc.status === 'Local Enquiry Approved') {
-      frm.add_custom_button(__('Selected'), function() {
-        frm.set_value('status', 'Selected');
-        frm.save();
-      }, __('Set Status'));
-    }
-    if (frm.doc.status === 'Accepted') {
-            frm.add_custom_button(__('Training Completed'), function() {
-                frm.set_value('status', 'Training Completed');
-                frm.save();
-            }, __('Set Status'));
-       }
-    if (frappe.user_roles.includes("HR Manager")) {
-            if (frm.doc.status === "Training Completed") {
-                frappe.db.get_value('Appointment Letter', { 'job_applicant': frm.doc.name }, 'name', function(result) {
-                    if (!result || !result.name) {
-                        frm.add_custom_button(__('Appointment Letter'), function() {
-                            frappe.new_doc('Appointment Letter', {
-                                job_applicant: frm.doc.name
-                            });
-                        }, __('Create'));
-                    } else {
-                        frm.remove_custom_button(__('Appointment Letter'), __('Create'));
-                    }
-                });
-            } else {
-                frm.remove_custom_button(__('Appointment Letter'), __('Create'));
-            }
-        }
-    if (frappe.user.has_role("HR Manager")) {
-      // Check if the status is "Selected"
-      if (frm.doc.status === "Selected") {
-        // Check if there's no existing Job Proposal linked to this Job Applicant
-        frappe.db.get_value('Job Proposal', { 'job_applicant': frm.doc.name }, 'name', function(result) {
-          if (!result || !result.name) {
-            // Add the "Job Proposal" button
-            frm.add_custom_button(__('Job Proposal'), function() {
-              // Redirect to Job Proposal Doctype
-              frappe.new_doc('Job Proposal', {
-                job_applicant: frm.doc.name
-              });
-            }, __('Create'));
-          }
-        });
-      }
-    }
+
   },
   status: function(frm) {
     frm.trigger('refresh');
@@ -75,6 +30,7 @@ function handle_custom_buttons(frm) {
                                     frm.add_custom_button(__('Local Enquiry Report'), function() {
                                         frappe.set_route('Form', 'Local Enquiry Report', createResponse.message);
                                     }, __('View'));
+                                    frm.refresh();
                                 }
                             }
                         });
@@ -107,6 +63,75 @@ function handle_custom_buttons(frm) {
                 }
             );
         });
+
+      if (frm.doc.status === 'Local Enquiry Approved') {
+          frm.add_custom_button(__('Selected'), function() {
+            frm.set_value('status', 'Selected');
+            frm.save();
+          }, __('Set Status'));
+        }
+      if (frm.doc.status === 'Accepted') {
+          frm.add_custom_button(__('Training Completed'), function() {
+              frm.set_value('status', 'Training Completed');
+              frm.save();
+          }, __('Set Status'));
+      }
+      if (frm.doc.status !== 'Rejected'&& frm.doc.status !== 'Selected') {
+           frm.add_custom_button(__('Rejected'), function() {
+               frm.set_value('status', 'Rejected');
+               frm.save();
+          }, __('Set Status'));
+      }
+      // Show "Hold" button only if status is neither "Rejected" nor "Hold"
+      if (frm.doc.status !== 'Hold' && frm.doc.status !== 'Rejected'&& frm.doc.status !== 'Selected') {
+          frm.add_custom_button(__('Hold'), function() {
+              frm.set_value('status', 'Hold');
+              frm.save();
+          }, __('Set Status'));
+      }
+      if (frm.doc.status === 'Hold') {
+         frm.add_custom_button(__('Selected'), function() {
+             frm.set_value('status', 'Selected');
+             frm.save();
+         }, __('Set Status'));
+      }
+
+
+       if (frappe.user_roles.includes("HR Manager")) {
+               // Handle "Appointment Letter" button for "Training Completed" status
+               if (frm.doc.status === "Training Completed") {
+                   frappe.db.get_value('Appointment Letter', { 'job_applicant': frm.doc.name }, 'name', function(result) {
+                       if (!result || !result.name) {
+                           frm.add_custom_button(__('Appointment Letter'), function() {
+                               frappe.new_doc('Appointment Letter', {
+                                   job_applicant: frm.doc.name
+                               });
+                           }, __('Create'));
+                       } else {
+                           frm.remove_custom_button(__('Appointment Letter'), __('Create'));
+                       }
+                   });
+             } else {
+                   frm.remove_custom_button(__('Appointment Letter'), __('Create'));
+               }
+
+               // Handle "Job Proposal" button for "Selected" status
+               if (frm.doc.status === "Selected") {
+                   frappe.db.get_value('Job Proposal', { 'job_applicant': frm.doc.name }, 'name', function(result) {
+                       if (!result || !result.name) {
+                           frm.add_custom_button(__('Job Proposal'), function() {
+                               frappe.new_doc('Job Proposal', {
+                                   job_applicant: frm.doc.name
+                               });
+                           }, __('Create'));
+                       } else {
+                           frm.remove_custom_button(__('Job Proposal'), __('Create'));
+                       }
+                   });
+             } else {
+                   frm.remove_custom_button(__('Job Proposal'), __('Create'));
+               }
+           }
     }
 }
 


### PR DESCRIPTION
## Feature description
1.Need to create custom button in job applicant doctype
2. optimize the code in job applicant doctype
3. implement  handling of "Local Enquiry Report" button creation and view logic

## Solution description
1 created custom button in  job applicant doctype
     -created the custom button in set status group button 
    -"Rejected" Button: Displays when the status is not "Rejected" or "Selected".
    -"Hold" Button: Displays when the status is neither "Rejected" nor "Hold". 
   -"Selected" Button: Displays only when the status is "Hold". via job applicant .js
2 optimized the code in job applicant doctype
    -added the custom button in one function via job applicant .js
3 implemented  handling of "Local Enquiry Report" button creation and view logic
  -Added frm.refresh() to ensure the form is properly updated after adding custom buttons

## Output screenshots (optional)
[Screencast from 07-11-24 02:04:35 PM IST.webm](https://github.com/user-attachments/assets/96a98e05-6385-4a10-8154-5ce195a9d3d7)

## Areas affected and ensured
job applicant doctype 

## Is there any existing behavior change of other features due to this code change?
no

## Was this feature tested on the browsers?
 
  - Mozilla Firefox

