### PR TITLE
feat : Add functionality to create Adhoc Budget from Project

### DIFF
--- a/beams/beams/custom_scripts/project/project.js
+++ b/beams/beams/custom_scripts/project/project.js
@@ -1,0 +1,11 @@
+frappe.ui.form.on('Project', {
+    //function adds a button to the 'Project' form to create an Adhoc Budget.
+    refresh: function (frm) {
+        frm.add_custom_button(__('Adhoc Budget'), function () {
+            frappe.model.open_mapped_doc({
+                method: "beams.beams.custom_scripts.project.project.create_adhoc_budget",
+                frm: frm,
+            });
+        }, __("Create"));
+    }
+});

--- a/beams/beams/custom_scripts/project/project.py
+++ b/beams/beams/custom_scripts/project/project.py
@@ -1,0 +1,29 @@
+import frappe
+from frappe.model.mapper import get_mapped_doc
+
+@frappe.whitelist()
+def create_adhoc_budget(source_name, target_doc=None):
+    """
+    Maps fields from the Project doctype to the Adhoc Budget doctype, including the
+    selected values from the 'budget_expense_types' field into the child table 'Budget Expense'.
+    """
+    project_doc = frappe.get_doc('Project', source_name)
+    adhoc_budget = get_mapped_doc("Project", source_name, {
+        "Project": {  
+                "doctype": "Adhoc Budget",  
+                "field_map": {
+                    "name": "project",  
+                    "expected_start_date": "expected_start_date",
+                    "expected_end_date": "expected_end_date",
+                    "project_name": "project_name",
+                    "generates_revenue": "generates_revenue"
+                }
+            }
+    }, target_doc)
+
+    for expense_type in project_doc.budget_expense_types:
+        adhoc_budget.append('budget_expense', {
+            'budget_expense_type': expense_type.budget_expense_type
+        })
+    return adhoc_budget
+

--- a/beams/beams/custom_scripts/project/project.py
+++ b/beams/beams/custom_scripts/project/project.py
@@ -15,7 +15,6 @@ def create_adhoc_budget(source_name, target_doc=None):
                     "name": "project",  
                     "expected_start_date": "expected_start_date",
                     "expected_end_date": "expected_end_date",
-                    "project_name": "project_name",
                     "generates_revenue": "generates_revenue"
                 }
             }

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -56,7 +56,8 @@ doctype_js = {
     "Employee Onboarding":"beams/custom_scripts/employee_onboarding/employee_onboarding.js",
     "Leave Application":"beams/custom_scripts/leave_application/leave_application.js",
     "Job Offer": "beams/custom_scripts/job_offer/job_offer.js",
-    "Appraisal":"beams/custom_scripts/appraisal/appraisal.js"
+    "Appraisal":"beams/custom_scripts/appraisal/appraisal.js",
+    "Project":"beams/custom_scripts/project/project.js"
 }
 doctype_list_js = {
     "Sales Invoice" : "beams/custom_scripts/sales_invoice/sales_invoice_list.js",


### PR DESCRIPTION
## Feature description

-  Added a feature to create an Adhoc Budget from a Project, including mapping relevant fields and transferring selected budget expense types.

## Solution description

- Implemented the `create_adhoc_budget` function to map fields from the Project doctype to the Adhoc Budget doctype.
- For each selected expense type in the Project, a corresponding entry is added to the `Budget Expense` child table in the Adhoc Budget.
- Introduced a custom button on the Project form to trigger the creation of the Adhoc Budget.

## Output screenshots (optional)
[Screencast from 01-15-2025 01:01:06 PM.webm](https://github.com/user-attachments/assets/b222cde2-47d1-42ac-8d16-3fbaf0d72f21)


## Areas affected and ensured

- `Project Doctype`
- `Adhoc Budget Doctype`

## Is there any existing behavior change of other features due to this code change?

- No

## Was this feature tested on the browsers?
 - Chrome
