### PR TITLE
TASK-2024-01034:Removed custom button create interview when status is  Training  Completed

### DIFF
--- a/beams/beams/custom_scripts/job_applicant/job_applicant.js
+++ b/beams/beams/custom_scripts/job_applicant/job_applicant.js
@@ -1,10 +1,53 @@
 frappe.ui.form.on('Job Applicant', {
-  refresh: function (frm) {
-    handle_custom_buttons(frm);
-    frm.toggle_display('applicant_interview_round', !frm.is_new());
-    // Add the "Set Status" group button with "Selected" option only if status is "Local Enquiry Approved"
+    refresh: function(frm) {
+        handle_custom_buttons(frm);
+        frm.toggle_display('applicant_interview_round', !frm.is_new());
 
-  },
+        if (frappe.user_roles.includes("HR Manager")) {
+            // Handle "Appointment Letter" button for "Training Completed" status
+            if (frm.doc.status === "Training Completed") {
+                frappe.db.get_value('Appointment Letter', { 'job_applicant': frm.doc.name }, 'name', function(result) {
+                    if (!result || !result.name) {
+                        frm.add_custom_button(__('Appointment Letter'), function() {
+                            frappe.new_doc('Appointment Letter', {
+                                job_applicant: frm.doc.name
+                            });
+                        }, __('Create'));
+                    } else {
+                        frm.remove_custom_button(__('Appointment Letter'), __('Create'));
+                    }
+                });
+
+                // Remove the "Interview" button when status is "Training Completed"
+                frm.remove_custom_button(__('Interview'), __('Create'));
+            } else {
+                frm.remove_custom_button(__('Appointment Letter'), __('Create'));
+            }
+
+            // Handle "Job Proposal" button for "Selected" status
+            if (frm.doc.status === "Selected") {
+                frappe.db.get_value('Job Proposal', { 'job_applicant': frm.doc.name }, 'name', function(result) {
+                    if (!result || !result.name) {
+                        frm.add_custom_button(__('Job Proposal'), function() {
+                            frappe.new_doc('Job Proposal', {
+                                job_applicant: frm.doc.name
+                            });
+                        }, __('Create'));
+                    } else {
+                        frm.remove_custom_button(__('Job Proposal'), __('Create'));
+                    }
+                });
+            } else {
+                frm.remove_custom_button(__('Job Proposal'), __('Create'));
+            }
+        }
+
+        // Remove "Interview" button if status is "Training Completed", "Job Proposal Created", or "Job Proposal Accepted"
+        if (['Training Completed', 'Job Proposal Created', 'Job Proposal Accepted'].includes(frm.doc.status)) {
+            frm.remove_custom_button(__('Interview'), __('Create'));
+        }
+    },
+
   status: function(frm) {
     frm.trigger('refresh');
   },

--- a/beams/beams/custom_scripts/job_applicant/job_applicant.js
+++ b/beams/beams/custom_scripts/job_applicant/job_applicant.js
@@ -120,6 +120,12 @@ function handle_custom_buttons(frm) {
       }
 
 
+        // Remove "Interview" button if status is "Training Completed"
+        if (frm.doc.status === 'Training Completed') {
+            frm.remove_custom_button(__('Interview'), __('Create'));
+        }
+
+
        if (frappe.user_roles.includes("HR Manager")) {
                // Handle "Appointment Letter" button for "Training Completed" status
                if (frm.doc.status === "Training Completed") {


### PR DESCRIPTION


## Feature description
Hide Interview Button in Job Applicant when the Job Applicant status is Training Completed.

## Analysis and design (optional)
Objective: The goal of this feature is to hide the "Interview" button on the Job Applicant form when the applicant's status is "Training Completed". This ensures that once an applicant has completed training, no further interviews can be scheduled for them.

## Solution description
    Modified the handle_custom_buttons function to check if the applicant's status is "Training Completed".
    If the status is "Training Completed", the "Interview" button is removed from the form using 
     frm.remove_custom_button().


## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/4c2c751d-85f8-450f-bd7b-f09f2c116590)

## Areas affected and ensured
Job Applicant doctype.
## Is there any existing behavior change of other features due to this code change?
        No.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox

