### PR TITLE
 feat :  Add functionality to create Transportation Request from Project

### DIFF
--- a/beams/beams/custom_scripts/project/project.js
+++ b/beams/beams/custom_scripts/project/project.js
@@ -7,5 +7,12 @@ frappe.ui.form.on('Project', {
                 frm: frm,
             });
         }, __("Create"));
+        // Adds a button to the 'Project' form to create an Transportation Request.
+        frm.add_custom_button(__('Transportation Request'), function () {
+            frappe.model.open_mapped_doc({
+                method: "beams.beams.custom_scripts.project.project.create_transportation_request",
+                frm: frm,
+            });
+        }, __("Create"));
     }
 });

--- a/beams/beams/custom_scripts/project/project.py
+++ b/beams/beams/custom_scripts/project/project.py
@@ -26,3 +26,19 @@ def create_adhoc_budget(source_name, target_doc=None):
         })
     return adhoc_budget
 
+@frappe.whitelist()
+def create_transportation_request(source_name, target_doc=None):
+    """
+    Maps fields from the Project doctype to the Transportation Request doctype'.
+    """
+    transportation_request = get_mapped_doc("Project", source_name, {
+        "Project": {  
+                "doctype": "Transportation Request",  
+                "field_map": {
+                    "name": "project",  
+                    "bureau": "bureau"
+                }
+            }
+    }, target_doc)
+    return transportation_request
+


### PR DESCRIPTION
## Feature description

-  Added a feature to create an Transporation Request from a Project, including mapping relevant fields.

## Solution description

- Implemented the `create_transportation_request` function to map fields from the Project doctype to the Transportation Request doctype.
- Introduced a custom button on the Project form to trigger the creation of the Transportation Request.

## Output screenshots (optional)
[Screencast from 01-21-2025 09:22:42 AM.webm](https://github.com/user-attachments/assets/a444b2f8-0953-44b5-ab77-4783792f80c4)

## Areas affected and ensured

- `Project Doctype`
- `Transportation Request  Doctype`

## Is there any existing behavior change of other features due to this code change?

- No

## Was this feature tested on the browsers?
 - Chrome
