### PR TITLE
feat :  Add fields in Job Proposal Doctype

### DIFF
--- a/beams/beams/doctype/job_proposal/job_proposal.json
+++ b/beams/beams/doctype/job_proposal/job_proposal.json
@@ -13,7 +13,11 @@
   "column_break_bavx",
   "designation",
   "proposed_ctc",
-  "amended_from"
+  "amended_from",
+  "section_break_jt",
+  "job_offer_term_template",
+  "column_break_ogbe",
+  "terms_and_conditions"
  ],
  "fields": [
   {
@@ -69,12 +73,32 @@
    "print_hide": 1,
    "read_only": 1,
    "search_index": 1
+  },
+  {
+   "fieldname": "job_offer_term_template",
+   "fieldtype": "Link",
+   "label": "Job Offer Term Template",
+   "options": "Job Offer Term Template"
+  },
+  {
+   "fieldname": "section_break_jt",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_ogbe",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "terms_and_conditions",
+   "fieldtype": "Link",
+   "label": "Select Terms and Conditions",
+   "options": "Terms and Conditions"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-11-05 16:54:19.670572",
+ "modified": "2024-11-07 12:14:17.566123",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Job Proposal",

--- a/beams/beams/doctype/job_proposal/job_proposal.py
+++ b/beams/beams/doctype/job_proposal/job_proposal.py
@@ -23,6 +23,10 @@ class JobProposal(Document):
 			job_offer.job_applicant = self.job_applicant
 			job_offer.designation = self.designation
 			job_offer.offer_date = getdate(today())
+			job_offer.job_proposal = self.name
+			job_offer.ctc = self.proposed_ctc
+			job_offer.job_offer_term_template = self.job_offer_term_template
+			job_offer.select_terms = self.terms_and_conditions
 			job_offer.flags.ignore_mandatory = True
 			job_offer.flags.ignore_validate = True
 			job_offer.insert()


### PR DESCRIPTION
## Feature description

- Need to Add fields "Job Offer Term Template" and "Terms and Condition" in Job proposal doctype

## Solution description

- Created 2 fields :  "Job Offer Term Template" and "Terms and Condition" in Job prposal doctype by pulling data from Job Proposal Doctype.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/8590ea5b-cd78-468a-bb3d-8fdc07ec0e69)
![image](https://github.com/user-attachments/assets/01de4784-eaa3-43ea-9891-ed01d9ae3954)


## Areas affected and ensured
`Job Proposal Doctype`

## Is there any existing behavior change of other features due to this code change?
Yes

## Was this feature tested on the browsers?
  - Chrome

