### PR TITLE
feat : Fetched all data to the dialog from appraisal template

### DIFF
--- a/beams/beams/custom_scripts/appraisal/appraisal.js
+++ b/beams/beams/custom_scripts/appraisal/appraisal.js
@@ -250,9 +250,9 @@ frappe.ui.form.on('Appraisal', {
             },
         });
 
-        const employeeCriteriaTable = [];
+        const employee_criteria_table = [];
         frm.doc.appraisal_kra.forEach(row => {
-            employeeCriteriaTable.push({
+            employee_criteria_table.push({
                 criteria: row.kra,
                 goals: row.kra_goals,
                 per_weightage: row.per_weightage,
@@ -260,10 +260,8 @@ frappe.ui.form.on('Appraisal', {
         });
 
         // Set the data and refresh the table in the dialog
-        dialog.fields_dict.employee_criteria.df.data = employeeCriteriaTable;
+        dialog.fields_dict.employee_criteria.df.data = employee_criteria_table;
         dialog.fields_dict.employee_criteria.refresh();
-
-
 
         // Fetch data from `appraisal_template`
         if (frm.doc.appraisal_template) {
@@ -273,21 +271,21 @@ frappe.ui.form.on('Appraisal', {
                     doctype: "Appraisal Template",
                     name: frm.doc.appraisal_template
                 },
-                callback: function (r) {
-                    if (r.message) {
+                callback: function (response) {
+                    if (response.message) {
                         // Populate department_criteria from department_rating_criteria
-                        const departmentCriteriaTable = r.message.department_rating_criteria.map(row => ({
+                        const department_criteria_table = response.message.department_rating_criteria.map(row => ({
                             criteria: row.criteria,
                             per_weightage: row.per_weightage
                         }));
-                        dialog.fields_dict.department_criteria.df.data = departmentCriteriaTable;
+                        dialog.fields_dict.department_criteria.df.data = department_criteria_table;
 
                         // Populate company_criteria from company_rating_criteria
-                        const companyCriteriaTable = r.message.company_rating_criteria.map(row => ({
+                        const company_criteria_table = response.message.company_rating_criteria.map(row => ({
                             criteria: row.criteria,
                             per_weightage: row.per_weightage
                         }));
-                        dialog.fields_dict.company_criteria.df.data = companyCriteriaTable;
+                        dialog.fields_dict.company_criteria.df.data = company_criteria_table;
 
                         dialog.fields_dict.department_criteria.refresh();
                         dialog.fields_dict.company_criteria.refresh();


### PR DESCRIPTION
## Feature description
- Change the arrangement of dialog as feedback last and all child table first
- Add goals field in child table employee criteria
- Make the dialog size extra large
- Except marks and feedback make all the fields of dialog as read only
- Remove add row option in child table of dialog
- Fetch data to department and company criteria from appraisal template
- Fetch data to employee criteria from appraisal_kra 

## Solution description
- Rearranged the dialog
- Added field to employee criteria of dialog - goals
- Set dialog size as extra large
- Setting All fields as read-only in child table except marks 
- Removed the add row option from the child table
- Fetched data to the child table of dialog from appraisal template and appraisal kra child table 

## Output screenshots (optional)
[Screencast from 09-01-25 09:31:06 AM IST.webm](https://github.com/user-attachments/assets/96103206-b2c8-416a-abd1-58ef63e461e9)

