### PR TITLE
    TASK-2024-01099:Add validation in Leave Application

### DIFF
--- a/beams/beams/doctype/beams_hr_settings/beams_hr_settings.json
+++ b/beams/beams/doctype/beams_hr_settings/beams_hr_settings.json
@@ -15,7 +15,6 @@
   "it_hod",
   "column_break_qbue",
   "tab_3_tab",
-  "penalty_leave_type",
   "maternity_leave_type",
   "column_break_pjdi",
   "compensatory_leave_type",
@@ -89,13 +88,6 @@
    "fieldname": "tab_3_tab",
    "fieldtype": "Tab Break",
    "label": " Leave Settings"
-  },
-  {
-   "description": "Leave Type for Unplanned Leave",
-   "fieldname": "penalty_leave_type",
-   "fieldtype": "Link",
-   "label": "Penalty Leave Type",
-   "options": "Leave Type"
   },
   {
    "description": "Leave Type for Double Shift Compensatory Leave",
@@ -206,7 +198,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-12-12 17:15:36.533065",
+ "modified": "2024-12-17 13:51:39.311320",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Beams HR Settings",

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -38,6 +38,7 @@ def after_install():
     create_custom_fields(get_leave_type_custom_fields(),ignore_validate=True)
     create_custom_fields(get_leave_application_custom_fields(),ignore_validate=True)
     create_custom_fields(get_employee_performance_feedback(),ignore_validate=True)
+    create_custom_fields(get_employment_type_custom_fields(),ignore_validate=True)
 
     #Creating BEAMS specific Property Setters
     create_property_setters(get_property_setters())
@@ -86,6 +87,7 @@ def before_uninstall():
     delete_custom_fields(get_leave_type_custom_fields())
     delete_custom_fields(get_leave_application_custom_fields())
     delete_custom_fields(get_employee_performance_feedback())
+    delete_custom_fields(get_employment_type_custom_fields())
 
 def delete_custom_fields(custom_fields: dict):
     '''
@@ -115,6 +117,22 @@ def get_shift_assignment_custom_fields():
                 "label": "Roster Type",
                 "options":"\nRegular\nDouble Shift",
                 "insert_after": "shift_type"
+            }
+        ]
+    }
+
+def get_employment_type_custom_fields():
+    '''
+    Custom fields that need to be added to the Employment Type DocType
+    '''
+    return {
+        "Employment Type": [
+            {
+                "fieldname": "penalty_leave_type",
+                "fieldtype": "Link",
+                "label": "Penalty Leave Type",
+                "options": "Leave Type",
+                "insert_after": "employee_type_name"
             }
         ]
     }
@@ -2205,6 +2223,13 @@ def get_property_setters():
         {
             "doctype_or_field": "DocField",
             "doc_type": "Job Requisition",
+            "field_name": "posting_date",
+            "property": "read_only",
+            "value": 1
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Leave Application",
             "field_name": "posting_date",
             "property": "read_only",
             "value": 1


### PR DESCRIPTION
## Feature description
-Remove 'Penalty Leave Type' from Beams HR Settings
-Add 'Penalty Leave Type' to Employment Type Doctype
-Validate leave application for absent days with allocation check
-Make Posting Date field read-only in Leave Application"

## Solution description
-Removed 'Penalty Leave Type' from Beams HR Settings.
-Added 'Penalty Leave Type' field in Employment Type Doctype.
-Added validation in Leave Application for absent days and leave allocation.
-Set Posting Date field to read-only.

## Output screenshots (optional)

![image](https://github.com/user-attachments/assets/54225d89-3279-454a-9138-2e0a33ae35fc)
![image](https://github.com/user-attachments/assets/0e84b572-d414-4801-bba4-820d1576cc44)


[Screencast from 19-12-24 09:37:28 AM IST.webm](https://github.com/user-attachments/assets/3acfad41-dad9-42e2-b367-42eed3770751)

[Screencast from 19-12-24 10:16:16 AM IST.webm](https://github.com/user-attachments/assets/a301b5bf-140e-4ceb-8a30-ac0cb0dbbd88)

[Screencast from 19-12-24 10:17:46 AM IST.webm](https://github.com/user-attachments/assets/1d5bec84-a113-4d75-8aba-bbd058d99459)


## Areas affected and ensured
-Leave Application Doctype
-Employment Doctype

## Is there any existing behavior change of other features due to this code change?
 Yes 

## Was this feature tested on the browsers?
 - Mozilla Firefox
  