### PR TITLE
TASK-2024-01166:Created new tab and child table

### DIFF
--- a/beams/beams/doctype/employee_documents/employee_documents.json
+++ b/beams/beams/doctype/employee_documents/employee_documents.json
@@ -1,0 +1,38 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2024-11-27 10:24:06.508079",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "document_name",
+  "attachment"
+ ],
+ "fields": [
+  {
+   "fieldname": "document_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Document "
+  },
+  {
+   "fieldname": "attachment",
+   "fieldtype": "Attach",
+   "in_list_view": 1,
+   "label": "Attachment"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2024-11-27 12:20:32.644004",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "Employee Documents",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/beams/beams/doctype/employee_documents/employee_documents.py
+++ b/beams/beams/doctype/employee_documents/employee_documents.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class EmployeeDocuments(Document):
+	pass

--- a/beams/beams/doctype/maternity_leave_request/maternity_leave_request.json
+++ b/beams/beams/doctype/maternity_leave_request/maternity_leave_request.json
@@ -41,7 +41,8 @@
    "fieldname": "leave_type",
    "fieldtype": "Link",
    "label": "Leave Type",
-   "options": "Leave Type"
+   "options": "Leave Type",
+   "reqd": 1
   },
   {
    "fieldname": "from_date",
@@ -77,7 +78,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-11-26 12:21:55.768879",
+ "modified": "2024-11-27 11:25:00.391202",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Maternity Leave Request",

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -111,7 +111,7 @@ def get_shift_assignment_custom_fields():
                 "fieldname": "roster_type",
                 "fieldtype": "Select",
                 "label": "Roster Type",
-                "options":"\nRegular\nOT",
+                "options":"\nRegular\nDouble Shift",
                 "insert_after": "shift_type"
             }
         ]
@@ -860,6 +860,64 @@ def get_employee_custom_fields():
                 "fieldtype": "Signature",
                 "label": "Signature",
                 "insert_after":"column_sign"
+            },
+            {
+                "fieldname": "documents_tab",
+                "fieldtype": "Tab Break",
+                "label": "Documents",
+                "insert_after": "internal_work_history"
+            },
+            {
+                "fieldname": "employee_documents",
+                "fieldtype": "Table",
+                "label": "Employee Documents",
+                "options":"Employee Documents",
+                "insert_after":"documents_tab"
+            }
+        ],
+
+        "Employee External Work History":[
+            {
+                "fieldname": "period_from",
+                "fieldtype": "Date",
+                "label": "Period From",
+                "insert_after": "designation"
+            },
+            {
+                "fieldname": "period_to",
+                "fieldtype": "Date",
+                "label": "Period To",
+                "insert_after": "period_from"
+            },
+            {
+                "fieldname": "last_position_held",
+                "fieldtype": "Data",
+                "label": "Last Position Held",
+                "insert_after": "period_to"
+            },
+            {
+                "fieldname": "job_responsibility",
+                "fieldtype": "Small Text",
+                "label": "Job Responsibility",
+                "insert_after": "last_position_held"
+            },
+            {
+                "fieldname": "designation_of_immediate_superior",
+                "fieldtype": "Data",
+                "label": "Designation Of Immediate Superior",
+                "insert_after": "job_responsibility"
+            },
+            {
+                "fieldname": "gross_salary_drawn",
+                "fieldtype": "Float",
+                "label": "Gross Salary Drawn ",
+                "insert_after": "designation_of_immediate_superior"
+            },
+            {
+                "fieldname": "reason_for_leaving",
+                "fieldtype": "Small Text",
+                "label": "Reason For Leaving",
+                "insert_after": "gross_salary_drown"
             }
         ]
     }
@@ -2123,6 +2181,13 @@ def get_property_setters():
             "property_type": "Check",
             "value":1
         },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Employee External Work History",
+            "field_name": "designation",
+            "property": "label",
+            "value":"Designation At The Time Of Joining"
+        }
     ]
 
 def get_material_request_custom_fields():


### PR DESCRIPTION
## Feature description

- Create a new tab Document in Employee
- Create a child table Employee Documents and add to tab Document
- Add fields in Employee external work history in tab profile

## Solution description

- Created a new tab Document in doctype Employee
- Created a child table Employee Documents to attach the documents
- Add fields in Employee external work history

## Output screenshots (optional)

![image](https://github.com/user-attachments/assets/07c469d2-18c4-4c92-ae73-b6c848996c9c)
![image](https://github.com/user-attachments/assets/65724372-e255-4eb9-9246-746e8c665e1f)



