### PR TITLE
fix:Change 'Stringer Type' field position to after 'Bureau'

### DIFF
--- a/beams/setup.py
+++ b/beams/setup.py
@@ -726,7 +726,7 @@ def get_employee_custom_fields():
                 "fieldtype": "Link",
                 "options": "Stringer Type",
                 "label": "Stringer Type",
-                "insert_after": "salutation"
+                "insert_after": "Bureau"
             },
             {
                 "fieldname": "leave_policy",


### PR DESCRIPTION
## Feature description
Set 'Stringer Type' field to follow 'Bureau'

## Solution description
Updated 'Stringer Type' field to appear after 'Bureau' in Employee doctype

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/a9a72c0d-ff3d-4d1f-8c92-4763f4faa6de)

## Areas affected and ensured
Employee Doctype

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Mozilla Firefox
  