### PR TITLE
feat:Updating Budget in Project on Approval of Adhoc Budget

### DIFF
--- a/beams/beams/doctype/adhoc_budget/adhoc_budget.py
+++ b/beams/beams/doctype/adhoc_budget/adhoc_budget.py
@@ -15,6 +15,7 @@ class AdhocBudget(Document):
     def on_update_after_submit(self):
         self.create_todo_on_verified_by_finance()
 
+
     def validate(self):
         self.validate_expected_revenue()
 
@@ -65,6 +66,7 @@ class AdhocBudget(Document):
                     })
 
     def on_submit(self):
+        self.update_project_budget_on_approval()
         if self.workflow_state == 'Approved':
             self.create_budget_from_adhoc_budget()
 
@@ -138,3 +140,20 @@ class AdhocBudget(Document):
 
         if  not self.expected_revenue > 0:
             frappe.throw(_("Expected Revenue should be greater than zero."))
+
+
+
+
+    def update_project_budget_on_approval(self):
+        """
+         Update the approved budget in the associated Project when the Adhoc Budget workflow state is 'Approved'.
+        """
+        if self.workflow_state == 'Approved':
+            project = self.project
+            if frappe.db.exists('Project', project):
+                project_doc = frappe.get_doc('Project', project)
+                current_approved_budget = project_doc.approved_budget or 0
+                new_approved_budget = current_approved_budget + self.total_budget_amount
+                project_doc.approved_budget = new_approved_budget
+                project_doc.save()
+                frappe.db.commit()

--- a/beams/beams/doctype/adhoc_budget/adhoc_budget.py
+++ b/beams/beams/doctype/adhoc_budget/adhoc_budget.py
@@ -15,7 +15,6 @@ class AdhocBudget(Document):
     def on_update_after_submit(self):
         self.create_todo_on_verified_by_finance()
 
-
     def validate(self):
         self.validate_expected_revenue()
 
@@ -141,9 +140,6 @@ class AdhocBudget(Document):
         if  not self.expected_revenue > 0:
             frappe.throw(_("Expected Revenue should be greater than zero."))
 
-
-
-
     def update_project_budget_on_approval(self):
         """
          Update the approved budget in the associated Project when the Adhoc Budget workflow state is 'Approved'.
@@ -156,4 +152,4 @@ class AdhocBudget(Document):
                 new_approved_budget = current_approved_budget + self.total_budget_amount
                 project_doc.approved_budget = new_approved_budget
                 project_doc.save()
-                frappe.db.commit()
+                


### PR DESCRIPTION
## Feature description
Update the approved budget in the associated Project when the Adhoc Budget workflow state is 'Approved'.


## Solution description
-  Verify the Adhoc Budget's `workflow_state` is 'Approved'.
-  Check if the associated Project exists in the database.
-  Fetch the Project document and ensure the `approved_budget` field is valid (default to 0 if None).
-  Add the Adhoc Budget's `total_budget_amount` to the Project's `approved_budget`.
-  Save the updated Project document and commit the changes to the database.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/6633b22f-6e82-4673-8c6e-39c4fcc6e2a9)
![image](https://github.com/user-attachments/assets/aa220222-bdd1-4a50-b5f7-cf20704555c1)
![image](https://github.com/user-attachments/assets/b9c71d8b-731f-42f9-834a-255c87de1f14)


## Areas affected and ensured
Project doctype,Adhoc Budget 

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox- yes 
  - Opera Mini
  - Safari
