### PR TITLE
TASK-2025-00089:Updated No of hired vehicles in Transportation Request

### DIFF
--- a/beams/beams/doctype/required_hired_vehicle_detail/required_hired_vehicle_detail.json
+++ b/beams/beams/doctype/required_hired_vehicle_detail/required_hired_vehicle_detail.json
@@ -44,14 +44,14 @@
    "fieldname": "no_of_vehicles",
    "fieldtype": "Int",
    "in_list_view": 1,
-   "label": "No.of Vehicles"
+   "label": "No. of Vehicles"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-01-21 12:17:37.564534",
+ "modified": "2025-01-21 15:07:05.956872",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Required Hired Vehicle Detail",

--- a/beams/beams/doctype/required_hired_vehicle_detail/required_hired_vehicle_detail.json
+++ b/beams/beams/doctype/required_hired_vehicle_detail/required_hired_vehicle_detail.json
@@ -8,7 +8,7 @@
   "section_break_iy51",
   "amended_from",
   "vehicle_type",
-  "noof_vehicles",
+  "no_of_vehicles",
   "license_plates"
  ],
  "fields": [
@@ -34,24 +34,24 @@
    "options": "Vehicle Type"
   },
   {
-   "fieldname": "noof_vehicles",
-   "fieldtype": "Int",
-   "in_list_view": 1,
-   "label": "No.of Vehicles"
-  },
-  {
    "allow_on_submit": 1,
    "fieldname": "license_plates",
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "License Plate(s)"
+  },
+  {
+   "fieldname": "no_of_vehicles",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "No.of Vehicles"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-01-18 15:58:19.804387",
+ "modified": "2025-01-21 12:17:37.564534",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Required Hired Vehicle Detail",

--- a/beams/beams/doctype/transportation_request/transportation_request.json
+++ b/beams/beams/doctype/transportation_request/transportation_request.json
@@ -18,6 +18,7 @@
   "requirements",
   "vehicles",
   "no_of_own_vehicles",
+  "no_of_hired_vehicles",
   "reason_for_rejection",
   "amended_from"
  ],
@@ -103,12 +104,18 @@
    "fieldname": "reason_for_rejection",
    "fieldtype": "Small Text",
    "label": "Reason for Rejection"
+  },
+  {
+   "fieldname": "no_of_hired_vehicles",
+   "fieldtype": "Int",
+   "label": "No of Hired Vehicles",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-01-20 13:21:57.993618",
+ "modified": "2025-01-21 13:10:03.648231",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Transportation Request",

--- a/beams/beams/doctype/vehicle_hire_request/vehicle_hire_request.py
+++ b/beams/beams/doctype/vehicle_hire_request/vehicle_hire_request.py
@@ -1,9 +1,42 @@
 # Copyright (c) 2025, efeone and contributors
 # For license information, please see license.txt
-
-# import frappe
+import frappe
 from frappe.model.document import Document
 
-
 class VehicleHireRequest(Document):
-	pass
+    def on_submit(self):
+        self.update_hired_vehicles_on_submit()
+
+    def on_cancel(self):
+        self.update_hired_vehicles_on_cancel()
+
+    def update_hired_vehicles_on_submit(self):
+        '''
+        Calculate the total number of vehicles from the required_vehicles child table
+        and update the linked Transportation Request.
+        '''
+        if self.required_vehicles:
+            # Calculate the total number of vehicles
+            total_vehicles = sum(row.no_of_vehicles or 0 for row in self.required_vehicles)
+
+            # Update the Transportation Request
+            if self.transportation_request:
+                frappe.db.set_value(
+                    "Transportation Request",
+                    self.transportation_request,
+                    "no_of_hired_vehicles",
+                    total_vehicles
+                )
+
+    def update_hired_vehicles_on_cancel(self):
+        '''
+        On  cancellation of Transportation Request reset the number of hired vehicles
+
+		'''
+        if self.transportation_request:
+            frappe.db.set_value(
+                "Transportation Request",
+                self.transportation_request,
+                "no_of_hired_vehicles",
+                0
+            )


### PR DESCRIPTION
## Feature description
Update No. of Hired Vehicles in Transportation Request on submission of Vehicle Hire Request.

## Solution description

- This update introduces logic to manage the no_of_hired_vehicles field in the linked Transportation Request document.
- On submitting a Vehicle Hire Request, the system will calculate the total number of vehicles from the required_vehicles child table and update the Transportation Request accordingly.
- On canceling a Vehicle Hire Request, the number of hired vehicles in the associated Transportation Request will be reset to 0.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/39e68fa6-a687-49b3-b348-570090d4a3f4)
![image](https://github.com/user-attachments/assets/03e7295b-dc88-4ca3-986f-2e53a40f6989)


## Areas affected and ensured
Transportation Request.

## Is there any existing behavior change of other features due to this code change?
      No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox

