### PR TITLE
    TASK-2025-00080:Create Workflow for Equipment Request

### DIFF
--- a/beams/beams/doctype/equipment_hire_request/equipment_hire_request.js
+++ b/beams/beams/doctype/equipment_hire_request/equipment_hire_request.js
@@ -3,10 +3,22 @@
 
 frappe.ui.form.on("Equipment Hire Request", {
     refresh(frm) {
-      frm.add_custom_button(__('Purchase Invoice'), function () {
-          var invoice = frappe.model.get_new_doc("Purchase Invoice");
-          invoice.posting_date = frm.doc.posting_date;
-          frappe.set_route("form", "Purchase Invoice", invoice.name);
-      }, __("Create"));
-    },
+        // Show the 'Purchase Invoice' button only if the document is submitted (docstatus == 1) and approved
+        if (frm.doc.docstatus == 1 && frm.doc.workflow_state == 'Approved') {
+
+            // Create 'Purchase Invoice' button
+            frm.add_custom_button(__('Purchase Invoice'), function () {
+                let invoice = frappe.model.get_new_doc("Purchase Invoice");
+                invoice.posting_date = frm.doc.posting_date; // Set posting date from the current document
+                frappe.set_route("form", "Purchase Invoice", invoice.name); // Redirect to the new Purchase Invoice form
+            }, __("Create"));
+
+            // Create 'Asset Movement' button
+            frm.add_custom_button(__('Asset Movement'), function () {
+                let asset_movement = frappe.model.get_new_doc("Asset Movement");
+                asset_movement.posting_date = frm.doc.posting_date; // Set posting date from the current document
+                frappe.set_route("form", "Asset Movement", asset_movement.name); // Redirect to the new Asset Movement form
+            }, __("Create"));
+        }
+    }
 });

--- a/beams/beams/doctype/equipment_hire_request/equipment_hire_request.json
+++ b/beams/beams/doctype/equipment_hire_request/equipment_hire_request.json
@@ -15,7 +15,9 @@
   "required_from",
   "required_to",
   "section_break_ozsg",
-  "required_items"
+  "required_items",
+  "section_break_tmmn",
+  "reason_for_rejection"
  ],
  "fields": [
   {
@@ -72,12 +74,22 @@
    "fieldtype": "Table",
    "label": "Required Items ",
    "options": "Required Hire Items Detail"
+  },
+  {
+   "fieldname": "section_break_tmmn",
+   "fieldtype": "Section Break"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "reason_for_rejection",
+   "fieldtype": "Small Text",
+   "label": "Reason for Rejection"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-01-18 13:28:12.615351",
+ "modified": "2025-01-20 11:18:53.832670",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Equipment Hire Request",

--- a/beams/fixtures/workflow.json
+++ b/beams/fixtures/workflow.json
@@ -3248,5 +3248,118 @@
   "workflow_data": null,
   "workflow_name": "Shift Swap Request",
   "workflow_state_field": "workflow_state"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Workflow",
+  "document_type": "Equipment Hire Request",
+  "is_active": 1,
+  "modified": "2025-01-21 12:48:26.638641",
+  "name": "Equipment Hire Request",
+  "override_status": 0,
+  "send_email_alert": 0,
+  "states": [
+   {
+    "allow_edit": "Operations User",
+    "avoid_status_override": 0,
+    "doc_status": "0",
+    "is_optional_state": 0,
+    "message": null,
+    "next_action_email_template": null,
+    "parent": "Equipment Hire Request",
+    "parentfield": "states",
+    "parenttype": "Workflow",
+    "state": "Draft",
+    "update_field": null,
+    "update_value": null,
+    "workflow_builder_id": null
+   },
+   {
+    "allow_edit": "Stock Manager",
+    "avoid_status_override": 0,
+    "doc_status": "1",
+    "is_optional_state": 0,
+    "message": null,
+    "next_action_email_template": null,
+    "parent": "Equipment Hire Request",
+    "parentfield": "states",
+    "parenttype": "Workflow",
+    "state": "Pending Approval",
+    "update_field": null,
+    "update_value": null,
+    "workflow_builder_id": null
+   },
+   {
+    "allow_edit": "Stock Manager",
+    "avoid_status_override": 0,
+    "doc_status": "1",
+    "is_optional_state": 0,
+    "message": null,
+    "next_action_email_template": null,
+    "parent": "Equipment Hire Request",
+    "parentfield": "states",
+    "parenttype": "Workflow",
+    "state": "Approved",
+    "update_field": null,
+    "update_value": null,
+    "workflow_builder_id": null
+   },
+   {
+    "allow_edit": "Stock Manager",
+    "avoid_status_override": 0,
+    "doc_status": "1",
+    "is_optional_state": 0,
+    "message": null,
+    "next_action_email_template": null,
+    "parent": "Equipment Hire Request",
+    "parentfield": "states",
+    "parenttype": "Workflow",
+    "state": "Rejected",
+    "update_field": null,
+    "update_value": null,
+    "workflow_builder_id": null
+   }
+  ],
+  "transitions": [
+   {
+    "action": "Request for Approval",
+    "allow_self_approval": 1,
+    "allowed": "Operations User",
+    "condition": null,
+    "next_state": "Pending Approval",
+    "parent": "Equipment Hire Request",
+    "parentfield": "transitions",
+    "parenttype": "Workflow",
+    "state": "Draft",
+    "workflow_builder_id": null
+   },
+   {
+    "action": "Approve",
+    "allow_self_approval": 1,
+    "allowed": "Stock Manager",
+    "condition": null,
+    "next_state": "Approved",
+    "parent": "Equipment Hire Request",
+    "parentfield": "transitions",
+    "parenttype": "Workflow",
+    "state": "Pending Approval",
+    "workflow_builder_id": null
+   },
+   {
+    "action": "Reject",
+    "allow_self_approval": 1,
+    "allowed": "Stock Manager",
+    "condition": "doc.reason_for_rejection",
+    "next_state": "Rejected",
+    "parent": "Equipment Hire Request",
+    "parentfield": "transitions",
+    "parenttype": "Workflow",
+    "state": "Pending Approval",
+    "workflow_builder_id": null
+   }
+  ],
+  "workflow_data": null,
+  "workflow_name": "Equipment Hire Request",
+  "workflow_state_field": "workflow_state"
  }
 ]

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -397,7 +397,7 @@ override_doctype_dashboards = {
 # }
 fixtures = [
     {"dt": "Workflow", "filters": [
-        ["name", "in", ["Customer Approval", "Account Approval", "Adhoc Budget","Supplier Approval", "Purchase Order Approval" , "Budget Approval" , "Batta Claim Approval","Purchase Invoice Workflow","Sales Invoice Approval","Stringer Bill Approval","Material Request Approval","Substitute Booking","Contract","Job Requisition Workflow","Enquiry Workflow","Job Proposal Workflow","Maternity Leave Request", "Shift Swap Request","Program Request Workflow","Transportation Request Workflow"]]
+        ["name", "in", ["Customer Approval", "Account Approval", "Adhoc Budget","Supplier Approval", "Purchase Order Approval" , "Budget Approval" , "Batta Claim Approval","Purchase Invoice Workflow","Sales Invoice Approval","Stringer Bill Approval","Material Request Approval","Substitute Booking","Contract","Job Requisition Workflow","Enquiry Workflow","Job Proposal Workflow","Maternity Leave Request", "Shift Swap Request","Program Request Workflow","Transportation Request Workflow","Equipment Hire Request"]]
     ]},
     {"dt": "Workflow State", "filters": [
         ["name", "in", ["Draft", "Pending Approval", "Approved", "Rejected", "Pending Finance Verification", "Verified By Finance","Rejected By Finance", "Pending Finance Approval", "Approved by Finance","Submitted","Cancelled","Completed","On Hold","Assigned to Enquiry Officer","Assigned to Admin","Enquiry on Progress","Applicant Accepted","Applicant Rejected","Pending HOD Approval","Pending HR Approval","Pending CEO Approval", "Pending CEO Final Approval","Closed"]]


### PR DESCRIPTION
## Feature description
      Added Equipment Hire Request workflow with states and transitions

## Solution description
      Added workflow states and transitions for Equipment Request
      Added 'Reason for Rejection' field and validation before rejection
      Created Asset Movement on approval

## Output screenshots (optional)

![image](https://github.com/user-attachments/assets/7c42ed70-2dc3-4263-85e8-cb60720cdcef)
![image](https://github.com/user-attachments/assets/fa8dd43f-f594-497a-a0f9-eb5184db2fe3)
![image](https://github.com/user-attachments/assets/a47d304d-1c6b-4f49-bd22-31576f1a0992)

[Screencast from 21-01-25 01:08:30 PM IST.webm](https://github.com/user-attachments/assets/7da2f581-4318-428c-b196-dbe54142a141)

[Screencast from 21-01-25 01:10:52 PM IST.webm](https://github.com/user-attachments/assets/1b9d03a6-2b38-49a9-843f-0890bedba3dd)


## Areas affected and ensured
      Equipment Hire Request Doctype

## Is there any existing behavior change of other features due to this code change?
      No

## Was this feature tested on the browsers?
      Mozilla Firefox
 