### PR TITLE
TASK-2025-00063 : New fields in program request

### DIFF
--- a/beams/beams/doctype/program_request/program_request.json
+++ b/beams/beams/doctype/program_request/program_request.json
@@ -15,6 +15,11 @@
   "posting_date",
   "start_date",
   "end_date",
+  "estimated_budget",
+  "section_break_gzmf",
+  "bureau",
+  "column_break_afok",
+  "project",
   "section_break_fdx9",
   "description",
   "requirements",
@@ -109,12 +114,37 @@
   {
    "fieldname": "column_break_teaq",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_gzmf",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "bureau",
+   "fieldtype": "Link",
+   "label": "Bureau",
+   "options": "Bureau"
+  },
+  {
+   "fieldname": "project",
+   "fieldtype": "Link",
+   "label": "Project",
+   "options": "Project"
+  },
+  {
+   "fieldname": "column_break_afok",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "estimated_budget",
+   "fieldtype": "Currency",
+   "label": "Estimated Budget"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-01-15 16:42:51.035022",
+ "modified": "2025-01-18 13:19:00.061148",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Program Request",

--- a/beams/beams/doctype/program_request/program_request.py
+++ b/beams/beams/doctype/program_request/program_request.py
@@ -35,6 +35,11 @@ class ProgramRequest(Document):
         Create a Project from the Program Request if the workflow state is 'Approved'.
         """
 
+        # Check if the Program Request already has a linked Project
+        if self.project:
+            frappe.msgprint(_("A Project is already linked to this Program Request: <b>{0}</b>").format(self.project), alert=True)
+            return
+
         # Get current Program Request details
         program_request_id = self.name
         program_request = frappe.get_doc('Program Request', program_request_id)
@@ -65,6 +70,7 @@ class ProgramRequest(Document):
             })
             project.insert(ignore_permissions=True)
 
+            self.db_set('project', project.name)
             frappe.msgprint(_("Project <b>{0}</b> has been created successfully.").format(project.project_name),indicator="green",alert=1,)
 
             return project.name


### PR DESCRIPTION
## Feature description
- Add field bureau and project in program request
- Add Project Link in Program Request on creation of Project from Program Request's Approval
- Bring a validation that if a link exist then no project should create

## Solution description
- Added field bureau , project and budget in program request 
- Whenever a new project is created on approval of program request a link is attached in the field project.
- If a project link  already exist in the field project then no new project is created

## Output screenshots (optional)
[Screencast from 18-01-25 07:17:12 PM IST.webm](https://github.com/user-attachments/assets/a506a572-bbc3-491a-8c2b-a447d77c38ef)



