### PR TITLE
fix: removed requested by custom field in job req

### DIFF
--- a/beams/setup.py
+++ b/beams/setup.py
@@ -1513,13 +1513,6 @@ def get_job_requisition_custom_fields():
                 "depends_on": "eval:doc.request_for == 'Employee Replacement'"
             },
             {
-                "fieldname": "requested_by",
-                "label": "Requested By",
-                "fieldtype": "Link",
-                "options": "Employee",
-                "insert_after": "employee_left"
-            },
-            {
                 "fieldname": "interview",
                 "fieldtype": "Section Break",
                 "label": "Interview Details",


### PR DESCRIPTION
## Issue description
Duplicate field issue during installation:
requested_by field in Job Requisition

## Solution description
Removed requested by custom field in job requisition in setup

## Areas affected and ensured
setup.py

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - Yes
  - Opera Mini
  - Safari
