### PR TITLE
TASK-2024-01080: maped the fields in job offer doctype

### DIFF
--- a/beams/setup.py
+++ b/beams/setup.py
@@ -182,7 +182,7 @@ def get_job_offer_custom_fields():
                 "fieldtype": "Link",
                 "label": "Job Proposal",
                 "options":"Job Proposal",
-                "insert_after": "job_applicant",
+                "insert_after": "applicant_email",
                 "read_only":1
             },
             {


### PR DESCRIPTION
##Issue description
1.Need to Arrange the fields in the job offer doctype

2.implement to map the fields in  job offer from job proposal doctype 

## Solution description

1.Arranged the fields in the job offer doctype

 -Placed Job Proposal and CTC field after field Job Applicant email Address.via setup.py

2.implemented to map the fields in  job offer from job proposal doctype 

-Fetched the content of Job Offer Terms and Terms and Condition from a linked job offer terms and Terms and Condition template

-Applied jinja template in terms and condition via job proposal.py
## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/35a1b15c-bb9b-49d6-847e-d2a0392f277b)
[Screencast from 16-11-24 10:23:36 AM IST.webm](https://github.com/user-attachments/assets/a7381912-974c-42d8-a996-c188fffc5cf8)

## Areas affected and ensured
job proposal
job offer

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Mozilla Firefox
  