### PR TITLE
fix : Bringing a validation that marks should not be empty

### DIFF
--- a/beams/beams/custom_scripts/appraisal/appraisal.js
+++ b/beams/beams/custom_scripts/appraisal/appraisal.js
@@ -222,17 +222,21 @@ frappe.ui.form.on('Appraisal', {
             size: 'extra-large',
             primary_action_label: 'Submit',
             primary_action(values) {
-                // Validate Marks (should be between 0 and 5)
+                // Validate Marks (should be between 0 and 5 and not null)
                 const validate_marks = (table) => {
-                    let isValid = true;
+                    let is_valid = true;
                     table.forEach(row => {
-                        if (row.marks < 0 || row.marks > 5) {
+                        if (row.marks === null || row.marks === undefined || row.marks === '') {
+                            frappe.msgprint(__('Marks cannot be empty.'));
+                            is_valid = false;
+                        } else if (row.marks < 0 || row.marks > 5) {
                             frappe.msgprint(__('Marks should be between 0 and 5.'));
-                            isValid = false;
+                            is_valid = false;
                         }
                     });
-                    return isValid;
+                    return is_valid;
                 };
+
                 if (
                     validate_marks(values.employee_criteria) &&
                     validate_marks(values.department_criteria) &&

--- a/beams/beams/custom_scripts/appraisal/appraisal.js
+++ b/beams/beams/custom_scripts/appraisal/appraisal.js
@@ -225,15 +225,21 @@ frappe.ui.form.on('Appraisal', {
                 // Validate Marks (should be between 0 and 5 and not null)
                 const validate_marks = (table) => {
                     let is_valid = true;
+                    let empty_marks_error_shown = false;
+                    let range_error_shown = false;
+
                     table.forEach(row => {
-                        if (row.marks === null || row.marks === undefined || row.marks === '') {
+                        if ((row.marks === null || row.marks === undefined || row.marks === '') && !empty_marks_error_shown) {
                             frappe.msgprint(__('Marks cannot be empty.'));
+                            empty_marks_error_shown = true;
                             is_valid = false;
-                        } else if (row.marks < 0 || row.marks > 5) {
+                        } else if ((row.marks < 0 || row.marks > 5) && !range_error_shown) {
                             frappe.msgprint(__('Marks should be between 0 and 5.'));
+                            range_error_shown = true;
                             is_valid = false;
                         }
                     });
+
                     return is_valid;
                 };
 


### PR DESCRIPTION
## Feature description
- Bring a Validation that on submitting mark should not be empty

## Solution description
- Whenever a dialog without entering a mark is submitted a alert message is given

## Output screenshots (optional)
[Screencast from 10-01-25 09:09:22 AM IST.webm](https://github.com/user-attachments/assets/8297e081-d889-4a8a-b23a-40a9b345e78c)


