### PR TITLE
TASK-2025-00039:Modified doctype Adhoc Budget

### DIFF
--- a/beams/beams/doctype/adhoc_budget/adhoc_budget.json
+++ b/beams/beams/doctype/adhoc_budget/adhoc_budget.json
@@ -9,6 +9,7 @@
   "project",
   "fiscal_year",
   "company",
+  "generates_revenue",
   "expected_revenue",
   "expected_revenue_reached",
   "column_break_zhmw",
@@ -43,10 +44,10 @@
    "reqd": 1
   },
   {
+   "depends_on": "eval:doc.generates_revenue;",
    "fieldname": "expected_revenue",
    "fieldtype": "Currency",
    "label": "Expected Revenue",
-   "non_negative": 1,
    "precision": "2",
    "reqd": 1
   },
@@ -140,12 +141,18 @@
    "label": "Company",
    "options": "Company",
    "reqd": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "generates_revenue",
+   "fieldtype": "Check",
+   "label": "Generates Revenue"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-09-03 17:22:50.245140",
+ "modified": "2025-01-14 14:25:27.931877",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Adhoc Budget",

--- a/beams/beams/doctype/adhoc_budget/adhoc_budget.py
+++ b/beams/beams/doctype/adhoc_budget/adhoc_budget.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe import _
 from frappe.desk.form.assign_to import add as add_assign
 from frappe.model.document import Document
 from frappe.utils.user import get_users_with_role
@@ -13,6 +14,9 @@ class AdhocBudget(Document):
 
     def on_update_after_submit(self):
         self.create_todo_on_verified_by_finance()
+
+    def validate(self):
+        self.validate_expected_revenue()
 
     def create_todo_on_creation_for_adhoc_budget(self):
         """
@@ -124,3 +128,13 @@ class AdhocBudget(Document):
 
         budget.insert()
         budget.submit()
+
+    def validate_expected_revenue(self):
+        """
+        Validate the 'expected_revenue' field in the Adhoc Budget.
+        """
+        if not self.expected_revenue:
+            frappe.throw(_("Expected Revenue is required."))
+
+        if  not self.expected_revenue > 0:
+            frappe.throw(_("Expected Revenue should be greater than zero."))


### PR DESCRIPTION
## Feature description
Add field in  Adhoc Budget DocType: Generates Revenue (a checkbox) .
Expected Revenue: This field is visible and required only if Generates Revenue is checked.
Validation should be added  as Expected Revenue cannot be less  than zero.

## Analysis and design (optional)
The Adhoc Budget DocType is modified by adding   field: Generates Revenue (a checkbox) .
Expected Revenue: This field is visible  only if Generates Revenue is checked.
Validation added as Expected Revenue cannot be less than zero.

## Solution description
The script will monitor changes to the Generates Revenue checkbox and toggle the visibility of the Expected Revenue field accordingly.
If Generates Revenue is checked, Expected Revenue becomes visible.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/7ebf630a-163d-4283-8dc9-8b8d8c31bb70)
![image](https://github.com/user-attachments/assets/841dee8a-3a52-4548-96b7-118aeb76ce76)


## Areas affected and ensured
List out the areas affected by your code changes.

## Is there any existing behavior change of other features due to this code change?
        No. 

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
