### PR TITLE
feat: Change status of Job Applicant according to Interview stages

### DIFF
--- a/beams/beams/custom_scripts/interview/interview.js
+++ b/beams/beams/custom_scripts/interview/interview.js
@@ -21,7 +21,7 @@ frappe.ui.form.on('Interview', {
             if (!frm.is_dirty() && frm.doc.docstatus == 0) {
                 frm.page.clear_primary_action();
                 frm.page.set_primary_action(__('Submit'), function () {
-                    frm.submit(); 
+                    frm.savesubmit();
                 });
             } else if (frm.is_dirty() && frm.doc.docstatus == 0) {
                 frm.page.clear_primary_action();

--- a/beams/beams/custom_scripts/interview/interview.py
+++ b/beams/beams/custom_scripts/interview/interview.py
@@ -150,9 +150,9 @@ def on_interview_creation(doc, method):
 
 
 def update_applicant_interview_round(doc, method):
-    """
+    '''
     Update the Applicant Interview Round child table in Job Applicant with interview reference and status on creation.
-    """
+    '''
     if doc.job_applicant and doc.interview_round:
         # Check if the Job Applicant exists
         if not frappe.db.exists("Job Applicant", doc.job_applicant):
@@ -172,9 +172,9 @@ def update_applicant_interview_round(doc, method):
                 break
 
 def mark_interview_completed(doc, method):
-    """
+    '''
     Mark the interview as completed in the Applicant Interview Round child table in Job Applicant upon submission of Interview.
-    """
+    '''
     if doc.job_applicant and doc.interview_round:
         job_applicant_doc = frappe.get_doc("Job Applicant", doc.job_applicant)
 

--- a/beams/beams/custom_scripts/interview/interview.py
+++ b/beams/beams/custom_scripts/interview/interview.py
@@ -137,3 +137,64 @@ def get_interview_feedback(interview_name):
         return feedback_data
     else:
         return None
+
+@frappe.whitelist()
+def on_interview_creation(doc, method):
+    '''
+    Set the Job Applicant's status to 'Interview Scheduled' when an Interview is created.
+    '''
+    job_applicant_doc = frappe.get_doc("Job Applicant", doc.job_applicant)
+    if job_applicant_doc.status != "Interview Scheduled":
+        job_applicant_doc.status = "Interview Scheduled"
+        job_applicant_doc.save()
+
+
+def update_applicant_interview_round(doc, method):
+    """
+    Update the Applicant Interview Round child table in Job Applicant with interview reference and status on creation.
+    """
+    if doc.job_applicant and doc.interview_round:
+        # Check if the Job Applicant exists
+        if not frappe.db.exists("Job Applicant", doc.job_applicant):
+            frappe.msgprint(f"Job Applicant {doc.job_applicant} does not exist.")
+            return
+
+        job_applicant_doc = frappe.get_doc("Job Applicant", doc.job_applicant)
+
+        # Find the corresponding interview round in the Job Applicant's applicant_interview_round table
+        for interview_round in job_applicant_doc.applicant_interview_round:
+            if interview_round.interview_round == doc.interview_round:
+                # Update the interview reference and status on creation or update
+                interview_round.interview_reference = doc.name
+                interview_round.interview_status = doc.status
+
+                job_applicant_doc.save(ignore_permissions=True)
+                break
+
+def mark_interview_completed(doc, method):
+    """
+    Mark the interview as completed in the Applicant Interview Round child table in Job Applicant upon submission of Interview.
+    """
+    if doc.job_applicant and doc.interview_round:
+        job_applicant_doc = frappe.get_doc("Job Applicant", doc.job_applicant)
+
+        # Find the corresponding interview round in the Job Applicant's applicant_interview_round table
+        for interview_round in job_applicant_doc.applicant_interview_round:
+            if interview_round.interview_round == doc.interview_round:
+                # Mark the interview as completed upon submission
+                interview_round.interview_completed = 1
+
+                job_applicant_doc.save(ignore_permissions=True)
+                break
+
+        all_interviews_completed = True
+        for interview_round in job_applicant_doc.applicant_interview_round:
+            if not interview_round.interview_completed:
+                all_interviews_completed = False
+                break
+
+        # If all interviews are completed, set the Job Applicant status to 'Interview Completed'
+        if all_interviews_completed:
+            job_applicant_doc.status = "Interview Completed"
+
+        job_applicant_doc.save(ignore_permissions=True)

--- a/beams/beams/custom_scripts/interview/interview.py
+++ b/beams/beams/custom_scripts/interview/interview.py
@@ -176,25 +176,26 @@ def mark_interview_completed(doc, method):
     Mark the interview as completed in the Applicant Interview Round child table in Job Applicant upon submission of Interview.
     '''
     if doc.job_applicant and doc.interview_round:
-        job_applicant_doc = frappe.get_doc("Job Applicant", doc.job_applicant)
+        if frappe.db.exists("Job Applicant", doc.job_applicant):
+            job_applicant_doc = frappe.get_doc("Job Applicant", doc.job_applicant)
 
-        # Find the corresponding interview round in the Job Applicant's applicant_interview_round table
-        for interview_round in job_applicant_doc.applicant_interview_round:
-            if interview_round.interview_round == doc.interview_round:
-                # Mark the interview as completed upon submission
-                interview_round.interview_completed = 1
+            # Find the corresponding interview round in the Job Applicant's applicant_interview_round table
+            for interview_round in job_applicant_doc.applicant_interview_round:
+                if interview_round.interview_round == doc.interview_round:
+                    # Mark the interview as completed upon submission
+                    interview_round.interview_completed = 1
 
-                job_applicant_doc.save(ignore_permissions=True)
-                break
+                    job_applicant_doc.save(ignore_permissions=True)
+                    break
 
-        all_interviews_completed = True
-        for interview_round in job_applicant_doc.applicant_interview_round:
-            if not interview_round.interview_completed:
-                all_interviews_completed = False
-                break
+            all_interviews_completed = True
+            for interview_round in job_applicant_doc.applicant_interview_round:
+                if not interview_round.interview_completed:
+                    all_interviews_completed = False
+                    break
 
-        # If all interviews are completed, set the Job Applicant status to 'Interview Completed'
-        if all_interviews_completed:
-            job_applicant_doc.status = "Interview Completed"
+            # If all interviews are completed, set the Job Applicant status to 'Interview Completed'
+            if all_interviews_completed:
+                job_applicant_doc.status = "Interview Completed"
 
-        job_applicant_doc.save(ignore_permissions=True)
+            job_applicant_doc.save(ignore_permissions=True)

--- a/beams/beams/custom_scripts/interview/interview.py
+++ b/beams/beams/custom_scripts/interview/interview.py
@@ -143,11 +143,11 @@ def on_interview_creation(doc, method):
     '''
     Set the Job Applicant's status to 'Interview Scheduled' when an Interview is created.
     '''
-    job_applicant_doc = frappe.get_doc("Job Applicant", doc.job_applicant)
-    if job_applicant_doc.status != "Interview Scheduled":
-        job_applicant_doc.status = "Interview Scheduled"
-        job_applicant_doc.save()
-
+    if frappe.db.exists("Job Applicant", doc.job_applicant):
+        job_applicant_doc = frappe.get_doc("Job Applicant", doc.job_applicant)
+        if job_applicant_doc.status != "Interview Scheduled":
+            job_applicant_doc.status = "Interview Scheduled"
+            job_applicant_doc.save()
 
 def update_applicant_interview_round(doc, method):
     '''

--- a/beams/beams/custom_scripts/interview_feedback/interview_feedback.py
+++ b/beams/beams/custom_scripts/interview_feedback/interview_feedback.py
@@ -1,0 +1,10 @@
+import frappe
+
+def on_interview_feedback_creation(doc, method):
+    '''
+    Update the Job Applicant's status to 'Interview Ongoing' when an Interview Feedback is created.
+    '''
+    job_applicant_doc = frappe.get_doc("Job Applicant", doc.job_applicant)
+    if job_applicant_doc.status != "Interview Ongoing":
+        job_applicant_doc.status = "Interview Ongoing"
+        job_applicant_doc.save()

--- a/beams/beams/custom_scripts/interview_feedback/interview_feedback.py
+++ b/beams/beams/custom_scripts/interview_feedback/interview_feedback.py
@@ -4,7 +4,8 @@ def on_interview_feedback_creation(doc, method):
     '''
     Update the Job Applicant's status to 'Interview Ongoing' when an Interview Feedback is created.
     '''
-    job_applicant_doc = frappe.get_doc("Job Applicant", doc.job_applicant)
-    if job_applicant_doc.status != "Interview Ongoing":
-        job_applicant_doc.status = "Interview Ongoing"
-        job_applicant_doc.save()
+    if frappe.db.exists("Job Applicant", doc.job_applicant):
+        job_applicant_doc = frappe.get_doc("Job Applicant", doc.job_applicant)
+        if job_applicant_doc.status != "Interview Ongoing":
+            job_applicant_doc.status = "Interview Ongoing"
+            job_applicant_doc.save()

--- a/beams/beams/custom_scripts/job_applicant/job_applicant.py
+++ b/beams/beams/custom_scripts/job_applicant/job_applicant.py
@@ -183,32 +183,6 @@ def fetch_interview_rounds(doc, method):
                                 'interview_round': round.interview_round
                             })
 
-def update_applicant_interview_round(doc, method):
-    """
-    Update the Applicant Interview Round child table in Job Applicant with interview reference and status.
-    """
-    if doc.job_applicant and doc.interview_round:
-        # Check if the Job Applicant exists
-        if not frappe.db.exists("Job Applicant", doc.job_applicant):
-            frappe.msgprint(f"Job Applicant {doc.job_applicant} does not exist.")
-            return
-
-        job_applicant_doc = frappe.get_doc("Job Applicant", doc.job_applicant)
-
-        for interview_round in job_applicant_doc.applicant_interview_round:
-            if interview_round.interview_round == doc.interview_round:
-                # Update the interview reference and status
-                interview_round.interview_reference = doc.name
-                interview_round.interview_status = doc.status
-                if doc.status == 'Cleared' or doc.status == 'Rejected':
-                    interview_round.interview_completed = 1
-                else:
-                    interview_round.interview_completed = 0
-
-                job_applicant_doc.save(ignore_permissions=True)
-                frappe.msgprint(f"Interview details updated for {doc.job_applicant} in round {doc.interview_round}")
-                break
-
 @frappe.whitelist()
 def fetch_location_from_job_opening(job_title, willing_to_work_on_location):
     """

--- a/beams/beams/doctype/expected_question_set/expected_question_set.json
+++ b/beams/beams/doctype/expected_question_set/expected_question_set.json
@@ -11,6 +11,7 @@
  ],
  "fields": [
   {
+   "columns": 2,
    "fieldname": "question",
    "fieldtype": "Small Text",
    "in_list_view": 1,
@@ -18,15 +19,17 @@
    "reqd": 1
   },
   {
+   "columns": 2,
    "fieldname": "weight",
    "fieldtype": "Float",
+   "in_list_view": 1,
    "label": "Weight"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-10-18 12:29:30.802263",
+ "modified": "2024-11-08 15:27:55.407234",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Expected Question Set",

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -203,7 +203,12 @@ doc_events = {
        "validate": "beams.beams.custom_scripts.department.department.validate"
     },
     "Interview": {
-        "on_update": "beams.beams.custom_scripts.job_applicant.job_applicant.update_applicant_interview_round"
+        "on_submit": "beams.beams.custom_scripts.interview.interview.mark_interview_completed",
+        "after_insert": "beams.beams.custom_scripts.interview.interview.on_interview_creation",
+        "on_update": "beams.beams.custom_scripts.interview.interview.update_applicant_interview_round"
+    },
+    "Interview Feedback": {
+        "after_insert": "beams.beams.custom_scripts.interview_feedback.interview_feedback.on_interview_feedback_creation"
     }
 
     }

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -1558,7 +1558,7 @@ def get_company_custom_fields():
                 "fieldname": "company_policy",
                 "fieldtype": "Text Editor",
                 "label": "Company Policy",
-                "insert_after": "company_policy_tab" 
+                "insert_after": "company_policy_tab"
             }
         ]
     }
@@ -1755,7 +1755,7 @@ def get_property_setters():
             "doc_type": "Job Applicant",
             "field_name": "status",
             "property": "options",
-            "value": "Open\nReplied\nRejected\nShortlisted from Interview\nLocal Enquiry Started\nLocal Enquiry Completed\nLocal Enquiry Rejected\nLocal Enquiry Approved\nSelected\nHold\nAccepted\nTraining Completed\nJob Proposal Created\nJob Proposal Accepted"
+            "value": "Open\nReplied\nRejected\nShortlisted from Interview\nLocal Enquiry Started\nLocal Enquiry Completed\nLocal Enquiry Rejected\nLocal Enquiry Approved\nSelected\nHold\nAccepted\nTraining Completed\nJob Proposal Created\nJob Proposal Accepted\nInterview Scheduled\nInterview Ongoing\nInterview Completed"
         },
         {
             "doctype_or_field": "DocType",


### PR DESCRIPTION
## Feature description
 Change status of Job Applicant to the following ones according to different interview stages
- Interview Scheduled(On Scheduling any of the interview listed in the Job Applicant)
- Interview Ongoing(On creation of any of the Interview Feedback creation linked to the Job Applicant)
- Interview Completed (On completion of all interview rounds in the Job Applicant - if the Interview Completed checkbox is checked for each interview round in the Applicant Interview Round table in Job Applicant)

Fixes:
- The interview document could not be submitted.
- Currently  Interview Completed checkbox in Applicant Interview Round child table is checked  when the interview document is created.
- Put fields Question and Weight in Expected Question Set table in Grid view.

## Solution description

- Set Job Applicant status to:
    "Interview Scheduled" when any interview is scheduled.
    "Interview Ongoing" when Interview Feedback is created.
    "Interview Completed" when all interview rounds are marked complete.
- Resolve Interview document submission issue.
- Only check Interview Completed in Applicant Interview Round on actual completion.
- Display Question and Weight in Expected Question Set grid.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/d07ed8d5-fd92-4edf-82b4-8f2726673d5c)
![image](https://github.com/user-attachments/assets/1819953f-4e63-4dc3-ab45-c8704e1e8828)
![image](https://github.com/user-attachments/assets/d6b721fb-a368-4111-b2dd-1cfeaa1006d7)


## Areas affected and ensured
Job Applicant
Interview

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
