### PR TITLE
fix:Leave type validation for Casual Leave made general for all leave types.

### DIFF
--- a/beams/beams/custom_scripts/leave_application/leave_application.js
+++ b/beams/beams/custom_scripts/leave_application/leave_application.js
@@ -1,8 +1,6 @@
 frappe.ui.form.on('Leave Application', {
     leave_type: function(frm) {
-        if (frm.doc.leave_type === "Casual Leave") {
-            validate_from_date(frm);
-        }
+      validate_from_date(frm);
         if (frm.doc.leave_type) {
             frappe.db.get_value('Leave Type', frm.doc.leave_type,['is_sick_leave', 'medical_leave_required'], function(value) {
                 if (value.is_sick_leave && frm.doc.from_date && frm.doc.to_date) {
@@ -24,10 +22,8 @@ frappe.ui.form.on('Leave Application', {
     },
 
     from_date: function(frm) {
-        if (frm.doc.leave_type === "Casual Leave") {
-            validate_from_date(frm);
-        }
-        frm.trigger('leave_type');
+      validate_from_date(frm);
+      frm.trigger('leave_type');
     },
     to_date: function(frm) {
         frm.trigger('leave_type');
@@ -40,7 +36,7 @@ function validate_from_date(frm) {
     }
 
     frappe.call({
-        method: 'beams.beams.custom_scripts.leave_application.leave_application.validate_casual_leave_application',
+        method: 'beams.beams.custom_scripts.leave_application.leave_application.validate_leave_advance_days',
         args: {
             from_date: frm.doc.from_date,
             leave_type: frm.doc.leave_type
@@ -48,11 +44,6 @@ function validate_from_date(frm) {
         callback: function(response) {
             if (response.exc) {
                 frm.set_value('from_date', '');
-                frappe.msgprint({
-                    title: __('Validation Error'),
-                    indicator: 'red',
-                    message: __('The From Date is invalid for the selected Leave Type.')
-                });
             }
         }
     });

--- a/beams/beams/custom_scripts/leave_application/leave_application.py
+++ b/beams/beams/custom_scripts/leave_application/leave_application.py
@@ -2,13 +2,14 @@ import frappe
 from frappe import _
 from frappe.utils import add_days, nowdate
 
+@frappe.whitelist()
 def validate_leave_type(doc, method):
-    validate_casual_leave_application(doc.from_date, doc.leave_type)
+    validate_leave_advance_days(doc.from_date, doc.leave_type)
 
 @frappe.whitelist()
-def validate_casual_leave_application(from_date, leave_type):
+def validate_leave_advance_days(from_date, leave_type):
     '''
-    Validates the `from_date` for Casual Leave based on the minimum advance days specified in the Leave Type.
+    Validates the `from_date` for Leave based on the minimum advance days specified in the Leave Type.
     '''
     if not leave_type:
         frappe.throw(_("Leave Type is required."))
@@ -29,6 +30,7 @@ def validate_casual_leave_application(from_date, leave_type):
             _("The From Date must be at least {0} days from today for the selected Leave Type.")
             .format(min_advance_days)
         )
+
 
 @frappe.whitelist()
 def validate_leave_application(doc, method):


### PR DESCRIPTION

## Feature description
Validate Leave Application based on the threshold defined in leave type doctype for all leave type.Currently it works for casual leaves only.

## Analysis and design (optional)
Add Validation in Leave Application
Implement a validation in the Leave Application DocType to ensure the From Date is at least the specified number of days from the current date, as defined in the selected Leave Type.

## Solution description
Implemented a validation function in the backend to ensure that the from_date in the Leave Application is at least the configured minimum number of days from the current date.

## Output screenshots (optional)
[Screencast from 2024-11-26 12-42-07.webm](https://github.com/user-attachments/assets/a22d95a0-68fb-46fd-b9c1-da895344133a)


## Is there any existing behavior change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox

