### PR TITLE
TASK-2024-01233:Reminder to HR Manager to ensure employee appraisals are created  before the due date.

### DIFF
--- a/beams/beams/doctype/beams_hr_settings/beams_hr_settings.json
+++ b/beams/beams/doctype/beams_hr_settings/beams_hr_settings.json
@@ -180,6 +180,7 @@
    "label": "Appraisal Settings"
   },
   {
+   "depends_on": "eval:doc.enable_appraisal_reminder;",
    "fieldname": "appraisal_creation_period",
    "fieldtype": "Int",
    "label": " Appraisal Creation Period"
@@ -189,6 +190,7 @@
    "fieldtype": "Column Break"
   },
   {
+   "depends_on": "eval:doc.enable_appraisal_reminder;",
    "fieldname": "appraisal_reminder_template",
    "fieldtype": "Link",
    "label": "Appraisal reminder Template",
@@ -204,7 +206,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-12-11 12:46:46.347731",
+ "modified": "2024-12-12 17:15:36.533065",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Beams HR Settings",

--- a/beams/beams/doctype/beams_hr_settings/beams_hr_settings.json
+++ b/beams/beams/doctype/beams_hr_settings/beams_hr_settings.json
@@ -29,7 +29,12 @@
   "enable_shift_notification",
   "column_break_vowd",
   "send_shift_creation_reminder",
-  "shift_creation_reminder_template"
+  "shift_creation_reminder_template",
+  "appraisal_settings_tab",
+  "appraisal_creation_period",
+  "enable_appraisal_reminder",
+  "column_break_rcin",
+  "appraisal_reminder_template"
  ],
  "fields": [
   {
@@ -167,12 +172,39 @@
    "fieldname": "enable_shift_notification",
    "fieldtype": "Check",
    "label": "Enable Shift Notification"
+  },
+  {
+   "description": "The timeframe in which the appraisal should be sent.",
+   "fieldname": "appraisal_settings_tab",
+   "fieldtype": "Tab Break",
+   "label": "Appraisal Settings"
+  },
+  {
+   "fieldname": "appraisal_creation_period",
+   "fieldtype": "Int",
+   "label": " Appraisal Creation Period"
+  },
+  {
+   "fieldname": "column_break_rcin",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "appraisal_reminder_template",
+   "fieldtype": "Link",
+   "label": "Appraisal reminder Template",
+   "options": "Email Template"
+  },
+  {
+   "default": "0",
+   "fieldname": "enable_appraisal_reminder",
+   "fieldtype": "Check",
+   "label": "Enable Appraisal Reminder"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-12-03 16:23:04.815166",
+ "modified": "2024-12-11 12:46:46.347731",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Beams HR Settings",

--- a/beams/beams/doctype/beams_hr_settings/beams_hr_settings.py
+++ b/beams/beams/doctype/beams_hr_settings/beams_hr_settings.py
@@ -105,3 +105,107 @@ def send_inapp_notification(user):
         'is_seen': 0
     })
     notification.insert(ignore_permissions=True)
+
+@frappe.whitelist()
+def send_appraisal_reminders():
+    '''
+    Send notifications to HR Managers based on the configured Appraisal Creation Period
+    and Enable Appraisal Reminder flag in Beams HR Settings.
+    '''
+    settings = frappe.get_doc('Beams HR Settings')
+    enable_appraisal_reminder = settings.enable_appraisal_reminder
+    appraisal_creation_period = settings.appraisal_creation_period  # Integer field representing the number of days
+    appraisal_reminder_template = settings.appraisal_reminder_template
+
+    if not enable_appraisal_reminder:
+        return
+
+    today = datetime.datetime.today().date()
+    hr_managers = frappe.get_list('User', filters={'role': 'HR Manager'})
+
+    if not hr_managers:
+        return
+
+    employees = frappe.get_all('Employee', fields=['name', 'employee_name', 'date_of_joining'])
+
+    # Set to track HR Managers that have already been notified today
+    notified_hr_managers = set()
+
+    for employee in employees:
+        joining_date = employee.date_of_joining
+        if not joining_date:
+            continue
+
+        # Calculate the appraisal due date by adding the appraisal creation period (in days)
+        appraisal_due_date = joining_date + datetime.timedelta(days=appraisal_creation_period)
+
+        # If the appraisal due date matches today's date, send reminder
+        if appraisal_due_date == today:
+            for hr_manager in hr_managers:
+                if hr_manager.name not in notified_hr_managers:
+                    user = frappe.get_doc('User', hr_manager.name)
+
+                    # Send reminder email and in-app notification
+                    send_appraisal_email_notification(user, appraisal_reminder_template, today, appraisal_creation_period)
+                    send_appraisal_inapp_notification(user, appraisal_reminder_template, today, appraisal_creation_period)
+
+                    notified_hr_managers.add(hr_manager.name)
+    return
+
+def send_appraisal_email_notification(user, appraisal_reminder_template, today, appraisal_creation_period):
+    '''
+    Send email notification to the HR Manager about the appraisal reminder.
+    '''
+    email_template = frappe.get_doc("Email Template", appraisal_reminder_template)
+
+    if not email_template:
+        return
+
+    subject = email_template.subject
+    email_content = email_template.response
+
+    if not subject or not email_content:
+        return
+
+    email_content = email_content.format(user_full_name=user.full_name)
+
+    # Send the email
+    frappe.sendmail(
+        recipients=user.email,
+        subject=subject,
+        content=email_content,
+        reference_doctype='User',
+        reference_name=user.name,
+        now=True
+    )
+
+
+def send_appraisal_inapp_notification(user, appraisal_reminder_template, today, appraisal_creation_period):
+    '''
+    Send in-app notification to the HR Manager about the appraisal reminder.
+    '''
+    # Fetch the notification template
+    notification_template = frappe.get_doc("Email Template", appraisal_reminder_template)
+
+    if not notification_template:
+        return
+
+    subject = notification_template.subject
+    notification_message = notification_template.response
+
+    if not subject or not notification_message:
+        return
+
+    notification_message = notification_message.format(user_full_name=user.full_name)
+
+    # Create the Notification Log for the user
+    notification = frappe.get_doc({
+        'doctype': 'Notification Log',
+        'subject': subject,
+        'for_user': user.name,
+        'type': 'Alert',
+        'email_content': notification_message,
+        'content': notification_message,
+        'is_seen': 0
+    })
+    notification.insert(ignore_permissions=True)

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -271,7 +271,8 @@ scheduler_events = {
         "beams.beams.custom_scripts.attendance.attendance.send_absence_reminder",
         "beams.beams.custom_scripts.attendance.attendance.send_absent_reminder",
         "beams.beams.doctype.compensatory_leave_log.compensatory_leave_log.expire_leave_allocation",
-        "beams.beams.doctype.beams_hr_settings.beams_hr_settings.send_shift_publication_notifications"
+        "beams.beams.doctype.beams_hr_settings.beams_hr_settings.send_shift_publication_notifications",
+        "beams.beams.doctype.beams_hr_settings.beams_hr_settings.send_appraisal_reminders"
 
     ],
 # "all": [


### PR DESCRIPTION
## Feature description
This feature sends notifications to HR Managers to remind them to create appraisals for employees. It checks the configured appraisal creation period and enables reminders based on the Beams HR Settings.

## Analysis and design (optional)

- Add the following field into Beams HR Settings:
- Enable Appraisal Reminder(Checkbox)
- Appraisal Creation Period(int)-Description-Days to send Appraisal Reminder
- Send a reminder to the HR Manager to create appraisals for employees based on their joining date and the Appraisal Creation Period configured in Beams HR Settings.
- Reminder should send only if Enable Appraisal Reminder(Checkbox) is checked in Beams HR Settings.
- 

## Solution description

- Fetching HR settings and verifying the "Enable Appraisal Reminder" flag.
- Calculating the appraisal due date based on employee joining date and the configured appraisal period.
- Sending reminders to HR Managers, including email and in-app notifications.


## Output screenshots (optional)

file:///home/zakkiyath/Videos/Screencasts/Screencast%20from%202024-12-11%2016-39-14.webm

## Areas affected and ensured
beams_hr_settings.py
beams_hr_settings.json
hooks.py

## Is there any existing behavior change of other features due to this code change?
       No.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  