### PR TITLE
feat : Employees marked absent during the leave period must adhere to penalty leave type policies

### DIFF
--- a/beams/beams/custom_scripts/leave_application/leave_application.py
+++ b/beams/beams/custom_scripts/leave_application/leave_application.py
@@ -46,18 +46,19 @@ def validate_leave_application(doc, method):
 
 def validate_leave_application(doc, method):
     """
-    Validates the leave application based on the penalty leave type in HR settings
-    only if:
-    1. The employee is marked absent on the leave application dates.
-    2. The posting date of the leave application is after the absent date(s).
+        Validates the leave application based on the penalty leave type in HR settings
+        only if:
+        1. The employee is marked absent on the leave application dates.
+        2. The posting date of the leave application is after the absent date(s).
     """
     # Fetch all absences for the employee within the leave application date range
     absences = frappe.get_all(
-        "Attendance",
+        'Attendance',
         filters={
             "employee": doc.employee,
             "status": "Absent",
             "attendance_date": ["between", [doc.from_date, doc.to_date]],
+            "docstatus": 1,
         },
         fields=["attendance_date"],
     )
@@ -70,47 +71,36 @@ def validate_leave_application(doc, method):
     ]
 
     if valid_absent_dates:
-        # Fetch employee name
-        employee_name = frappe.db.get_value("Employee", doc.employee, "employee_name")
+        employee_name = doc.employee_name
 
         # Fetch leave details using the get_leave_details function
         leave_details = get_leave_details(doc.employee, doc.posting_date)
-        leave_allocation = leave_details.get("leave_allocation", {})
-        penalty_leave_type = frappe.db.get_single_value("Beams HR Settings", "penalty_leave_type")
+        leave_allocations = leave_details.get('leave_allocation', {})
+        lwps = leave_details.get('lwps', [])
+        penalty_leave_type = frappe.db.get_single_value('Beams HR Settings', 'penalty_leave_type')
 
         if not penalty_leave_type:
-            frappe.throw("Penalty leave type is not set in Beams HR Settings.")
+            frappe.throw('Penalty leave type is not set in Beams HR Settings')
 
         # Check if penalty leave type exists in the leave allocation
-        if penalty_leave_type not in leave_allocation:
-            if doc.leave_type != "Leave Without Pay":
+        if penalty_leave_type not in leave_allocations:
+            if doc.leave_type not in lwps:
                 frappe.throw(
-                    "No allocation found for penalty leave type '{0}' for Employee '{1} ({2})'. "
-                    "Please apply for 'Leave Without Pay'.".format(
-                        penalty_leave_type, employee_name, doc.employee
-                    )
+                    "As per the penalty policy, only 'Leave Without Pay' can be applied for Employee '<b>{0}:{1}</b>'".format(doc.employee, doc.employee_name)
                 )
             return
-
-        leave_data = leave_allocation[penalty_leave_type]
-
+        leave_data = leave_allocations.get(penalty_leave_type)
         # Retrieve necessary data from leave details
-        remaining_leaves = leave_data.get("remaining_leaves", 0)
-        total_leaves_allocated = leave_data.get("total_leaves", 0)
-        expired_leaves = leave_data.get("expired_leaves", 0)
-        leaves_taken = leave_data.get("leaves_taken", 0)
+        availabe_leaves = leave_data.get("remaining_leaves", 0)
 
         # Check if the leave balance is exhausted
-        if remaining_leaves <= 0 and doc.leave_type != "Leave Without Pay":
-            frappe.throw(
-                "'{0} ({1})' has exhausted the '{2}' leave balance. Please apply for 'Leave Without Pay'.".format(
-                    employee_name, doc.employee, penalty_leave_type
+        if availabe_leaves < doc.total_leave_days:
+            if doc.leave_type not in lwps:
+                frappe.throw(
+                    "As per the penalty policy, only 'Leave Without Pay' can be applied for Employee '<b>{0}:{1}</b>'".format(doc.employee, doc.employee_name)
                 )
-            )
-
-        if remaining_leaves > 0 and doc.leave_type != penalty_leave_type:
-            frappe.throw(
-                "'{0} ({1})' can only apply for '{2}' leave. Remaining balance: {3}.".format(
-                    employee_name, doc.employee, penalty_leave_type, remaining_leaves
+        else:
+            if doc.leave_type != penalty_leave_type:
+                frappe.throw(
+                    "As per the penalty policy, only '<b>{0}</b>' can be applied for Employee '<b>{1}:{2}</b>'".format(penalty_leave_type, doc.employee, doc.employee_name)
                 )
-            )

--- a/beams/beams/custom_scripts/leave_application/leave_application.py
+++ b/beams/beams/custom_scripts/leave_application/leave_application.py
@@ -83,11 +83,14 @@ def validate_leave_application(doc, method):
 
         # Check if penalty leave type exists in the leave allocation
         if penalty_leave_type not in leave_allocation:
-            frappe.throw(
-                "No allocation found for penalty leave type '{0}' for Employee '{1} ({2})'.".format(
-                    penalty_leave_type, employee_name, doc.employee
+            if doc.leave_type != "Leave Without Pay":
+                frappe.throw(
+                    "No allocation found for penalty leave type '{0}' for Employee '{1} ({2})'. "
+                    "Please apply for 'Leave Without Pay'.".format(
+                        penalty_leave_type, employee_name, doc.employee
+                    )
                 )
-            )
+            return
 
         leave_data = leave_allocation[penalty_leave_type]
 

--- a/beams/beams/custom_scripts/leave_application/leave_application.py
+++ b/beams/beams/custom_scripts/leave_application/leave_application.py
@@ -1,6 +1,7 @@
 import frappe
 from frappe import _
 from frappe.utils import add_days, nowdate
+from hrms.hr.doctype.leave_application.leave_application import get_leave_details
 
 @frappe.whitelist()
 def validate_leave_type(doc, method):
@@ -42,3 +43,71 @@ def validate_leave_application(doc, method):
         if leave_type_details.medical_leave_required and doc.total_leave_days > leave_type_details.medical_leave_required:
             if not doc.medical_certificate:
                 frappe.throw(_("Medical certificate is required for sick leave exceeding {0} days.").format(leave_type_details.medical_leave_required))
+
+def validate_leave_application(doc, method):
+    """
+    Validates the leave application based on the penalty leave type in HR settings
+    only if:
+    1. The employee is marked absent on the leave application dates.
+    2. The posting date of the leave application is after the absent date(s).
+    """
+    # Fetch all absences for the employee within the leave application date range
+    absences = frappe.get_all(
+        "Attendance",
+        filters={
+            "employee": doc.employee,
+            "status": "Absent",
+            "attendance_date": ["between", [doc.from_date, doc.to_date]],
+        },
+        fields=["attendance_date"],
+    )
+
+    # Filter valid absent dates where the posting date is after the attendance date
+    valid_absent_dates = [
+        absence["attendance_date"]
+        for absence in absences
+        if frappe.utils.getdate(doc.posting_date) >= frappe.utils.getdate(absence["attendance_date"])
+    ]
+
+    if valid_absent_dates:
+        # Fetch employee name
+        employee_name = frappe.db.get_value("Employee", doc.employee, "employee_name")
+
+        # Fetch leave details using the get_leave_details function
+        leave_details = get_leave_details(doc.employee, doc.posting_date)
+        leave_allocation = leave_details.get("leave_allocation", {})
+        penalty_leave_type = frappe.db.get_single_value("Beams HR Settings", "penalty_leave_type")
+
+        if not penalty_leave_type:
+            frappe.throw("Penalty leave type is not set in Beams HR Settings.")
+
+        # Check if penalty leave type exists in the leave allocation
+        if penalty_leave_type not in leave_allocation:
+            frappe.throw(
+                "No allocation found for penalty leave type '{0}' for Employee '{1} ({2})'.".format(
+                    penalty_leave_type, employee_name, doc.employee
+                )
+            )
+
+        leave_data = leave_allocation[penalty_leave_type]
+
+        # Retrieve necessary data from leave details
+        remaining_leaves = leave_data.get("remaining_leaves", 0)
+        total_leaves_allocated = leave_data.get("total_leaves", 0)
+        expired_leaves = leave_data.get("expired_leaves", 0)
+        leaves_taken = leave_data.get("leaves_taken", 0)
+
+        # Check if the leave balance is exhausted
+        if remaining_leaves <= 0 and doc.leave_type != "Leave Without Pay":
+            frappe.throw(
+                "'{0} ({1})' has exhausted the '{2}' leave balance. Please apply for 'Leave Without Pay'.".format(
+                    employee_name, doc.employee, penalty_leave_type
+                )
+            )
+
+        if remaining_leaves > 0 and doc.leave_type != penalty_leave_type:
+            frappe.throw(
+                "'{0} ({1})' can only apply for '{2}' leave. Remaining balance: {3}.".format(
+                    employee_name, doc.employee, penalty_leave_type, remaining_leaves
+                )
+            )

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -237,6 +237,9 @@ doc_events = {
     "Employee Checkin":{
         "after_insert":"beams.beams.custom_scripts.employee_checkin.employee_checkin.handle_employee_checkin_out"
     },
+    "Leave Application":{
+        "validate":"beams.beams.custom_scripts.leave_application.leave_application.validate_leave_application"
+    },
     "Leave Allocation":{
         "on_submit":"beams.beams.custom_scripts.leave_allocation.leave_allocation.create_new_compensatory_leave_log",
         "on_update_after_submit":"beams.beams.custom_scripts.leave_allocation.leave_allocation.create_new_log_on_update",


### PR DESCRIPTION
## Feature description
Add leave application validation for penalty leave balance
    - Retrieve penalty leave type from Beams HR Settings.
    - Compute the total allocated and used penalty leave for the employee.
    - Posting date of the leave application must be after the dates of absence.
    - Enforce 'Leave Without Pay' if no penalty leave balance is remaining.
    - Prevent applying for non-penalty leave types when penalty leave balance is available.
    - Provide clear error messages to enforce leave application rules

## Solution description
Implemented validation for leave application based on penalty leave balance
 - Fetched penalty leave type from Beams HR Settings.
 - Employees marked absent during the leave period must adhere to penalty leave type policies.
 - Calculated total allocated and used penalty leave for the employee.
 - Restricted non-penalty leave types if penalty leave balance was available.
 - Enforced 'Leave Without Pay' when penalty leave balance was exhausted.
 - Displayed relevant error messages for leave application restrictions.

## Output screenshots (optional)
[Screencast from 27-11-24 04:48:08 PM IST.webm](https://github.com/user-attachments/assets/e866a2b5-ccd3-4fda-8fa4-4fc2426770dc)
[Screencast from 27-11-24 04:55:18 PM IST.webm](https://github.com/user-attachments/assets/8b8617f2-7238-46eb-ad85-3b05aa2b9ca9)

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox