### PR TITLE
    TASK-2024-01053:Create doctype Training Request

### DIFF
--- a/beams/beams/doctype/training_request/test_training_request.py
+++ b/beams/beams/doctype/training_request/test_training_request.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, efeone and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestTrainingRequest(FrappeTestCase):
+	pass

--- a/beams/beams/doctype/training_request/training_request.js
+++ b/beams/beams/doctype/training_request/training_request.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2024, efeone and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Training Request", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/beams/beams/doctype/training_request/training_request.json
+++ b/beams/beams/doctype/training_request/training_request.json
@@ -30,6 +30,7 @@
    "reqd": 1
   },
   {
+   "default": "Today",
    "fieldname": "posting_date",
    "fieldtype": "Date",
    "label": "Posting Date"
@@ -99,7 +100,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-11-12 11:49:41.154278",
+ "modified": "2024-11-12 12:32:15.936776",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Training Request",

--- a/beams/beams/doctype/training_request/training_request.json
+++ b/beams/beams/doctype/training_request/training_request.json
@@ -49,7 +49,7 @@
   {
    "fieldname": "training_requested_by",
    "fieldtype": "Link",
-   "label": "Training Requested by",
+   "label": "Training Requested By",
    "options": "Employee"
   },
   {
@@ -91,7 +91,7 @@
    "fieldtype": "Column Break"
   },
   {
-   "fetch_from": "training_requested_by.employee",
+   "fetch_from": "training_requested_by.employee_name",
    "fieldname": "training_requested_byname",
    "fieldtype": "Data",
    "label": "Training Requested By(Name)",
@@ -100,7 +100,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-11-12 12:32:15.936776",
+ "modified": "2024-11-12 12:42:55.187000",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Training Request",

--- a/beams/beams/doctype/training_request/training_request.json
+++ b/beams/beams/doctype/training_request/training_request.json
@@ -1,0 +1,149 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "format:TR-EMP-{####}",
+ "creation": "2024-11-12 09:22:32.657845",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "training_request_details_section",
+  "training_requested_by",
+  "training_requested_byname",
+  "remarks",
+  "column_break_cdgq",
+  "posting_date",
+  "expected_training_completion",
+  "status",
+  "training_event",
+  "section_break_vayc",
+  "employee",
+  "employee_name",
+  "column_break_imdc"
+ ],
+ "fields": [
+  {
+   "fieldname": "employee",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Employee",
+   "options": "Employee",
+   "reqd": 1
+  },
+  {
+   "fieldname": "posting_date",
+   "fieldtype": "Date",
+   "label": "Posting Date"
+  },
+  {
+   "fieldname": "expected_training_completion",
+   "fieldtype": "Date",
+   "label": "Expected Training Completion Date"
+  },
+  {
+   "fieldname": "remarks",
+   "fieldtype": "Small Text",
+   "label": "Remarks",
+   "reqd": 1
+  },
+  {
+   "fieldname": "training_requested_by",
+   "fieldtype": "Link",
+   "label": "Training Requested by",
+   "options": "Employee"
+  },
+  {
+   "default": "Open",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "label": "Status",
+   "options": "Open\nTraining Scheduled\nTraining Completed"
+  },
+  {
+   "fetch_from": "employee.employee_name",
+   "fieldname": "employee_name",
+   "fieldtype": "Data",
+   "label": "Employee Name"
+  },
+  {
+   "fieldname": "training_request_details_section",
+   "fieldtype": "Section Break",
+   "label": "Training Request Details"
+  },
+  {
+   "fieldname": "training_event",
+   "fieldtype": "Link",
+   "label": "Training Event",
+   "options": "Training Event",
+   "read_only": 1
+  },
+  {
+   "fieldname": "section_break_vayc",
+   "fieldtype": "Section Break",
+   "label": "Employee Details"
+  },
+  {
+   "fieldname": "column_break_cdgq",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_imdc",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "training_requested_by.employee",
+   "fieldname": "training_requested_byname",
+   "fieldtype": "Data",
+   "label": "Training Requested By(Name)",
+   "read_only": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2024-11-12 11:49:41.154278",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "Training Request",
+ "naming_rule": "Expression",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "HOD",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "HR Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/beams/beams/doctype/training_request/training_request.py
+++ b/beams/beams/doctype/training_request/training_request.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class TrainingRequest(Document):
+	pass


### PR DESCRIPTION
## Feature description
Create 'Training Request' doctype with fields

## Solution description
Added 'Training Request' doctype with the following fields:
- Employee (Link to Employee, mandatory)
- Posting Date (Date)
- Expected Training Completion Date (Date)
- Remarks (Small Text, mandatory)
- Training Requested by (Link to Employee)
- Training Requested By (Name, Data, Read-only, fetched from 'Training Requested by' field)
- Training Event (Link to Training Event, Read-only)
- Status (Select: Open, Training Scheduled, Training Completed)

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/41340d3b-1b5e-4b63-b3af-da425c0e4d23)
![image](https://github.com/user-attachments/assets/07929d20-8c4b-46f9-b084-f79c6dfc9147)
![image](https://github.com/user-attachments/assets/94b0f5d6-d063-4d76-8c8c-e0f4df021dc0)
![image](https://github.com/user-attachments/assets/50b9611c-cde9-4525-883c-8f5d2b6e8f73)

## Is there any existing behavior change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?
  - Mozilla Firefox
  