### PR TITLE
feat : Set employee relieving date based on resignation letter date and notice period

### DIFF
--- a/beams/beams/custom_scripts/employee/employee.py
+++ b/beams/beams/custom_scripts/employee/employee.py
@@ -1,7 +1,7 @@
 import frappe
 from frappe import _
 from frappe.model.mapper import get_mapped_doc
-from frappe.utils import getdate, nowdate
+from frappe.utils import getdate, nowdate, add_days
 
 @frappe.whitelist()
 def create_event(employee_id=None, hod_user=None, target_doc=None):
@@ -79,3 +79,11 @@ def after_insert_employee(doc, method):
     # Save and submit the leave policy assignment
     leave_policy_assignment.insert()
     leave_policy_assignment.submit()
+
+
+def set_employee_relieving_date(doc, method):
+    """
+    Automatically set the relieving_date based on resignation_letter_date and notice_number_of_days.
+    """
+    if doc.resignation_letter_date and doc.notice_number_of_days:
+        doc.relieving_date = add_days(getdate(doc.resignation_letter_date), doc.notice_number_of_days)

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -250,7 +250,8 @@ doc_events = {
         "validate": "beams.beams.custom_scripts.leave_application.leave_application.validate"
     },
     "Employee" : {
-        "after_insert": "beams.beams.custom_scripts.employee.employee.after_insert_employee"
+        "after_insert": "beams.beams.custom_scripts.employee.employee.after_insert_employee",
+        "validate": "beams.beams.custom_scripts.employee.employee.set_employee_relieving_date"
     },
     "Job Offer" : {
         "on_submit":"beams.beams.custom_scripts.job_offer.job_offer.make_employee"


### PR DESCRIPTION

## Feature description

-  Set the relieving_date in the Employee doctype based on the resignation_letter_date and notice_number_of_days.

## Solution description

- Added logic to compute the relieving_date by adding the notice_number_of_days to the resignation_letter_date.
- Ensures the relieving_date is updated dynamically when both fields are provided.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/4f355477-a66f-44fa-9cd1-c5e80dd85c8c)
![image](https://github.com/user-attachments/assets/1a16b67d-56b5-487e-bd9e-7c6b2f22f5dd)

## Areas affected and ensured
`Employee Doctype`

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
