### PR TITLE
feat:Added Custom Button to create CPAL from Employee Onboarding

### DIFF
--- a/beams/beams/custom_scripts/employee_onboarding/employee_onboarding.js
+++ b/beams/beams/custom_scripts/employee_onboarding/employee_onboarding.js
@@ -1,0 +1,75 @@
+frappe.ui.form.on('Employee Onboarding', {
+    refresh: function(frm) {
+        // Check if CPAL already exists for the employee
+        frappe.call({
+            method: "frappe.client.get_list",
+            args: {
+                doctype: 'Company Policy Acceptance Log',
+                filters: {
+                    'employee': frm.doc.employee
+                },
+                fields: ['name']
+            },
+            callback: function(response) {
+                // If CPAL exists, move the button under the 'View' button group
+                if (response.message && response.message.length > 0) {
+                    frm.add_custom_button(__('Company Policy Acceptance Log'), function () {
+                        frappe.set_route('Form', 'Company Policy Acceptance Log', response.message[0].name);
+                    }, __('View'));
+                } else if (frm.doc.docstatus === 1) {
+                    // Only proceed with CPAL button creation if the document is submitted and no CPAL exists
+                    frm.add_custom_button(__('Company Policy Acceptance Log'), function () {
+                        frappe.call({
+                            method: "beams.beams.custom_scripts.employee_onboarding.employee_onboarding.create_cpal",
+                            args: {
+                                source_name: frm.doc.name  // Ensure source_name is passed correctly
+                            },
+                            callback: function(response) {
+                                if (response.message) {
+                                    // Route to CPAL document form
+                                    frappe.set_route('Form', 'Company Policy Acceptance Log', response.message);
+                                }
+                            },
+                        });
+                    }, __('Create'));
+                }
+            }
+        });
+    },
+
+  employee: function(frm) {
+    // If employee is selected, fetch employee details
+    if (frm.doc.employee) {
+      frappe.call({
+        method: 'beams.beams.custom_scripts.employee_onboarding.employee_onboarding.get_employee_details',
+        args: {
+          employee_id: frm.doc.employee
+        },
+        callback: function(response) {
+          if (response.message) {
+            let employee = response.message;
+            // Set the fetched values in the Employee Onboarding form
+            frm.set_value('department', employee.department);
+            frm.set_value('designation', employee.designation);
+            frm.set_value('date_of_joining', employee.date_of_joining);
+            frm.set_value('holiday_list', employee.holiday_list);
+            frm.set_value('employee_grade', employee.employee_grade);
+            frm.refresh_fields();
+          }
+        }
+      });
+    }
+  },
+
+  job_applicant: function(frm) {
+    if (frm.doc.job_applicant) {
+      frappe.db.get_value('Job Offer', { 'job_applicant': frm.doc.job_applicant }, 'name', function(value) {
+      if (value) {
+        // If the value is returned, set the job_offer field with the name of the job offer
+        frm.set_value('job_offer', value.name);
+        frm.refresh_fields();
+          }
+        });
+        }
+      }
+});

--- a/beams/beams/custom_scripts/employee_onboarding/employee_onboarding.py
+++ b/beams/beams/custom_scripts/employee_onboarding/employee_onboarding.py
@@ -1,0 +1,51 @@
+import frappe
+from frappe.model.mapper import get_mapped_doc
+
+@frappe.whitelist()
+# Create a Company Policy Acceptance Log  Document by mapping fields from employee onboarding
+def create_cpal(source_name):
+    # Get the Employee Onboarding document
+    onboarding_doc = frappe.get_doc('Employee Onboarding', source_name)
+
+    # Check if a CPAL already exists for this Employee Onboarding document
+    existing_cpal = frappe.db.get_value('Company Policy Acceptance Log',
+                                        {'employee': onboarding_doc.employee, 'company': onboarding_doc.company},
+                                        'name')
+
+    if existing_cpal:
+        # If a CPAL already exists, return the existing CPAL document name
+        return existing_cpal
+
+    # Fetch the company_policy from the Company doctype
+    company_policy = frappe.db.get_value('Company', onboarding_doc.company, 'company_policy')
+
+    # Create a mapped document using get_mapped_doc
+    cpal_doc = get_mapped_doc(
+        "Employee Onboarding",
+        source_name,
+        {
+            "Employee Onboarding": {
+                "doctype": "Company Policy Acceptance Log",
+                "field_map": {
+                    "employee": "employee",
+                    "employee_name": "employee_name",
+                    "department": "department",
+                    "date_of_joining": "date_of_joining",
+                    "company": "company"
+                }
+            }
+        }
+    )
+    cpal_doc.insert(ignore_permissions=True)
+    return cpal_doc.name
+
+@frappe.whitelist()
+def get_employee_details(employee_id):
+        employee = frappe.get_doc('Employee', employee_id)
+        return {
+            'department': employee.department,
+            'designation': employee.designation,
+            'date_of_joining': employee.date_of_joining,
+            'holiday_list': employee.holiday_list,
+            'employee_grade': employee.grade
+        }

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -44,7 +44,8 @@ doctype_js = {
     "Interview":"beams/custom_scripts/interview/interview.js",
     "Employee":"beams/custom_scripts/employee/employee.js",
     "Event":"beams/custom_scripts/event/event.js",
-    "Training Event":"beams/custom_scripts/training_event/training_event.js"
+    "Training Event":"beams/custom_scripts/training_event/training_event.js",
+    "Employee Onboarding":"beams/custom_scripts/employee_onboarding/employee_onboarding.js"
 }
 doctype_list_js = {
     "Sales Invoice" : "beams/custom_scripts/sales_invoice/sales_invoice_list.js",
@@ -217,6 +218,7 @@ doc_events = {
     "Interview Feedback": {
         "after_insert": "beams.beams.custom_scripts.interview_feedback.interview_feedback.on_interview_feedback_creation"
     }
+
 }
 
 

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -1810,6 +1810,14 @@ def get_property_setters():
             "property": "hidden",
             "value": 1
         },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Employee Boarding Activity",
+            "field_name": "required_for_employee_creation",
+            "property": "hidden",
+            "property_type": "Check",
+            "value": 1
+        }
     ]
 
 def get_material_request_custom_fields():


### PR DESCRIPTION
## Feature description
Hide Employee Button in Employee onboarding doctype.
Hide Required for Employee Creation checkbox in Activities child table in Employee onboarding doctype.
Add a button labeled "Company Policy Acceptance Log" Under Create Group button in the Onboard Employee DocType.
Create it and show it in draft

## Analysis and design (optional)
Field visibility modifications in core DocType
Child table field adjustments:required for employee creation.
New button addition in the toolbar section:Comany Policy Acceptance Log.

## Solution description
Create Employee from Employee Onboarding is disabled.
When a Job Applicant is selected the Job Offer corresponding to the employee is fetched.Also the employee details of the 
employee(Department,Designation,Date of Joining,Employee Grade and Holiday List) are automatically populated.
Company Policy Acceptance Log button is added to create and view CPAL document.

## Output screenshots (optional)

[Screencast from 2024-11-15 14-22-46.webm](https://github.com/user-attachments/assets/cd2cfe00-3888-40e1-a6c5-3a5e66ca6e6e)

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
