### PR TITLE
fix:add validation for start date

### DIFF
--- a/beams/beams/doctype/program_request/program_request.js
+++ b/beams/beams/doctype/program_request/program_request.js
@@ -17,9 +17,8 @@ frappe.ui.form.on('Program Request', {
                                 args: { program_request_id: frm.doc.name },
                                 callback: function (r) {
                                     if (r.message) {
-                                        // Redirect to the created project after successful creation
                                         frappe.set_route('Form', 'Project', r.message);
-                                    } 
+                                    }
                                 }
                             });
                         }).addClass('btn-primary');
@@ -27,5 +26,11 @@ frappe.ui.form.on('Program Request', {
                 }
             });
         }
+    },
+    start_date: function (frm) {
+        frm.call("validate_start_date_and_end_dates");
+    },
+    end_date: function (frm) {
+        frm.call("validate_start_date_and_end_dates");
     }
 });

--- a/beams/beams/doctype/program_request/program_request.json
+++ b/beams/beams/doctype/program_request/program_request.json
@@ -41,6 +41,7 @@
    "fieldname": "posting_date",
    "fieldtype": "Date",
    "label": "Posting Date",
+   "read_only": 1,
    "reqd": 1
   },
   {
@@ -113,7 +114,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-01-15 14:33:05.263807",
+ "modified": "2025-01-15 16:42:51.035022",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Program Request",

--- a/beams/beams/doctype/program_request/program_request.py
+++ b/beams/beams/doctype/program_request/program_request.py
@@ -5,6 +5,8 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 from frappe.utils import get_link_to_form
+from frappe.utils import getdate
+from frappe import _
 
 class ProgramRequest(Document):
     def validate(self):
@@ -12,11 +14,21 @@ class ProgramRequest(Document):
 
     @frappe.whitelist()
     def validate_start_date_and_end_dates(self):
-        '''
-        Validates that the start date is not later than the end date
-        '''
-        if self.start_date > self.end_date:
-            frappe.throw(msg="Start Date cannot be after End Date", title="Message")
+        """
+        Validates that start_date and end_date are properly set and checks
+        if start_date is not later than end_date.
+        """
+        if not self.start_date or not self.end_date:
+            return
+        # Convert dates to proper date objects
+        start_date = getdate(self.start_date)
+        end_date = getdate(self.end_date)
+
+        if start_date > end_date:
+            frappe.throw(
+                msg=_("Start Date cannot be after End Date."),
+                title=_("Validation Error")
+            )
 
 @frappe.whitelist()
 def create_project_from_program_request(program_request_id):

--- a/beams/beams/doctype/program_request/program_request.py
+++ b/beams/beams/doctype/program_request/program_request.py
@@ -7,7 +7,16 @@ from frappe.model.document import Document
 from frappe.utils import get_link_to_form
 
 class ProgramRequest(Document):
-    pass
+    def validate(self):
+        self.validate_start_date_and_end_dates()
+
+    @frappe.whitelist()
+    def validate_start_date_and_end_dates(self):
+        '''
+        Validates that the start date is not later than the end date
+        '''
+        if self.start_date > self.end_date:
+            frappe.throw(msg="Start Date cannot be after End Date", title="Message")
 
 @frappe.whitelist()
 def create_project_from_program_request(program_request_id):


### PR DESCRIPTION
## Feature description
This feature ensures that the start date of a program request cannot be later than the end date
set Posting Date to read-only
## Solution description

- Implemented a validate_start_date_and_end_dates method within the ProgramRequest class.
- This method checks if the start_date is greater than the end_date.


## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/e568c339-2fdc-4fb0-9eca-49c12d28386b)
![image](https://github.com/user-attachments/assets/edccd5ea-803f-4be6-b404-3a8542d497af)


## Areas affected and ensured
- Program Request Document:
 - Start and End date fields are now logically validated.
- Ensures no erroneous data is saved, enhancing the data consistency for program requests.

## Is there any existing behavior change of other features due to this code change?
yes

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox- yes
  - Opera Mini
  - Safari
