### PR TITLE
     TASK-2024-01031: hide event button on Employee doctype before save

### DIFF
--- a/beams/beams/custom_scripts/employee/employee.js
+++ b/beams/beams/custom_scripts/employee/employee.js
@@ -26,7 +26,7 @@ frappe.ui.form.on('Employee', {
                     }
                 });
             }, 'Create');
-        }
+
 
         // Check if employee name exists for the logged-in user and add 'Event' button if available
         frappe.call({
@@ -49,5 +49,6 @@ frappe.ui.form.on('Employee', {
                 }
             }
         });
+      }
     }
 });

--- a/beams/beams/custom_scripts/job_requisition/job_requisition.py
+++ b/beams/beams/custom_scripts/job_requisition/job_requisition.py
@@ -51,7 +51,7 @@ def create_job_opening_from_job_requisition(doc, method):
             # Insert the Job Opening document
             job_opening.insert()
             frappe.msgprint(
-                'Journal Opening Created: <a href="{0}">{1}</a>'.format(get_url_to_form(job_opening.doctype, job_opening.name), job_opening.name),
+                'Job Opening Created: <a href="{0}">{1}</a>'.format(get_url_to_form(job_opening.doctype, job_opening.name), job_opening.name),
                 alert=True, indicator='green')
 
 @frappe.whitelist()

--- a/beams/beams/custom_scripts/job_requisition/job_requisition.py
+++ b/beams/beams/custom_scripts/job_requisition/job_requisition.py
@@ -51,7 +51,7 @@ def create_job_opening_from_job_requisition(doc, method):
             # Insert the Job Opening document
             job_opening.insert()
             frappe.msgprint(
-                'Journal Entry Created: <a href="{0}">{1}</a>'.format(get_url_to_form(job_opening.doctype, job_opening.name), job_opening.name),
+                'Journal Opening Created: <a href="{0}">{1}</a>'.format(get_url_to_form(job_opening.doctype, job_opening.name), job_opening.name),
                 alert=True, indicator='green')
 
 @frappe.whitelist()


### PR DESCRIPTION
## Issue  description
1.Need to hide event  button on Employee doctype before save
2. Need to change the alert message while creating the job opening from the job requisition doctype

## Solution description
1.implemented to hide the event button while before saving the employee doctype for hod user
 -when hod user creating the event only show after saving via employee.py
2.changed the alert message while creating the job opening from the job requisition via job requisition.py


## Output screenshots (optional)
[Uploading Screencast from 18-11-24 12:25:35 PM IST.webm…]()

![Screenshot from 2024-11-18 12-45-00](https://github.com/user-attachments/assets/3322778b-8da3-47bc-b98b-293544bba097)

[Screencast from 18-11-24 12:44:46 PM IST.webm](https://github.com/user-attachments/assets/3c300e6c-a08d-4b79-9a4f-d6dcc8b5831e)
5e8b)


## Areas affected and ensured
Employee

## Is there any existing behavior change of other features due to this code change?
 No

## Was this feature tested on the browsers?
  - Mozilla Firefox
 
