### PR TITLE
TASK-2024-01149:Leave Policy Assignment created and Submitted on creation of Employee.

### DIFF
--- a/beams/beams/custom_scripts/employee/employee.py
+++ b/beams/beams/custom_scripts/employee/employee.py
@@ -38,33 +38,35 @@ def get_employee_name_for_user(user_id):
 
 @frappe.whitelist()
 def after_insert_employee(doc, method):
-    # Fetch Beams HR Settings
-    default_settings = frappe.get_doc('Beams HR Settings')
-    leave_policy = default_settings.default_leave_policy
-    leave_period = default_settings.leave_period
+    '''This function is triggered after an Employee record is created.
+       It fetches the default leave policy and leave period from the Beams HR Settings,
+    validates the configurations, and automatically creates and submits a Leave Policy Assignment.'''
 
+# Fetch default leave policy and leave period from Beams HR Settings using frappe.db.get_single_value
+    leave_policy = frappe.db.get_single_value('Beams HR Settings', 'default_leave_policy')
+    leave_period = frappe.db.get_single_value('Beams HR Settings', 'leave_period')
     if not leave_policy or not leave_period:
         frappe.throw(_("Default Leave Policy or Leave Period is not configured in Beams HR Settings."))
 
     leave_period_details = frappe.db.get_value(
-        "Leave Period",
+        'Leave Period',
         leave_period,
-        ["from_date", "to_date"],
+        ['from_date', 'to_date'],
         as_dict=True,
     )
 
     if not leave_period_details:
-        frappe.throw(_("Leave Period {0} does not exist.").format(leave_period))
+        frappe.throw(_('Leave Period {0} does not exist.').format(leave_period))
 
     # Create Leave Policy Assignment
     leave_policy_assignment = frappe.get_doc({
-        "doctype": "Leave Policy Assignment",
-        "employee": doc.name,
-        "leave_policy": leave_policy,
-        "leave_period": leave_period,
-        "assignment_based_on": "Leave Period",
-        "effective_from": leave_period_details.from_date,
-        "effective_to": leave_period_details.to_date,
+        'doctype': 'Leave Policy Assignment',
+        'employee': doc.name,
+        'leave_policy': leave_policy,
+        'leave_period': leave_period,
+        'assignment_based_on': 'Leave Period',
+        'effective_from': leave_period_details.from_date,
+        'effective_to': leave_period_details.to_date,
     })
 
     leave_policy_assignment.insert()

--- a/beams/beams/custom_scripts/employee/employee.py
+++ b/beams/beams/custom_scripts/employee/employee.py
@@ -1,5 +1,7 @@
 import frappe
+from frappe import _
 from frappe.model.mapper import get_mapped_doc
+from frappe.utils import getdate, nowdate
 
 @frappe.whitelist()
 def create_event(employee_id=None, hod_user=None, target_doc=None):
@@ -28,8 +30,42 @@ def create_event(employee_id=None, hod_user=None, target_doc=None):
 
 @frappe.whitelist()
 def get_employee_name_for_user(user_id):
-    """
+    '''
     Fetch the Employee name associated with the given user_id.
-    """
+    '''
     employee_name = frappe.db.get_value("Employee", {"user_id": user_id}, "name")
     return employee_name
+
+@frappe.whitelist()
+def after_insert_employee(doc, method):
+    # Fetch Beams HR Settings
+    default_settings = frappe.get_doc('Beams HR Settings')
+    leave_policy = default_settings.default_leave_policy
+    leave_period = default_settings.leave_period
+
+    if not leave_policy or not leave_period:
+        frappe.throw(_("Default Leave Policy or Leave Period is not configured in Beams HR Settings."))
+
+    leave_period_details = frappe.db.get_value(
+        "Leave Period",
+        leave_period,
+        ["from_date", "to_date"],
+        as_dict=True,
+    )
+
+    if not leave_period_details:
+        frappe.throw(_("Leave Period {0} does not exist.").format(leave_period))
+
+    # Create Leave Policy Assignment
+    leave_policy_assignment = frappe.get_doc({
+        "doctype": "Leave Policy Assignment",
+        "employee": doc.name,
+        "leave_policy": leave_policy,
+        "leave_period": leave_period,
+        "assignment_based_on": "Leave Period",
+        "effective_from": leave_period_details.from_date,
+        "effective_to": leave_period_details.to_date,
+    })
+
+    leave_policy_assignment.insert()
+    leave_policy_assignment.submit()

--- a/beams/beams/doctype/beams_hr_settings/beams_hr_settings.json
+++ b/beams/beams/doctype/beams_hr_settings/beams_hr_settings.json
@@ -17,7 +17,11 @@
   "tab_3_tab",
   "penalty_leave_type",
   "column_break_pjdi",
-  "compensatory_leave_type"
+  "compensatory_leave_type",
+  "section_break_wu5q",
+  "default_leave_policy",
+  "column_break_laz7",
+  "leave_period"
  ],
  "fields": [
   {
@@ -90,12 +94,32 @@
   {
    "fieldname": "column_break_pjdi",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_wu5q",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "default_leave_policy",
+   "fieldtype": "Link",
+   "label": " Default Leave Policy",
+   "options": "Leave Policy"
+  },
+  {
+   "fieldname": "column_break_laz7",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "leave_period",
+   "fieldtype": "Link",
+   "label": "Leave Period",
+   "options": "Leave Period"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-11-19 16:56:49.566987",
+ "modified": "2024-11-25 15:45:40.757049",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Beams HR Settings",

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -247,7 +247,12 @@ doc_events = {
             "beams.beams.custom_scripts.leave_application.leave_application.validate_leave_type",
             "beams.beams.custom_scripts.leave_application.leave_application.validate_leave_application"
          ]
+    },
+    "Employee" : {
+        "after_insert": "beams.beams.custom_scripts.employee.employee.after_insert_employee"
+
     }
+
 }
 
 

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -693,6 +693,13 @@ def get_employee_custom_fields():
                 "options": "Stringer Type",
                 "label": "Stringer Type",
                 "insert_after": "salutation"
+            },
+            {
+                "fieldname": "leave_policy",
+                "fieldtype": "Link",
+                "options": "Leave Policy",
+                "label": "Leave Policy",
+                "insert_after": "attendance_device_id"
             }
         ]
     }


### PR DESCRIPTION

## Feature description
Add following fields:
    Employee DocType:
        Added a new field Leave Policy (Link, options: Leave Policy).
    Beams HR Settings DocType:
        Add a new field Default Leave Policy (Link, options: Leave Policy).
        Add a new field Leave Period (Link, options: Leave Period).
    Leave Policy Assignment:
        A Leave Policy Assignment should be automatically created when an Employee is created.
        The assignment will be based on the Default Leave Policy and Leave Period configured in the Beams HR Settings DocType.
        The Leave Policy Assignment will be submitted automatically after creation.

## Analysis and design (optional)
This feature enhances the Employee and Beams HR Settings DocTypes by adding fields for leave policies and leave periods. It automatically assigns the correct leave policy and leave period to each newly created Employee based on the configuration in Beams HR Settings. 

## Solution description

-         Added the field Leave Policy (Link, options: Leave Policy) to the Employee DocType.
-         Added the field Default Leave Policy (Link, options: Leave Policy) to the Beams HR Settings DocType.
-         Added the field Leave Period (Link, options: Leave Period) to the Beams HR Settings DocType.

## Output screenshots (optional)
[Screencast from 2024-11-26 12-42-07.webm](https://github.com/user-attachments/assets/27ea789a-acbe-42d9-953a-38b359e12340)


## Areas affected and ensured
Leave Policy Assignment.

## Is there any existing behavior change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  