### PR TITLE
feat:validation for Technical Request

### DIFF
--- a/beams/beams/doctype/technical_request/technical_request.js
+++ b/beams/beams/doctype/technical_request/technical_request.js
@@ -27,6 +27,13 @@ frappe.ui.form.on('Technical Request', {
     workflow_state: function(frm) {
         // Trigger visibility logic when the workflow state changes
         toggle_reason_for_rejection_field(frm);
+    },
+    // Trigger validation when the "required_from" field is updated
+    required_from: function (frm) {
+        frm.call("validate_required_from_and_required_to");
+    },
+    required_to: function (frm) {
+        frm.call("validate_required_from_and_required_to");
     }
 });
 

--- a/beams/beams/doctype/technical_request/technical_request.json
+++ b/beams/beams/doctype/technical_request/technical_request.json
@@ -30,6 +30,7 @@
    "reqd": 1
   },
   {
+   "fetch_from": "project.bureau",
    "fieldname": "bureau",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -114,7 +115,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-01-22 14:40:16.380805",
+ "modified": "2025-01-24 09:48:25.425153",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Technical Request",

--- a/beams/beams/doctype/technical_request/technical_request.py
+++ b/beams/beams/doctype/technical_request/technical_request.py
@@ -1,11 +1,35 @@
 # Copyright (c) 2025, efeone and contributors
 # For license information, please see license.txt
 
-from frappe.model.document import Document
 import frappe
+from frappe.model.document import Document
+from frappe.utils import getdate
+from frappe import _  # Import _ for translations
+
 
 class TechnicalRequest(Document):
     def on_cancel(self):
         # Validate that "Reason for Rejection" is filled if the status is "Rejected"
         if self.workflow_state == "Rejected" and not self.reason_for_rejection:
             frappe.throw("Please provide a Reason for Rejection before rejecting this request.")
+
+    def validate(self):
+        self.validate_required_from_and_required_to()
+
+    @frappe.whitelist()
+    def validate_required_from_and_required_to(self):
+        """
+        Validates that required_from and required_to are properly set and checks
+        if required_from is not later than required_to.
+        """
+        if not self.required_from or not self.required_to:
+            return
+        # Convert dates to proper date objects
+        required_from = getdate(self.required_from)
+        required_to = getdate(self.required_to)
+
+        if required_from > required_to:
+            frappe.throw(
+                msg=_("Required From cannot be after Required To."),
+                title=_("Validation Error")
+            )

--- a/beams/beams/doctype/technical_request/technical_request.py
+++ b/beams/beams/doctype/technical_request/technical_request.py
@@ -31,5 +31,5 @@ class TechnicalRequest(Document):
         if required_from > required_to:
             frappe.throw(
                 msg=_("Required From cannot be after Required To."),
-                title=_("Validation Error")
+                title=_("Message")
             )


### PR DESCRIPTION
## Feature description
- validation for Technical Request
- Fetch Bureau  from project to Technical Request


## Solution description
- A validate method is implemented in the TechnicalRequest DocType to enforce validation logic whenever the document is saved.
- The solution adds client-side validation triggers for the required_from and required_to fields in the TechnicalRequest form.
-  Fetch Bureau  from project to Technical Request


## Output screenshots (optional)

![image](https://github.com/user-attachments/assets/13aa6aaa-7453-4d19-9da0-421a7a10abea)


## Areas affected and ensured
- Technical Request

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox-yes
  - Opera Mini
  - Safari
