### PR TITLE
TASK-2024-01145_fix:Enhance form layout and data fetching in employee-related doctype

### DIFF
--- a/beams/beams/doctype/bank_details/bank_details.json
+++ b/beams/beams/doctype/bank_details/bank_details.json
@@ -8,8 +8,9 @@
  "field_order": [
   "account_no",
   "name_of_bank",
-  "type_of_account",
   "branch",
+  "column_break_oytg",
+  "type_of_account",
   "ifsc_code"
  ],
  "fields": [
@@ -42,12 +43,16 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "IFSC code"
+  },
+  {
+   "fieldname": "column_break_oytg",
+   "fieldtype": "Column Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-11-29 10:55:43.731959",
+ "modified": "2024-12-02 13:40:34.345798",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Bank Details",

--- a/beams/beams/doctype/esi/esi.json
+++ b/beams/beams/doctype/esi/esi.json
@@ -36,7 +36,8 @@
   "date",
   "column_break_gwmk",
   "column_break_alnc",
-  "signature"
+  "signature",
+  "amended_from"
  ],
  "fields": [
   {
@@ -51,37 +52,44 @@
    "label": "Full Name"
   },
   {
+   "fetch_from": "employee.name_of_father",
    "fieldname": "name_of_father",
    "fieldtype": "Data",
    "label": "Name of Father"
   },
   {
+   "fetch_from": "employee.name_of_spouse",
    "fieldname": "name_of_spouses",
    "fieldtype": "Data",
    "label": "Name of Spouse"
   },
   {
+   "fetch_from": "employee.marital_status",
    "fieldname": "marital_status",
    "fieldtype": "Select",
    "label": "Marital Status",
    "options": "Single\nMarried\nDivorced\nWidowed"
   },
   {
+   "fetch_from": "employee.current_address",
    "fieldname": "present_address",
    "fieldtype": "Small Text",
    "label": "Present Address"
   },
   {
+   "fetch_from": "employee.pincode",
    "fieldname": "pin_code",
    "fieldtype": "Data",
    "label": "Pin Code"
   },
   {
+   "fetch_from": "employee.cell_number",
    "fieldname": "mobile_number",
-   "fieldtype": "Phone",
+   "fieldtype": "Data",
    "label": "Mobile Number"
   },
   {
+   "fetch_from": "employee.personal_email",
    "fieldname": "email_id",
    "fieldtype": "Data",
    "label": "Email ID"
@@ -92,22 +100,26 @@
    "label": "Additional Information"
   },
   {
+   "fetch_from": "employee.aadhar_id",
    "fieldname": "aadhar_id",
    "fieldtype": "Data",
    "label": "Aadhar ID"
   },
   {
+   "fetch_from": "employee.date_of_birth",
    "fieldname": "date_of_birth",
    "fieldtype": "Date",
    "label": "Date of Birth"
   },
   {
+   "fetch_from": "employee.gender",
    "fieldname": "gender",
    "fieldtype": "Link",
    "label": "Gender",
    "options": "Gender"
   },
   {
+   "fetch_from": "employee.date_of_appointment",
    "fieldname": "date_of_appointment",
    "fieldtype": "Date",
    "label": "Date of Appointment"
@@ -126,8 +138,7 @@
   },
   {
    "fieldname": "signature_section_section",
-   "fieldtype": "Section Break",
-   "label": "Signature Section"
+   "fieldtype": "Section Break"
   },
   {
    "fieldname": "date",
@@ -181,6 +192,7 @@
    "options": "Bank Details"
   },
   {
+   "fetch_from": "employee.permanent_address",
    "fieldname": "permanent_address",
    "fieldtype": "Small Text",
    "label": "Permanent Address"
@@ -188,8 +200,10 @@
   {
    "fieldname": "employee",
    "fieldtype": "Link",
+   "in_list_view": 1,
    "label": "Employee",
-   "options": "Employee"
+   "options": "Employee",
+   "reqd": 1
   },
   {
    "fieldname": "column_break_grvo",
@@ -198,12 +212,22 @@
   {
    "fieldname": "column_break_alnc",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "ESI",
+   "print_hide": 1,
+   "read_only": 1,
+   "search_index": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-11-30 10:12:53.962239",
+ "modified": "2024-12-02 13:40:05.333767",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "ESI",

--- a/beams/beams/doctype/family_details/family_details.json
+++ b/beams/beams/doctype/family_details/family_details.json
@@ -8,8 +8,9 @@
  "field_order": [
   "nameas_per_adhar",
   "relationship_with_employee",
-  "date_of_birth",
   "whether_residing_with_employee",
+  "column_break_ldhk",
+  "date_of_birth",
   "state",
   "district"
  ],
@@ -55,12 +56,16 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "District"
+  },
+  {
+   "fieldname": "column_break_ldhk",
+   "fieldtype": "Column Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-11-25 14:49:33.447218",
+ "modified": "2024-12-02 13:36:31.733787",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Family Details",


### PR DESCRIPTION
## Feature description

-Add column breaks and fetch functionality for employee-related doctype

## Solution description

- Added 'Column Break' fields to `Bank Details`, `ESI`, and `Family Details` doctypes for improved form structure.
- Implemented `fetch_from` for fields like `Name of Father`, `Name of Spouse`, and `Marital Status` in the `ESI` doctype to pull data from linked Employee records.
- Updated field order in `Bank Details` and `Family Details` doctypes for better data organization.

## Output screenshots (optional)

[Screencast from 02-12-24 03:07:02 PM IST.webm](https://github.com/user-attachments/assets/05feeca2-50bd-4f4c-ba9e-1939007bfa41)


## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox
  