### PR TITLE
fix:Refactor Appraisal button logic and enhance HR settings

### DIFF
--- a/beams/beams/custom_scripts/appraisal/appraisal.js
+++ b/beams/beams/custom_scripts/appraisal/appraisal.js
@@ -1,5 +1,6 @@
 frappe.ui.form.on('Appraisal', {
     refresh: function (frm) {
+        frm.remove_custom_button(__('View Goals'));
         // Remove the button by targeting its full class list
         setTimeout(() => {
             $('.new-feedback-btn.btn.btn-sm.d-inline-flex.align-items-center.justify-content-center.px-3.py-2.border').remove();
@@ -50,45 +51,25 @@ frappe.ui.form.on('Appraisal', {
         }
 
         // Add Custom Button for One to One Meeting
-      if (frm.doc.docstatus === 1 && frm.doc.employee) {
-          frappe.db.get_value('Employee Performance Feedback',
-              { employee: frm.doc.employee, docstatus: 1 },
-              'feedback').then(response => {
+        if (frm.doc.employee) {
+        // Always add the custom button
+        frm.add_custom_button(__('One to One Meeting'), function () {
+            // Directly map appraisal to event without checking Employee Performance Feedback
+            frappe.model.open_mapped_doc({
+                method: "beams.beams.custom_scripts.appraisal.appraisal.map_appraisal_to_event", // Mapping method
+                args: { source_name: frm.doc.name },
+                frm: frm
+            });
 
-              if (response && response.message && response.message.feedback) {
-                  frm.add_custom_button(__('One to One Meeting'), function () {
-
-                      // Call the method to map the appraisal to event
-                      frappe.call({
-                          method: "beams.beams.custom_scripts.appraisal.appraisal.map_appraisal_to_event",
-                          args: {
-                              source_name: frm.doc.name
-                          },
-                          callback: function (r) {
-                              if (r.message) {
-                                  const event_name = r.message;
-
-                                  // Use open_mapped_doc to map and open the Event form
-                                  frappe.model.open_mapped_doc({
-                                      method: "beams.beams.custom_scripts.appraisal.appraisal.map_appraisal_to_event", // Mapping method
-                                      args: { source_name: frm.doc.name },
-                                      frm: frm
-                                  });
-
-                                  // call the assign tasks sequentially function after mapping
-                                  frappe.call({
-                                      method: "beams.beams.custom_scripts.appraisal.appraisal.assign_tasks_sequentially",
-                                      args: {
-                                          doc: frm.doc.name
-                                      }
-                                  });
-                              }
-                          }
-                      });
-                  }, __('Create'));
-              }
-          });
-      }
+            // Call assign tasks sequentially function after mapping
+            frappe.call({
+                method: "beams.beams.custom_scripts.appraisal.appraisal.assign_tasks_sequentially",
+                args: {
+                    doc: frm.doc.name
+                }
+            });
+        }, __('Create'));
+    }
 
         frappe.call({
             method: "beams.beams.custom_scripts.appraisal.appraisal.get_categories_table",
@@ -261,7 +242,7 @@ frappe.ui.form.on('Appraisal', {
         const dialog = new frappe.ui.Dialog({
             title: 'Add Category',
             fields: [
-                { label: 'Select Category', fieldname: 'select_category', fieldtype: 'Link', options: 'Category', reqd: 1 },
+                { label: 'Select Category', fieldname: 'select_category', fieldtype: 'Link', options: 'Category', only_select: 1, reqd: 1 },
                 { label: 'Remarks', fieldname: 'remarks', fieldtype: 'Text', reqd: 1 },
             ],
             primary_action_label: 'Submit',

--- a/beams/beams/doctype/beams_hr_settings/beams_hr_settings.json
+++ b/beams/beams/doctype/beams_hr_settings/beams_hr_settings.json
@@ -6,10 +6,10 @@
  "engine": "InnoDB",
  "field_order": [
   "default_local_enquiry_duration",
+  "enable_absence_reminders",
   "absence_reminder_duration",
   "column_break_lmqd",
   "permanent_employment_type",
-  "enable_absence_reminders",
   "notification_settings_tab",
   "notification_to_admin_department_to_create_id_card_section",
   "notification_to_admin",
@@ -209,6 +209,7 @@
    "fieldtype": "Column Break"
   },
   {
+   "depends_on": "eval:doc.enable_absence_reminders == 1",
    "description": "Days after absence without leave to notify the Reporting Manager",
    "fieldname": "absence_reminder_duration",
    "fieldtype": "Int",
@@ -224,7 +225,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-12-24 15:54:22.187120",
+ "modified": "2025-01-09 11:24:00.923221",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Beams HR Settings",

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -2358,6 +2358,21 @@ def get_property_setters():
         },
         {
             "doctype_or_field": "DocField",
+            "doc_type": "Appraisal Template",
+            "field_name": "rating_criteria",
+            "property": "label",
+            "value": "Employee Criteria"
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Employee Feedback Rating",
+            "field_name": "rating_criteria",
+            "property": "read_only",
+            "property_type": "Table",
+            "value": 1
+        },
+        {
+            "doctype_or_field": "DocField",
             "doc_type": "Job Requisition",
             "field_name": "status",
             "property": "read_only",


### PR DESCRIPTION
## Feature description
     --Updated Appraisal custom button logic and HR settings configuration

## Solution description
    --Removed unnecessary button logic and adjusted conditions for the "One to One Meeting"
    -- Updated property settings to reflect changes in template and feedback fields
    --Added dependency logic for "absence_reminder_duration" to trigger only when "enable_absence_reminders" is enabled.  

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/a92bc632-dd81-4f3c-b03b-31a42f892422)

[Screencast from 09-01-25 02:37:38 PM IST.webm](https://github.com/user-attachments/assets/e9c2515a-2eb2-4aff-ba5c-4ba97f01f382)

![image](https://github.com/user-attachments/assets/2c87964e-5bcf-4ef1-941d-bf682b156e80)

![image](https://github.com/user-attachments/assets/2d423bc1-a7e0-4814-b9db-162e45235ba7)


## Is there any existing behavior change of other features due to this code change?
    -- No. 

## Was this feature tested on the browsers?
    -- Mozilla Firefox
  