### PR TITLE
    TASK-2024-01028:Added fields in custom doctype Company

### DIFF
--- a/beams/setup.py
+++ b/beams/setup.py
@@ -31,7 +31,7 @@ def after_install():
     create_custom_fields(get_interview_feedback_custom_fields(),ignore_validate=True)
     create_custom_fields(get_skill_assessment_custom_fields(), ignore_validate=True)
     create_custom_fields(get_job_offer_custom_fields(), ignore_validate=True)
-
+    create_custom_fields(get_company_custom_fields(), ignore_validate=True)
 
     #Creating BEAMS specific Property Setters
     create_property_setters(get_property_setters())
@@ -73,6 +73,7 @@ def before_uninstall():
     delete_custom_fields(get_interview_round_custom_fields())
     delete_custom_fields(get_skill_assessment_custom_fields())
     delete_custom_fields(get_job_offer_custom_fields())
+    delete_custom_fields(get_company_custom_fields())
 
 def delete_custom_fields(custom_fields: dict):
     '''
@@ -1540,6 +1541,28 @@ def get_job_opening_custom_fields():
             }
         ]
     }
+
+def get_company_custom_fields():
+    '''
+        Custom fields that need to be added to the Company Doctype
+    '''
+    return {
+        "Company": [
+            {
+                "fieldname": "company_policy_tab",
+                "fieldtype": "Tab Break",
+                "label": "Company Policy",
+                "insert_after": "dashboard_tab"
+            },
+            {
+                "fieldname": "company_policy",
+                "fieldtype": "Text Editor",
+                "label": "Company Policy",
+                "insert_after": "company_policy_tab" 
+            }
+        ]
+    }
+
 
 def create_property_setters(property_setter_datas):
     '''


### PR DESCRIPTION
## Feature description
Clearly and coAdd a new tab to the Company DocType named Company Policy.
 In this new tab, add a field:
    Company Policy: Text Editor.ncisely describe the feature.

## Analysis and design (optional)
   New Tab Added:A new tab, Company Policy, has been added after the existing dashboard_tab in the Company 
    DocType.
New Field:
        A Text Editor field named Company Policy has been added to the Company Policy tab to allow users to input and f 
       ormat the company’s policy text.

## Solution description
The company_policy_tab is a Tab Break field inserted after the dashboard_tab.
The company_policy field is a Text Editor field, designed for the company policy text, and is placed directly after the company_policy_tab

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/8dc39a0f-879e-4a7f-94cb-f0b147500557)

## Areas affected and ensured
List out the areas affected by your code changes.
setup.py

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
