### PR TITLE
    TASK-2024-01055:Change status in Training Request and add Custom button to create Event

### DIFF
--- a/beams/beams/custom_scripts/training_event/training_event.py
+++ b/beams/beams/custom_scripts/training_event/training_event.py
@@ -7,3 +7,19 @@ def get_open_training_requests():
         filters={"status": "Open"},
         fields=["name", "employee", "employee_name"]
     )
+
+def on_update(doc,method):
+    '''
+    Updates the status of linked Training Requests when a Training Event is saved,
+    based on the event's status.
+    '''
+    status_mapping = {
+        "Scheduled": "Training Scheduled",
+        "Completed": "Training Completed",
+        "Cancelled": "Open"
+    }
+    
+    if doc.event_status in status_mapping:
+        for row in doc.employees:
+            print(row.training_request)
+            frappe.db.set_value("Training Request", row.training_request, "status", status_mapping[doc.event_status])

--- a/beams/beams/custom_scripts/training_event/training_event.py
+++ b/beams/beams/custom_scripts/training_event/training_event.py
@@ -18,8 +18,7 @@ def on_update(doc,method):
         "Completed": "Training Completed",
         "Cancelled": "Open"
     }
-    
+
     if doc.event_status in status_mapping:
         for row in doc.employees:
-            print(row.training_request)
             frappe.db.set_value("Training Request", row.training_request, "status", status_mapping[doc.event_status])

--- a/beams/beams/doctype/training_request/training_request.js
+++ b/beams/beams/doctype/training_request/training_request.js
@@ -1,8 +1,22 @@
 // Copyright (c) 2024, efeone and contributors
 // For license information, please see license.txt
-
-// frappe.ui.form.on("Training Request", {
-// 	refresh(frm) {
-
-// 	},
-// });
+frappe.ui.form.on('Training Request', {
+    refresh: function(frm) {
+        if (!frm.is_new() && frappe.user.has_role("HR Manager")) {
+            frm.add_custom_button(__('Training Event'), () => {
+                // Create a new Training Event
+                frappe.model.with_doctype('Training Event', function() {
+                    let training_event = frappe.model.get_new_doc('Training Event');
+                    // Add the employee from Training Request to the child table in Training Event
+                    if (frm.doc.employee) {
+                        let child = frappe.model.add_child(training_event, 'employees');
+                        child.employee = frm.doc.employee;
+                        child.training_request = frm.doc.name;
+                    }
+                    // Open the new Training Event document
+                    frappe.set_route('Form', 'Training Event', training_event.name);
+                });
+            }, __('Create'));
+        }
+    }
+});

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -163,6 +163,10 @@ doc_events = {
     "Customer": {
         "after_insert": "beams.beams.custom_scripts.account.account.create_todo_on_creation_for_customer"
     },
+    "Training Event": {
+         "on_update": "beams.beams.custom_scripts.training_event.training_event.on_update",
+          "on_update_after_submit": "beams.beams.custom_scripts.training_event.training_event.on_update"
+    },
     "Supplier": {
         "after_insert": "beams.beams.custom_scripts.account.account.create_todo_on_creation_for_supplier"
     },


### PR DESCRIPTION
## Feature description
-Add "Create Training Event"Custom button in Training Request
Set status of linked Training Requests based on Training Event status

## Solution description
- Added a new option "Training Event" in the "Create" button group of the Training Request doctype.
- Adds the employee from the Training Request to the Training Event Employee child table.
- Updates the Training Request status based on the Training Event status
- Ensured the "Create Training Event" option is accessible only to the HR Manager role.

## Output screenshots (o
[Screencast from 14-11-24 02:26:43 PM IST.webm](https://github.com/user-attachments/assets/fc44b41b-371a-4eed-94b2-c48b519d50ac)

[Screencast from 14-11-24 02:31:16 PM IST.webm](https://github.com/user-attachments/assets/a6a1ef9e-50d7-4cf8-936f-d5e9cc887b4f)

![image](https://github.com/user-attachments/assets/86febe4d-460b-4c2c-8069-302ca7bd8b0a)


## Areas affected and ensured
Training Request  Doctype
Training Event Doctype

## Is there any existing behavior change of other features due to this code change?
No. 

## Was this feature tested on the browsers?
    - Mozilla Firefox
 