### PR TITLE
TASK-2024-01211:Create Doctype Document Type

### DIFF
--- a/beams/beams/doctype/document_type/document_type.js
+++ b/beams/beams/doctype/document_type/document_type.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2024, efeone and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Document Type", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/beams/beams/doctype/document_type/document_type.json
+++ b/beams/beams/doctype/document_type/document_type.json
@@ -1,0 +1,41 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2024-12-03 16:35:08.109001",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "document_type"
+ ],
+ "fields": [
+  {
+   "fieldname": "document_type",
+   "fieldtype": "Data",
+   "label": "Document Type"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2024-12-03 16:36:21.802097",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "Document Type",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/beams/beams/doctype/document_type/document_type.json
+++ b/beams/beams/doctype/document_type/document_type.json
@@ -1,6 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
+ "autoname": "field:document_type",
  "creation": "2024-12-03 16:35:08.109001",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -11,15 +12,17 @@
   {
    "fieldname": "document_type",
    "fieldtype": "Data",
-   "label": "Document Type"
+   "label": "Document Type",
+   "unique": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-12-03 16:36:21.802097",
+ "modified": "2024-12-03 17:09:33.185332",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Document Type",
+ "naming_rule": "By fieldname",
  "owner": "Administrator",
  "permissions": [
   {

--- a/beams/beams/doctype/document_type/document_type.py
+++ b/beams/beams/doctype/document_type/document_type.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class DocumentType(Document):
+	pass

--- a/beams/beams/doctype/document_type/test_document_type.py
+++ b/beams/beams/doctype/document_type/test_document_type.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, efeone and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestDocumentType(FrappeTestCase):
+	pass

--- a/beams/beams/doctype/employee_documents/employee_documents.json
+++ b/beams/beams/doctype/employee_documents/employee_documents.json
@@ -12,9 +12,10 @@
  "fields": [
   {
    "fieldname": "document_name",
-   "fieldtype": "Data",
+   "fieldtype": "Link",
    "in_list_view": 1,
-   "label": "Document "
+   "label": "Document ",
+   "options": "Document Type"
   },
   {
    "fieldname": "attachment",
@@ -26,7 +27,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-11-27 12:20:32.644004",
+ "modified": "2024-12-03 16:38:37.629574",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Employee Documents",


### PR DESCRIPTION
## Feature description
-Create Doctype Document Type

-## Solution description
Created "Document Type" Doctype with a "Document Type" field
Added "Document" field (Link to "Document Type") in Employee Documents child table.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/8920b8b5-90fd-4ed0-88ef-b4dd3ac67fe8)
![image](https://github.com/user-attachments/assets/bcfdfc1b-3166-4885-b9c8-1e912ae5e8b4)
![image](https://github.com/user-attachments/assets/290627d2-6a51-4ccf-9358-b33aa91a5173)


## Areas affected and ensured
Employee Doctype

## Is there any existing behavior change of other features due to this code change?
 Yes 

## Was this feature tested on the browsers?
 - Mozilla Firefox
 