### PR TITLE
feat:Add Absence Reminder Configuration to Beams HR Settings

### DIFF
--- a/beams/beams/doctype/beams_hr_settings/beams_hr_settings.json
+++ b/beams/beams/doctype/beams_hr_settings/beams_hr_settings.json
@@ -6,8 +6,10 @@
  "engine": "InnoDB",
  "field_order": [
   "default_local_enquiry_duration",
+  "absence_reminder_duration",
   "column_break_lmqd",
   "permanent_employment_type",
+  "enable_absence_reminders",
   "notification_settings_tab",
   "notification_to_admin_department_to_create_id_card_section",
   "notification_to_admin",
@@ -205,12 +207,24 @@
   {
    "fieldname": "column_break_lmqd",
    "fieldtype": "Column Break"
+  },
+  {
+   "description": "Days after absence without leave to notify the Reporting Manager",
+   "fieldname": "absence_reminder_duration",
+   "fieldtype": "Int",
+   "label": "Absence Reminder Duration"
+  },
+  {
+   "default": "0",
+   "fieldname": "enable_absence_reminders",
+   "fieldtype": "Check",
+   "label": "Absence Reminders"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-12-18 15:20:39.547250",
+ "modified": "2024-12-24 15:54:22.187120",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Beams HR Settings",


### PR DESCRIPTION
## Feature description
    - Add Absence Reminder Configuration to Beams HR Settings

## Solution description
     - Introduced 'Absence Reminder Duration' field in Beams HR Settings to set the duration after which absence reminders are sent.
     - Added 'Enable Absence Reminders' checkbox to enable or disable absence reminders.
     - Updated 'send_absence_reminder' function to check the settings and send reminders only if enabled, based on the configured  reminder duration.
     
## Output screenshots (optional)

[Screencast from 24-12-24 05:01:59 PM IST.webm](https://github.com/user-attachments/assets/a9e9df36-bf59-4db6-967e-e01d908dc652)

[Screencast from 24-12-24 05:05:06 PM IST.webm](https://github.com/user-attachments/assets/425ed918-4fae-44f8-a24d-01b16cb4c59e)


## Areas affected and ensured
    -Leave Application Doctype 
    -Beams HR Settings Doctype


## Is there any existing behavior change of other features due to this code change?
    -Yes . 

## Was this feature tested on the browsers?
    - Mozilla Firefox
  
