### PR TITLE
fix:Removed 'Local Enquiry Report' and 'Interview' buttons based on status

### DIFF
--- a/beams/beams/custom_scripts/job_applicant/job_applicant.js
+++ b/beams/beams/custom_scripts/job_applicant/job_applicant.js
@@ -144,8 +144,8 @@ function handle_custom_buttons(frm) {
                 }, __('Set Status'));
             }
 
-            // Remove "Interview" button if status is "Training Completed", "Job Proposal Created", "Job Proposal Accepted or "Interview Completed"
-            if (['Training Completed', 'Job Proposal Created', 'Job Proposal Accepted', 'Interview Completed'].includes(frm.doc.status)) {
+            // Remove "Interview" button if status is "Training Completed", "Job Proposal Created", "Job Proposal Accepted ,"Interview Completed" or "Selected"
+            if (['Training Completed', 'Job Proposal Created', 'Job Proposal Accepted', 'Interview Completed', 'Selected'].includes(frm.doc.status)) {
                 frm.remove_custom_button(__('Interview'), __('Create'));
             }
 
@@ -181,6 +181,26 @@ frappe.ui.form.on('Applicant Interview Round', {
                 new_interview.status = 'Pending';
                 frappe.set_route('Form', 'Interview', new_interview.name);
             });
+        }
+    }
+});
+
+frappe.ui.form.on('Job Applicant', {
+    refresh: function(frm) {
+        const statuses = [
+            'Document Uploaded', 'Open', 'Pending Document Upload', 'Shortlisted',
+            'Local Enquiry Approved', 'Selected', 'Local Enquiry Started',
+            'Local Enquiry Rejected', 'Local Enquiry Completed'
+        ];
+
+        if (statuses.includes(frm.doc.status)) {
+          // Remove "Local Enquiry Report" button for the specified statuses
+            frm.remove_custom_button(__('Local Enquiry Report'), __('Create'));
+
+            if (frm.doc.status !== 'Document Uploaded') {
+          // Additionally remove "Interview" button except for "Document Uploaded" status
+                frm.remove_custom_button(__('Interview'), __('Create'));
+            }
         }
     }
 });

--- a/beams/beams/doctype/esi/esi.json
+++ b/beams/beams/doctype/esi/esi.json
@@ -225,8 +225,9 @@
   }
  ],
  "index_web_pages_for_search": 1,
+ "is_submittable": 1,
  "links": [],
- "modified": "2024-12-04 10:13:46.659327",
+ "modified": "2024-12-04 17:25:24.425945",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "ESI",

--- a/beams/beams/doctype/esi/esi.json
+++ b/beams/beams/doctype/esi/esi.json
@@ -225,9 +225,8 @@
   }
  ],
  "index_web_pages_for_search": 1,
- "is_submittable": 1,
  "links": [],
- "modified": "2024-12-02 13:40:05.333767",
+ "modified": "2024-12-04 10:13:46.659327",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "ESI",
@@ -244,7 +243,6 @@
    "report": 1,
    "role": "System Manager",
    "share": 1,
-   "submit": 1,
    "write": 1
   }
  ],


### PR DESCRIPTION
## Feature description
-Modify button visibility based on specific statuses

## Solution description
- Removed "Local Enquiry Report" button for the following statuses: 'Document Uploaded', 'Open', 'Pending Document Upload', 'Shortlisted', 'Local Enquiry Approved', 'Selected', 'Local Enquiry Started', 'Local Enquiry Rejected', 'Local Enquiry Completed'.
- Removed "Interview" button for all statuses except 'Document Uploaded'.
- Updated permissions and fields for the "ESI" doctype, including removal of the "submit" permission and adjustments to "write" permissions.

##Post the output screenshots, if a UI is affected or added due to this feature.

[Screencast from 04-12-24 04:52:51 PM IST.webm](https://github.com/user-attachments/assets/abfa3d3c-1567-42e1-88fc-ae0e70b93432)


![image](https://github.com/user-attachments/assets/cf7ffb43-03a0-4562-84ca-c68c966145cf)


## Is there any existing behavior change of other features due to this code change?
 Yes . 

## Was this feature tested on the browsers?
  - Mozilla Firefox
  