### PR TITLE
feat:Created doctype Compensatory Leave Log

### DIFF
--- a/beams/beams/doctype/compensatory_leave_log/compensatory_leave_log.js
+++ b/beams/beams/doctype/compensatory_leave_log/compensatory_leave_log.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2024, efeone and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Compensatory Leave Log", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/beams/beams/doctype/compensatory_leave_log/compensatory_leave_log.json
+++ b/beams/beams/doctype/compensatory_leave_log/compensatory_leave_log.json
@@ -1,0 +1,92 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "format:{CLL}-{YY}-{####}",
+ "creation": "2024-11-15 16:35:34.018714",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "employee",
+  "employee_name",
+  "column_break_qawu",
+  "leave_type",
+  "leave_allocation",
+  "section_break_dskx",
+  "start_date",
+  "column_break_flmr",
+  "end_date"
+ ],
+ "fields": [
+  {
+   "fieldname": "employee",
+   "fieldtype": "Link",
+   "label": "Employee",
+   "options": "Employee"
+  },
+  {
+   "fieldname": "start_date",
+   "fieldtype": "Date",
+   "label": " Start Date"
+  },
+  {
+   "fieldname": "end_date",
+   "fieldtype": "Date",
+   "label": "End Date"
+  },
+  {
+   "fieldname": "leave_allocation",
+   "fieldtype": "Link",
+   "label": "Leave Allocation",
+   "options": "Leave Allocation"
+  },
+  {
+   "fetch_from": "employee.first_name",
+   "fieldname": "employee_name",
+   "fieldtype": "Data",
+   "label": "Employee Name"
+  },
+  {
+   "fetch_from": "employee.first_name",
+   "fieldname": "section_break_dskx",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_qawu",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "leave_type",
+   "fieldtype": "Link",
+   "label": "Leave Type",
+   "options": "Leave Type"
+  },
+  {
+   "fieldname": "column_break_flmr",
+   "fieldtype": "Column Break"
+  }
+ ],
+ "links": [],
+ "modified": "2024-11-15 17:09:00.364846",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "Compensatory Leave Log",
+ "naming_rule": "Expression",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/beams/beams/doctype/compensatory_leave_log/compensatory_leave_log.json
+++ b/beams/beams/doctype/compensatory_leave_log/compensatory_leave_log.json
@@ -40,7 +40,7 @@
    "options": "Leave Allocation"
   },
   {
-   "fetch_from": "employee.first_name",
+   "fetch_from": "employee.employee_name",
    "fieldname": "employee_name",
    "fieldtype": "Data",
    "label": "Employee Name"
@@ -66,7 +66,7 @@
   }
  ],
  "links": [],
- "modified": "2024-11-15 17:09:00.364846",
+ "modified": "2024-11-16 09:54:06.701739",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Compensatory Leave Log",

--- a/beams/beams/doctype/compensatory_leave_log/compensatory_leave_log.json
+++ b/beams/beams/doctype/compensatory_leave_log/compensatory_leave_log.json
@@ -46,7 +46,6 @@
    "label": "Employee Name"
   },
   {
-   "fetch_from": "employee.first_name",
    "fieldname": "section_break_dskx",
    "fieldtype": "Section Break"
   },

--- a/beams/beams/doctype/compensatory_leave_log/compensatory_leave_log.py
+++ b/beams/beams/doctype/compensatory_leave_log/compensatory_leave_log.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class CompensatoryLeaveLog(Document):
+	pass

--- a/beams/beams/doctype/compensatory_leave_log/test_compensatory_leave_log.py
+++ b/beams/beams/doctype/compensatory_leave_log/test_compensatory_leave_log.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, efeone and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestCompensatoryLeaveLog(FrappeTestCase):
+	pass


### PR DESCRIPTION
## Feature description
Add essential fields to the Compensatory Leave Log doctype to track employee compensatory leave details including employee information, date ranges, leave type, and leave allocation. Also implement naming series for the doctype.

## Analysis and design (optional)
Create doctype Compensatory Leave Log:
          Add following fields :
  Employee(Link, Employee, Mandatory), Start Date(Date), End Date(Date), Leave Type(Link, option-Leave Type),Leave Allocation(Link, option-Leave Allocation)


Set naming series for Compensatory Leave Log doctype.

## Solution description
Added the following fields to Compensatory Leave Log doctype:

-           Employee (Link)Link to Employee doctype,Mandatory field.
-           Employee Name(fetch from Employee)
-            Leave Type (Link),Link to Leave Type doctype
-           Leave Allocation (Link),Link to Leave Allocation doctype
-            Start Date (Date)
-           End Date (Date)

Added naming series for Compensatory Leave Log:Format: COMP-LEAVE-.YYYY.-

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/bd569309-6ddc-4e22-b343-4452b113e53a)


## Is there any existing behavior change of other features due to this code change?
 No. If Yes,

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox

