### PR TITLE
feat:Update sick leave and proof document dependency logic

### DIFF
--- a/beams/setup.py
+++ b/beams/setup.py
@@ -2203,7 +2203,7 @@ def get_property_setters():
             "field_name": "designation",
             "property": "label",
             "value":"Designation At The Time Of Joining"
-        },
+        }
     ]
 
 def get_material_request_custom_fields():

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -1921,24 +1921,17 @@ def get_leave_type_custom_fields():
                 "insert_after": "max_continuous_days_allowed"
             },
             {
-               "fieldname": "is_sick_leave",
-               "fieldtype": "Check",
-               "label": "Is Sick Leave",
-               "insert_after": "is_optional_leave"
-           },
-           {
                "fieldname": "is_proof_document",
                "fieldtype": "Check",
                "label": "Is Proof Document Required",
-               "depends_on": "eval:doc.is_sick_leave",
-               "insert_after": "is_sick_leave"
+               "insert_after": "is_optional_leave"
 
             },
             {
               "fieldname": "medical_leave_required",
                "fieldtype": "Float",
                "label": "Medical Leave Required for Days",
-               "depends_on": "eval:doc.is_proof_document && doc.is_sick_leave",
+               "depends_on": "eval:doc.is_proof_document",
                "insert_after": "is_proof_document"
             }
 
@@ -2210,7 +2203,7 @@ def get_property_setters():
             "field_name": "designation",
             "property": "label",
             "value":"Designation At The Time Of Joining"
-        }
+        },
     ]
 
 def get_material_request_custom_fields():


### PR DESCRIPTION
## Feature description
Adjust field dependencies and positioning for leave Type

## Solution description
- Removed `is_sick_leave` field and adjusted dependencies accordingly.
- Updated the `is_proof_document` field to be positioned after `is_optional_leave` instead of `is_sick_leave`.
- Modified `medical_leave_required` field dependency to rely solely on `is_proof_document`.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/5c8ab9ef-1b3a-45ab-aef7-9f9bed4d7d43)
![image](https://github.com/user-attachments/assets/0785033c-4b6a-407e-8596-1414ead63dd3)

## Is there any existing behavior change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?
  - Mozilla Firefox
 