### PR TITLE
 TASK-2024-01142:  Fixed the validation in leave application doctype

### DIFF
--- a/beams/beams/custom_scripts/leave_application/leave_application.js
+++ b/beams/beams/custom_scripts/leave_application/leave_application.js
@@ -4,10 +4,14 @@ frappe.ui.form.on('Leave Application', {
             validate_from_date(frm);
         }
         if (frm.doc.leave_type) {
-            frappe.db.get_value('Leave Type', frm.doc.leave_type, 'is_sick_leave', function(value) {
+            frappe.db.get_value('Leave Type', frm.doc.leave_type,['is_sick_leave', 'medical_leave_required'], function(value) {
                 if (value.is_sick_leave && frm.doc.from_date && frm.doc.to_date) {
                     var duration = frappe.datetime.get_diff(frm.doc.to_date, frm.doc.from_date) + 1;
-                    frm.set_df_property('medical_certificate', 'hidden', duration <= 2);
+                    if (value.medical_leave_required) {
+                        frm.set_df_property('medical_certificate', 'hidden', duration <= value.medical_leave_required);
+                    } else {
+                        frm.set_df_property('medical_certificate', 'hidden', true);
+                    }
                 } else {
                     frm.set_df_property('medical_certificate', 'hidden', true);
                 }

--- a/beams/beams/custom_scripts/leave_application/leave_application.py
+++ b/beams/beams/custom_scripts/leave_application/leave_application.py
@@ -35,13 +35,10 @@ def validate_leave_application(doc, method):
     """
     Validation for Leave Application:
     - Check if the leave_type in Leave Application has the is_sick_leave field checked.
-    - If the leave duration exceeds 2 days, ensure a medical certificate is attached.
-    - Display a validation error if the document is not attached when required.
+    - Validate medical certificate requirement based on the 'medical_leave_required' threshold in Leave Type.
     """
-    is_sick_leave = frappe.db.get_value("Leave Type", doc.leave_type, "is_sick_leave")
-
-    if is_sick_leave:
-        if doc.total_leave_days > 2:
+    leave_type_details = frappe.db.get_value("Leave Type", doc.leave_type, ["is_sick_leave", "medical_leave_required"], as_dict=True)
+    if leave_type_details and leave_type_details.is_sick_leave:
+        if leave_type_details.medical_leave_required and doc.total_leave_days > leave_type_details.medical_leave_required:
             if not doc.medical_certificate:
-                frappe.throw(_("Medical certificate is required for sick leave exceeding 2 days."))
-                
+                frappe.throw(_("Medical certificate is required for sick leave exceeding {0} days.").format(leave_type_details.medical_leave_required))


### PR DESCRIPTION
## Issue  description

1. Implement logic to  show or hide the 'medical_certificate' field based on leave type and duration 
2. implement  validation for medical certificate requirements for sick leave .

 

## Solution description
 1.Implement logic to  show or hide the 'medical_certificate' field based on leave type and duration.
  -implemented the logic that show or hide the 'medical_certificate' field based on leave type is is_sick_leave (checkbox) checked 
    and the from_date and to_date duration check exceeds more than medical_leave_required field in leave type in leave application via leave application.js 

2.implemented  validation for medical certificate requirements for sick leave exceeding 2 days
   -implemented the validation that if  is_sick_leave (checkbox) leave type and   exceeds more than medical_leave_required field in   leave type the no medical certificate is selected validation message  is shown

## Output screenshots (optional)
[Screencast from 26-11-24 10:56:52 AM IST.webm](https://github.com/user-attachments/assets/f1402f84-2e32-48ed-a5fb-de26995273d3)



## Areas affected and ensured
leave type
leave application 

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox
  
