### PR TITLE
feat : Add Custom Fields in Quotation,Sales Order and Sales Invoice

### DIFF
--- a/beams/beams/custom_scripts/sales_order/sales_order.py
+++ b/beams/beams/custom_scripts/sales_order/sales_order.py
@@ -103,3 +103,8 @@ def check_overdue_invoices(customer):
         fields=['name', 'due_date'])
 
     return overdue_invoices
+
+def set_region_from_quotation(doc, method):
+    if doc.reference_id:
+        quotation = frappe.get_doc("Quotation", doc.reference_id)
+        doc.region = quotation.region

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -175,7 +175,8 @@ doc_events = {
     },
     "Sales Order": {
         "autoname": "beams.beams.custom_scripts.sales_order.sales_order.autoname",
-        "before_save": "beams.beams.custom_scripts.sales_order.sales_order.validate_sales_order_amount_with_quotation"
+        "before_save": "beams.beams.custom_scripts.sales_order.sales_order.validate_sales_order_amount_with_quotation",
+        "before_insert": "beams.beams.custom_scripts.sales_order.sales_order.set_region_from_quotation"
         },
     "Contract": {
         "on_update": "beams.beams.custom_scripts.contract.contract.create_todo_on_contract_verified_by_finance",

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -289,6 +289,28 @@ def get_sales_invoice_custom_fields():
                 "insert_after": "actual_customer_group"
             },
             {
+                "fieldname": "region",
+                "fieldtype": "Link",
+                "options": "Region",
+                "label": "Region",
+                "insert_after": "is_reverse_charge"
+            },
+            {
+                "fieldname": "executive",
+                "fieldtype": "Link",
+                "options": "Employee",
+                "label": "Executive",
+                "insert_after": "due_date"
+            },
+            {
+                "fieldname": "executive_name",
+                "fieldtype": "Data",
+                "label": "Executive Name",
+                "insert_after": "executive",
+                "fetch_from": "executive.employee_name",
+                "read_only": 1
+            },
+            {
                 "fieldname": "is_barter_invoice",
                 "fieldtype": "Check",
                 "label": "Is Barter Invoice",
@@ -420,6 +442,21 @@ def get_quotation_custom_fields():
                 "read_only": 1,
                 "fetch_from": "actual_customer.customer_group",
                 "insert_after": "actual_customer"
+            },
+            {
+                "fieldname": "executive",
+                "fieldtype": "Link",
+                "label": "Executive",
+                "options":"Employee",
+                "insert_after": "sales_type"
+            },
+            {
+                "fieldname": "executive_name_",
+                "fieldtype": "Data",
+                "label": "Executive Name",
+                "insert_after": "executive",
+                "fetch_from": "executive.employee_name",
+                "read_only": 1
             },
             {
                 "fieldname": "executive_name",
@@ -1766,6 +1803,28 @@ def get_sales_order_custom_fields():
                 "label": "Include in IBF",
                 "read_only": 1,
                 "insert_after": "actual_customer_group"
+            },
+            {
+                "fieldname": "region",
+                "fieldtype": "Link",
+                "label": "Region",
+                "options": "Region",
+                "insert_after": "is_reverse_charge"
+            },
+            {
+                "fieldname": "executive",
+                "fieldtype": "Link",
+                "label": "Executive",
+                "options": "Employee",
+                "insert_after": "delivery_date"
+            },
+            {
+                "fieldname": "executive_name",
+                "fieldtype": "Data",
+                "label": "Executive Name",
+                "fetch_from": "executive.employee_name",
+                "insert_after": "executive",
+                "read_only": 1
             },
             {
                 "fieldname": "is_barter_invoice",


### PR DESCRIPTION
## Feature description
-Add Custom Fields in Quotation,Sales Order and Sales Invoice.
-Fetch region in Sales Order from Release Order.

## Solution description
-Added Region,Executive, and Executive Name fields in Quotation,Sales Order,and Sales Invoice.
-Updated Region in Sales Order from Release Order

## Output screenshots (optional)
[Screencast from 08-11-24 11:50:17 AM IST.webm](https://github.com/user-attachments/assets/99ef3529-3640-45a8-abb1-25f821d6ebb5)

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox
