### PR TITLE
fix : Remove unnecessary custom buttons on unsaved forms

### DIFF
--- a/beams/beams/custom_scripts/training_event/training_event.js
+++ b/beams/beams/custom_scripts/training_event/training_event.js
@@ -1,5 +1,11 @@
 frappe.ui.form.on('Training Event', {
     refresh: function(frm) {
+      if (frm.doc.docstatus !== 1) {
+        setTimeout(() => {
+          frm.remove_custom_button('Training Result');
+          frm.remove_custom_button('Training Feedback');
+        }, 5);
+      }
         if (!frm.is_new() && frappe.user.has_role("HR Manager")) {
             // Create the main group button "Training Request"
             frm.add_custom_button("Training Request", () => {


### PR DESCRIPTION
## Feature description
- Remove unnecessary custom buttons on unsaved forms 

## Solution description
- 'Training Result' and 'Training Feedback' buttons are removed when the Training Event document is not submitted 

## Output screenshots (optional)
[Screencast from 16-11-24 10:00:16 AM IST.webm](https://github.com/user-attachments/assets/02c6e20c-06c4-4985-b704-7146114ec818)

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox
