### PR TITLE
feat: Update the value of is_edited in Customer doctype

### DIFF
--- a/beams/beams/custom_scripts/customer/customer.py
+++ b/beams/beams/custom_scripts/customer/customer.py
@@ -1,0 +1,22 @@
+import frappe
+from frappe import _
+from frappe.model.document import Document
+
+def set_is_edited_after_insert(doc, method):
+    '''
+    Sets the `is_edited` field to 0 after document insertion
+    '''
+    if hasattr(doc, 'is_edited'):
+        doc.db_set('is_edited', 0)
+
+def validate_customer_workflow(doc, method):
+    '''
+    Marks the document as edited if approved and modified after its creation date
+    '''
+    if doc.workflow_state == "Approved":
+        creation_date = frappe.utils.get_datetime(doc.creation)
+        modified_date = frappe.utils.get_datetime(doc.modified)
+        
+        if creation_date.date() != modified_date.date():
+            if hasattr(doc, 'is_edited'):
+                doc.is_edited = 1

--- a/beams/beams/custom_scripts/customer/customer.py
+++ b/beams/beams/custom_scripts/customer/customer.py
@@ -2,14 +2,14 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 
-def validate_customer_workflow(doc, method):
+def mark_as_edited_if_approved(doc, method):
     '''
     Marks the document as edited if approved and modified after its creation date
     '''
     if doc.workflow_state == "Approved":
-        creation_date = frappe.utils.get_datetime(doc.creation)
-        current_date = frappe.utils.get_datetime(frappe.utils.now())
+        creation_date = frappe.utils.get_date(doc.creation)
+        current_date = frappe.utils.get_date(frappe.utils.now())
 
-        if creation_date.date() != current_date.date():
+        if creation_date != current_date:
             if hasattr(doc, 'is_edited'):
                 doc.is_edited = 1

--- a/beams/beams/custom_scripts/customer/customer.py
+++ b/beams/beams/custom_scripts/customer/customer.py
@@ -2,21 +2,14 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 
-def set_is_edited_after_insert(doc, method):
-    '''
-    Sets the `is_edited` field to 0 after document insertion
-    '''
-    if hasattr(doc, 'is_edited'):
-        doc.db_set('is_edited', 0)
-
 def validate_customer_workflow(doc, method):
     '''
     Marks the document as edited if approved and modified after its creation date
     '''
     if doc.workflow_state == "Approved":
         creation_date = frappe.utils.get_datetime(doc.creation)
-        modified_date = frappe.utils.get_datetime(doc.modified)
-        
-        if creation_date.date() != modified_date.date():
+        current_date = frappe.utils.get_datetime(frappe.utils.now())
+
+        if creation_date.date() != current_date.date():
             if hasattr(doc, 'is_edited'):
                 doc.is_edited = 1

--- a/beams/beams/custom_scripts/customer/customer.py
+++ b/beams/beams/custom_scripts/customer/customer.py
@@ -7,8 +7,8 @@ def mark_as_edited_if_approved(doc, method):
     Marks the document as edited if approved and modified after its creation date
     '''
     if doc.workflow_state == "Approved":
-        creation_date = frappe.utils.get_date(doc.creation)
-        current_date = frappe.utils.get_date(frappe.utils.now())
+        creation_date = frappe.utils.getdate(doc.creation)
+        current_date = frappe.utils.getdate()
 
         if creation_date != current_date:
             if hasattr(doc, 'is_edited'):

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -175,10 +175,7 @@ doc_events = {
         "after_insert": "beams.beams.custom_scripts.account.account.create_todo_on_creation_for_account"
     },
     "Customer": {
-        "after_insert": [
-        "beams.beams.custom_scripts.account.account.create_todo_on_creation_for_customer",
-        "beams.beams.custom_scripts.customer.customer.set_is_edited_after_insert"
-        ],
+        "after_insert": "beams.beams.custom_scripts.account.account.create_todo_on_creation_for_customer",
         "validate": "beams.beams.custom_scripts.customer.customer.validate_customer_workflow"
     },
     "Training Event": {

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -176,7 +176,7 @@ doc_events = {
     },
     "Customer": {
         "after_insert": "beams.beams.custom_scripts.account.account.create_todo_on_creation_for_customer",
-        "validate": "beams.beams.custom_scripts.customer.customer.validate_customer_workflow"
+        "validate": "beams.beams.custom_scripts.customer.customer.mark_as_edited_if_approved"
     },
     "Training Event": {
          "on_update": "beams.beams.custom_scripts.training_event.training_event.on_update",

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -175,7 +175,11 @@ doc_events = {
         "after_insert": "beams.beams.custom_scripts.account.account.create_todo_on_creation_for_account"
     },
     "Customer": {
-        "after_insert": "beams.beams.custom_scripts.account.account.create_todo_on_creation_for_customer"
+        "after_insert": [
+        "beams.beams.custom_scripts.account.account.create_todo_on_creation_for_customer",
+        "beams.beams.custom_scripts.customer.customer.set_is_edited_after_insert"
+        ],
+        "validate": "beams.beams.custom_scripts.customer.customer.validate_customer_workflow"
     },
     "Training Event": {
          "on_update": "beams.beams.custom_scripts.training_event.training_event.on_update",

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -403,6 +403,8 @@ def get_customer_custom_fields():
                 "fieldtype": "Check",
                 "label": "Is Edited",
                 "hidden": 1,
+                "default": 0,
+                "no_copy":1,
                 "insert_after": "is_agent"
             }
         ]


### PR DESCRIPTION
## Feature description
- Set is_edited field to 0 after the document insertion
- Marks the document as edited if approved and modified after its creation date

## Solution description
- The is_edited field was set to 0 after the document was inserted.
- The document was marked as edited if it was approved and modified after its creation date.

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox
