### PR TITLE
    TASK-2024-01031: Create Event from the Employee doctype

### DIFF
--- a/beams/beams/custom_scripts/employee/employee.js
+++ b/beams/beams/custom_scripts/employee/employee.js
@@ -1,0 +1,31 @@
+frappe.ui.form.on('Employee', {
+    /*
+    * When the form is refreshed, this script checks if the logged-in user has the "HOD" role
+    * and if they have an associated Employee record. If both conditions are met, a custom
+    * "Event" button is added to the form.
+    */
+    refresh: function(frm) {
+        if (frappe.user.has_role("HOD")) {
+            frappe.call({
+                method: "beams.beams.custom_scripts.employee.employee.get_employee_name_for_user",
+                args: {
+                    user_id: frappe.session.user
+                },
+                callback: function(response) {
+                    if (response.message) {
+                        frm.add_custom_button(__('Event'), function() {
+                            frappe.model.open_mapped_doc({
+                                method: "beams.beams.custom_scripts.employee.employee.create_event",
+                                frm: frm,
+                                args: {
+                                    "employee_id": frm.doc.name,
+                                    "hod_user": frappe.session.user
+                                }
+                            });
+                        }, __('Create'));
+                     }
+                }
+            });
+        }
+    }
+});

--- a/beams/beams/custom_scripts/employee/employee.py
+++ b/beams/beams/custom_scripts/employee/employee.py
@@ -1,0 +1,35 @@
+import frappe
+from frappe.model.mapper import get_mapped_doc
+
+@frappe.whitelist()
+def create_event(employee_id=None, hod_user=None, target_doc=None):
+    """
+    Create an Event document mapped from an Employee record, adding both the Employee and the HOD
+    as participants in the Event.
+    """
+    user = frappe.session.user
+    if not employee_id:
+        employee_id = frappe.get_value("Employee", {"user_id": user}, "name")
+    hod_user = hod_user or user
+    hod_employee_id = frappe.get_value("Employee", {"user_id": hod_user}, "name")
+    doc = get_mapped_doc("Employee", employee_id, {
+        "Employee": {
+            "doctype": "Event"
+        }
+    }, target_doc)
+    employee_participant = doc.append("event_participants", {})
+    employee_participant.reference_docname = employee_id
+    employee_participant.reference_doctype = "Employee"
+    hod_participant = doc.append("event_participants", {})
+    hod_participant.reference_docname = hod_employee_id
+    hod_participant.reference_doctype = "Employee"
+
+    return doc
+
+@frappe.whitelist()
+def get_employee_name_for_user(user_id):
+    """
+    Fetch the Employee name associated with the given user_id.
+    """
+    employee_name = frappe.db.get_value("Employee", {"user_id": user_id}, "name")
+    return employee_name

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -41,7 +41,8 @@ doctype_js = {
     "Job Applicant" :"beams/custom_scripts/job_applicant/job_applicant.js",
     "Budget":"beams/custom_scripts/budget/budget.js",
     "Interview Feedback":"beams/custom_scripts/interview_feedback/interview_feedback.js",
-    "Interview":"beams/custom_scripts/interview/interview.js"
+    "Interview":"beams/custom_scripts/interview/interview.js",
+    "Employee":"beams/custom_scripts/employee/employee.js"
 }
 doctype_list_js = {
     "Sales Invoice" : "beams/custom_scripts/sales_invoice/sales_invoice_list.js",


### PR DESCRIPTION
## Feature description

1. Add a custom "Event" button in the Employee doctype
2. Implement functionality to map the selected Employee and the HOD user as participants in the created Event.

## Solution description
1. Created a custom "Event" button in the Employee doctype.
- visible to users with the HOD user  with employee id via employe.py and employee.js
2. implemented functionality to map the selected Employee and the HOD user as participants in the created Event.
     -implemented logic to map the  participants in event via employee.js and employee.py
3. Added new file for emloyee via hooks.py

## Output screenshots (optional)
[Screencast from 13-11-24 04:53:26 PM IST.webm](https://github.com/user-attachments/assets/ed6b15d8-0c4a-476d-acb5-fa092de117a3)

## Areas affected and ensured
employee doctype
 event doctype

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Mozilla Firefox
 