### PR TITLE
feat:update job applicant status based on workflow state

### DIFF
--- a/beams/beams/doctype/local_enquiry_report/local_enquiry_report.py
+++ b/beams/beams/doctype/local_enquiry_report/local_enquiry_report.py
@@ -10,10 +10,16 @@ class LocalEnquiryReport(Document):
         self.information_required()
         self.set_expected_completion_date()
         self.information_required()
-        
-    def on_submit(self):
-        if self.docstatus == 1:
-            update_job_applicant_status(self.name)
+
+    def on_update(self):
+        if self.workflow_state == "Approved":
+            update_job_applicant_status(self.name, "Local Enquiry Approved")
+        elif self.workflow_state == "Enquiry on Progress":
+            update_job_applicant_status(self.name, "Local Enquiry Started")
+        elif self.workflow_state == "Pending Approval":
+            update_job_applicant_status(self.name, "Local Enquiry Completed")
+        elif self.workflow_state == "Rejected":
+            update_job_applicant_status(self.name, "Local Enquiry Rejected")
 
     def information_required(self):
         """
@@ -69,18 +75,30 @@ def set_status_to_overdue():
 
         frappe.db.commit()
 
-@frappe.whitelist()
-def update_job_applicant_status(local_enquiry_report):
+def update_job_applicant_status(local_enquiry_report, status=None):
     '''
     This function retrieves the specified Local Enquiry Report and, if a Job Applicant is linked to it,
-    updates the applicant's status to "Local Enquiry Approved" and saves the changes.
+    updates the applicant's status based on the provided status and saves the changes.
+    If no status is provided, it checks the status from the workflow state.
     '''
     report = frappe.get_doc("Local Enquiry Report", local_enquiry_report)
     job_applicant = report.job_applicant
-    designation = report.designation
 
     if job_applicant:
         applicant_doc = frappe.get_doc("Job Applicant", job_applicant)
-        applicant_doc.status = "Local Enquiry Approved"
+
+        if status:
+            applicant_doc.status = status
+        else:
+            # Set the status based on the workflow state (you can modify these conditions)
+            if report.workflow_state == "Approved":
+                applicant_doc.status = "Local Enquiry Approved"
+            if report.workflow_state == "Enquiry on Progress":
+                applicant_doc.status = "Local Enquiry Started"
+            elif report.workflow_state == "Pending Approval":
+                applicant_doc.status = "Local Enquiry Completed"
+            elif report.workflow_state == "Rejected":
+                applicant_doc.status = "Local Enquiry Rejected"
+
         applicant_doc.save()
-        frappe.msgprint(f"Status of Job Applicant {applicant_doc.name} updated to 'Local Enquiry Approved'.")
+        frappe.msgprint(f"Status of Job Applicant {applicant_doc.name} updated to '{applicant_doc.status}'.")

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -1671,7 +1671,7 @@ def get_property_setters():
             "doc_type": "Job Applicant",
             "field_name": "status",
             "property": "options",
-            "value": "Open\nReplied\nRejected\nLocal Enquiry Approved\nSelected\nHold\nAccepted\nTraining Completed"
+            "value": "Open\nReplied\nRejected\nLocal Enquiry Approved\nSelected\nHold\nAccepted\nTraining Completed\nLocal Enquiry Started\nLocal Enquiry Completed\nLocal Enquiry Rejected"
         },
         {
             "doctype_or_field": "DocType",


### PR DESCRIPTION
## Feature description
Update Job Applicant status based on workflow state in Local Enquiry Report on update
Add new status options to the Job Applicant doctype status field

## Solution description
Changed Job Applicant status field based on the workflow state in Local Enquiry Report
Add 'Local Enquiry Started', 'Local Enquiry Completed', and 'Local Enquiry Rejected' to Job Applicant status options

## Output screenshots (optional)
[Screencast from 07-11-24 02:47:54 PM IST.webm](https://github.com/user-attachments/assets/bb3db959-1d83-4bcc-ad69-3e7435ed4b30)

## Areas affected and ensured
Local Enquiry Report Doctype
Job Applicant Doctype

## Is there any existing behavior change of other features due to this code change?
 No

## Was this feature tested on the browsers?
    - Mozilla Firefox
  