### PR TITLE
fix: Updated Job Applicant status based on interview outcomes

### DIFF
--- a/beams/beams/custom_scripts/interview/interview.py
+++ b/beams/beams/custom_scripts/interview/interview.py
@@ -138,3 +138,31 @@ def mark_interview_completed(doc, method):
                 job_applicant_doc.status = "Interview Completed"
 
             job_applicant_doc.save(ignore_permissions=True)
+			
+@frappe.whitelist()
+def update_job_applicant_status(doc, method=None):
+    # Extract job applicant from the submitted document
+    job_applicant = doc.job_applicant
+
+    # Get all interviews scheduled for the given job applicant
+    interviews = frappe.get_all(
+        "Interview",
+        filters={"job_applicant": job_applicant},
+        fields=["name", "status"]
+    )
+
+    # Check the statuses of all interviews
+    total_interviews = len(interviews)
+    cleared_interviews = sum(1 for interview in interviews if interview["status"] == "Cleared")
+    rejected_interviews = sum(1 for interview in interviews if interview["status"] == "Rejected")
+
+    # Update Job Applicant status
+    if total_interviews == cleared_interviews and total_interviews > 0:
+        # If all interviews are cleared
+        frappe.db.set_value("Job Applicant", job_applicant, "status", "Interview Completed")
+    elif rejected_interviews > 0:
+        # If any interview is rejected
+        frappe.db.set_value("Job Applicant", job_applicant, "status", "Interview Ongoing")
+    else:
+        # Default case: If interviews are pending or under review
+        frappe.db.set_value("Job Applicant", job_applicant, "status", "Interview Ongoing")

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -258,6 +258,9 @@ doc_events = {
     },
     "Job Offer" : {
         "on_submit":"beams.beams.custom_scripts.job_offer.job_offer.make_employee"
+    },
+    "Interview": {
+        "on_submit": "beams.beams.custom_scripts.interview.interview.update_job_applicant_status"
     }
 }
 


### PR DESCRIPTION
## Feature description
     Automate Status Updates Based On Interview Outcomes

## Solution description
     Set to "Interview Completed" when all interviews were cleared.
     Set to "Interview Ongoing" when any interview was rejected or pending.

## Output screenshots (optional)

 [Screencast from 11-12-24 04:03:50 PM IST.webm](https://github.com/user-attachments/assets/6e1eb42c-94f2-4ba2-861f-763d4f0f38b8)

        

## Areas affected and ensured
     Interview Doctype 

## Is there any existing behavior change of other features due to this code change?
     Yes.

## Was this feature tested on the browsers?
     - Mozilla Firefox
