### PR TITLE
TASK-2024-01029:Added Custom Button to create CPAL from Employee Onboarding

### DIFF
--- a/beams/beams/custom_scripts/employee_onboarding/employee_onboarding.js
+++ b/beams/beams/custom_scripts/employee_onboarding/employee_onboarding.js
@@ -1,0 +1,105 @@
+frappe.ui.form.on('Employee Onboarding', {
+  refresh: function(frm) {
+      // Make a server call to check if a CPAL already exists for the employee
+      frappe.call({
+          method: 'frappe.client.get_list',
+          args: {
+              doctype: 'Company Policy Acceptance Log',
+              filters: {
+                  'employee': frm.doc.employee
+              },
+              fields: ['name'],
+              limit_page_length: 1
+          },
+          callback: function(response) {
+              if (response.message && response.message.length > 0) {
+                  // If CPAL document exists, show the 'View CPAL' button
+                  frm.remove_custom_button(__('Company Policy Acceptance Log'));
+                  frm.add_custom_button(__('Company Policy Acceptance Log'), function () {
+                      frappe.set_route('Form', 'Company Policy Acceptance Log', response.message[0].name);
+                  }, __('View'));
+              } else {
+                  // If no CPAL exists, show the 'Create CPAL' button
+                  frm.add_custom_button(__('Company Policy Acceptance Log'), function () {
+                      frappe.call({
+                          method: "beams.beams.custom_scripts.employee_onboarding.employee_onboarding.create_cpal",
+                          args: {
+                              source_name: frm.doc.name
+                          },
+                          callback: function(response) {
+                              if (response.message) {
+                                  // Route to CPAL document form
+                                  frappe.set_route('Form', 'Company Policy Acceptance Log', response.message);
+                              } else {
+                                  frappe.msgprint(__('Failed to create CPAL.'));
+                              }
+                          },
+                          error: function(err) {
+                              frappe.msgprint(__('Error occurred while creating CPAL: ' + err.message));
+                          }
+                      });
+                  }, __('Create'));
+              }
+          },
+      });
+
+      // Check if the Activities child table exists
+      if (frm.fields_dict['activities']) {
+          // Hide the 'Required for Employee Creation' field in the grid
+          frm.fields_dict['activities'].grid.toggle_display('required_for_employee_creation', false);
+      }
+      frm.set_df_property('job_offer', 'read_only', 1);
+
+  },
+
+  employee: function(frm) {
+      // If employee is selected, fetch employee details
+      if (frm.doc.employee) {
+          frappe.call({
+              method: 'frappe.client.get',
+              args: {
+                  doctype: 'Employee',
+                  name: frm.doc.employee
+              },
+              callback: function(response) {
+                  if (response.message) {
+                      let employee = response.message;
+                      // Set the fetched values in the Employee Onboarding form
+                      frm.set_value('department', employee.department);
+                      frm.set_value('designation', employee.designation);
+                      frm.set_value('date_of_joining', employee.date_of_joining);
+                      frm.set_value('holiday_list', employee.holiday_list);
+                      frm.set_value('employee_grade', employee.grade);
+                      frm.refresh_fields(); // Refresh fields to ensure they are updated
+                  } else {
+                      frappe.msgprint(__('No employee details found.'));
+                  }
+              },
+          });
+      }
+  },
+
+  job_applicant: function(frm) {
+      // If job applicant is selected, fetch the job offer related to the applicant
+      if (frm.doc.job_applicant) {
+          frappe.call({
+              method: 'frappe.client.get',
+              args: {
+                  doctype: 'Job Offer',
+                  filters: { 'job_applicant': frm.doc.job_applicant }, // Fetch job offer based on job applicant
+                  fields: ['name']
+              },
+              callback: function(response) {
+                  if (response.message) {
+                      // Set the name of the job offer in the Employee Onboarding form
+                      frm.set_value('job_offer', response.message.name);
+                      frm.set_df_property('job_offer', 'read_only', 1);
+                      frm.refresh_fields();
+                  } else {
+                      frappe.msgprint(__('No job offer found for the selected applicant.'));
+                  }
+              },
+          });
+      }
+  }
+});

--- a/beams/beams/custom_scripts/employee_onboarding/employee_onboarding.py
+++ b/beams/beams/custom_scripts/employee_onboarding/employee_onboarding.py
@@ -1,0 +1,44 @@
+import frappe
+from frappe.model.mapper import get_mapped_doc
+
+@frappe.whitelist()
+# Create a Company Policy Acceptance Log  Document by mapping fields from employee onboarding 
+def create_cpal(source_name):
+    # Get the Employee Onboarding document
+    onboarding_doc = frappe.get_doc('Employee Onboarding', source_name)
+
+    # Check if a CPAL already exists for this Employee Onboarding document
+    existing_cpal = frappe.db.get_value('Company Policy Acceptance Log',
+                                        {'employee': onboarding_doc.employee, 'company': onboarding_doc.company},
+                                        'name')
+
+    if existing_cpal:
+        # If a CPAL already exists, return the existing CPAL document name
+        return existing_cpal
+
+    # Fetch the company_policy from the Company doctype
+    company_policy = frappe.db.get_value('Company', onboarding_doc.company, 'company_policy')
+
+    # Create a mapped document using get_mapped_doc
+    cpal_doc = get_mapped_doc(
+        "Employee Onboarding",
+        source_name,
+        {
+            "Employee Onboarding": {
+                "doctype": "Company Policy Acceptance Log",
+                "field_map": {
+                    "employee": "employee",
+                    "employee_name": "employee_name",
+                    "department": "department",
+                    "date_of_joining": "date_of_joining",
+                    "company": "company"
+                }
+            }
+        }
+    )
+
+    # Insert the new CPAL document into the database
+    cpal_doc.insert(ignore_permissions=True)
+
+    # Return the name of the created CPAL document
+    return cpal_doc.name

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -43,7 +43,9 @@ doctype_js = {
     "Interview Feedback":"beams/custom_scripts/interview_feedback/interview_feedback.js",
     "Interview":"beams/custom_scripts/interview/interview.js",
     "Employee":"beams/custom_scripts/employee/employee.js",
-    "Event":"beams/custom_scripts/event/event.js"
+    "Event":"beams/custom_scripts/event/event.js",
+    "Employee Onboarding":"beams/custom_scripts/employee_onboarding/employee_onboarding.js"
+
 }
 doctype_list_js = {
     "Sales Invoice" : "beams/custom_scripts/sales_invoice/sales_invoice_list.js",
@@ -211,6 +213,10 @@ doc_events = {
     },
     "Interview Feedback": {
         "after_insert": "beams.beams.custom_scripts.interview_feedback.interview_feedback.on_interview_feedback_creation"
+    },
+    "Employee Onboarding": {
+        "on_submit":  "beams.beams.custom_scripts.employee_onboarding.employee_onboarding.create_cpal"
+
     }
 
     }

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -218,8 +218,7 @@ doc_events = {
         "on_submit":  "beams.beams.custom_scripts.employee_onboarding.employee_onboarding.create_cpal"
 
     }
-
-    }
+}
 
 
 # Scheduled Tasks


### PR DESCRIPTION
## Feature description
Hide Employee Button in Employee onboarding doctype.
Hide Required for Employee Creation checkbox in Activities child table in Employee onboarding doctype.
Add a button labeled "Company Policy Acceptance Log" Under Create Group button in the Onboard Employee DocType.
Create it and show it in draft

## Analysis and design (optional)
Field visibility modifications in core DocType
Child table field adjustments
New button addition in the toolbar sectionn

## Solution description
Create Employee from Employee Onboarding is disabled.
When a Job Applicant is selected the Job Offer corresponding to the employee is fetched.Also the employee details of the 
employee(Department,Designation,Date of Joining,Employee Grade and Holiday List) are automatically populated.
Company Policy Acceptance Log button is added to create and view CPAL document.

## Output screenshots (optional)

[Screencast from 2024-11-13 15-15-42.webm](https://github.com/user-attachments/assets/c627a787-bb9f-4ed4-9734-49a8907cbb56)


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  
