### PR TITLE
fix:Project Created from Program Request automatically

### DIFF
--- a/beams/beams/doctype/program_request/program_request.js
+++ b/beams/beams/doctype/program_request/program_request.js
@@ -1,36 +1,8 @@
-// // Copyright (c) 2025, efeone and contributors
-// // For license information, please see license.txt
+// Copyright (c) 2025, efeone and contributors
+// For license information, please see license.txt
 
 frappe.ui.form.on('Program Request', {
-    refresh: function (frm) {
-        // Check if a Project exists for this Program Request
-        if (frm.doc.workflow_state === 'Approved') {
-            frappe.call({
-                method: 'beams.beams.doctype.program_request.program_request.check_project_exists',
-                args: { program_request_id: frm.doc.name },
-                callback: function (r) {
-                    if (!r.message) {
-                        // Add the "Create Project" button if no project exists
-                        frm.add_custom_button(__('Create Project'), function () {
-                            frappe.call({
-                                method: 'beams.beams.doctype.program_request.program_request.create_project_from_program_request',
-                                args: { program_request_id: frm.doc.name },
-                                callback: function (r) {
-                                    if (r.message) {
-                                        frappe.set_route('Form', 'Project', r.message);
-                                    }
-                                }
-                            });
-                        }).addClass('btn-primary');
-                    }
-                }
-            });
-        }
-    },
-    start_date: function (frm) {
-        frm.call("validate_start_date_and_end_dates");
-    },
-    end_date: function (frm) {
-        frm.call("validate_start_date_and_end_dates");
-    }
+    // refresh: function (frm) {
+    //
+    // }
 });

--- a/beams/beams/doctype/program_request/program_request.py
+++ b/beams/beams/doctype/program_request/program_request.py
@@ -29,38 +29,40 @@ class ProgramRequest(Document):
                 msg=_("Start Date cannot be after End Date."),
                 title=_("Validation Error")
             )
+    def on_update_after_submit(self):
+        self.create_project_from_program_request()
 
-@frappe.whitelist()
-def create_project_from_program_request(program_request_id):
-    '''
-    Create a Project from the Program Request.
-    '''
-    # Fetch the Program Request document
-    program_request = frappe.get_doc('Program Request', program_request_id)
 
-    # Check if a Project already exists
-    if frappe.db.exists("Project", {"program": program_request_id}):
-        frappe.throw(_("A Project is already linked to this Program Request."))
+    @frappe.whitelist()
+    def create_project_from_program_request(self):
+        '''
+        Create a Project from the Program Request.
+        '''
+        #  Get the current Program Request ID
+        program_request_id = self.name
 
-    # Create a new Project document
-    project = frappe.get_doc({
-        'doctype': 'Project',
-        'project_name': program_request.program_name,
-        'program': program_request.name,
-        'expected_start_date': program_request.start_date,
-        'expected_end_date': program_request.end_date
-    })
-    project.insert(ignore_permissions=True)  # Insert the new Project
+        # Fetch the Program Request document
+        program_request = frappe.get_doc('Program Request', program_request_id)
 
-    # Return the name of the created Project
-    return project.name
+        # Check if a Project already exists
+        if frappe.db.exists("Project", {"program": program_request_id}):
+            frappe.throw(_("A Project is already linked to this Program Request."))
 
-@frappe.whitelist()
-def check_project_exists(program_request_id):
-    '''
-    Check if a Project exists for the given Program Request.
-    '''
-    program_request = frappe.get_doc('Program Request', program_request_id)
-    program_name = program_request.program_name
+        # Create a new Project document
+        project = frappe.get_doc({
+            'doctype': 'Project',
+            'project_name': program_request.program_name,
+            'program': program_request.name,
+            'expected_start_date': program_request.start_date,
+            'expected_end_date': program_request.end_date
+        })
+        project.insert(ignore_permissions=True)  # Insert the new Project
 
-    return frappe.db.exists("Project", {"project_name": program_name})
+        frappe.msgprint(
+            _("Project <b>" + project.project_name + "</b> has been created successfully."),
+            indicator="green",
+            alert=1,
+        )
+
+        # Return the name of the created Project
+        return project.name

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -217,8 +217,8 @@ def get_Project_custom_fields():
                 "insert_after": "sales_order"
             },
             {
-                "fieldname": "program",
-                "label": "Program",
+                "fieldname": "program_request",
+                "label": "Program Request",
                 "fieldtype": "Link",
                 "options": "Program Request",
                 "insert_after": "program_section"
@@ -865,14 +865,6 @@ def get_purchase_invoice_custom_fields():
                 "read_only": 1,
                 "options": "Bureau",
                 "insert_after": "supplier"
-            },
-            {
-                "fieldname": "cost_center",
-                "fieldtype": "Link",
-                "label": "Cost Center",
-                "read_only": 1,
-                "options": "Cost Center",
-                "insert_after": "bureau"
             }
         ]
     }


### PR DESCRIPTION
## Feature description

- [ ] - Create Project from Program Request automatically(Button trigger has to be removed)
- [ ] - Rename Program field in Project as Program Request.

## Solution description

- Project now created from Program Request on approval of workflow.Button trigger was removed.
- Progam field was renamed as Program Request.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/120283ca-3be7-4c9d-80f6-9b46b554f80c)
![image](https://github.com/user-attachments/assets/03a17eab-a444-4ade-97cf-aba2bc9a5b8a)


## Areas affected and ensured
Program Request and Project doctype.

## Is there any existing behavior change of other features due to this code change?
       No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
