### PR TITLE
feat:Created system and email notification to publish shifts.

### DIFF
--- a/beams/beams/doctype/beams_hr_settings/beams_hr_settings.json
+++ b/beams/beams/doctype/beams_hr_settings/beams_hr_settings.json
@@ -26,6 +26,7 @@
   "shift_settings_tab",
   "shift_publisher_role",
   "shift_publication_day",
+  "enable_shift_notification",
   "column_break_vowd",
   "send_shift_creation_reminder",
   "shift_creation_reminder_template"
@@ -160,12 +161,18 @@
   {
    "fieldname": "column_break_vowd",
    "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "enable_shift_notification",
+   "fieldtype": "Check",
+   "label": "Enable Shift Notification"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-12-02 13:27:24.641723",
+ "modified": "2024-12-03 16:23:04.815166",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Beams HR Settings",

--- a/beams/beams/doctype/beams_hr_settings/beams_hr_settings.py
+++ b/beams/beams/doctype/beams_hr_settings/beams_hr_settings.py
@@ -104,11 +104,4 @@ def send_inapp_notification(user):
         'content': notification_message,
         'is_seen': 0
     })
-
     notification.insert(ignore_permissions=True)
-
-    frappe.publish_realtime(
-        event='new_notification',
-        message=notification_message,
-        user=user.name
-    )

--- a/beams/beams/doctype/beams_hr_settings/beams_hr_settings.py
+++ b/beams/beams/doctype/beams_hr_settings/beams_hr_settings.py
@@ -1,9 +1,114 @@
 # Copyright (c) 2024, efeone and contributors
 # For license information, please see license.txt
-
-# import frappe
+import frappe
+import datetime
 from frappe.model.document import Document
-
+from frappe import _
+from frappe.email.doctype.email_account.email_account import EmailAccount
 
 class BeamsHRSettings(Document):
-	pass
+    pass
+
+@frappe.whitelist()
+def send_shift_publication_notifications():
+    '''
+    Send notifications to users with the 'Shift Publisher' role
+    based on the configured Shift Publication Day and Reminder Lead Time.
+    '''
+
+    settings = frappe.get_doc('Beams HR Settings')
+    enable_shift_notification = settings.enable_shift_notification  # New checkbox field
+    shift_publication_day = settings.shift_publication_day
+    shift_publisher_role = settings.shift_publisher_role
+    send_shift_creation_reminder = settings.send_shift_creation_reminder
+    shift_creation_reminder_template = settings.shift_creation_reminder_template
+
+    if not enable_shift_notification:
+        return
+
+    today = datetime.datetime.today()
+    days_of_week = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday']
+    publication_index = days_of_week.index(shift_publication_day)
+    reminder_index = (publication_index - int(send_shift_creation_reminder)) % 7
+    reminder_day = days_of_week[reminder_index]
+
+    if today.strftime('%A') != reminder_day:
+        return
+
+    shift_publishers = frappe.utils.user.get_users_with_role(shift_publisher_role)
+    if not shift_publishers:
+        return
+
+    # Send notifications to each user with the Shift Publisher role
+    for user_email in shift_publishers:
+        user = frappe.get_doc('User', user_email)
+        send_email_notification(user, shift_creation_reminder_template)
+        send_inapp_notification(user)
+
+@frappe.whitelist()
+def send_email_notification(user, shift_creation_reminder_template):
+    '''
+    Send email notification to the user using the email template.
+    '''
+    email_template = frappe.get_doc("Email Template", shift_creation_reminder_template)
+
+    if not email_template:
+        return
+
+    subject = email_template.subject
+    email_content = email_template.response
+
+    if not subject or not email_content:
+        return
+
+    email_content = email_content.format(user_full_name=user.full_name)
+
+    # Send the email with the subject and formatted content
+    frappe.sendmail(
+        recipients=user.email,
+        subject=subject,
+        content=email_content,
+        reference_doctype='User',
+        reference_name=user.name,
+        now=True
+    )
+
+
+@frappe.whitelist()
+def send_inapp_notification(user):
+    '''
+    Send in-app notification to the user similar to the send_system_notification function.
+    '''
+    settings = frappe.get_doc("Beams HR Settings")
+    shift_creation_reminder_template = settings.shift_creation_reminder_template
+    notification_template = frappe.get_doc("Email Template", shift_creation_reminder_template)
+
+    if not notification_template:
+        return
+
+    subject = notification_template.subject
+    notification_message = notification_template.response
+
+    if not subject or not notification_message:
+        return
+
+    notification_message = notification_message.format(user_full_name=user.full_name)
+
+    # Create the Notification Log for the user
+    notification = frappe.get_doc({
+        'doctype': 'Notification Log',
+        'subject': subject,
+        'for_user': user.name,
+        'type': 'Alert',
+        'email_content': notification_message,
+        'content': notification_message,
+        'is_seen': 0
+    })
+
+    notification.insert(ignore_permissions=True)
+
+    frappe.publish_realtime(
+        event='new_notification',
+        message=notification_message,
+        user=user.name
+    )

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -255,12 +255,10 @@ doc_events = {
     },
     "Employee" : {
         "after_insert": "beams.beams.custom_scripts.employee.employee.after_insert_employee"
-
     },
     "Job Offer" : {
         "on_submit":"beams.beams.custom_scripts.job_offer.job_offer.make_employee"
     }
-
 }
 
 
@@ -272,7 +270,9 @@ scheduler_events = {
         "beams.beams.doctype.local_enquiry_report.local_enquiry_report.set_status_to_overdue",
         "beams.beams.custom_scripts.attendance.attendance.send_absence_reminder",
         "beams.beams.custom_scripts.attendance.attendance.send_absent_reminder",
-        "beams.beams.doctype.compensatory_leave_log.compensatory_leave_log.expire_leave_allocation"
+        "beams.beams.doctype.compensatory_leave_log.compensatory_leave_log.expire_leave_allocation",
+        "beams.beams.doctype.beams_hr_settings.beams_hr_settings.send_shift_publication_notifications"
+
     ],
 # "all": [
 # "beams.tasks.all"

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -2479,7 +2479,7 @@ def get_beams_roles():
     '''
         Method to get BEAMS specific roles
     '''
-    return ['Production Manager', 'CEO', 'Company Secretary', 'HOD','Enquiry Officer','Enquiry Manager']
+    return ['Production Manager', 'CEO', 'Company Secretary', 'HOD','Enquiry Officer','Enquiry Manager','Shift Publisher']
 
 def get_custom_translations():
     '''


### PR DESCRIPTION
## Feature description
This feature introduces a system to send notifications (both email and in-app) to users responsible for publishing shifts. The notifications are triggered based on a configurable Shift Publication Day and Reminder Lead Time. Notifications are sent only when the Enable Shift Notification checkbox is selected in Beams HR Settings.

## Analysis and design (optional)
Create role 'Shift Publisher'.
Send Notification to Users with 'Shift Publisher' role on Shift Publication Day configured in Beams HR Settings and notification should be based on Email template configured in Shift Creation Reminder Template in Beams HR Settings

## Solution description
Configuration in Beams HR Settings:

    Added the Enable Shift Notification checkbox t
      fields:
        Shift Publication Day: The day on which shifts are scheduled to be published.
        Shift Publisher Role: Role of users responsible for shift publishing.
        Send Shift Creation Reminder: Number of days before the publication day when reminders are sent.
        Shift Creation Reminder Template: Template used for email and in-app notifications.
If Enabled a notifications an email and system notification is sent to user with specified role to publish Shift Details.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/bc2ddfe5-9010-4158-abcb-ab813ed74758)
![image](https://github.com/user-attachments/assets/7455a333-9cf0-4800-807d-440d290ce388)


## Is there any existing behavior change of other features due to this code change?
       No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox

