### PR TITLE
TASK-2024-01321:Enable One-to-One Meeting creation from Appraisal

### DIFF
--- a/beams/beams/custom_scripts/appraisal/appraisal.js
+++ b/beams/beams/custom_scripts/appraisal/appraisal.js
@@ -5,7 +5,7 @@ frappe.ui.form.on('Appraisal', {
             frappe.call({
                 method: "beams.beams.custom_scripts.appraisal.appraisal.get_feedback_for_appraisal",
                 args: {
-                    appraisal_name: frm.doc.name 
+                    appraisal_name: frm.doc.name
                 },
                 callback: function (res) {
                     if (res.message) {
@@ -31,5 +31,24 @@ frappe.ui.form.on('Appraisal', {
         } else {
             $(frm.fields_dict['appraisal_summary'].wrapper).html('<p>Please save the Appraisal to view the summary.</p>');
         }
+
+        // Add Custom Button for One to One Meeting
+        if (frm.doc.docstatus === 1 && frm.doc.employee) {
+            frappe.db.get_value('Employee Performance Feedback',
+                { employee: frm.doc.employee, docstatus: 1 },
+                'feedback'
+            ).then(response => {
+                if (response && response.message && response.message.feedback) {
+                    frm.add_custom_button(__('One to One Meeting'), function () {
+                        frappe.model.open_mapped_doc({
+                            method: "beams.beams.custom_scripts.appraisal.appraisal.map_appraisal_to_event",
+                            frm: frm
+                        });
+                    }, __('Create'));
+                }
+            });
+        }
     }
 });
+
+  


### PR DESCRIPTION
## Feature description
     --Add One-to-One Meeting creation from Appraisal  

## Solution description
     --Added a custom button "One to One Meeting" to the Appraisal form for submitted appraisals with feedback.
     --Introduced `map_appraisal_to_event` to map appraisal details to a new Event.
     --adds the employee and logged-in user as participants in the Event.

## Output screenshots (optional)
[Screencast from 02-01-25 10:00:44 AM IST.webm](https://github.com/user-attachments/assets/f7ce57db-249c-4bf6-aa1c-261fa33cb359)

## Areas affected and ensured
     --Appraisal Doctype
     --Event Doctype

## Is there any existing behavior change of other features due to this code change?
     -- No.
## Was this feature tested on the browsers?
     -- Mozilla Firefox
 