### PR TITLE
feat:Added fields in employee doctype

### DIFF
--- a/beams/beams/custom_scripts/leave_application/leave_application.py
+++ b/beams/beams/custom_scripts/leave_application/leave_application.py
@@ -10,27 +10,25 @@ def validate_leave_type(doc, method):
 def validate_leave_advance_days(from_date, leave_type):
     '''
     Validates the `from_date` for Leave based on the minimum advance days specified in the Leave Type.
+    If min_advance_days is 0 or not provided, no validation is performed.
     '''
     if not leave_type:
         frappe.throw(_("Leave Type is required."))
 
-    # Fetch the Leave Type document
     leave_type_doc = frappe.get_doc("Leave Type", leave_type)
-
-    # Get the minimum advance days for the leave type
     min_advance_days = leave_type_doc.min_advance_days or 0
 
-    # Get the current date and calculate the minimum allowed from_date
+    if min_advance_days == 0:
+        return
+
     current_date = nowdate()
     min_allowed_date = add_days(current_date, min_advance_days)
 
-    # Check if the provided from_date is before the minimum allowed date
     if from_date and from_date < min_allowed_date:
         frappe.throw(
             _("The From Date must be at least {0} days from today for the selected Leave Type.")
             .format(min_advance_days)
         )
-
 
 @frappe.whitelist()
 def validate_leave_application(doc, method):

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -822,6 +822,32 @@ def get_employee_custom_fields():
                 "label": "Type of Account",
                 "depends_on": "eval:doc.salary_mode == 'Bank'",
                 "insert_after":"bank_ac_no"
+            },
+            {
+                "fieldname": "section_break_date",
+                "fieldtype": "Section Break",
+                "label": "",
+                "insert_after":"family_details"
+            },
+            {
+                "fieldname": "date",
+                "fieldtype": "Date",
+                "label": "Date",
+                "insert_after":"section_break_date"
+
+            },
+
+            {
+                "fieldname": "column_sign",
+                "fieldtype": "Column Break",
+                "label": "",
+                "insert_after":"date"
+            },
+            {
+                "fieldname": "signature",
+                "fieldtype": "Signature",
+                "label": "Signature",
+                "insert_after":"column_sign"
             }
         ]
     }


### PR DESCRIPTION
## Feature description
Add date and Signature field after family details child table(ESI tab) of  employee doctype .

## Analysis and design (optional)
Add fields date and Signature in employee.
Fix issue that if minimum advance days is not provided validation should be skipped.

## Solution description
A section break has been added after the family_details field .A Date field is added with the label "Date" after the section break.A column break field is placed after the date field.A signature field with the label "Signature" is added after the column break for user signature input.

In leave Application If min_advance_days in leave type is 0 or not set, no validation is skipped for the leave date.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/77444a9e-4188-4d87-b409-8a32b33693ce)


## Areas affected and ensured
Leave Application
Employee

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox

