### PR TITLE
feat:Add 'Training Status' field to Employee doctype

### DIFF
--- a/beams/setup.py
+++ b/beams/setup.py
@@ -832,6 +832,13 @@ def get_employee_custom_fields():
                 "insert_after": "disabilities"
             },
             {
+                "fieldname": "training_status",
+                "fieldtype": "Select",
+                "options":"Not Started\nIn Progress\nCompleted\nNot Completed\nPartially Completed",
+                "label": "Training Status",
+                "insert_after": "status"
+            },
+            {
                 "fieldname": "court_proceedings",
                 "fieldtype": "Select",
                 "options":"Yes\nNo",


### PR DESCRIPTION
## Feature description
     Add field 'Training Status' to Employee

## Solution description
     Added 'Training Status' field to Employee doctype

## Output screenshots (optional)
    ![image](https://github.com/user-attachments/assets/7d9a2c0d-43bd-46ab-936f-04475c63a6dd)

## Areas affected and ensured
    Employee Doctype

## Is there any existing behavior change of other features due to this code change?
     No

## Was this feature tested on the browsers?
    - Mozilla Firefox
 