### PR TITLE
fix:Email field fetched from Prefered Email field of Employee doctype.

### DIFF
--- a/beams/beams/doctype/provident_fund/provident_fund.json
+++ b/beams/beams/doctype/provident_fund/provident_fund.json
@@ -19,7 +19,7 @@
   "mobile",
   "permanent_address",
   "column_break_fomp",
-  "company_email",
+  "email",
   "current_address",
   "previous_employment_details_tab",
   "earlier_provident_fund",
@@ -178,12 +178,6 @@
    "label": "Mobile"
   },
   {
-   "fetch_from": "employee_id.prefered_contact_email",
-   "fieldname": "company_email",
-   "fieldtype": "Data",
-   "label": " Email"
-  },
-  {
    "fieldname": "column_break_lwqx",
    "fieldtype": "Column Break"
   },
@@ -243,11 +237,17 @@
   {
    "fieldname": "column_break_crbu",
    "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "employee_id.prefered_email",
+   "fieldname": "email",
+   "fieldtype": "Data",
+   "label": " Email"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-12-02 13:43:16.750727",
+ "modified": "2024-12-04 12:57:05.600934",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Provident Fund",


### PR DESCRIPTION
## Feature description
Fetch Email from the Preferred Email field of Employee.

## Analysis and design (optional)
Email is  now fetched from the Preferred Email field rather than Preferred Contact Email.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/1bdab78f-326d-417b-919e-14cda61d01ab)


## Is there any existing behavior change of other features due to this code change?
    No.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
mu
