### PR TITLE
feat:validation for Reason for Rejection ,  vehicles child table set to editable 

### DIFF
--- a/beams/beams/doctype/transportation_request/transportation_request.js
+++ b/beams/beams/doctype/transportation_request/transportation_request.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2025, efeone and contributors
 // For license information, please see license.txt
 frappe.ui.form.on("Transportation Request", {
-    refresh(frm) {
+    refresh: function (frm) {
         // Show the "Purchase Invoice" button only if the status is "Approved"
         if (frm.doc.workflow_state === "Approved") {
             frm.add_custom_button(__('Purchase Invoice'), function () {
@@ -20,12 +20,20 @@ frappe.ui.form.on("Transportation Request", {
                 });
             }, __("Create"));
         }
-        // Show or hide the child table "vehicles" based on whether the form is new
-        if (!frm.is_new() || frm.doc.workflow_state === "Pending Approval") {
-            frm.set_df_property("vehicles", "hidden", false);
-        } else {
-            frm.set_df_property("vehicles", "hidden", true);
-        }
 
+        // Toggle read-only state of "vehicles" child table based on workflow state
+        if (frm.doc.workflow_state === "Pending Approval") {
+            frm.set_df_property("vehicles", "read_only", false);
+        } else {
+            frm.set_df_property("vehicles", "read_only", true);
+        }
+    },
+
+    // Event handlers for the child table "vehicles"
+    vehicles_add: function (frm, cdt, cdn) {
+        frm.set_value("no_of_own_vehicles", frm.doc.vehicles.length);
+    },
+    vehicles_remove: function (frm, cdt, cdn) {
+        frm.set_value("no_of_own_vehicles", frm.doc.vehicles.length);
     },
 });

--- a/beams/beams/doctype/transportation_request/transportation_request.js
+++ b/beams/beams/doctype/transportation_request/transportation_request.js
@@ -20,9 +20,8 @@ frappe.ui.form.on("Transportation Request", {
                 });
             }, __("Create"));
         }
-
         // Show or hide the child table "vehicles" based on whether the form is new
-        if (!frm.is_new()) {
+        if (!frm.is_new() || frm.doc.workflow_state === "Pending Approval") {
             frm.set_df_property("vehicles", "hidden", false);
         } else {
             frm.set_df_property("vehicles", "hidden", true);

--- a/beams/beams/doctype/transportation_request/transportation_request.json
+++ b/beams/beams/doctype/transportation_request/transportation_request.json
@@ -70,6 +70,7 @@
    "label": "Requirements"
   },
   {
+   "allow_on_submit": 1,
    "fieldname": "vehicles",
    "fieldtype": "Table",
    "label": "Vehicles",
@@ -115,7 +116,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-01-21 13:10:03.648231",
+ "modified": "2025-01-22 09:48:29.790282",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Transportation Request",

--- a/beams/beams/doctype/transportation_request/transportation_request.json
+++ b/beams/beams/doctype/transportation_request/transportation_request.json
@@ -77,6 +77,7 @@
    "options": "Vehicle Detail"
   },
   {
+   "allow_on_submit": 1,
    "fieldname": "no_of_own_vehicles",
    "fieldtype": "Int",
    "label": "No.of Own Vehicles",
@@ -116,7 +117,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-01-22 09:48:29.790282",
+ "modified": "2025-01-22 10:31:51.454439",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Transportation Request",

--- a/beams/beams/doctype/transportation_request/transportation_request.py
+++ b/beams/beams/doctype/transportation_request/transportation_request.py
@@ -6,7 +6,13 @@ from frappe.model.mapper import get_mapped_doc
 
 
 class TransportationRequest(Document):
-    def validate(self):
+
+    def on_cancel(self):
+        # Validate that "Reason for Rejection" is filled if the status is "Rejected"
+        if self.workflow_state == "Rejected" and not self.reason_for_rejection:
+            frappe.throw("Please provide a Reason for Rejection before rejecting this request.")
+
+    def on_change(self):
         self.update_no_of_own_vehicles()
 
     def update_no_of_own_vehicles(self):

--- a/beams/beams/doctype/transportation_request/transportation_request.py
+++ b/beams/beams/doctype/transportation_request/transportation_request.py
@@ -12,7 +12,7 @@ class TransportationRequest(Document):
         if self.workflow_state == "Rejected" and not self.reason_for_rejection:
             frappe.throw("Please provide a Reason for Rejection before rejecting this request.")
 
-    def on_change(self):
+    def before_update_after_submit(self):
         self.update_no_of_own_vehicles()
 
     def update_no_of_own_vehicles(self):
@@ -20,10 +20,8 @@ class TransportationRequest(Document):
         Calculate the total number of rows in the "Vehicles" child table
         and update the "No. of Own Vehicles" field.
         '''
-        # Count the rows in the "vehicles" child table
+        # Always calculate and update the value regardless of the state
         total_vehicles = len(self.vehicles or [])
-
-        # Update the "no_of_own_vehicles" field
         self.no_of_own_vehicles = total_vehicles
 
 


### PR DESCRIPTION

## Feature description
validation for Reason for Rejection is filled if the status is Rejected and vehicles child table set to editable when Pending Approval state


## Solution description
-  validation for Reason for Rejection is filled if the status is Rejected
- checked to allow on submit of vehicles in transportation request,allow_on_submit 
- vehicles child table set to editable  in transportation request
- Calculate the total number of rows in the "Vehicles" child table  and update the "No. of Own Vehicles" field  in the pending approval state too

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/ca929115-e35c-4a47-be82-e89047457dff)
![image](https://github.com/user-attachments/assets/2c15b615-d506-4ea0-a179-c5935f9c3c81)
![image](https://github.com/user-attachments/assets/6eea2983-238f-429c-9198-6ad86fca9fa5)
![image](https://github.com/user-attachments/assets/8f6b12d6-afac-4421-8dea-17d74ec1db2b)


## Areas affected and ensured
transportation request and its doctype

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox-yes
  - Opera Mini
  - Safari
