### PR TITLE
TASK-2024-01221:Create doctype KYC Document

### DIFF
--- a/beams/beams/doctype/compensatory_leave_log/compensatory_leave_log.json
+++ b/beams/beams/doctype/compensatory_leave_log/compensatory_leave_log.json
@@ -66,8 +66,9 @@
    "fieldtype": "Column Break"
   }
  ],
+ "in_create": 1,
  "links": [],
- "modified": "2024-11-18 15:41:30.615408",
+ "modified": "2024-12-05 09:57:44.791248",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Compensatory Leave Log",

--- a/beams/beams/doctype/kyc_details/kyc_details.json
+++ b/beams/beams/doctype/kyc_details/kyc_details.json
@@ -14,11 +14,13 @@
  "fields": [
   {
    "fieldname": "kyc_document_type",
-   "fieldtype": "Data",
+   "fieldtype": "Link",
    "in_list_view": 1,
-   "label": "KYC Document Type"
+   "label": "KYC Document Type",
+   "options": "KYC Document"
   },
   {
+   "fetch_from": "kyc_document_type.document_name",
    "fieldname": "name_as_on_kyc_document",
    "fieldtype": "Data",
    "in_list_view": 1,
@@ -40,7 +42,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-11-27 09:57:39.233652",
+ "modified": "2024-12-04 16:06:41.683312",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "KYC Details",

--- a/beams/beams/doctype/kyc_document/kyc_document.js
+++ b/beams/beams/doctype/kyc_document/kyc_document.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2024, efeone and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("KYC Document", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/beams/beams/doctype/kyc_document/kyc_document.json
+++ b/beams/beams/doctype/kyc_document/kyc_document.json
@@ -1,6 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
+ "autoname": "field:document_type",
  "creation": "2024-12-04 16:00:20.859974",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -12,7 +13,8 @@
   {
    "fieldname": "document_type",
    "fieldtype": "Data",
-   "label": "Document Type"
+   "label": "Document Type",
+   "unique": 1
   },
   {
    "fieldname": "document_name",
@@ -22,10 +24,11 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-12-04 16:06:12.816439",
+ "modified": "2024-12-05 10:45:04.817150",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "KYC Document",
+ "naming_rule": "By fieldname",
  "owner": "Administrator",
  "permissions": [
   {

--- a/beams/beams/doctype/kyc_document/kyc_document.json
+++ b/beams/beams/doctype/kyc_document/kyc_document.json
@@ -1,0 +1,47 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2024-12-04 16:00:20.859974",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "document_type",
+  "document_name"
+ ],
+ "fields": [
+  {
+   "fieldname": "document_type",
+   "fieldtype": "Data",
+   "label": "Document Type"
+  },
+  {
+   "fieldname": "document_name",
+   "fieldtype": "Data",
+   "label": "Document Name"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2024-12-04 16:06:12.816439",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "KYC Document",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/beams/beams/doctype/kyc_document/kyc_document.py
+++ b/beams/beams/doctype/kyc_document/kyc_document.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class KYCDocument(Document):
+	pass

--- a/beams/beams/doctype/kyc_document/test_kyc_document.py
+++ b/beams/beams/doctype/kyc_document/test_kyc_document.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, efeone and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestKYCDocument(FrappeTestCase):
+	pass


### PR DESCRIPTION
## Feature description

- Create doctype KYC Document and make KYC Document Type field  (of Provident Fund doctype) link to this doctype.
- Restrict Compensatory Leave Log creation from front end.

## Analysis and design (optional)
Create doctype KYC Document and add following field into it:
Document Type(Data)
add this doctype as Link field inside child table KYC Documents child table in Provident Fund Doctype
KYC Document(Link,option-KYC Document)

## Solution description
KYC Document Doctype has following  fields:
  Document Type (Type: Data)
  Document Name.

 Changes in Provident Fund Doctype:
   Child table KYC Details field  KYC Document Type field is made Link field  and linked to KYC Document doctype.
    Name as on KYC Document  field value fetched from Document Name field of KYC Document.

 User cannot create button checked to restrict document creation by user.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/2dec8060-f679-4da7-a5ce-ebf68d7e3446)
![image](https://github.com/user-attachments/assets/bf8800df-3c25-4397-b0f0-1dabc9ecd92f)
![Uploading image.png…]()

## Is there any existing behavior change of other features due to this code change?
        No. 

## Was this feature tested on the browsers?
  - Chrome
