### PR TITLE
TASK-2024-00984: Reorganize notification fields in Beams HR Settings

### DIFF
--- a/beams/beams/doctype/beams_hr_settings/beams_hr_settings.json
+++ b/beams/beams/doctype/beams_hr_settings/beams_hr_settings.json
@@ -11,8 +11,6 @@
   "notification_to_admin",
   "admin_hod",
   "column_break_gvvx",
-  "notification_to_it_department_for_login_credentials_section",
-  "column_break_nlxx",
   "notification_to_it",
   "it_hod",
   "column_break_qbue",
@@ -35,28 +33,19 @@
   },
   {
    "fieldname": "notification_to_admin_department_to_create_id_card_section",
-   "fieldtype": "Section Break",
-   "label": "Notification to Admin Department to Create ID Card"
+   "fieldtype": "Section Break"
   },
   {
-   "fieldname": "notification_to_it_department_for_login_credentials_section",
-   "fieldtype": "Section Break",
-   "label": "Notification to IT Department to Login Credentials"
-  },
-  {
-   "description": " ",
-   "fieldname": "column_break_nlxx",
-   "fieldtype": "Column Break"
-  },
-  {
-   "description": "Based on Job Applicant you can apply jinja formatting like {{ doc.name }} ",
+   "description": "Notification Message to Admin Department to Create ID Card.\n\nHelp:\nBased on Job Applicant you can apply jinja formatting like {{ doc.name }} ",
    "fieldname": "notification_to_admin",
-   "fieldtype": "Small Text"
+   "fieldtype": "Small Text",
+   "label": "Admin Notification Message"
   },
   {
-   "description": "Based on Job Applicant you can apply jinja formatting like {{ doc.name }} ",
+   "description": "Notification Message to IT Department to Create Login Credentials. Help:\nBased on Job Applicant you can apply jinja formatting like {{ doc.name }} ",
    "fieldname": "notification_to_it",
-   "fieldtype": "Small Text"
+   "fieldtype": "Small Text",
+   "label": "IT Notification Message"
   },
   {
    "fieldname": "admin_hod",
@@ -106,7 +95,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-11-15 16:56:49.566987",
+ "modified": "2024-11-14 16:15:26.260627",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Beams HR Settings",

--- a/beams/beams/doctype/beams_hr_settings/beams_hr_settings.json
+++ b/beams/beams/doctype/beams_hr_settings/beams_hr_settings.json
@@ -95,7 +95,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-11-14 16:15:26.260627",
+ "modified": "2024-11-19 16:56:49.566987",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Beams HR Settings",

--- a/beams/beams/doctype/compensatory_leave_log/compensatory_leave_log.json
+++ b/beams/beams/doctype/compensatory_leave_log/compensatory_leave_log.json
@@ -20,8 +20,10 @@
   {
    "fieldname": "employee",
    "fieldtype": "Link",
+   "in_list_view": 1,
    "label": "Employee",
-   "options": "Employee"
+   "options": "Employee",
+   "reqd": 1
   },
   {
    "fieldname": "start_date",
@@ -65,7 +67,7 @@
   }
  ],
  "links": [],
- "modified": "2024-11-16 09:54:06.701739",
+ "modified": "2024-11-18 15:41:30.615408",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Compensatory Leave Log",


### PR DESCRIPTION
## Feature description
Reorganize the notification fields in the Beams HR Settings DocType to improve clarity, usability, and structure.
Employee field should be mandatory in Compensatory Leave Log doctype.

## Solution description

- Removed section break Notification to IT Department to Login Credentials
- Removed section break Notification to Admin Department to Create ID Card
- Updated descriptions and labels for better clarity:
   a) notification_to_admin: Renamed to "Admin Notification Message" .
   b)notification_to_it: Renamed to "IT Notification Message" and enhanced description.
- Made Employee field mandatory in Compensatory Leave Log doctype.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/35fec334-4d8a-43af-a2ab-230b41a8908a)

## Areas affected and ensured
- Beams HR Settings DocType: Notification fields and layout.

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox
