### PR TITLE
feat:Added Employee details in Provident fund doctype

### DIFF
--- a/beams/beams/custom_scripts/leave_application/leave_application.js
+++ b/beams/beams/custom_scripts/leave_application/leave_application.js
@@ -1,30 +1,35 @@
 frappe.ui.form.on('Leave Application', {
     leave_type: function(frm) {
-      validate_from_date(frm);
+        validate_from_date(frm);
         if (frm.doc.leave_type) {
             frappe.db.get_value('Leave Type', frm.doc.leave_type,['is_sick_leave', 'medical_leave_required'], function(value) {
                 if (value.is_sick_leave && frm.doc.from_date && frm.doc.to_date) {
                     var duration = frappe.datetime.get_diff(frm.doc.to_date, frm.doc.from_date) + 1;
-                    if (value.medical_leave_required) {
-                        frm.set_df_property('medical_certificate', 'hidden', duration <= value.medical_leave_required);
+                    if (value.medical_leave_required && duration > value.medical_leave_required) {
+                        frm.set_df_property('medical_certificate', 'hidden', false);
+                        frm.set_df_property('medical_certificate', 'reqd', true);
                     } else {
-                        frm.set_df_property('medical_certificate', 'hidden', true);
+                        frm.set_df_property('medical_certificate', 'hidden', false);
+                        frm.set_df_property('medical_certificate', 'reqd', false);
                     }
                 } else {
                     frm.set_df_property('medical_certificate', 'hidden', true);
+                    frm.set_df_property('medical_certificate', 'reqd', false);
                 }
                 frm.refresh_field('medical_certificate');
             });
         } else {
             frm.set_df_property('medical_certificate', 'hidden', true);
+            frm.set_df_property('medical_certificate', 'reqd', false);
             frm.refresh_field('medical_certificate');
         }
     },
 
     from_date: function(frm) {
-      validate_from_date(frm);
-      frm.trigger('leave_type');
+        validate_from_date(frm);
+        frm.trigger('leave_type');
     },
+
     to_date: function(frm) {
         frm.trigger('leave_type');
     }

--- a/beams/beams/custom_scripts/leave_application/leave_application.py
+++ b/beams/beams/custom_scripts/leave_application/leave_application.py
@@ -32,17 +32,20 @@ def validate_leave_advance_days(from_date, leave_type):
         )
 
 @frappe.whitelist()
-def validate_leave_application(doc, method):
-    """
-    Validation for Leave Application:
+def validate_sick_leave(doc, method):
+    '''
+    Validation for Sick Leave Application:
     - Check if the leave_type in Leave Application has the is_sick_leave field checked.
     - Validate medical certificate requirement based on the 'medical_leave_required' threshold in Leave Type.
-    """
-    leave_type_details = frappe.db.get_value("Leave Type", doc.leave_type, ["is_sick_leave", "medical_leave_required"], as_dict=True)
+    '''
+    # Get leave type details
+    leave_type_details = frappe.db.get_value("Leave Type",doc.leave_type,["is_sick_leave", "medical_leave_required"],as_dict=True)
+
     if leave_type_details and leave_type_details.is_sick_leave:
         if leave_type_details.medical_leave_required and doc.total_leave_days > leave_type_details.medical_leave_required:
             if not doc.medical_certificate:
                 frappe.throw(_("Medical certificate is required for sick leave exceeding {0} days.").format(leave_type_details.medical_leave_required))
+
 
 def validate_leave_application(doc, method):
     """

--- a/beams/beams/doctype/provident_fund/provident_fund.js
+++ b/beams/beams/doctype/provident_fund/provident_fund.js
@@ -1,8 +1,33 @@
-// Copyright (c) 2024, efeone and contributors
-// For license information, please see license.txt
+frappe.ui.form.on('Provident Fund', {
+    employee_id: function (frm) {
+        if (frm.doc.employee_id) {
+            frappe.call({
+                method: 'beams.beams.doctype.provident_fund.provident_fund.get_employee_by_name',
+                args: {
+                    employee_name: frm.doc.employee_name,
+                },
+                callback: function (r) {
+                    if (r.message) {
+                        let employee = r.message;
 
-// frappe.ui.form.on("Provident Fund", {
-// 	refresh(frm) {
-
-// 	},
-// });
+                        if (!frm.doc.employee_name) {
+                            frm.set_value('employee_name', employee.employee_name);
+                        }
+                        frm.set_value('department', employee.department);
+                        frm.set_value('designation', employee.designation);
+                        frm.set_value('mobile', employee.cell_number);
+                        frm.set_value('personal_email', employee.personal_email);
+                        frm.set_value('company_email', employee.company_email);
+                        frm.set_value('name_of_father', employee.name_of_father);
+                        frm.set_value('gender', employee.gender);
+                        frm.set_value('user_id', employee.user_id);
+                        frm.set_value('date_of_birth', employee.date_of_birth);
+                        frm.set_value('current_address', employee.current_address);
+                        frm.set_value('permanent_address', employee.permanent_address);
+                        frm.refresh_fields();
+                    }
+                },
+            });
+        }
+    },
+});

--- a/beams/beams/doctype/provident_fund/provident_fund.js
+++ b/beams/beams/doctype/provident_fund/provident_fund.js
@@ -1,6 +1,8 @@
 // Copyright (c) 2024, efeone and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on('Provident Fund', {
-//
+// frappe.ui.form.on("Provident Fund", {
+// 	refresh(frm) {
+
+// 	},
 // });

--- a/beams/beams/doctype/provident_fund/provident_fund.js
+++ b/beams/beams/doctype/provident_fund/provident_fund.js
@@ -1,33 +1,6 @@
-frappe.ui.form.on('Provident Fund', {
-    employee_id: function (frm) {
-        if (frm.doc.employee_id) {
-            frappe.call({
-                method: 'beams.beams.doctype.provident_fund.provident_fund.get_employee_by_name',
-                args: {
-                    employee_name: frm.doc.employee_name,
-                },
-                callback: function (r) {
-                    if (r.message) {
-                        let employee = r.message;
+// Copyright (c) 2024, efeone and contributors
+// For license information, please see license.txt
 
-                        if (!frm.doc.employee_name) {
-                            frm.set_value('employee_name', employee.employee_name);
-                        }
-                        frm.set_value('department', employee.department);
-                        frm.set_value('designation', employee.designation);
-                        frm.set_value('mobile', employee.cell_number);
-                        frm.set_value('personal_email', employee.personal_email);
-                        frm.set_value('company_email', employee.company_email);
-                        frm.set_value('name_of_father', employee.name_of_father);
-                        frm.set_value('gender', employee.gender);
-                        frm.set_value('user_id', employee.user_id);
-                        frm.set_value('date_of_birth', employee.date_of_birth);
-                        frm.set_value('current_address', employee.current_address);
-                        frm.set_value('permanent_address', employee.permanent_address);
-                        frm.refresh_fields();
-                    }
-                },
-            });
-        }
-    },
-});
+// frappe.ui.form.on('Provident Fund', {
+//
+// });

--- a/beams/beams/doctype/provident_fund/provident_fund.json
+++ b/beams/beams/doctype/provident_fund/provident_fund.json
@@ -161,6 +161,7 @@
    "options": "Employee"
   },
   {
+   "fetch_from": "employee_id.department",
    "fieldname": "department",
    "fieldtype": "Link",
    "label": "Department",
@@ -172,16 +173,19 @@
    "label": "Address and Contacts"
   },
   {
+   "fetch_from": "employee_id.personal_email",
    "fieldname": "personal_email",
    "fieldtype": "Data",
    "label": "Personal Email"
   },
   {
+   "fetch_from": "employee_id.cell_number",
    "fieldname": "mobile",
    "fieldtype": "Data",
    "label": "Mobile"
   },
   {
+   "fetch_from": "employee_id.company_email",
    "fieldname": "company_email",
    "fieldtype": "Data",
    "label": " Company Email"
@@ -191,6 +195,7 @@
    "fieldtype": "Column Break"
   },
   {
+   "fetch_from": "employee_id.designation",
    "fieldname": "designation",
    "fieldtype": "Link",
    "label": "Designation",
@@ -201,6 +206,7 @@
    "fieldtype": "Column Break"
   },
   {
+   "fetch_from": "employee_id.user_id",
    "fieldname": "user_id",
    "fieldtype": "Link",
    "label": " User ID",
@@ -213,27 +219,32 @@
    "options": "Company"
   },
   {
+   "fetch_from": "employee_id.name_of_father",
    "fieldname": "name_of_father",
    "fieldtype": "Data",
    "label": "Father's Name"
   },
   {
+   "fetch_from": "employee_id.gender",
    "fieldname": "gender",
    "fieldtype": "Link",
    "label": "Gender",
    "options": "Gender"
   },
   {
+   "fetch_from": "employee_id.date_of_birth",
    "fieldname": "date_of_birth",
    "fieldtype": "Date",
    "label": "Date of Birth"
   },
   {
+   "fetch_from": "employee_id.permanent_address",
    "fieldname": "permanent_address",
    "fieldtype": "Small Text",
    "label": "Permanent Address"
   },
   {
+   "fetch_from": "employee_id.current_address",
    "fieldname": "current_address",
    "fieldtype": "Small Text",
    "label": "Current Address"
@@ -241,7 +252,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-11-30 10:01:01.418803",
+ "modified": "2024-12-02 11:39:22.767430",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Provident Fund",

--- a/beams/beams/doctype/provident_fund/provident_fund.json
+++ b/beams/beams/doctype/provident_fund/provident_fund.json
@@ -1,13 +1,29 @@
 {
  "actions": [],
  "allow_rename": 1,
- "autoname": "format: PF-{YY}-{####}",
+ "autoname": "format: PF-{employee_id}",
  "creation": "2024-11-26 14:34:05.866299",
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
+  "employee_id",
+  "employee_name",
+  "name_of_father",
+  "gender",
+  "column_break_lwqx",
+  "date_of_birth",
+  "company",
+  "designation",
+  "department",
+  "address_and_contacts_section",
+  "mobile",
+  "user_id",
+  "permanent_address",
+  "column_break_fomp",
+  "company_email",
+  "personal_email",
+  "current_address",
   "previous_employment_details_tab",
-  "details_of_uan",
   "earlier_provident_fund",
   "earlier_pension_scheme",
   "details_uan",
@@ -19,6 +35,7 @@
   "other_details_tab",
   "international_worker",
   "country_of_origin",
+  "details_of_uan",
   "educational_qualification",
   "column_break_xfjn",
   "specially_abled",
@@ -130,11 +147,101 @@
   {
    "fieldname": "section_break_rsiu",
    "fieldtype": "Section Break"
+  },
+  {
+   "fetch_from": "employee_id.first_name",
+   "fieldname": "employee_name",
+   "fieldtype": "Data",
+   "label": "Employee Name"
+  },
+  {
+   "fieldname": "employee_id",
+   "fieldtype": "Link",
+   "label": "Employee ID",
+   "options": "Employee"
+  },
+  {
+   "fieldname": "department",
+   "fieldtype": "Link",
+   "label": "Department",
+   "options": "Department"
+  },
+  {
+   "fieldname": "address_and_contacts_section",
+   "fieldtype": "Section Break",
+   "label": "Address and Contacts"
+  },
+  {
+   "fieldname": "personal_email",
+   "fieldtype": "Data",
+   "label": "Personal Email"
+  },
+  {
+   "fieldname": "mobile",
+   "fieldtype": "Data",
+   "label": "Mobile"
+  },
+  {
+   "fieldname": "company_email",
+   "fieldtype": "Data",
+   "label": " Company Email"
+  },
+  {
+   "fieldname": "column_break_lwqx",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "designation",
+   "fieldtype": "Link",
+   "label": "Designation",
+   "options": "Designation"
+  },
+  {
+   "fieldname": "column_break_fomp",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "user_id",
+   "fieldtype": "Link",
+   "label": " User ID",
+   "options": "User"
+  },
+  {
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "label": "Company",
+   "options": "Company"
+  },
+  {
+   "fieldname": "name_of_father",
+   "fieldtype": "Data",
+   "label": "Father's Name"
+  },
+  {
+   "fieldname": "gender",
+   "fieldtype": "Link",
+   "label": "Gender",
+   "options": "Gender"
+  },
+  {
+   "fieldname": "date_of_birth",
+   "fieldtype": "Date",
+   "label": "Date of Birth"
+  },
+  {
+   "fieldname": "permanent_address",
+   "fieldtype": "Small Text",
+   "label": "Permanent Address"
+  },
+  {
+   "fieldname": "current_address",
+   "fieldtype": "Small Text",
+   "label": "Current Address"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-11-27 16:44:27.571190",
+ "modified": "2024-11-30 10:01:01.418803",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Provident Fund",

--- a/beams/beams/doctype/provident_fund/provident_fund.py
+++ b/beams/beams/doctype/provident_fund/provident_fund.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024, efeone and contributors
+# For license information, please see license.txt
+
 import frappe
 from frappe import _
 from frappe.model.document import Document

--- a/beams/beams/doctype/provident_fund/provident_fund.py
+++ b/beams/beams/doctype/provident_fund/provident_fund.py
@@ -1,9 +1,87 @@
-# Copyright (c) 2024, efeone and contributors
-# For license information, please see license.txt
-
-# import frappe
+import frappe
+from frappe import _
 from frappe.model.document import Document
 
-
 class ProvidentFund(Document):
-	pass
+    def validate(self):
+        '''
+        This method is triggered before saving the document to check if
+        the Provident Fund record already exists for the employee.
+        '''
+        self.check_existing_provident_fund()
+
+    def check_existing_provident_fund(self):
+        '''
+        Checks if a Provident Fund record already exists for the employee.
+        If it exists, raises an error to prevent duplication.
+        '''
+        if not self.employee_name:
+            frappe.throw(_("Employee Name is required"))
+
+        # Check if Provident Fund record already exists for the employee
+        existing_record = frappe.db.get_value(
+            "Provident Fund",
+            {"employee_name": self.employee_name},
+            "name"
+        )
+
+        if existing_record:
+            frappe.throw(_("A Provident Fund record already exists for this employee."))
+
+@frappe.whitelist()
+def get_employee_by_name(employee_name):
+    '''
+    Fetch employee details based on employee_name.
+    '''
+    if not employee_name:
+        frappe.throw(_("Employee Name is required"))
+
+    employee = frappe.db.get_value(
+        "Employee",
+        {"employee_name": employee_name},
+        [
+            "employee_number",
+            "employee_name",
+            "department",
+            "designation",
+            "cell_number",
+            "personal_email",
+            "company_email",
+            "user_id",
+            "name_of_father",
+            "gender",
+            "date_of_birth",
+            "permanent_address",
+            "current_address",
+        ],
+        as_dict=True,
+    )
+
+    if not employee:
+        frappe.throw(_("No Employee found with the given Name"))
+
+    return employee
+
+@frappe.whitelist()
+def get_or_create_provident_fund(employee_name):
+    '''
+    Fetch or create a Provident Fund record for the employee.
+    '''
+    if not employee_name:
+        frappe.throw(_("Employee Name is required"))
+
+    # Check if Provident Fund record already exists for the employee
+    existing_record = frappe.db.get_value(
+        "Provident Fund",
+        {"employee_name": employee_name},
+        "name"
+    )
+
+    if existing_record:
+        return frappe.get_doc("Provident Fund", existing_record)
+
+    provident_fund = frappe.new_doc("Provident Fund")
+    provident_fund.employee_name = employee_name
+    provident_fund.insert()
+
+    return provident_fund

--- a/beams/beams/doctype/provident_fund/provident_fund.py
+++ b/beams/beams/doctype/provident_fund/provident_fund.py
@@ -4,84 +4,21 @@ from frappe.model.document import Document
 
 class ProvidentFund(Document):
     def validate(self):
-        '''
-        This method is triggered before saving the document to check if
-        the Provident Fund record already exists for the employee.
-        '''
         self.check_existing_provident_fund()
 
     def check_existing_provident_fund(self):
         '''
         Checks if a Provident Fund record already exists for the employee.
-        If it exists, raises an error to prevent duplication.
+        If it exists raises an error to prevent duplication.
         '''
         if not self.employee_name:
             frappe.throw(_("Employee Name is required"))
 
-        # Check if Provident Fund record already exists for the employee
         existing_record = frappe.db.get_value(
             "Provident Fund",
-            {"employee_name": self.employee_name},
+            {"employee_name": self.employee_name, "name": ["!=", self.name]},
             "name"
         )
 
         if existing_record:
             frappe.throw(_("A Provident Fund record already exists for this employee."))
-
-@frappe.whitelist()
-def get_employee_by_name(employee_name):
-    '''
-    Fetch employee details based on employee_name.
-    '''
-    if not employee_name:
-        frappe.throw(_("Employee Name is required"))
-
-    employee = frappe.db.get_value(
-        "Employee",
-        {"employee_name": employee_name},
-        [
-            "employee_number",
-            "employee_name",
-            "department",
-            "designation",
-            "cell_number",
-            "personal_email",
-            "company_email",
-            "user_id",
-            "name_of_father",
-            "gender",
-            "date_of_birth",
-            "permanent_address",
-            "current_address",
-        ],
-        as_dict=True,
-    )
-
-    if not employee:
-        frappe.throw(_("No Employee found with the given Name"))
-
-    return employee
-
-@frappe.whitelist()
-def get_or_create_provident_fund(employee_name):
-    '''
-    Fetch or create a Provident Fund record for the employee.
-    '''
-    if not employee_name:
-        frappe.throw(_("Employee Name is required"))
-
-    # Check if Provident Fund record already exists for the employee
-    existing_record = frappe.db.get_value(
-        "Provident Fund",
-        {"employee_name": employee_name},
-        "name"
-    )
-
-    if existing_record:
-        return frappe.get_doc("Provident Fund", existing_record)
-
-    provident_fund = frappe.new_doc("Provident Fund")
-    provident_fund.employee_name = employee_name
-    provident_fund.insert()
-
-    return provident_fund

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -237,9 +237,6 @@ doc_events = {
     "Employee Checkin":{
         "after_insert":"beams.beams.custom_scripts.employee_checkin.employee_checkin.handle_employee_checkin_out"
     },
-    "Leave Application":{
-        "validate":"beams.beams.custom_scripts.leave_application.leave_application.validate_leave_application"
-    },
     "Leave Allocation":{
         "on_submit":"beams.beams.custom_scripts.leave_allocation.leave_allocation.create_new_compensatory_leave_log",
         "on_update_after_submit":"beams.beams.custom_scripts.leave_allocation.leave_allocation.create_new_log_on_update",
@@ -249,7 +246,8 @@ doc_events = {
     "Leave Application" : {
         "validate":[
             "beams.beams.custom_scripts.leave_application.leave_application.validate_leave_type",
-            "beams.beams.custom_scripts.leave_application.leave_application.validate_leave_application"
+            "beams.beams.custom_scripts.leave_application.leave_application.validate_sick_leave",
+            "beams.beams.custom_scripts.leave_application.leave_application.validate_leave_application",
          ]
     },
     "Employee" : {

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -1995,7 +1995,7 @@ def get_leave_type_custom_fields():
         "Leave Type": [
             {
                 "fieldname": "min_advance_days",
-                "fieldtype": "Float",
+                "fieldtype": "Int",
                 "label": "Minimum Advance Days",
                 "description": "Specifies the minimum number of days required to apply for this leave.",
                 "insert_after": "max_continuous_days_allowed"


### PR DESCRIPTION
## Feature description
Add Employee details in Provident Fund doctype.
Validation fot Sick Leave Applications.

## Analysis and design (optional)

## Solution description
Added following fields to Provident Fund doctype.

-            employee_number
-             employee_name
-             department"
-             designation
-             cell_number
-             personal_email
-             company_email
-             user_id
-             name_of_father
-             gender
-            date_of_birth
-            permanent_address
-             current_address
- 

Fetch and auto-populate employee data in the Provident Fund doctype when employee is selected.
Medical Certificate attach field made mandatory if leave days exceeds than 2 days for sick leave type. 

## Output screenshots (optional)
[Screencast from 2024-12-02 09-53-38.webm](https://github.com/user-attachments/assets/652ec0a4-7d34-4cf3-84a7-bbc6043ceada)

[Screencast from 2024-12-02 09-55-30.webm](https://github.com/user-attachments/assets/5c6779ce-5819-47bc-bdd1-917c9253f3ef)

## Is there any existing behavior change of other features due to this code change?
 No.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox

