### PR TITLE
feat:Add a button in Award Record to Create JV against the total amont

### DIFF
--- a/beams/beams/doctype/award_record/award_record.js
+++ b/beams/beams/doctype/award_record/award_record.js
@@ -1,6 +1,45 @@
 // Copyright (c) 2025, efeone and contributors
 // For license information, please see license.txt
 
+frappe.ui.form.on('Award Record', {
+    refresh: function (frm) {
+        if (!frm.is_new() && frm.doc.total_amount > 0) {
+            frm.add_custom_button(__('Create Journal Voucher'), function () {
+                create_jv(frm);
+            }, __('Actions'));
+        }
+    }
+});
+
+function create_jv(frm) {
+    // Fetch Default Award Expense Account from BEAMS Admin Settings
+    frappe.call({
+        method: 'frappe.client.get',
+        args: {
+            doctype: 'BEAMS Admin Settings'
+        },
+        callback: function (r) {
+            if (r.message && r.message.default_award_expense_account) {
+                const default_account = r.message.default_award_expense_account;
+
+                // Create a new Journal Entry
+                frappe.new_doc('Journal Entry', {
+                    voucher_type: 'Journal Entry',
+                    accounts: [
+                        {
+                            account: default_account,
+                            debit_in_account_currency: frm.doc.total_amount
+                        }
+                    ],
+                    user_remark: `Award Record: ${frm.doc.name}`
+                });
+            } else {
+                frappe.msgprint(__('Please set the Default Award Expense Account in BEAMS Admin Settings.'));
+            }
+        }
+    });
+}
+
 frappe.ui.form.on("Award Expense Detail", {
     amount: function (frm) {
         frm.call("update_total_amount");

--- a/beams/beams/doctype/beams_admin_settings/beams_admin_settings.js
+++ b/beams/beams/doctype/beams_admin_settings/beams_admin_settings.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, efeone and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("BEAMS Admin Settings", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/beams/beams/doctype/beams_admin_settings/beams_admin_settings.json
+++ b/beams/beams/doctype/beams_admin_settings/beams_admin_settings.json
@@ -1,0 +1,43 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-01-23 12:22:12.615425",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "default_award_expense_account"
+ ],
+ "fields": [
+  {
+   "fieldname": "default_award_expense_account",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": " Default Award Expense Account",
+   "options": "Account",
+   "reqd": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "issingle": 1,
+ "links": [],
+ "modified": "2025-01-23 12:24:10.828869",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "BEAMS Admin Settings",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/beams/beams/doctype/beams_admin_settings/beams_admin_settings.py
+++ b/beams/beams/doctype/beams_admin_settings/beams_admin_settings.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class BEAMSAdminSettings(Document):
+	pass

--- a/beams/beams/doctype/beams_admin_settings/test_beams_admin_settings.py
+++ b/beams/beams/doctype/beams_admin_settings/test_beams_admin_settings.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, efeone and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestBEAMSAdminSettings(FrappeTestCase):
+	pass


### PR DESCRIPTION

## Feature description
[TASK-2025-00127] - Add a button in the Award Record to Create JV against the total amount in the Award Record

## Solution description
- created "BEAMS Admin Settings": with - Default Award Expense Account (Link/Account)* fields 
- .Add a "Create Journal Voucher" button to the **Award Record** DocType, visible when `total_amount` > 0.  
- fetch the **Default Award Expense Account** from the **BEAMS Admin Settings **
- Automatically create a **Journal Entry (JV)** with the fetched account as the debit account, a credit account from the **Award Record**, and the `total_amount`.  

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/ab2dd02b-0b37-47c9-9971-fae500164386)

![image](https://github.com/user-attachments/assets/38553746-1ade-4cfb-a9f6-17ebfac79a43)
![image](https://github.com/user-attachments/assets/cb027c11-f7f0-4c87-936b-cd2dcca8b670)

List out the areas affected by your code changes.
- Award Record DocType
- BEAMS Admin Settings DocType
- Journal Entry DocType
## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox-yes
  - Opera Mini
  - Safari
