### PR TITLE
fix:Assignment to Asessment officers triggered when Category is added  by officer

### DIFF
--- a/beams/beams/custom_scripts/appraisal/appraisal.js
+++ b/beams/beams/custom_scripts/appraisal/appraisal.js
@@ -5,6 +5,13 @@ frappe.ui.form.on('Appraisal', {
         setTimeout(() => {
             $('.new-feedback-btn.btn.btn-sm.d-inline-flex.align-items-center.justify-content-center.px-3.py-2.border').remove();
         }, 500);
+        // Hide dashboard
+        $('.form-dashboard-section').hide();
+        setTimeout(() => {
+            $('.new-feedback-btn.btn.btn-sm.d-inline-flex.align-items-center.justify-content-center.px-3.py-2.border').remove();
+        }, 500);
+
+        frm.set_df_property('final_score', 'hidden', 1);
 
         if (!frm.is_new()) {
             // Add custom button to trigger the feedback dialog
@@ -54,19 +61,11 @@ frappe.ui.form.on('Appraisal', {
         if (frm.doc.employee) {
         // Always add the custom button
         frm.add_custom_button(__('One to One Meeting'), function () {
-            // Directly map appraisal to event without checking Employee Performance Feedback
+
             frappe.model.open_mapped_doc({
-                method: "beams.beams.custom_scripts.appraisal.appraisal.map_appraisal_to_event", // Mapping method
+                method: "beams.beams.custom_scripts.appraisal.appraisal.map_appraisal_to_event",
                 args: { source_name: frm.doc.name },
                 frm: frm
-            });
-
-            // Call assign tasks sequentially function after mapping
-            frappe.call({
-                method: "beams.beams.custom_scripts.appraisal.appraisal.assign_tasks_sequentially",
-                args: {
-                    doc: frm.doc.name
-                }
             });
         }, __('Create'));
     }
@@ -95,6 +94,11 @@ frappe.ui.form.on('Appraisal', {
                 frm.events.open_add_category_dialog(frm);
             });
         }
+		// Hide the chart by targeting its container
+		if (frm.dashboard.wrapper) {
+			frm.dashboard.wrapper.find('.chart-container').hide(); // Adjust selector as needed
+		}
+
     },
 
     show_feedback_dialog: function (frm) {


### PR DESCRIPTION
## Feature description
The assignment to Assessment Officers was triggered when Create One to One  button was clicked.But now it is triggered when Officer adds a Category.
Remove Dashboard for KRA  in Appraisal doctype.

## Analysis and design 
 Assessment officer notification is triggered when Officer adds Category of the employee.

## Solution description
Triggering function when One to one is created is removed and was triggered when Category is added.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/610874f8-a2dc-4d77-b97e-62fecb4e6831)
![image](https://github.com/user-attachments/assets/ed64e322-3ba2-4af2-9063-23eb1792fff7)


## Is there any existing behavior change of other features due to this code change?
       No.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
