### PR TITLE
TASK-2025-00019:Validate the  Resume Attachment as PDF in Job Applicant Doctype

### DIFF
--- a/beams/beams/custom_scripts/interview/interview.js
+++ b/beams/beams/custom_scripts/interview/interview.js
@@ -32,6 +32,25 @@ frappe.ui.form.on('Interview', {
                 });
             }
         }
+        if (frm.doc.job_applicant && !frm.is_new()) {
+            frm.add_custom_button(__('Job Applicant'), function () {
+                frappe.set_route('Form', 'Job Applicant', frm.doc.job_applicant);
+            }, 'View');
+
+            frm.add_custom_button(__('Resume'), function () {
+                frappe.db.get_value('Job Applicant', frm.doc.job_applicant, 'resume_attachment')
+                .then(r => {
+                    let site_url = frappe.urllib.get_base_url();
+                    let resume_path = r.message.resume_attachment;
+                    if (!resume_path) {
+                        frappe.msgprint("No Attached Resume");
+                    } else {
+                        let file_url = `${site_url}${resume_path}`;
+                        window.open(file_url, '_blank');
+                    }
+                });
+            }, 'View');
+        }
     },
     show_custom_feedback_dialog: function (frm, data, question_data, feedback_exists) {
         let fields = frm.events.get_fields_for_custom_feedback();

--- a/beams/beams/custom_scripts/job_applicant/job_applicant.js
+++ b/beams/beams/custom_scripts/job_applicant/job_applicant.js
@@ -27,7 +27,16 @@ frappe.ui.form.on('Job Applicant', {
             // Clear location if checkbox is unchecked
             frm.set_value('location', '');
         }
-    }
+    },
+    validate: function (frm) {
+       const resume_attachment = frm.doc.resume_attachment;
+       if (resume_attachment) {
+           const file_extension = resume_attachment.split('.').pop().toLowerCase();
+           if (file_extension !== 'pdf') {
+               frappe.throw(__('Only PDF files are allowed for Resume Attachment.'));
+           }
+       }
+   }
 });
 
 function handle_custom_buttons(frm) {

--- a/beams/beams/custom_scripts/job_applicant/job_applicant.js
+++ b/beams/beams/custom_scripts/job_applicant/job_applicant.js
@@ -29,14 +29,20 @@ frappe.ui.form.on('Job Applicant', {
         }
     },
     validate: function (frm) {
-       const resume_attachment = frm.doc.resume_attachment;
-       if (resume_attachment) {
-           const file_extension = resume_attachment.split('.').pop().toLowerCase();
-           if (file_extension !== 'pdf') {
-               frappe.throw(__('Only PDF files are allowed for Resume Attachment.'));
-           }
-       }
-   }
+      const resume_attachment = frm.doc.resume_attachment;
+      if (resume_attachment) {
+          const file_extension = resume_attachment.split('.').pop().toLowerCase();
+          if (file_extension !== 'pdf') {
+              frappe.msgprint({
+                  title: __('Validation for Resume '),
+                  message: __('Only PDF files are allowed for Resume Attachment.'),
+                  indicator: 'red'
+              });
+              frappe.validated = false;
+          }
+      }
+  }
+
 });
 
 function handle_custom_buttons(frm) {

--- a/beams/beams/custom_scripts/job_applicant/job_applicant.py
+++ b/beams/beams/custom_scripts/job_applicant/job_applicant.py
@@ -5,6 +5,7 @@ from frappe.utils import get_url, now_datetime
 from frappe.utils import nowdate
 from frappe.utils import get_url_to_form
 from frappe.utils.password import encrypt
+import os
 
 def get_permission_query_conditions(user):
 	if not user:
@@ -176,3 +177,12 @@ def fetch_department(doc, method):
             doc.department = department
         else:
             frappe.throw(f"Department not found for the selected Job Opening: {doc.job_title}")
+
+def validate_resume_attachment(doc, method):
+    if doc.resume_attachment:
+        file_doc = frappe.get_doc("File", {"file_url": doc.resume_attachment})
+        file_name = file_doc.file_name
+        file_extension = os.path.splitext(file_name)[1].lower()
+
+        if file_extension != '.pdf':
+            frappe.throw("Only PDF files are allowed for Resume Attachment.")

--- a/beams/beams/custom_scripts/job_applicant/job_applicant.py
+++ b/beams/beams/custom_scripts/job_applicant/job_applicant.py
@@ -101,6 +101,7 @@ def send_magic_link(applicant_id):
 		else:
 			frappe.msgprint('Email Template "Job Applicant Follow Up" does not exist.', alert=True)
 
+@frappe.whitelist
 def generate_magic_link(applicant_id):
 	'''
         Generates and returns a magic link URL for the specified job applicant
@@ -177,7 +178,6 @@ def fetch_department(doc, method):
             doc.department = department
         else:
             frappe.throw(f"Department not found for the selected Job Opening: {doc.job_title}")
-
 def validate_resume_attachment(doc, method):
     if doc.resume_attachment:
         file_doc = frappe.get_doc("File", {"file_url": doc.resume_attachment})
@@ -185,4 +185,8 @@ def validate_resume_attachment(doc, method):
         file_extension = os.path.splitext(file_name)[1].lower()
 
         if file_extension != '.pdf':
-            frappe.throw("Only PDF files are allowed for Resume Attachment.")
+            frappe.msgprint(
+                msg=_('Only PDF files are allowed for Resume Attachment'),
+                title=_('Validation for Resume'),
+                indicator="red"
+            )

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -222,7 +222,8 @@ doc_events = {
             "beams.beams.custom_scripts.job_applicant.job_applicant.validate",
             "beams.beams.custom_scripts.job_applicant.job_applicant.validate_unique_application",
             "beams.beams.custom_scripts.job_applicant.job_applicant.fetch_designation",
-            "beams.beams.custom_scripts.job_applicant.job_applicant.fetch_department"
+            "beams.beams.custom_scripts.job_applicant.job_applicant.fetch_department",
+            "beams.beams.custom_scripts.job_applicant.job_applicant.validate_resume_attachment"
             ],
         "after_insert":"beams.beams.custom_scripts.job_applicant.job_applicant.set_interview_rounds"
     },

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -2706,7 +2706,15 @@ def get_property_setters():
             "property": "reqd",
             "property_type": "Check",
             "value": 0
-        }
+        },
+            {
+                "doctype_or_field": "DocField",
+                "doc_type": "Job Applicant",
+                "field_name": "resume_link",
+                "property": "hidden",
+                "property_type": "Data",
+                "value": 1
+            }
     ]
 
 


### PR DESCRIPTION
## Feature description
In Job Applicant Doctype, 
Hide 'Resume Link' field and Add validation for 'Resume Attachment' field that only PDF format should be allowed
In Interview doctype,
Add the "view" group button for 'Job Applicant' and 'Resume'
## Solution description
In Job Applicant Doctype Hide the 'Resume Link' field and added validation for 'Resume Attachment' field that only PDF format should be allowed.
In Interview Doctype Created "View" group button that contains Job Applicant and Resume after the interview saved .. 
When 'job applicant' button is clicked,it should be redirected to Job Applicant's document and when 'Resume' button is clicked,it should be redirected to Job Applicant's document.
## Output screenshots (optional)

[Screencast from 09-01-25 10:23:36 AM IST.webm](https://github.com/user-attachments/assets/e97f6400-4efb-4ca6-ae1c-9562d34e5bc6)

[Screencast from 09-01-25 10:26:44 AM IST.webm](https://github.com/user-attachments/assets/98ecfeb0-9708-46c3-94f3-ecac7a0bc80f)

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Mozilla Firefox

