### PR TITLE
 TASK-2024-01099:Add leave application validation for penalty leave balance

### DIFF
--- a/beams/beams/custom_scripts/leave_application/leave_application.py
+++ b/beams/beams/custom_scripts/leave_application/leave_application.py
@@ -1,0 +1,29 @@
+import frappe
+def validate_leave_application(doc, method):
+    '''
+    Validates the leave application based on the penalty leave type set in the HR settings.
+    '''
+    penalty_leave_type = frappe.get_single('Beams HR Settings').penalty_leave_type
+
+    # Get total allocated leaves for the penalty leave type
+    total_allocated = frappe.db.get_value(
+        'Leave Allocation', {'employee': doc.employee, 'leave_type': penalty_leave_type}, 'total_leaves_allocated'
+    ) or 0
+
+    # Calculate leaves used for the penalty leave type
+    leaves_used = frappe.db.sql("""
+        SELECT SUM(total_leave_days)
+        FROM `tabLeave Application`
+        WHERE employee = %s AND leave_type = %s AND docstatus = 1
+    """, (doc.employee, penalty_leave_type))[0][0] or 0
+
+    # Remaining leave balance
+    leave_balance = total_allocated - leaves_used
+
+    # If no balance left, enforce Leave Without Pay
+    if leave_balance == 0 and doc.leave_type != 'Leave Without Pay':
+        frappe.throw('Your \'{0}\' leave balance is exhausted. Apply for \'Leave Without Pay\'.'.format(penalty_leave_type))
+
+    # If penalty leave balance exists, restrict applying for other leave types
+    if leave_balance > 0 and doc.leave_type != penalty_leave_type:
+        frappe.throw('You can only apply for \'{0}\' leave. Remaining balance: {1}.'.format(penalty_leave_type, leave_balance))

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -163,6 +163,10 @@ doc_events = {
     },
     "Purchase Invoice": {
         "before_save": "beams.beams.custom_scripts.purchase_invoice.purchase_invoice.before_save"
+
+    },
+    "Training Event": {
+         "on_update": "beams.beams.custom_scripts.training_event.training_event.on_update"
     },
     "Account": {
         "after_insert": "beams.beams.custom_scripts.account.account.create_todo_on_creation_for_account"
@@ -233,6 +237,9 @@ doc_events = {
     "Leave Allocation":{
         "on_submit":"beams.beams.custom_scripts.leave_allocation.leave_allocation.create_new_compensatory_leave_log",
         "on_update_after_submit":"beams.beams.custom_scripts.leave_allocation.leave_allocation.create_new_log_on_update"
+    },
+    "Leave Application": {
+        "validate":"beams.beams.custom_scripts.leave_application.leave_application.validate_leave_application"
     }
 }
 


### PR DESCRIPTION
## Feature description
Add leave application validation for penalty leave balance
    -Retrieve penalty leave type from Beams HR Settings.
    -Compute the total allocated and used penalty leave for the employee.
    -Enforce 'Leave Without Pay' if no penalty leave balance is remaining.
    -Prevent applying for non-penalty leave types when penalty leave balance is available.
    -Provide clear error messages to enforce leave application rules

## Solution description
Implemented validation for leave application based on penalty leave balance
- Fetched penalty leave type from Beams HR Settings.
- Calculated total allocated and used penalty leave for the employee.
- Restricted non-penalty leave types if penalty leave balance was available.
- Enforced 'Leave Without Pay' when penalty leave balance was exhausted.
- Displayed relevant error messages for leave application restrictions.

## Output screenshots
[Screencast from 21-11-24 12:24:58 PM IST.webm](https://github.com/user-attachments/assets/5650fd1a-a1c2-42e4-889f-98bc1313252a)


[Screencast from 21-11-24 12:27:24 PM IST.webm](https://github.com/user-attachments/assets/7d1b2f4e-580d-429d-94c4-cd75f620c6f7)


## Areas affected and ensured
Beams HR Settings Doctype
Leave Allocation Doctype
Leave Application Doctype

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
 - Mozilla Firefox
  