### PR TITLE
    TASK-2025-00037:Customize Project doctype

### DIFF
--- a/beams/beams/doctype/project_expense_type/project_expense_type.json
+++ b/beams/beams/doctype/project_expense_type/project_expense_type.json
@@ -1,0 +1,33 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-01-15 09:26:28.916893",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "budget_expense_type"
+ ],
+ "fields": [
+  {
+   "fieldname": "budget_expense_type",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Budget Expense Type",
+   "options": "Budget Expense Type",
+   "reqd": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2025-01-15 09:51:40.701899",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "Project Expense Type",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/beams/beams/doctype/project_expense_type/project_expense_type.py
+++ b/beams/beams/doctype/project_expense_type/project_expense_type.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class ProjectExpenseType(Document):
+	pass

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -47,6 +47,8 @@ def after_install():
     create_custom_fields(get_appraisal_custom_fields(),ignore_validate=True)
     create_custom_fields(get_appraisal_kra_custom_fields(),ignore_validate=True)
     create_custom_fields(get_event_custom_fields(),ignore_validate=True)
+    create_custom_fields(get_Project_custom_fields(),ignore_validate=True)
+
 
 
     #Creating BEAMS specific Property Setters
@@ -105,6 +107,7 @@ def before_uninstall():
     delete_custom_fields(get_appraisal_custom_fields())
     delete_custom_fields(get_appraisal_kra_custom_fields())
     delete_custom_fields(get_event_custom_fields())
+    delete_custom_fields(get_Project_custom_fields())
 
 
 def delete_custom_fields(custom_fields: dict):
@@ -135,6 +138,58 @@ def get_shift_assignment_custom_fields():
                 "label": "Roster Type",
                 "options":"\nRegular\nDouble Shift",
                 "insert_after": "shift_type"
+            }
+        ]
+    }
+
+def get_Project_custom_fields():
+    '''
+    Custom fields that need to be added to the Project Doctype
+    '''
+    return {
+        "Project": [
+            {
+                "fieldname": "program_section",
+                "fieldtype": "Section Break",
+                "label": "Program Details",
+                "collapsible": 1,
+                "insert_after": "sales_order"
+            },
+            {
+                "fieldname": "program",
+                "label": "Program",
+                "fieldtype": "Link",
+                "options": "Program Request",
+                "insert_after": "program_section"
+            },
+            {
+                "fieldname": "column_break_program",
+                "fieldtype": "Column Break",
+                "insert_after": "generates_revenue"
+            },
+            {
+                "fieldname": "program_type",
+                "label": "Program Type",
+                "fieldtype": "Link",
+                "options": "Program Type",
+                "insert_after": "column_break_program",
+                "fetch_from": "program.program_type",
+                "read_only": 1
+            },
+            {
+                "fieldname": "budget_expense_types",
+                "fieldtype": "Table MultiSelect",
+                "label": "Budget Expense Types",
+                'options':"Project Expense Type",
+                "insert_after": "program_type"
+            },
+            {
+                "fieldname": "generates_revenue",
+                "fieldtype": "Check",
+                "label": "Generates Revenue",
+                "read_only": 1,
+                "fetch_from": "program.generates_revenue",
+                "insert_after": "program"
             }
         ]
     }


### PR DESCRIPTION
## Feature description
Add  fields to the Project Doctype to manage program-specific details, including:

## Solution description
Added Program Details section to Project doctype
- Included new fields:
  - Program: A Link field to associate the project with a 'Program Request'.
  -Generates Revenue: A Read-Only checkbox, fetched from the associated program, indicating if the program generates revenue.
 -Program Type: A Read-Only Link field, fetched from the associated program, to define the program type.
 -Budget Expense Types: A MultiSelect table, linked to 'Project Expense Type', for selecting applicable expense types.
Created a child table for 'Project Expense Type

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/9a300984-71a5-41d3-ae4d-478a149552b5)
![image](https://github.com/user-attachments/assets/e558237f-3eff-4df6-aceb-b4a96b194284)
![image](https://github.com/user-attachments/assets/e558237f-3eff-4df6-aceb-b4a96b194284)

## Areas affected and ensured
Project Doctype

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
 Mozilla Firefox
  