### PR TITLE
feat: Expire Compensatory Leave Allocation with in a 30 days

### DIFF
--- a/beams/beams/doctype/compensatory_leave_log/compensatory_leave_log.py
+++ b/beams/beams/doctype/compensatory_leave_log/compensatory_leave_log.py
@@ -1,9 +1,62 @@
 # Copyright (c) 2024, efeone and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
+from frappe.utils import getdate, nowdate, add_days
 
 
 class CompensatoryLeaveLog(Document):
-	pass
+    pass
+
+@frappe.whitelist()
+def expire_leave_allocation():
+    '''
+    Expire leave allocations for all compensatory leave logs if no leave application exists.
+    '''
+    today = getdate(nowdate())
+
+    # Fetch all compensatory leave logs that are older than 30 days
+    logs = frappe.get_all('Compensatory Leave Log', filters={
+        'end_date': ('<=', today)
+    })
+
+    for log in logs:
+        log_doc = frappe.get_doc('Compensatory Leave Log', log.name)
+
+        # Fetch all leave applications for the same employee and leave type that are approved
+        leave_application = frappe.get_all('Leave Application', filters={
+            'employee': log_doc.employee,
+            'leave_type': log_doc.leave_type,
+            'docstatus': 1  # Approved leave applications
+        })
+
+        # Check if there is any leave application that overlaps with the compensatory leave
+        overlap_found = False
+        for application in leave_application:
+            leave_app_doc = frappe.get_doc('Leave Application', application.name)
+            leave_from = getdate(leave_app_doc.from_date)
+            leave_to = getdate(leave_app_doc.to_date)
+
+            # Check if the leave application period overlaps with the compensatory leave log period
+            if (leave_from <= log_doc.end_date and leave_to >= log_doc.start_date):
+                overlap_found = True
+                break
+
+        # If there is an overlap, do not reduce leave
+        if overlap_found:
+            continue
+        else:
+            # Fetch the leave allocation and reduce the leave
+            leave_allocation = frappe.get_all('Leave Allocation', filters={
+                'employee': log_doc.employee,
+                'leave_type': log_doc.leave_type
+            })
+
+            if leave_allocation:
+                leave_allocation_doc = frappe.get_doc('Leave Allocation', leave_allocation[0].name)
+
+                # Ensure we are not reducing the leave if it has already been reduced to 0 or below
+                if leave_allocation_doc.new_leaves_allocated > 0:
+                    leave_allocation_doc.new_leaves_allocated -= 1  # Decrease one leave from allocation
+                    leave_allocation_doc.save()

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -240,7 +240,7 @@ doc_events = {
     "Leave Allocation":{
         "on_submit":"beams.beams.custom_scripts.leave_allocation.leave_allocation.create_new_compensatory_leave_log",
         "on_update_after_submit":"beams.beams.custom_scripts.leave_allocation.leave_allocation.create_new_log_on_update",
-        "validate": "beams.beams.custom_scripts.leave_allocation.leave_allocation.validate"        
+        "validate": "beams.beams.custom_scripts.leave_allocation.leave_allocation.validate"
 
     },
     "Leave Application" : {
@@ -264,7 +264,8 @@ scheduler_events = {
     "daily": [
         "beams.beams.doctype.local_enquiry_report.local_enquiry_report.set_status_to_overdue",
         "beams.beams.custom_scripts.attendance.attendance.send_absence_reminder",
-        "beams.beams.custom_scripts.attendance.attendance.send_absent_reminder"
+        "beams.beams.custom_scripts.attendance.attendance.send_absent_reminder",
+        "beams.beams.doctype.compensatory_leave_log.compensatory_leave_log.expire_leave_allocation"
     ],
 # "all": [
 # "beams.tasks.all"

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -871,8 +871,14 @@ def get_employee_custom_fields():
                 "fieldname": "employee_documents",
                 "fieldtype": "Table",
                 "label": "Employee Documents",
-                "options":"Employee Documents",
+                "options":"Employee Documents",    
                 "insert_after":"documents_tab"
+            },
+            {
+                "fieldname": "no_of_children",
+                "fieldtype": "Data",
+                "label": "No.of Children",
+                "insert_after":"marital_status"
             }
         ],
 


### PR DESCRIPTION
## Feature description

- This feature execute a scheduler job on daily to expire the leave allocation Get the Compensatory Leave Log ends on Yesterday If not a Leave Application Exists (for the Leave Type and the Yesterday included in the leave dates), then reduce a leave from the leave allocation linked to the Compensatory Leave Log.
- Add No of Children field in Employee doctype.

## Solution description
 Created Scheduler Function:

-  Fetch all Compensatory Leave Logs with an end_date of yesterday.
-  Verify if a Leave Application exists for the corresponding employee, leave type, and if yesterday’s date is covered in the application period.
-  If no such leave application exists, reduce one day from the corresponding Leave Allocation.
-  Ensure leave balances do not fall below zero.
- Added No of Children field in Employee doctype.


## Output screenshots (optional)
[Screencast from 11-28-2024 09:50:07 AM.webm](https://github.com/user-attachments/assets/779c4b23-5804-4963-8005-86607704ecf5)

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
