### PR TITLE
fix : Removing todo and Adding some validation

### DIFF
--- a/beams/beams/doctype/maternity_leave_request/maternity_leave_request.js
+++ b/beams/beams/doctype/maternity_leave_request/maternity_leave_request.js
@@ -2,22 +2,46 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Maternity Leave Request', {
-    setup: function (frm) {
-        // Set filter for employee field to only show Female employees
-        frm.set_query('employee', function () {
-            return {
-                filters: {
-                    gender: 'Female'
-                }
-            };
-        });
-    },
-    birth_count: function(frm) {
-        // Check the value of birth_count and set no_of_days accordingly
-        if (frm.doc.birth_count === 1 || frm.doc.birth_count === 2) {
-            frm.set_value('no_of_days', 180);  // Set no_of_days to 180 if birth_count is 1 or 2
-        } else if (frm.doc.birth_count >= 3) {
-            frm.set_value('no_of_days', 90);   // Set no_of_days to 90 if birth_count is 3 or more
-        }
-    }
+		setup: function (frm) {
+				// Set filter for employee field to only show Female employees
+				frm.set_query('employee', function () {
+						return {
+								filters: {
+										gender: 'Female'
+								}
+						};
+				});
+		},
+
+		onload: function (frm) {
+				// Fetch Maternity Leave Type from HR Settings and set it to the leave_type field
+				frappe.db.get_doc('Beams HR Settings').then(hr_settings => {
+						if (hr_settings && hr_settings.maternity_leave_type) {
+								frm.set_value('leave_type', hr_settings.maternity_leave_type);
+						}
+				});
+		},
+
+		validate: function(frm) {
+				// Check if Maternity Leave Type is set in the Beams HR Settings
+				frappe.db.get_doc('Beams HR Settings').then(hr_settings => {
+						if (!hr_settings || !hr_settings.maternity_leave_type) {
+								frappe.msgprint(__('Maternity Leave Type is not set in HR Settings. Please configure it to proceed.'), 'Validation Error', 'red');
+								frappe.validated = false; // Prevent saving the form
+						}
+				});
+
+				// Validate birth_count to be greater than 0
+				if (frm.doc.birth_count <= 0) {
+						frappe.msgprint(__('Birth count must be greater than 0.'), 'Validation Error', 'red');
+						frappe.validated = false; 
+				} else {
+						// Check the value of birth_count and set no_of_days accordingly
+						if (frm.doc.birth_count === 1 || frm.doc.birth_count === 2) {
+								frm.set_value('no_of_days', 180);
+						} else if (frm.doc.birth_count >= 3) {
+								frm.set_value('no_of_days', 90);
+						}
+				}
+		}
 });

--- a/beams/beams/doctype/maternity_leave_request/maternity_leave_request.js
+++ b/beams/beams/doctype/maternity_leave_request/maternity_leave_request.js
@@ -2,46 +2,60 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Maternity Leave Request', {
-		setup: function (frm) {
-				// Set filter for employee field to only show Female employees
-				frm.set_query('employee', function () {
-						return {
-								filters: {
-										gender: 'Female'
-								}
-						};
-				});
-		},
+    setup: function (frm) {
+        // Set filter for employee field to only show Female employees
+        frm.set_query('employee', function () {
+            return {
+                filters: {
+                    gender: 'Female'
+                }
+            };
+        });
+    },
 
-		onload: function (frm) {
-				// Fetch Maternity Leave Type from HR Settings and set it to the leave_type field
-				frappe.db.get_doc('Beams HR Settings').then(hr_settings => {
-						if (hr_settings && hr_settings.maternity_leave_type) {
-								frm.set_value('leave_type', hr_settings.maternity_leave_type);
-						}
-				});
-		},
+    onload: function (frm) {
+        // Fetch Maternity Leave Type from HR Settings and set it to the leave_type field using get_single_value
+        frappe.call({
+            method: 'frappe.client.get_single_value',
+            args: {
+                doctype: 'Beams HR Settings',
+                field: 'maternity_leave_type'
+            },
+            callback: function (r) {
+                if (r.message) {
+                    frm.set_value('leave_type', r.message);
+                }
+            }
+        });
+    },
 
-		validate: function(frm) {
-				// Check if Maternity Leave Type is set in the Beams HR Settings
-				frappe.db.get_doc('Beams HR Settings').then(hr_settings => {
-						if (!hr_settings || !hr_settings.maternity_leave_type) {
-								frappe.msgprint(__('Maternity Leave Type is not set in HR Settings. Please configure it to proceed.'), 'Validation Error', 'red');
-								frappe.validated = false; // Prevent saving the form
-						}
-				});
+    validate: function (frm) {
+        // Check if Maternity Leave Type is set in the Beams HR Settings using get_single_value
+        frappe.call({
+            method: 'frappe.client.get_single_value',
+            args: {
+                doctype: 'Beams HR Settings',
+                field: 'maternity_leave_type'
+            },
+            callback: function (r) {
+                if (!r.message) {
+                    frappe.msgprint(__('Maternity Leave Type is not set in HR Settings. Please configure it to proceed.'), 'Validation Error', 'red');
+                    frappe.validated = false; // Prevent saving the form
+                }
+            }
+        });
 
-				// Validate birth_count to be greater than 0
-				if (frm.doc.birth_count <= 0) {
-						frappe.msgprint(__('Birth count must be greater than 0.'), 'Validation Error', 'red');
-						frappe.validated = false; 
-				} else {
-						// Check the value of birth_count and set no_of_days accordingly
-						if (frm.doc.birth_count === 1 || frm.doc.birth_count === 2) {
-								frm.set_value('no_of_days', 180);
-						} else if (frm.doc.birth_count >= 3) {
-								frm.set_value('no_of_days', 90);
-						}
-				}
-		}
+        // Validate birth_count to be greater than 0
+        if (frm.doc.birth_count <= 0) {
+            frappe.msgprint(__('Birth count must be greater than 0.'), 'Validation Error', 'red');
+            frappe.validated = false;
+        } else {
+            // Check the value of birth_count and set no_of_days accordingly
+            if (frm.doc.birth_count === 1 || frm.doc.birth_count === 2) {
+                frm.set_value('no_of_days', 180);
+            } else if (frm.doc.birth_count >= 3) {
+                frm.set_value('no_of_days', 90);
+            }
+        }
+    }
 });

--- a/beams/beams/doctype/maternity_leave_request/maternity_leave_request.json
+++ b/beams/beams/doctype/maternity_leave_request/maternity_leave_request.json
@@ -42,6 +42,7 @@
    "fieldtype": "Link",
    "label": "Leave Type",
    "options": "Leave Type",
+   "read_only": 1,
    "reqd": 1
   },
   {
@@ -78,7 +79,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-11-27 11:25:00.391202",
+ "modified": "2024-11-29 11:34:18.989409",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Maternity Leave Request",

--- a/beams/beams/doctype/maternity_leave_request/maternity_leave_request.py
+++ b/beams/beams/doctype/maternity_leave_request/maternity_leave_request.py
@@ -3,22 +3,17 @@
 
 import frappe
 from frappe.model.document import Document
-from frappe.desk.form.assign_to import add as add_assign
+from frappe.desk.form.assign_to import add as add_assign, remove as remove_assign
 from frappe.utils import add_days
 from frappe.utils.user import get_users_with_role
+
 
 class MaternityLeaveRequest(Document):
 
 	def on_update(self):
 		# Check if the workflow state is "Approved"
 		if self.workflow_state == "Approved":
-			# Fetch the Maternity Leave Type from HR Settings
-			maternity_leave_type = frappe.db.get_single_value("Beams HR Settings", "maternity_leave_type")
-
-			# Check if the Leave Type matches the Maternity Leave Type
-			if self.leave_type == maternity_leave_type:
-				self.create_leave_allocation()
-
+			self.create_leave_allocation()
 
 		# Create ToDo for HOD when the request is created
 		if self.workflow_state == "Pending HOD Approval":
@@ -26,12 +21,13 @@ class MaternityLeaveRequest(Document):
 
 		# Create ToDo for HR Manager when the request is in "Pending HR Approval"
 		if self.workflow_state == "Pending HR Approval":
+			self.remove_assignment_by_role("HOD")
 			self.create_todo_for_hr_manager()
 
 	def create_leave_allocation(self):
-		'''
+		"""
 		Create a Leave Allocation for the employee when a Maternity Leave Request is approved.
-		'''
+		"""
 		# Calculate the To Date as 365 days from the From Date
 		to_date = add_days(self.from_date, 365)
 
@@ -47,13 +43,15 @@ class MaternityLeaveRequest(Document):
 		leave_allocation.insert(ignore_permissions=True)
 		leave_allocation.submit()
 
-		frappe.msgprint(f"Leave Allocation created for {self.employee} ({self.leave_type}) from {self.from_date} to {to_date}.",alert=True, indicator='green')
-
+		frappe.msgprint(
+			f"Leave Allocation created for {self.employee} ({self.leave_type}) from {self.from_date} to {to_date}.",
+			alert=True, indicator='green'
+		)
 
 	def create_todo_for_hod(self):
-		'''
+		"""
 		Create a ToDo task for the HOD of the employee's department when a Maternity Leave Request is created.
-		'''
+		"""
 		# Get the department of the employee
 		department = frappe.db.get_value("Employee", self.employee, "department")
 
@@ -77,11 +75,10 @@ class MaternityLeaveRequest(Document):
 			"description": admin_message
 		})
 
-
 	def create_todo_for_hr_manager(self):
-		'''
+		"""
 		Create a ToDo task for the HR Manager when the workflow state is "Pending HR Approval".
-		'''
+		"""
 		hr_manager_users = get_users_with_role("HR Manager")
 
 		if not hr_manager_users:
@@ -95,3 +92,25 @@ class MaternityLeaveRequest(Document):
 			"name": self.name,
 			"description": admin_message
 		})
+
+		frappe.msgprint("ToDo created for HR Manager.", alert=True)
+
+	def remove_assignment_by_role(self, role):
+		"""
+		Removes ToDo assignments for users with a specific role for a given document.
+		"""
+		users = get_users_with_role(role)
+		if users:
+			for user in users:
+				if frappe.db.exists('ToDo', {
+					'reference_type': self.doctype,
+					'reference_name': self.name,
+					'allocated_to': user,
+					'status': 'Open'
+				}):
+					remove_assign(
+						doctype=self.doctype,
+						name=self.name,
+						assign_to=user
+					)
+					frappe.msgprint(f"Assignment for {user} removed.", alert=True)

--- a/beams/beams/doctype/maternity_leave_request/maternity_leave_request.py
+++ b/beams/beams/doctype/maternity_leave_request/maternity_leave_request.py
@@ -25,9 +25,9 @@ class MaternityLeaveRequest(Document):
 			self.create_todo_for_hr_manager()
 
 	def create_leave_allocation(self):
-		"""
+		'''
 		Create a Leave Allocation for the employee when a Maternity Leave Request is approved.
-		"""
+		'''
 		# Calculate the To Date as 365 days from the From Date
 		to_date = add_days(self.from_date, 365)
 
@@ -49,9 +49,9 @@ class MaternityLeaveRequest(Document):
 		)
 
 	def create_todo_for_hod(self):
-		"""
+		'''
 		Create a ToDo task for the HOD of the employee's department when a Maternity Leave Request is created.
-		"""
+		'''
 		# Get the department of the employee
 		department = frappe.db.get_value("Employee", self.employee, "department")
 
@@ -76,9 +76,9 @@ class MaternityLeaveRequest(Document):
 		})
 
 	def create_todo_for_hr_manager(self):
-		"""
+		'''
 		Create a ToDo task for the HR Manager when the workflow state is "Pending HR Approval".
-		"""
+		'''
 		hr_manager_users = get_users_with_role("HR Manager")
 
 		if not hr_manager_users:
@@ -96,9 +96,9 @@ class MaternityLeaveRequest(Document):
 		frappe.msgprint("ToDo created for HR Manager.", alert=True)
 
 	def remove_assignment_by_role(self, role):
-		"""
+		'''
 		Removes ToDo assignments for users with a specific role for a given document.
-		"""
+		'''
 		users = get_users_with_role(role)
 		if users:
 			for user in users:


### PR DESCRIPTION
## Issue description
- Remove todo in maternity leave request for hod after  creating todo for hr
- Set the validation that the birth count should greater than 0 
- Set a validation that if the maternity leave type in beams hr settings is not configured alert

## Solution description
- Removed the todo after changing workflow status to pending hr approval from hod
- A validation is given that birth count cannot be 0 and material leave type field cant be empty

## Output screenshots (optional)
[Screencast from 29-11-24 12:13:01 PM IST.webm](https://github.com/user-attachments/assets/77233939-9d34-4997-824e-89d6c7271bfc)




