### PR TITLE
feat:Added new tab shift settings in HR settings

### DIFF
--- a/beams/beams/doctype/beams_hr_settings/beams_hr_settings.json
+++ b/beams/beams/doctype/beams_hr_settings/beams_hr_settings.json
@@ -146,7 +146,7 @@
    "options": "\nSunday\nMonday\nTuesday\nWednesday\nThursday\nFriday\nSaturday"
   },
   {
-   "description": "When Scheduling Reminder Need to be Sent (In days).",
+   "description": "Days in advance to send shift scheduling reminders.",
    "fieldname": "send_shift_creation_reminder",
    "fieldtype": "Int",
    "label": "Send Shift Creation Reminder"
@@ -165,7 +165,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-12-02 12:54:43.187891",
+ "modified": "2024-12-02 13:27:24.641723",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Beams HR Settings",

--- a/beams/beams/doctype/beams_hr_settings/beams_hr_settings.json
+++ b/beams/beams/doctype/beams_hr_settings/beams_hr_settings.json
@@ -22,7 +22,13 @@
   "section_break_wu5q",
   "default_leave_policy",
   "column_break_laz7",
-  "leave_period"
+  "leave_period",
+  "shift_settings_tab",
+  "shift_publisher_role",
+  "shift_publication_day",
+  "column_break_vowd",
+  "send_shift_creation_reminder",
+  "shift_creation_reminder_template"
  ],
  "fields": [
   {
@@ -115,18 +121,51 @@
    "fieldtype": "Link",
    "label": "Leave Period",
    "options": "Leave Period"
- },
- {
+  },
+  {
    "fieldname": "maternity_leave_type",
    "fieldtype": "Link",
    "label": "Maternity Leave Type",
    "options": "Leave Type"
+  },
+  {
+   "fieldname": "shift_settings_tab",
+   "fieldtype": "Tab Break",
+   "label": "Shift Settings"
+  },
+  {
+   "fieldname": "shift_publisher_role",
+   "fieldtype": "Link",
+   "label": "Shift Publisher Role",
+   "options": "Role"
+  },
+  {
+   "fieldname": "shift_publication_day",
+   "fieldtype": "Select",
+   "label": "Shift Publication Day ",
+   "options": "\nSunday\nMonday\nTuesday\nWednesday\nThursday\nFriday\nSaturday"
+  },
+  {
+   "description": "When Scheduling Reminder Need to be Sent (In days).",
+   "fieldname": "send_shift_creation_reminder",
+   "fieldtype": "Int",
+   "label": "Send Shift Creation Reminder"
+  },
+  {
+   "fieldname": "shift_creation_reminder_template",
+   "fieldtype": "Link",
+   "label": "Shift Creation Reminder Template",
+   "options": "Email Template"
+  },
+  {
+   "fieldname": "column_break_vowd",
+   "fieldtype": "Column Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-11-26 15:02:40.794800",
+ "modified": "2024-12-02 12:54:43.187891",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Beams HR Settings",


### PR DESCRIPTION
## Feature description
Added a new tab in Beams HR Settings under Shift Settings. The tab includes fields to configure shift publication and reminder settings:

- Shift Publisher Role: Link to role .
- Shift Publication Day: Select  field (Monday to Sunday).
- Send Shift Creation Reminder: Integer field,When Scheduling Reminder Need to be Sent (In days) description.
- Shift Creation Reminder Template: Link to an email template.

## Analysis and design (optional)
Add New Tab break in Beams HR Settings : Shift Settings
Shift Publisher Role : Link to Role 
Shift Publication Day : Select, Monday, Tuesday,.... Sunday 
Send Shift Creation Reminder : Int, Description- When Scheduling Reminder Need to be Sent (In days) 
Shift Creation Reminder Template: Link to Email Template

## Solution description
Added the fields as mentioned above.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/8a9d609d-5cef-4c0d-9816-c059a69919af)

## Areas affected and ensured
Beams HR Settings.

## Is there any existing behavior change of other features due to this code change?
  No. 

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  
