### PR TITLE
feat: Customize Customer doctype

### DIFF
--- a/beams/api/api.py
+++ b/beams/api/api.py
@@ -94,7 +94,7 @@ def get_agency_list(start=0, page_length=20, agency_name=None):
 	'''
 		API to get List of Agency
 	'''
-	agency_fields = ['name as agency_id', 'customer_name as agency_name', 'region', 'gstin', 'pan as pan_no', 'default_currency as currency']
+	agency_fields = ['name as agency_id', 'customer_name as agency_name', 'region', 'gstin', 'pan as pan_no', 'default_currency as currency', 'is_edited']
 	filters = { 'is_agent':1 }
 	if agency_name:
 		filters = { 'is_agent':1, 'customer_name':['like', '%{0}%'.format(agency_name)] }
@@ -109,7 +109,7 @@ def get_client_list(start=0, page_length=20, client_name=None):
 	'''
 		API to get List of Client
 	'''
-	client_fields = ['name as client_id', 'customer_name as client_name', 'region', 'gstin', 'pan as pan_no', 'default_currency as currency']
+	client_fields = ['name as client_id', 'customer_name as client_name', 'region', 'gstin', 'pan as pan_no', 'default_currency as currency', 'is_edited']
 	filters = { 'is_agent':0 }
 	if client_name:
 		filters = { 'is_agent':0, 'customer_name':['like', '%{0}%'.format(client_name)] }

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -328,6 +328,7 @@ def get_customer_custom_fields():
                 "fieldtype": "Link",
                 "label": "Region",
                 "options": "Region",
+                "mandatory_depends_on": "eval:doc.is_agent",
                 "insert_after": "msme_status"
             },
             {
@@ -335,6 +336,13 @@ def get_customer_custom_fields():
                 "fieldtype": "Check",
                 "label": "Is Agency",
                 "insert_after": "region"
+            },
+            {
+                "fieldname": "is_edited",
+                "fieldtype": "Check",
+                "label": "Is Edited",
+                "hidden": 1,
+                "insert_after": "is_agent"
             }
         ]
     }


### PR DESCRIPTION
## Feature description
- Need to add custom fields in Customer Doctype

## Solution description
- Set mandatory on Region based on is agency checkbox.
- Added is editable checkbox in Customer

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/149632f1-fa03-4ee7-ad73-6fe34fb46666)

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox
