### PR TITLE
TASK-2025-00019:Added Copy to Clipboard functionality for magic link in Job Applicant

### DIFF
--- a/beams/beams/custom_scripts/job_applicant/job_applicant.js
+++ b/beams/beams/custom_scripts/job_applicant/job_applicant.js
@@ -111,24 +111,35 @@ function handle_custom_buttons(frm) {
                 }
             });
 
-            if (!frm.doc.is_form_submitted) {
-                // Button for Sending Magic Link
-                frm.add_custom_button(__('Send Magic Link'), function () {
-                    frappe.confirm('Are you sure you want to send the magic link to the candidate?', function () {
-                        frappe.call({
-                            method: 'beams.beams.custom_scripts.job_applicant.job_applicant.send_magic_link',
-                            args: {
-                                applicant_id: frm.doc.name
-                            },
-                            callback: function (r) {
-                                if (r.message) {
-                                    frm.reload_doc();
-                                }
-                            }
-                        });
-                    });
-                });
-            }
+            frm.add_custom_button(__('Send Magic Link'), function () {
+          // Confirm the action with the user
+          frappe.confirm('Are you sure you want to send the magic link to the candidate?', function () {
+              // Call the backend method to generate and send the magic link
+              frappe.call({
+                  method: 'beams.beams.custom_scripts.job_applicant.job_applicant.send_magic_link', // Ensure the correct method path
+                  args: {
+                      applicant_id: frm.doc.name // Send the applicant's ID to the backend
+                  },
+                  callback: function (r) {
+                      console.log(r);
+                      if (r.message) {
+                          // Assuming r.message contains the magic link URL
+                          // Optionally, copy the magic link to the clipboard
+                          navigator.clipboard.writeText(r.message)
+                              .then(function () {
+                                  frappe.show_alert(__('Magic Link copied to clipboard!'));
+                              })
+                              .catch(function (err) {
+                                  frappe.show_alert(__('Failed to copy Magic Link to clipboard'));
+                              });
+
+                          // Optionally, you can reload the document if needed
+                          frm.reload_doc();
+                      }
+                  }
+              });
+          });
+      });
 
             if (frm.doc.status === 'Accepted') {
                 frm.add_custom_button(__('Training Completed'), function () {

--- a/beams/beams/custom_scripts/job_applicant/job_applicant.py
+++ b/beams/beams/custom_scripts/job_applicant/job_applicant.py
@@ -97,7 +97,7 @@ def send_magic_link(applicant_id):
 			)
 			frappe.msgprint(f'Magic link sent to {email_id}')
 			frappe.db.set_value('Job Applicant', applicant_id, 'status', 'Pending Document Upload')
-			return 1
+			return link
 		else:
 			frappe.msgprint('Email Template "Job Applicant Follow Up" does not exist.', alert=True)
 


### PR DESCRIPTION
## Feature description
Add the 'Copy to Clipboard' functionality for magic link in Job Applicant

## Solution description
Added 'Copy to Clipboard' functionality for magic link in Job Applicant
## Output screenshots (optional)
[Screencast from 15-01-25 04:01:33 PM IST.webm](https://github.com/user-attachments/assets/38a6ea67-c588-48b3-a8fd-b540f68a5e3a)



## Areas affected and ensured
In Job Applicant doctype while clicking the "send magic link" button that magic link is copied to the Clipboard 

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Mozilla Firefox
 
