### PR TITLE
feat: Implement shift swap to update shift assignments on approval of shift swap request.

### DIFF
--- a/beams/beams/doctype/shift_swap_request/shift_swap_request.py
+++ b/beams/beams/doctype/shift_swap_request/shift_swap_request.py
@@ -107,7 +107,7 @@ class ShiftSwapRequest(Document):
         Triggered after the Shift Swap Request is updated.
         Initiates the shift swap if the workflow state is "Approved".
         '''
-        if self.workflow_state == "Approved":
+        if self.workflow_state == "Approved" and self.get_db_value("workflow_state") == "Pending Approval":
             self.swap_shifts()
 
     def swap_shifts(self):


### PR DESCRIPTION
## Feature description
Enables shift swapping between two employees upon approval of a "Shift Swap Request." This feature allows the cancellation of current shifts and creation of swapped assignments.

## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description
- Implemented the swap_shifts method to:
      1.Fetch and cancel the existing Shift Assignment records for both employees.
      2.Create and submit new Shift Assignment records with swapped details.
- Executed shift swap logic on approval of the Shift Swap Request

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/7d623a0b-0efe-4d22-a932-1035805baf85)
![image](https://github.com/user-attachments/assets/f318d5ac-2141-461c-9c29-a6525d30d189)
![image](https://github.com/user-attachments/assets/7120dde3-42bb-48a8-a23a-7bfc4eeecac3)
![image](https://github.com/user-attachments/assets/739f009a-c4e7-4c64-97c6-c819a6d5aff2)

## Areas affected and ensured

- Shift Assignment DocType: Existing records  are updated or canceled based on swap logic.
- Shift Swap Request workflow:  shift swap on approval state.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Mozilla Firefox
 