### PR TITLE
fix: Add Applicant Rejected state to job application workflow

### DIFF
--- a/beams/beams/doctype/company_policy_acceptance_log/company_policy_acceptance_log.json
+++ b/beams/beams/doctype/company_policy_acceptance_log/company_policy_acceptance_log.json
@@ -17,10 +17,9 @@
   "company_policy",
   "date",
   "section_break_nxcd",
-  "read_and_accepted",
-  "column_break_qvpd",
   "digital_sign",
-  "amended_from"
+  "column_break_qvpd",
+  "read_and_accepted"
  ],
  "fields": [
   {
@@ -41,18 +40,21 @@
    "read_only": 1
   },
   {
+   "fetch_from": "employee.department",
    "fieldname": "department",
    "fieldtype": "Link",
    "label": "Department",
    "options": "Department"
   },
   {
+   "fetch_from": "employee.designation",
    "fieldname": "designation",
    "fieldtype": "Link",
    "label": "Designation",
    "options": "Designation"
   },
   {
+   "fetch_from": "employee.date_of_joining",
    "fieldname": "date_of_joining",
    "fieldtype": "Date",
    "label": "Date Of Joining"
@@ -100,22 +102,12 @@
   {
    "fieldname": "column_break_qvpd",
    "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "amended_from",
-   "fieldtype": "Link",
-   "label": "Amended From",
-   "no_copy": 1,
-   "options": "Company Policy Acceptance Log",
-   "print_hide": 1,
-   "read_only": 1,
-   "search_index": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-11-11 15:44:35.479870",
+ "modified": "2024-11-13 15:01:20.876944",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Company Policy Acceptance Log",

--- a/beams/beams/doctype/company_policy_acceptance_log/company_policy_acceptance_log.json
+++ b/beams/beams/doctype/company_policy_acceptance_log/company_policy_acceptance_log.json
@@ -19,7 +19,8 @@
   "section_break_nxcd",
   "digital_sign",
   "column_break_qvpd",
-  "read_and_accepted"
+  "read_and_accepted",
+  "amended_from"
  ],
  "fields": [
   {
@@ -102,12 +103,22 @@
   {
    "fieldname": "column_break_qvpd",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "Company Policy Acceptance Log",
+   "print_hide": 1,
+   "read_only": 1,
+   "search_index": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-11-13 15:01:20.876944",
+ "modified": "2024-11-14 13:55:03.631141",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Company Policy Acceptance Log",

--- a/beams/fixtures/workflow.json
+++ b/beams/fixtures/workflow.json
@@ -2503,7 +2503,7 @@
   "doctype": "Workflow",
   "document_type": "Job Proposal",
   "is_active": 1,
-  "modified": "2024-11-07 09:52:43.950169",
+  "modified": "2024-11-14 12:13:57.718240",
   "name": "Job Proposal Workflow",
   "override_status": 0,
   "send_email_alert": 0,
@@ -2582,6 +2582,21 @@
     "update_field": null,
     "update_value": null,
     "workflow_builder_id": null
+   },
+   {
+    "allow_edit": "HR Manager",
+    "avoid_status_override": 0,
+    "doc_status": "2",
+    "is_optional_state": 0,
+    "message": null,
+    "next_action_email_template": null,
+    "parent": "Job Proposal Workflow",
+    "parentfield": "states",
+    "parenttype": "Workflow",
+    "state": "Applicant Rejected",
+    "update_field": null,
+    "update_value": null,
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -2627,6 +2642,18 @@
     "allowed": "HR Manager",
     "condition": null,
     "next_state": "Applicant Accepted",
+    "parent": "Job Proposal Workflow",
+    "parentfield": "transitions",
+    "parenttype": "Workflow",
+    "state": "Approved",
+    "workflow_builder_id": null
+   },
+   {
+    "action": "Reject",
+    "allow_self_approval": 1,
+    "allowed": "HR Manager",
+    "condition": null,
+    "next_state": "Applicant Rejected",
     "parent": "Job Proposal Workflow",
     "parentfield": "transitions",
     "parenttype": "Workflow",

--- a/beams/fixtures/workflow_state.json
+++ b/beams/fixtures/workflow_state.json
@@ -75,15 +75,6 @@
   "docstatus": 0,
   "doctype": "Workflow State",
   "icon": "",
-  "modified": "2024-08-17 14:26:48.530305",
-  "name": "Draft",
-  "style": "",
-  "workflow_state_name": "Draft"
- },
- {
-  "docstatus": 0,
-  "doctype": "Workflow State",
-  "icon": "",
   "modified": "2024-10-02 11:07:13.425158",
   "name": "On Hold",
   "style": "",
@@ -101,11 +92,38 @@
  {
   "docstatus": 0,
   "doctype": "Workflow State",
+  "icon": "",
+  "modified": "2024-11-05 12:11:26.754828",
+  "name": "Applicant Accepted",
+  "style": "",
+  "workflow_state_name": "Applicant Accepted"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Workflow State",
+  "icon": "",
+  "modified": "2024-11-14 12:12:19.950288",
+  "name": "Applicant Rejected",
+  "style": "",
+  "workflow_state_name": "Applicant Rejected"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Workflow State",
   "icon": "ok-sign",
   "modified": "2024-08-03 14:59:52.132982",
   "name": "Approved",
   "style": "Success",
   "workflow_state_name": "Approved"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Workflow State",
+  "icon": "",
+  "modified": "2024-10-21 13:14:39.863524",
+  "name": "Assigned to Enquiry Officer",
+  "style": "Primary",
+  "workflow_state_name": "Assigned to Enquiry Officer"
  },
  {
   "docstatus": 0,
@@ -129,10 +147,10 @@
   "docstatus": 0,
   "doctype": "Workflow State",
   "icon": "",
-  "modified": "2024-10-21 13:14:39.863524",
-  "name": "Assigned to Enquiry Officer",
-  "style": "Primary",
-  "workflow_state_name": "Assigned to Enquiry Officer"
+  "modified": "2024-08-17 14:26:48.530305",
+  "name": "Draft",
+  "style": "",
+  "workflow_state_name": "Draft"
  },
  {
   "docstatus": 0,
@@ -142,14 +160,5 @@
   "name": "Enquiry on Progress",
   "style": "Success",
   "workflow_state_name": "Enquiry on Progress"
- },
- {
-  "docstatus": 0,
-  "doctype": "Workflow State",
-  "icon": "",
-  "modified": "2024-11-05 12:11:26.754828",
-  "name": "Applicant Accepted",
-  "style": "",
-  "workflow_state_name": "Applicant Accepted"
  }
 ]

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -324,7 +324,7 @@ fixtures = [
         ["name", "in", ["Customer Approval", "Account Approval", "Adhoc Budget","Supplier Approval", "Purchase Order Approval" , "Budget Approval" , "Batta Claim Approval","Purchase Invoice Workflow","Sales Invoice Approval","Stringer Bill Approval","Material Request Approval","Substitute Booking","Contract","Job Requisition Workflow","Enquiry Workflow","Job Proposal Workflow"]]
     ]},
     {"dt": "Workflow State", "filters": [
-        ["name", "in", ["Draft", "Pending Approval", "Approved", "Rejected", "Pending Finance Verification", "Verified By Finance","Rejected By Finance", "Pending Finance Approval", "Approved by Finance","Submitted","Cancelled","Completed","On Hold","Assigned to Enquiry Officer","Assigned to Admin","Enquiry on Progress","Applicant Accepted"]]
+        ["name", "in", ["Draft", "Pending Approval", "Approved", "Rejected", "Pending Finance Verification", "Verified By Finance","Rejected By Finance", "Pending Finance Approval", "Approved by Finance","Submitted","Cancelled","Completed","On Hold","Assigned to Enquiry Officer","Assigned to Admin","Enquiry on Progress","Applicant Accepted","Applicant Rejected"]]
     ]},
     {"dt": "Workflow Action Master", "filters": [
         ["name", "in", ["Submit for Approval","Reopen", "Approve", "Reject", "Send For Finance Verification", "Verify", "Send for Approval","Submit","Cancel","Send Email To Party","Put On Hold","Assign to Admin","Assign to Enquiry Officer","Start Enquiry","Enquiry Completed","Accept"]]


### PR DESCRIPTION
## Feature description
- This feature adds an additional state, "Applicant Rejected," to the job application workflow.
- the fields department,designation,Date of Joining from Employee in Company Acceptance Log should be get from employee selected in Company Policy Acceptance Log Doctype.

## Solution description
- Added the "Applicant Rejected" state to the job application workflow and configured a transition from "Approved" to "Applicant Rejected" for the HR Manager role.
- fetched department,designation,Date of Joining from Employee in Company Acceptance Log Doctype.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/bab2e660-ad0a-462f-ac80-a5478681a66d)
![image](https://github.com/user-attachments/assets/a2d0620a-428a-4b3d-975e-1785eb0c0abd)
![image](https://github.com/user-attachments/assets/77e9f8a9-7b77-4ef3-936e-219f7aa4e315)


## Areas affected and ensured
Job Proposal Workflow
Company Policy Acceptance Log Doctype

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Mozilla Firefox
