### PR TITLE
TASK-2025-00098 : Cancellation of stock entry on cancel of makeup consumption entry

### DIFF
--- a/beams/beams/doctype/makeup_consumption_entry/makeup_consumption_entry.json
+++ b/beams/beams/doctype/makeup_consumption_entry/makeup_consumption_entry.json
@@ -11,6 +11,7 @@
   "cost_center",
   "column_break_tabr",
   "posting_date",
+  "stock_entry",
   "section_break_rqhw",
   "items",
   "remarks",
@@ -67,12 +68,19 @@
    "print_hide": 1,
    "read_only": 1,
    "search_index": 1
+  },
+  {
+   "fieldname": "stock_entry",
+   "fieldtype": "Link",
+   "label": "Stock Entry",
+   "options": "Stock Entry",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-01-21 15:49:50.198242",
+ "modified": "2025-01-24 10:24:04.549004",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Makeup Consumption Entry",

--- a/beams/beams/doctype/makeup_consumption_entry/makeup_consumption_entry.py
+++ b/beams/beams/doctype/makeup_consumption_entry/makeup_consumption_entry.py
@@ -5,16 +5,18 @@ import frappe
 from frappe.model.document import Document
 from frappe import _
 
-
 class MakeupConsumptionEntry(Document):
 
     def on_submit(self):
         self.create_stock_entry()
 
+    def on_cancel(self):
+        self.cancel_stock_entry()
+
     def create_stock_entry(self):
         '''
         Creates a Stock Entry (Material Issue) for the items listed
-        in the Makeup Consumption Entry document.
+        in the Makeup Consumption Entry document and links it.
         '''
         # Create a new Stock Entry
         stock_entry = frappe.new_doc("Stock Entry")
@@ -26,12 +28,27 @@ class MakeupConsumptionEntry(Document):
                 "item_code": item.item_code,
                 "qty": item.qty,
                 "s_warehouse": self.source_warehouse,
-                "allow_zero_valuation_rate": 1,
             })
 
         # Save and Submit the Stock Entry
         stock_entry.insert()
         stock_entry.submit()
 
+        # Link the Stock Entry to the current Makeup Consumption Entry
+        self.db_set("stock_entry", stock_entry.name)
+
         # Notify user
-        frappe.msgprint("Stock entry created successfully.", alert=True)
+        frappe.msgprint(_("Stock entry {0} created successfully.").format(stock_entry.name), alert=True)
+
+    def cancel_stock_entry(self):
+        '''
+        Cancels the linked Stock Entry when the Makeup Consumption Entry is canceled.
+        '''
+        if self.stock_entry:
+            # Fetch the linked Stock Entry
+            stock_entry = frappe.get_doc("Stock Entry", self.stock_entry)
+
+            # Cancel the Stock Entry if its status is Submitted
+            if stock_entry.docstatus == 1:  # 1 means Submitted
+                stock_entry.cancel()
+                frappe.msgprint(_("Linked Stock Entry {0} has been canceled.").format(self.stock_entry), alert=True)


### PR DESCRIPTION
## Feature description
- Add a field stock entry in makeup consumption entry that link to corresponding stock entry
- On cancel of makeup consumption entry cancel the corresponding stock entry

## Solution description
- A new link field added and set as read only
- On submission of makeup consumption entry a stock entry is created and that is linked to the field
- On cancellation of makeup consumption entry the corresponding stock is cancelled

## Output screenshots (optional)
[Screencast from 24-01-25 10:36:33 AM IST.webm](https://github.com/user-attachments/assets/e9c47cac-1356-494f-9c70-819468bf410c)



