### PR TITLE
feat:Created Technical Support Request from Project

### DIFF
--- a/beams/beams/custom_scripts/project/project.js
+++ b/beams/beams/custom_scripts/project/project.js
@@ -1,12 +1,13 @@
 frappe.ui.form.on('Project', {
-    //function adds a button to the 'Project' form to create an Adhoc Budget.
-    refresh: function (frm) {
+    refresh(frm) {
+      //function adds a button to the 'Project' form to create an Adhoc Budget.
         frm.add_custom_button(__('Adhoc Budget'), function () {
             frappe.model.open_mapped_doc({
                 method: "beams.beams.custom_scripts.project.project.create_adhoc_budget",
                 frm: frm,
             });
         }, __("Create"));
+
         // Adds a button to the 'Project' form to create an Transportation Request.
         frm.add_custom_button(__('Transportation Request'), function () {
             frappe.model.open_mapped_doc({
@@ -14,5 +15,100 @@ frappe.ui.form.on('Project', {
                 frm: frm,
             });
         }, __("Create"));
-    }
-});
+
+
+      // Add "Technical Support Request" button under the "Create" group
+      frm.add_custom_button(__('Technical Support Request'), function () {
+          // Open a dialog with the specified fields
+          let dialog = new frappe.ui.Dialog({
+              title: 'Technical Support Request',
+              fields: [
+                  {
+                      fieldtype: 'Table',
+                      label: 'Requirements',
+                      fieldname: 'requirements',
+                      reqd: 1,
+                      fields: [
+                          {
+                              label: 'Department',
+                              fieldtype: 'Link',
+                              fieldname: 'department',
+                              options: 'Department',
+                              in_list_view: 1,
+                              reqd: 1
+                          },
+                          {
+                              label: 'Designation',
+                              fieldtype: 'Link',
+                              fieldname: 'designation',
+                              options: 'Designation',
+                              in_list_view: 1,
+                              reqd: 1
+                          },
+                          {
+                              label: 'Required From',
+                              fieldtype: 'Datetime',
+                              fieldname: 'required_from',
+                              in_list_view: 1,
+                              reqd: 1
+                          },
+                          {
+                              label: 'Required To',
+                              fieldtype: 'Datetime',
+                              fieldname: 'required_to',
+                              in_list_view: 1,
+                              reqd: 1
+                          },
+                          {
+                              label: 'Remarks',
+                              fieldtype: 'Small Text',
+                              fieldname: 'remarks',
+                              in_list_view: 1
+                          }
+                      ]
+                  }
+              ],
+              size: 'large',
+              primary_action_label: 'Submit',
+              primary_action: function () {
+                  let values = dialog.get_values();
+                  if (values && values.requirements) {
+                      // Perform validation for each row
+                      for (let i = 0; i < values.requirements.length; i++) {
+                          let row = values.requirements[i];
+
+                          if (!row.required_from || !row.required_to) {
+                              frappe.msgprint({
+                                  title: __('Validation Error'),
+                                  message: __('Please fill both "Required From" and "Required To" in #row  {0}.', [i + 1]),
+                                  indicator: 'red'
+                              });
+                              return;
+                          }
+
+                          // Ensure Required To is later than Required From
+                          if (row.required_to <= row.required_from) {
+                              frappe.msgprint({
+                                  title: __('Validation Error'),
+                                  message: __('"Required To" must be later than "Required From" in # row {0}.', [i + 1]),
+                                  indicator: 'red'
+                              });
+                              return;
+                          }
+                      }
+
+                      frappe.call({
+                          method: 'beams.beams.custom_scripts.project.project.create_technical_support_request',
+                          args: {
+                              project_id: frm.doc.name,
+                              requirements: JSON.stringify(values.requirements)
+                          },
+                      });
+                      dialog.hide();
+                  }
+              }
+          });
+          dialog.show();
+        }, __("Create"));
+     }
+  });

--- a/beams/beams/custom_scripts/project/project.py
+++ b/beams/beams/custom_scripts/project/project.py
@@ -1,5 +1,8 @@
 import frappe
 from frappe.model.mapper import get_mapped_doc
+import json
+from frappe import _
+from frappe.utils import nowdate
 
 @frappe.whitelist()
 def create_adhoc_budget(source_name, target_doc=None):
@@ -9,10 +12,10 @@ def create_adhoc_budget(source_name, target_doc=None):
     """
     project_doc = frappe.get_doc('Project', source_name)
     adhoc_budget = get_mapped_doc("Project", source_name, {
-        "Project": {  
-                "doctype": "Adhoc Budget",  
+        "Project": {
+                "doctype": "Adhoc Budget",
                 "field_map": {
-                    "name": "project",  
+                    "name": "project",
                     "expected_start_date": "expected_start_date",
                     "expected_end_date": "expected_end_date",
                     "generates_revenue": "generates_revenue"
@@ -32,13 +35,56 @@ def create_transportation_request(source_name, target_doc=None):
     Maps fields from the Project doctype to the Transportation Request doctype'.
     """
     transportation_request = get_mapped_doc("Project", source_name, {
-        "Project": {  
-                "doctype": "Transportation Request",  
+        "Project": {
+                "doctype": "Transportation Request",
                 "field_map": {
-                    "name": "project",  
+                    "name": "project",
                     "bureau": "bureau"
                 }
             }
     }, target_doc)
     return transportation_request
 
+@frappe.whitelist()
+def create_technical_support_request(project_id, requirements):
+    ''' Create Technical Support Request document '''
+
+    # Parse the JSON input
+    requirements = json.loads(requirements)
+
+    # Validate the Project ID
+    if not frappe.db.exists('Project', project_id):
+        frappe.throw(_("Invalid Project ID: {0}").format(project_id))
+
+    # Fetch Project details
+    project = frappe.get_doc('Project', project_id)
+
+    # Iterate over the requirements and create Technical Support Requests
+    for req in requirements:
+        department = frappe.db.get_value("Department", req['department'], "name")
+        designation = frappe.db.get_value("Designation", req['designation'], "name")
+        bureau =frappe.db.get_value("Project", project_id, "bureau")
+        remarks = req.get('remarks', "")
+        required_from = req.get('required_from')
+        required_to = req.get('required_to')
+
+        # Validate mandatory fields
+        if not department or not designation:
+            frappe.throw(_("Both Department and Designation are required."))
+
+        # Create the Technical Support Request document
+        doc = frappe.get_doc({
+            'doctype': 'Technical Support Request',
+            'project': project_id,
+            'department': department,
+            'designation': designation,
+            'remarks': remarks,
+            'posting_date': nowdate(),
+            'bureau':bureau,
+            'required_from': required_from,
+            'required_to': required_to
+        })
+        doc.insert(ignore_permissions=True)
+        frappe.msgprint(_("Technical Support Request created successfully for project: {0}.").format(project.project_name), indicator="green", alert=1)
+
+    return

--- a/beams/beams/doctype/program_request/program_request.py
+++ b/beams/beams/doctype/program_request/program_request.py
@@ -64,7 +64,7 @@ class ProgramRequest(Document):
             project = frappe.get_doc({
                 'doctype': 'Project',
                 'project_name': program_request.program_name,
-                'program': program_request_id,
+                'program_request': program_request_id,
                 'expected_start_date': program_request.start_date,
                 'expected_end_date': program_request.end_date,
             })

--- a/beams/beams/doctype/technical_support_request/technical_support_request.json
+++ b/beams/beams/doctype/technical_support_request/technical_support_request.json
@@ -30,7 +30,7 @@
    "fieldname": "bureau",
    "fieldtype": "Link",
    "label": "Bureau ",
-   "options": "Project"
+   "options": "Bureau"
   },
   {
    "fieldname": "posting_date",
@@ -92,7 +92,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-01-18 15:26:08.724484",
+ "modified": "2025-01-21 09:45:31.484787",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Technical Support Request",


### PR DESCRIPTION
## Feature description
Add a button in Project to create a  Technical Support Request by taking values from a popup dialog box and create a Technical Support Request.

## Analysis and design (optional)

Add a Button "Technical Support Request" in "Create" group in Project
On click, Show a popup with the following fields:
- Requirements(Table with the below fields):
-- Department (Link/Department)
-- Designation (Link/Designation)
-- Remarks (Small Text)

Once the popup is submitted with values, create Technical Support Request with Each Lines of Table in Background,

## Solution description

- A new button "Technical Support Request" is added in the "Create" group within the Project module.
- Clicking this button opens a popup dialog.
- The popup contains a table with fields for Department, Designation, and Remarks.
- After submitting the form, a background process is triggered to create a new Technical Support Request for each row in the table.

## Output screenshots (optional)

![image](https://github.com/user-attachments/assets/785961c2-9974-4580-8ff2-9ac7eda2b507)
![image](https://github.com/user-attachments/assets/0a76cc87-0c88-4478-bfca-8da050a5e59b)
![image](https://github.com/user-attachments/assets/17e54e69-52a6-4c10-b5cd-44a5cd50a4d7)


## Areas affected and ensured
Project doctype
Technical Support Request doctype.

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox

