### PR TITLE
TASK-2024-01100 : Leave allocation and Compensatory leave is created for employe…

### DIFF
--- a/beams/beams/custom_scripts/employee_checkin/employee_checkin.py
+++ b/beams/beams/custom_scripts/employee_checkin/employee_checkin.py
@@ -60,5 +60,3 @@ def handle_employee_checkin_out(doc, method):
         })
         leave_allocation_doc.insert()
         leave_allocation_doc.submit()
-
-    frappe.db.commit()

--- a/beams/beams/custom_scripts/employee_checkin/employee_checkin.py
+++ b/beams/beams/custom_scripts/employee_checkin/employee_checkin.py
@@ -1,0 +1,64 @@
+import frappe
+from frappe.utils import add_days, today
+from datetime import datetime
+
+def handle_employee_checkin_out(doc, method):
+    """
+    Handles Employee Checkin with type OUT:
+    - Creates or updates Leave Allocation.
+    - Triggers Compensatory Leave Log creation in Leave Allocation logic.
+    """
+    if doc.log_type != "OUT":
+        return
+
+    # Fetch Compensatory Leave Type
+    compensatory_leave_type = frappe.db.get_single_value("Beams HR Settings", "compensatory_leave_type")
+    if not compensatory_leave_type:
+        frappe.throw("Compensatory Leave Type is not configured in Beams HR Settings.")
+
+    # Parse time from the Employee Checkin log
+    doc_time = datetime.strptime(doc.time, "%Y-%m-%d %H:%M:%S") if isinstance(doc.time, str) else doc.time
+    start_date = doc_time.date()
+    end_date = add_days(start_date, 30)
+    today_date = today()
+
+    # Verify Shift Assignment with roster_type 'OT'
+    shift_assignment = frappe.db.sql("""
+        SELECT name FROM `tabShift Assignment`
+        WHERE employee = %s
+          AND roster_type = 'OT'
+          AND %s BETWEEN start_date AND end_date
+    """, (doc.employee, today_date), as_dict=True)
+
+    if not shift_assignment:
+        return
+
+    # Fetch Leave Allocation
+    leave_allocation = frappe.get_all(
+        "Leave Allocation",
+        filters={"employee": doc.employee, "leave_type": compensatory_leave_type},
+        fields=["name", "to_date", "new_leaves_allocated"],
+        limit=1
+    )
+
+    if leave_allocation:
+        # Update existing Leave Allocation
+        allocation = frappe.get_doc("Leave Allocation", leave_allocation[0].name)
+        if allocation.to_date < end_date:
+            allocation.to_date = end_date
+        allocation.new_leaves_allocated += 1
+        allocation.save()
+    else:
+        # Create new Leave Allocation
+        leave_allocation_doc = frappe.new_doc("Leave Allocation")
+        leave_allocation_doc.update({
+            "employee": doc.employee,
+            "leave_type": compensatory_leave_type,
+            "from_date": start_date,
+            "to_date": end_date,
+            "new_leaves_allocated": 1,
+        })
+        leave_allocation_doc.insert()
+        leave_allocation_doc.submit()
+
+    frappe.db.commit()

--- a/beams/beams/custom_scripts/leave_allocation/leave_allocation.py
+++ b/beams/beams/custom_scripts/leave_allocation/leave_allocation.py
@@ -1,0 +1,87 @@
+import frappe
+from frappe.utils import today, add_days
+from datetime import datetime
+
+def create_new_log_on_update(doc, method):
+    """
+    Automatically creates or updates Compensatory Leave Log based on Leave Allocation changes,
+    but uses Employee Checkin data for date calculations.
+    """
+    # Fetch the previous document state
+    previous_doc = doc.get_doc_before_save()
+
+    # Handle updates to Leave Allocation, checking if dates or allocated leaves have changed
+    if previous_doc.to_date != doc.to_date or previous_doc.new_leaves_allocated != doc.new_leaves_allocated:
+        # Fetch the latest Employee Checkin log for the employee (log_type = OUT)
+        checkin_data = frappe.db.get_all(
+            "Employee Checkin",
+            filters={"employee": doc.employee, "log_type": "OUT"},
+            fields=["time"],
+            order_by="time desc",  # Get the latest "OUT" log
+            limit=1
+        )
+
+        if not checkin_data:
+            frappe.throw(f"No checkin data found for employee {doc.employee}.")
+
+        # If time is already a datetime object, use it directly
+        doc_time = checkin_data[0].time
+
+        # Extract the date directly from the datetime object
+        start_date = doc_time.date() if isinstance(doc_time, datetime) else datetime.strptime(doc_time, "%Y-%m-%d %H:%M:%S").date()
+
+        end_date = add_days(start_date, 30)  # Add 30 days to the start date
+
+        # Create or update the Compensatory Leave Log
+        log_doc = frappe.new_doc("Compensatory Leave Log")
+        log_doc.update({
+            "employee": doc.employee,
+            "employee_name": doc.employee_name,
+            "leave_type": doc.leave_type,
+            "leave_allocation": doc.name,
+            "start_date": start_date,
+            "end_date": end_date,
+        })
+        log_doc.insert()
+
+    frappe.db.commit()
+
+
+def create_new_compensatory_leave_log(doc, method):
+    """
+    Automatically creates a Compensatory Leave Log based on Leave Allocation data,
+    using Employee Checkin data for date calculations.
+    """
+    # Fetch the latest Employee Checkin log for the employee (log_type = OUT)
+    checkin_data = frappe.db.get_all(
+        "Employee Checkin",
+        filters={"employee": doc.employee, "log_type": "OUT"},
+        fields=["time"],
+        order_by="time desc",  # Get the latest "OUT" log
+        limit=1
+    )
+
+    if not checkin_data:
+        frappe.throw(f"No checkin data found for employee {doc.employee}.")
+
+    # If time is already a datetime object, use it directly
+    doc_time = checkin_data[0].time
+
+    # Extract the date directly from the datetime object
+    start_date = doc_time.date() if isinstance(doc_time, datetime) else datetime.strptime(doc_time, "%Y-%m-%d %H:%M:%S").date()
+
+    end_date = add_days(start_date, 30)  # Add 30 days to the start date
+
+    # Create the Compensatory Leave Log
+    log_doc = frappe.new_doc("Compensatory Leave Log")
+    log_doc.update({
+        "employee": doc.employee,
+        "employee_name": doc.employee_name,
+        "leave_type": doc.leave_type,
+        "leave_allocation": doc.name,
+        "start_date": start_date,
+        "end_date": end_date,
+    })
+    log_doc.insert()
+
+    frappe.db.commit()

--- a/beams/beams/custom_scripts/leave_allocation/leave_allocation.py
+++ b/beams/beams/custom_scripts/leave_allocation/leave_allocation.py
@@ -44,7 +44,6 @@ def create_new_log_on_update(doc, method):
         })
         log_doc.insert()
 
-    frappe.db.commit()
 
 
 def create_new_compensatory_leave_log(doc, method):
@@ -83,5 +82,3 @@ def create_new_compensatory_leave_log(doc, method):
         "end_date": end_date,
     })
     log_doc.insert()
-
-    frappe.db.commit()

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -226,8 +226,14 @@ doc_events = {
     "Interview Feedback": {
         "after_insert": "beams.beams.custom_scripts.interview_feedback.interview_feedback.after_insert",
         "validate": "beams.beams.custom_scripts.interview_feedback.interview_feedback.validate"
+    },
+    "Employee Checkin":{
+        "after_insert":"beams.beams.custom_scripts.employee_checkin.employee_checkin.handle_employee_checkin_out"
+    },
+    "Leave Allocation":{
+        "on_submit":"beams.beams.custom_scripts.leave_allocation.leave_allocation.create_new_compensatory_leave_log",
+        "on_update_after_submit":"beams.beams.custom_scripts.leave_allocation.leave_allocation.create_new_log_on_update"
     }
-
 }
 
 

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -34,6 +34,7 @@ def after_install():
     create_custom_fields(get_company_custom_fields(), ignore_validate=True)
     create_custom_fields(get_training_event_employee_custom_fields(), ignore_validate=True)
     create_custom_fields(get_attendance_request_custom_fields(),ignore_validate=True)
+    create_custom_fields(get_shift_assignment_custom_fields(),ignore_validate=True)
     #Creating BEAMS specific Property Setters
     create_property_setters(get_property_setters())
 
@@ -77,6 +78,7 @@ def before_uninstall():
     delete_custom_fields(get_company_custom_fields())
     delete_custom_fields(get_training_event_employee_custom_fields())
     delete_custom_fields(get_attendance_request_custom_fields())
+    delete_custom_fields(get_shift_assignment_custom_fields())
 
 def delete_custom_fields(custom_fields: dict):
     '''
@@ -93,6 +95,23 @@ def delete_custom_fields(custom_fields: dict):
             },
         )
         frappe.clear_cache(doctype=doctype)
+
+def get_shift_assignment_custom_fields():
+    '''
+    Custom fields that need to be added to the Shift Assignment DocType
+    '''
+    return {
+        "Shift Assignment": [
+            {
+                "fieldname": "roster_type",
+                "fieldtype": "Select",
+                "label": "Roster Type",
+                "options":"\nRegular\nOT",
+                "insert_after": "shift_type"
+            }
+        ]
+    }
+
 
 def get_attendance_request_custom_fields():
     """
@@ -1653,6 +1672,13 @@ def get_property_setters():
             "doc_type": "Job Requisition",
             "field_name": "status",
             "property": "read_only",
+            "value": 1
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Leave Allocation",
+            "field_name": "to_date",
+            "property": "allow_on_submit",
             "value": 1
         },
         {


### PR DESCRIPTION
## Feature description

- Create a field roster type in shift assignment
- Set end date in leave allocation as allow on submit
- On creation of employee check out check whether he had a shift assignment as ot then create a leave allocation
- When there exist a leave allocation for the employee, increment the new leave allocated field by one and change the end date as     validity of 30 days
- Corresponding to the leave allocation created or updated create a compensatory leave log

## Solution description

- Created the roster field and set end date as allow on submit through setup
- When a employee checkout checks whether he had a shift assignment as ot for that day and time then checks if there exist a leave allocation if yes updated the number of leaves and extended the validity of end date by 30 days . if not then create a new leave allocation
- Whenever a leave allocation is created or updated automatically a new compensatory leave log is created as start date as the employee checkout date and end date as 30 days extended

## Output screenshots (optional)
[Screencast from 20-11-24 01:19:46 PM IST.webm](https://github.com/user-attachments/assets/8ba847d3-ad01-465c-99bc-edcd61c817f2)



