### PR TITLE
TASK-2024-01055:Updated the Status of Training Request on cancel of Training event.

### DIFF
--- a/beams/beams/custom_scripts/training_event/training_event.py
+++ b/beams/beams/custom_scripts/training_event/training_event.py
@@ -22,3 +22,12 @@ def on_update(doc,method):
     if doc.event_status in status_mapping:
         for row in doc.employees:
             frappe.db.set_value("Training Request", row.training_request, "status", status_mapping[doc.event_status])
+
+@frappe.whitelist()
+def on_cancel(doc, method):
+    """
+    Updates the status of linked Training Requests to 'Open' when a Training Event is canceled.
+    """
+    for row in doc.employees:
+        if row.training_request:
+            frappe.db.set_value("Training Request", row.training_request, "status", "Open")

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -173,7 +173,8 @@ doc_events = {
     },
     "Training Event": {
          "on_update": "beams.beams.custom_scripts.training_event.training_event.on_update",
-          "on_update_after_submit": "beams.beams.custom_scripts.training_event.training_event.on_update"
+          "on_update_after_submit": "beams.beams.custom_scripts.training_event.training_event.on_update",
+          "on_cancel": "beams.beams.custom_scripts.training_event.training_event.on_cancel"
     },
     "Supplier": {
         "after_insert": "beams.beams.custom_scripts.account.account.create_todo_on_creation_for_supplier"


### PR DESCRIPTION
## issue description
1. implement to update the status of training request on cancellation of training event doctype

## Solution description
1.  Implemented to update the status of training request on cancel of training event doctype
  - on cancel of  training event corresponding training request status become open only  for hr manager user via hooks.py 
    and via training event.py


## Output screenshots (optional)
[Screencast from 19-11-24 03:19:12 PM IST.webm](https://github.com/user-attachments/assets/4b421da8-56f9-4e54-98cf-913d83ad4f24)



## Areas affected and ensured
Training Event doctype
Training Request doctype

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox
  
