### PR TITLE
fix : Prevent duplicate entries in 'employees' child table for training requests

### DIFF
--- a/beams/beams/custom_scripts/training_event/training_event.js
+++ b/beams/beams/custom_scripts/training_event/training_event.js
@@ -4,7 +4,7 @@ frappe.ui.form.on('Training Event', {
             // Create the main group button "Training Request"
             frm.add_custom_button("Training Request", () => {
                 show_training_request_dialog(frm);
-            }, "Get Employees from");
+            }, "Get Employees");
         }
     }
 });
@@ -16,11 +16,6 @@ function show_training_request_dialog(frm) {
         title: "Select Training Requests",
         fields: [
             {
-                fieldname: "name",
-                label: "Name",
-                fieldtype: "Data"
-            },
-            {
                 fieldname: "request_table",
                 label: "Training Requests",
                 fieldtype: "Table",
@@ -31,6 +26,7 @@ function show_training_request_dialog(frm) {
                         fieldtype: "Data",
                         fieldname: "training_request_name",
                         label: "Request Name",
+                        read_only: 1,
                         in_list_view: 1
                     },
                     {
@@ -38,12 +34,14 @@ function show_training_request_dialog(frm) {
                         fieldname: "employee",
                         options: "Employee",
                         label: "Employee",
+                        read_only: 1,
                         in_list_view: 1
                     },
                     {
                         fieldtype: "Data",
                         fieldname: "employee_name",
                         label: "Employee Name",
+                        read_only: 1,
                         in_list_view: 1
                     }
                 ]
@@ -77,7 +75,7 @@ function show_training_request_dialog(frm) {
 // Function to fetch training requests using the custom server-side method
 function fetch_training_requests(frm, dialog) {
     frappe.call({
-        method: "beams.beams.custom_scripts.training_event.training_event.get_open_training_requests", 
+        method: "beams.beams.custom_scripts.training_event.training_event.get_open_training_requests",
         callback: function(r) {
             if (r.message) {
                 let rows = [];
@@ -104,11 +102,16 @@ function fetch_training_requests(frm, dialog) {
 
 // Function to process selected training requests and add them to the Employees child table
 function process_selected_requests(frm, selected_requests) {
+    let existing_employees = frm.doc.employees.map(row => row.employee);
+
     selected_requests.forEach(request => {
-        let row = frm.add_child("employees");
-        row.employee = request.employee;
-        row.employee_name = request.employee_name;
-        row.training_request = request.training_request_name;
+        // Check if the employee is already in the child table
+        if (!existing_employees.includes(request.employee)) {
+            let row = frm.add_child("employees");
+            row.employee = request.employee;
+            row.employee_name = request.employee_name;
+            row.training_request = request.training_request_name;
+        }
     });
 
     frm.refresh_field("employees");


### PR DESCRIPTION
## Feature description
-  Updated dialog in Training event.

## Solution description
- Changed Custom Button name 'Get Employees From' to 'Get Employees'.
- Implemented dialog with read-only fields to display selectable training requests.
- Removed Name Field in Dialog.
- Implemented check to prevent duplicate entries in the 'employees' child table when processing selected training requests.

## Output screenshots (optional)
[Screencast from 14-11-24 05:32:10 PM IST.webm](https://github.com/user-attachments/assets/1a808eb0-82ce-4201-8314-70e8d8b86e64)

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox
