### PR TITLE
feat: set Category on Appraisal doctype based on Final Average Score

### DIFF
--- a/beams/beams/custom_scripts/appraisal/appraisal.js
+++ b/beams/beams/custom_scripts/appraisal/appraisal.js
@@ -318,13 +318,13 @@ frappe.ui.form.on('Appraisal', {
 
         dialog.show();
     },
-    
+
     // Function to open the Add Category dialog
     open_add_category_dialog: function (frm) {
         const dialog = new frappe.ui.Dialog({
             title: 'Add Category',
             fields: [
-                { label: 'Select Category', fieldname: 'select_category', fieldtype: 'Link', options: 'Category', only_select: 1, reqd: 1 },
+                { label: 'Select Category', fieldname: 'select_category', fieldtype: 'Link', options: 'Appraisal Category', only_select: 1, reqd: 1 },
                 { label: 'Remarks', fieldname: 'remarks', fieldtype: 'Text', reqd: 1 },
             ],
             primary_action_label: 'Submit',
@@ -370,7 +370,7 @@ frappe.ui.form.on('Appraisal', {
         dialog.show();
     },
 
-    //Updates or clears child tables based on the selected appraisal template by fetching and populating criteria data 
+    //Updates or clears child tables based on the selected appraisal template by fetching and populating criteria data
     appraisal_template: function (frm) {
         if (frm.doc.appraisal_template) {
             frappe.call({
@@ -406,7 +406,7 @@ frappe.ui.form.on('Appraisal', {
                         frm.refresh_field("employee_self_kra_rating");
                         frm.refresh_field("dept_self_kra_rating");
                         frm.refresh_field("company_self_kra_rating");
-                    } 
+                    }
                 }
             });
         } else {
@@ -428,5 +428,5 @@ function set_table_properties(frm, table_name) {
     });
     frm.set_df_property(table_name, 'cannot_add_rows', true);
     frm.set_df_property(table_name, 'cannot_delete_rows', true);
-    frm.set_df_property(table_name, 'cannot_delete_all_rows', true);   
+    frm.set_df_property(table_name, 'cannot_delete_all_rows', true);
 }

--- a/beams/beams/custom_scripts/appraisal/appraisal.py
+++ b/beams/beams/custom_scripts/appraisal/appraisal.py
@@ -401,14 +401,19 @@ def calculate_total_and_average(doc, table):
     '''
     total = 0
     count = 0
-    for row in doc.get(table, []):
+    rows = doc.get(table, [])
+    if not rows:
+        return total, 0  # No rows to calculate, return total 0 and average 0
+
+    for row in rows:
         if row.marks:
             total += float(row.marks)
             count += 1
             row.rating = (float(row.marks) / 5)
+
+    # Calculate average if count > 0
     average = total / count if count > 0 else 0
     return total, average
-
 
 @frappe.whitelist()
 def get_category_based_on_marks(final_average_score):

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -276,7 +276,10 @@ doc_events = {
     },
     "Appraisal":{
         "on_update_after_submit":"beams.beams.custom_scripts.appraisal.appraisal.assign_tasks_sequentially",
-        "validate": "beams.beams.custom_scripts.appraisal.appraisal.validate_appraisal"
+        "validate": [
+            "beams.beams.custom_scripts.appraisal.appraisal.validate_appraisal",
+            "beams.beams.custom_scripts.appraisal.appraisal.set_category_based_on_marks"
+        ]
     }
 }
 

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -2287,13 +2287,22 @@ def get_appraisal_custom_fields():
 				"label": "Appraisal Summary",
 				"insert_after": "final_assesment_tab_break"
 			},
+        	{
+				"fieldname": "category_based_on_marks",
+				"fieldtype": "Link",
+                "options": "Category",
+				"label": "Category based on marks",
+				"insert_after": "category_html",
+                "read_only": 1
+			},
 			{
 				"fieldname": "category_details",
 				"fieldtype": "Table",
 				"label": "Category Details",
 				"options": "Category Details",
-				"insert_after": "category_html",
-				"allow_on_submit": 1
+				"insert_after": "category_based_on_marks",
+				"allow_on_submit": 1,
+                "read_only": 1
 			},
             {
                 "fieldname": "event_reference",
@@ -2364,7 +2373,13 @@ def get_appraisal_custom_fields():
                 "label": "Average Company Self Score",
                 "insert_after": "total_company_self_kra_rating",
                 "read_only": 1
-            }
+            },
+            {
+                "fieldname": "final_average_score",
+                "fieldtype": "Float",
+                "label": "Final Average Score",
+                "insert_after": "employee_image"
+            },
         ]
     }
 


### PR DESCRIPTION
## Feature description
Added functionality to calculate and set the category for an Appraisal based on the final_average_score.

## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description
-   get_category_based_on_marks:
    Fetches the top category where appraisal_threshold is less than or equal to the given final_average_score.
    Returns the name of the category.

-   set_category_based_on_marks:
    Hooks into the Appraisal lifecycle using the method parameter (e.g., before_save).
    Updates the category_based_on_marks field with the calculated category.



## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.

## Areas affected and ensured
Appraisal DocType: Category assignment logic.
Appraisal Category DocType: Thresholds used for category calculation.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
