### PR TITLE
    TASK-2024-01087:Add Leave Settings tab in Beams Hr Settings

### DIFF
--- a/beams/beams/doctype/beams_hr_settings/beams_hr_settings.json
+++ b/beams/beams/doctype/beams_hr_settings/beams_hr_settings.json
@@ -15,7 +15,11 @@
   "column_break_nlxx",
   "notification_to_it",
   "it_hod",
-  "column_break_qbue"
+  "column_break_qbue",
+  "tab_3_tab",
+  "penalty_leave_type",
+  "column_break_pjdi",
+  "compensatory_leave_type"
  ],
  "fields": [
   {
@@ -73,12 +77,36 @@
   {
    "fieldname": "column_break_qbue",
    "fieldtype": "Column Break"
+  },
+  {
+   "description": "Leave Type for Double Shift Compensatory Leave",
+   "fieldname": "tab_3_tab",
+   "fieldtype": "Tab Break",
+   "label": " Leave Settings"
+  },
+  {
+   "description": "Leave Type for Unplanned Leave",
+   "fieldname": "penalty_leave_type",
+   "fieldtype": "Link",
+   "label": "Penalty Leave Type",
+   "options": "Leave Type"
+  },
+  {
+   "description": "Leave Type for Double Shift Compensatory Leave",
+   "fieldname": "compensatory_leave_type",
+   "fieldtype": "Link",
+   "label": "Compensatory Leave Type",
+   "options": "Leave Type"
+  },
+  {
+   "fieldname": "column_break_pjdi",
+   "fieldtype": "Column Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-11-08 15:10:42.837861",
+ "modified": "2024-11-15 16:56:49.566987",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Beams HR Settings",


### PR DESCRIPTION
## Feature description
- Add a new "Leave Settings" tab with the following fields:
 - Penalty Leave Type: Link field to specify leave type for unplanned leaves
 - Compensatory Leave Type: Link field for double-shift compensatory leaves
 
## Solution description
-Introduced a new tab for managing leave configurations:  
 - Penalty Leave Type: For unplanned leaves  
 - Compensatory Leave Type: For double-shift compensatory leaves  
 - Enhanced layout using Tab Break and Column Break fields.  
 - Provided descriptions for better clarity of the  fields.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/8f2f041b-644c-468d-832d-37410fa1769a)
![image](https://github.com/user-attachments/assets/0af98f3a-42f4-495f-b36e-f498cf85d0b4)

## Areas affected and ensured
Beams Hr Settings Doctype

## Is there any existing behavior change of other features due to this code change?
 No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
   - Mozilla Firefox
  