### PR TITLE
fix:Added Employee link in shift assignment and department validation

### DIFF
--- a/beams/beams/doctype/shift_swap_request/shift_swap_request.js
+++ b/beams/beams/doctype/shift_swap_request/shift_swap_request.js
@@ -11,5 +11,16 @@ frappe.ui.form.on('Shift Swap Request', {
                 }
             };
         };
+    },
+    onload: function (frm) {
+      // Only fetch employee if the field is not set
+      if (!frm.doc.employee) {
+        frappe.db.get_value('Employee', { 'user_id': frappe.session.user }, 'name')
+        .then(response => {
+          if (response.message) {
+            frm.set_value('employee', response.message.name);
+          }
+        });
+      }
     }
 });

--- a/beams/beams/doctype/shift_swap_request/shift_swap_request.py
+++ b/beams/beams/doctype/shift_swap_request/shift_swap_request.py
@@ -16,18 +16,32 @@ class ShiftSwapRequest(Document):
 
         # Validate shift assignments
         if not self.has_valid_shift_assignment():
-            frappe.throw(f'Employee {self.employee} does not have a valid shift assignment in the given date range.')
+            employee_name = frappe.db.get_value('Employee', self.employee, 'employee_name')
+            employee_link = f'<a href="/app/employee/{self.employee}" target="_blank">{employee_name}</a>'
+            frappe.throw(f'Employee {employee_link} does not have a valid shift assignment in the given date range.')
+
         if not self.has_valid_shift_assignment(swap=1):
-            frappe.throw(f'Swap With Employee {self.swap_with_employee} does not have a valid shift assignment in the given date range.')
+            swap_employee_name = frappe.db.get_value('Employee', self.swap_with_employee, 'employee_name')
+            swap_employee_link = f'<a href="/app/employee/{self.swap_with_employee}" target="_blank">{swap_employee_name}</a>'
+            frappe.throw(f'Swap With Employee {swap_employee_link} does not have a valid shift assignment in the given date range.')
 
         # Validate department
         employee_department = frappe.db.get_value('Employee', self.employee, 'department')
         swap_employee_department = frappe.db.get_value('Employee', self.swap_with_employee, 'department')
 
         if employee_department != swap_employee_department:
+            # Fetch employee names
+            employee_name = frappe.db.get_value('Employee', self.employee, 'employee_name')
+            swap_employee_name = frappe.db.get_value('Employee', self.swap_with_employee, 'employee_name')
+
+            employee_link = f'<a href="/app/employee/{self.employee}" target="_blank">{employee_name}</a>'
+            swap_employee_link = f'<a href="/app/employee/{self.swap_with_employee}" target="_blank">{swap_employee_name}</a>'
+
             frappe.throw(
-                f'Employee {self.employee} and Swap With Employee {self.swap_with_employee} must belong to the same department.'
+                f'Employee {employee_link} and Swap With Employee {swap_employee_link} must belong to the same department.',
+                title="Department Mismatch"
             )
+
 
     def has_valid_shift_assignment(self, swap=0):
         '''


### PR DESCRIPTION
## Feature description
The Shift Swap Request Doctype requires validation for shift assignments and department matching between employees.
Populate employee field automatically when an employee logs in.

## Analysis and design (optional)
This feature enhances error messages for shift assignment and department validation in the Shift Swap Request form by converting employee references into clickable links. When an error occurs, users are now able to click on the employee name .
Added client script to populate employee when employeeis logged in.

## Solution description

- The has_valid_shift_assignment and employee_department validation checks have been enhanced to show error messages containing clickable links to the relevant Employee documents.
- The employee name is fetched from the Employee Doctype using frappe.db.get_value.
- If an error occurs, the employee name is embedded within an HTML link (<a href="/app/employee/{employee_id}" target="_blank">{employee_name}</a>) which allows users to open the Employee record in a new tab.

- ## Output screenshots (optional)
-
![image](https://github.com/user-attachments/assets/8cebc73d-b7df-4853-87bf-4f526940b2f4)

![image](https://github.com/user-attachments/assets/381f63aa-1a82-4a0a-8996-2b1b45708a5c)


## Areas affected and ensured
Shift Swap Request

## Is there any existing behavior change of other features due to this code change?
    No. 

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox

