### PR TITLE
feat : Validate Leave Application during Notice Period

### DIFF
--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -247,11 +247,7 @@ doc_events = {
 
     },
     "Leave Application" : {
-        "validate":[
-            "beams.beams.custom_scripts.leave_application.leave_application.validate_leave_type",
-            "beams.beams.custom_scripts.leave_application.leave_application.validate_sick_leave",
-            "beams.beams.custom_scripts.leave_application.leave_application.validate_leave_application",
-         ]
+        "validate": "beams.beams.custom_scripts.leave_application.leave_application.validate"
     },
     "Employee" : {
         "after_insert": "beams.beams.custom_scripts.employee.employee.after_insert_employee"

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -87,7 +87,6 @@ def before_uninstall():
     delete_custom_fields(get_leave_application_custom_fields())
     delete_custom_fields(get_employee_performance_feedback())
 
-
 def delete_custom_fields(custom_fields: dict):
     '''
     Method to Delete custom fields
@@ -1985,8 +1984,14 @@ def get_leave_type_custom_fields():
                "label": "Medical Leave Required for Days",
                "depends_on": "eval:doc.is_proof_document",
                "insert_after": "is_proof_document"
-            }
+            },
+            {
+               "fieldname": "allow_in_notice_period",
+               "fieldtype": "Check",
+               "label": "Allow in Notice Period",
+               "insert_after": "is_compensatory"
 
+            }
         ]
     }
 


### PR DESCRIPTION
## Feature description

- [ ] Added validation to ensure employees cannot apply for certain leave types during the notice period. 
- [ ] This is determined by comparing the from_date in the Leave Application with the resignation_letter_date from the Employee record.
- [ ] The validation checks that the selected leave_type is not allowed in the notice period.

## Solution description

- [ ] - Fetched resignation_letter_date from the Employee record using frappe.db.get_value.
- [ ] - Validated that from_date falls within the notice period.
- [ ] - Checked if the selected leave type's allow_in_notice_period field is unchecked.
- [ ] - Threw a validation error with a formatted, bold message if the conditions were met.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/af8cce92-7363-45c4-a046-904d0094e5a0)
![image](https://github.com/user-attachments/assets/5a2ba3af-5455-4997-9812-03a7b604ac4e)

## Areas affected and ensured
`Leave Application Doctype`

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
