### PR TITLE
    TASK-2024-01151:Hide Interview button for 'Interview Completed' status

### DIFF
--- a/beams/beams/custom_scripts/job_applicant/job_applicant.js
+++ b/beams/beams/custom_scripts/job_applicant/job_applicant.js
@@ -144,8 +144,8 @@ function handle_custom_buttons(frm) {
                 }, __('Set Status'));
             }
 
-            // Remove "Interview" button if status is "Training Completed", "Job Proposal Created", or "Job Proposal Accepted"
-            if (['Training Completed', 'Job Proposal Created', 'Job Proposal Accepted'].includes(frm.doc.status)) {
+            // Remove "Interview" button if status is "Training Completed", "Job Proposal Created", "Job Proposal Accepted or "Interview Completed"
+            if (['Training Completed', 'Job Proposal Created', 'Job Proposal Accepted', 'Interview Completed'].includes(frm.doc.status)) {
                 frm.remove_custom_button(__('Interview'), __('Create'));
             }
 


### PR DESCRIPTION
## Feature description
Hide "Interview" button for "Interview Completed" status  

## Solution description
Added "Interview Completed" to the conditions for removing the "Interview" button in Job Applicant.  

## Output screenshots (optional)
[Screencast from 26-11-24 03:03:58 PM IST.webm](https://github.com/user-attachments/assets/92228b05-dac2-4c69-930f-9aca9de79266)

## Areas affected and ensured
Job Applicant Doctype

## Is there any existing behavior change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?
   - Mozilla Firefox
 
  
