### PR TITLE
fix: Conditional display and reset of fields in Job Requisition based on 'Request For' selection

### DIFF
--- a/beams/beams/custom_scripts/job_requisition/job_requisition.js
+++ b/beams/beams/custom_scripts/job_requisition/job_requisition.js
@@ -110,9 +110,23 @@ frappe.ui.form.on('Job Requisition', {
     },
 
     request_for: function(frm) {
-        // When request_for changes, reset the employee_left field
-        frm.set_value('employee_left', []);
-        frm.refresh_field('employee_left');  // Refresh the field to apply the new query
+        // Clear all related fields when changing the Request For option
+        frm.set_value('staffing_plan', '');
+        frm.set_value('employee_left', '');
+
+        // Show/hide fields based on the selected option
+        if (frm.doc.request_for === 'Staffing Plan') {
+            frm.toggle_display('staffing_plan', true);
+            frm.toggle_display('employee_left', false);
+           // Hide Employee Left field
+        } else if (frm.doc.request_for === 'Employee Exit') {
+            frm.toggle_display('employee_left', true);
+            frm.toggle_display('staffing_plan', false);
+        } else {
+            // If no option or any other option, hide all fields
+            frm.toggle_display('staffing_plan', false);
+            frm.toggle_display('employee_left', false);
+        }
     },
 
     onload: function(frm) {

--- a/beams/beams/custom_scripts/job_requisition/job_requisition.py
+++ b/beams/beams/custom_scripts/job_requisition/job_requisition.py
@@ -4,15 +4,6 @@ import frappe
 from frappe.utils import nowdate
 from frappe import ValidationError
 
-
-def validate_job_requisition(doc, method):
-    # Adjusted to use request_for instead of request_type
-    if doc.request_for == 'Employee Exit':
-        if not doc.employee_left:
-            raise ValidationError("Please select at least one employee who has left.")
-    else:
-        doc.employee_left = []
-
 @frappe.whitelist()
 def create_job_opening_from_job_requisition(doc, method):
     '''

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -190,7 +190,6 @@ doc_events = {
     "Job Requisition": {
         "on_update": ["beams.beams.custom_scripts.job_requisition.job_requisition.create_job_opening_from_job_requisition",
                       "beams.beams.custom_scripts.job_requisition.job_requisition.on_update"],
-        "validate":  "beams.beams.custom_scripts.job_requisition.job_requisition.validate_job_requisition"
     },
     "Journal Entry": {
         "on_cancel": "beams.beams.custom_scripts.journal_entry.journal_entry.on_cancel"

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -33,7 +33,7 @@ def after_install():
     create_custom_fields(get_job_offer_custom_fields(), ignore_validate=True)
     create_custom_fields(get_company_custom_fields(), ignore_validate=True)
     create_custom_fields(get_training_event_employee_custom_fields(), ignore_validate=True)
-    
+
     #Creating BEAMS specific Property Setters
     create_property_setters(get_property_setters())
 
@@ -790,7 +790,7 @@ def get_job_requisition_custom_fields():
                 "fieldname": "request_for",
                 "label": "Request For",
                 "fieldtype": "Select",
-                "options": "\nEmployee Exit\nStaffing Plan\nUnplanned",
+                "options": "Employee Exit\nStaffing Plan\nUnplanned",
                 "insert_after": "naming_series"
             },
             {
@@ -1784,7 +1784,7 @@ def get_property_setters():
             "doc_type": "Job Requisition",
             "field_name": "status",
             "property": "options",
-            "value": "Pending\nOpen & Approved\nRejected\nFilled\nOn Hold\nCancelled"
+            "value": "Pending\nOpen & Approved\nRejected\nOn Hold\nCancelled"
         }
     ]
 


### PR DESCRIPTION

## Feature description
This feature introduces dynamic field visibility in the Job Requisition form, where fields appear or disappear based on the selection in the Request For dropdown. It ensures that only relevant fields (Staffing Plan, Unplanned, Employee Left) are displayed, and any previously entered data in hidden fields is cleared .

## Solution description
- The Request For field now controls which fields are shown:
    Staffing Plan field appears when "Staffing Plan" is selected.
    Unplanned field appears when "Unplanned" is selected.
    Employee Left field appears when "Employee Exit" is selected.
Switching options clears any data in hidden fields.

- Removed option 'Filled' from Status field in Job Requisition because when Job Requisition is Cancelled status becomes Filled instead of Cancelled.
- Removed White space from Request for select field in Job Requisition.
- Removed server side code that throws unnecessary validation error which prevents Job Requisition document from being saved.

## Output screenshots (optional)
[Screencast from 11-13-2024 02:39:13 PM.webm](https://github.com/user-attachments/assets/3e72496f-5228-4573-b785-868ad4f0c9d5)

## Areas affected and ensured
Job Requisition

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox
 