### PR TITLE
feat:TASK-2025-00146-Created DocType Visitor Pass and its validation

### DIFF
--- a/beams/beams/doctype/inward_register/inward_register.js
+++ b/beams/beams/doctype/inward_register/inward_register.js
@@ -1,8 +1,17 @@
 // Copyright (c) 2025, efeone and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Inward Register", {
-// 	refresh(frm) {
-
-// 	},
-// });
+frappe.ui.form.on("Inward Register", {
+    refresh: function (frm) {
+        if (frm.doc.docstatus === 1) {  // Show the button only if the document is submitted (docstatus === 1)
+            frm.add_custom_button(__('Create Visitor Pass'), function () {
+                frappe.new_doc("Visitor Pass", {
+                    inward_register: frm.doc.name,  // Link the current Inward Register
+                    issued_date: frappe.datetime.now_date(),  // Set default issued date to today
+                    issued_time: frappe.datetime.now_time(),  // Set default issued time to now
+                    issued_to: frm.doc.visitor_name  // Fetch the visitor name
+                });
+            });
+        }
+    }
+});

--- a/beams/beams/doctype/visitor_pass/test_visitor_pass.py
+++ b/beams/beams/doctype/visitor_pass/test_visitor_pass.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, efeone and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestVisitorPass(FrappeTestCase):
+	pass

--- a/beams/beams/doctype/visitor_pass/visitor_pass.js
+++ b/beams/beams/doctype/visitor_pass/visitor_pass.js
@@ -1,0 +1,21 @@
+// Copyright (c) 2025, efeone and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on("Visitor Pass", {
+  issued_date: function (frm) {
+      frm.call("validate_issued_date_and_expire_on");
+      frm.call("validate_issued_date_and_returned_date");
+
+  },
+  expire_on: function (frm) {
+      frm.call("validate_issued_date_and_expire_on");
+  },
+  returned_date:function(frm){
+    frm.call("validate_issued_date_and_returned_date");
+
+  }
+
+	// refresh(frm) {
+  //
+	// },
+});

--- a/beams/beams/doctype/visitor_pass/visitor_pass.js
+++ b/beams/beams/doctype/visitor_pass/visitor_pass.js
@@ -15,7 +15,4 @@ frappe.ui.form.on("Visitor Pass", {
 
   }
 
-	// refresh(frm) {
-  //
-	// },
 });

--- a/beams/beams/doctype/visitor_pass/visitor_pass.json
+++ b/beams/beams/doctype/visitor_pass/visitor_pass.json
@@ -1,0 +1,112 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "format:VS-{YY}-{#####}",
+ "creation": "2025-01-24 10:53:50.771157",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "section_break_nrae",
+  "inward_register",
+  "issued_date",
+  "issued_time",
+  "issued_to",
+  "column_break_eucm",
+  "expire_on",
+  "returned_date",
+  "returned_time",
+  "amended_from"
+ ],
+ "fields": [
+  {
+   "fieldname": "section_break_nrae",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "Visitor Pass",
+   "print_hide": 1,
+   "read_only": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "inward_register",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Inward Register ",
+   "options": "Inward Register",
+   "reqd": 1
+  },
+  {
+   "default": "Today",
+   "fieldname": "issued_date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "Issued Date",
+   "reqd": 1
+  },
+  {
+   "default": "Now",
+   "fieldname": "issued_time",
+   "fieldtype": "Time",
+   "in_list_view": 1,
+   "label": "Issued Time",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "inward_register.vistor_name",
+   "fieldname": "issued_to",
+   "fieldtype": "Data",
+   "label": "Issued To"
+  },
+  {
+   "fieldname": "expire_on",
+   "fieldtype": "Datetime",
+   "label": "Expire on "
+  },
+  {
+   "fieldname": "returned_date",
+   "fieldtype": "Date",
+   "label": "Returned Date "
+  },
+  {
+   "fieldname": "returned_time",
+   "fieldtype": "Time",
+   "label": "Returned Time "
+  },
+  {
+   "fieldname": "column_break_eucm",
+   "fieldtype": "Column Break"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "is_submittable": 1,
+ "links": [],
+ "modified": "2025-01-24 13:32:13.778424",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "Visitor Pass",
+ "naming_rule": "Expression",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/beams/beams/doctype/visitor_pass/visitor_pass.py
+++ b/beams/beams/doctype/visitor_pass/visitor_pass.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2025, efeone and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe import _
+from frappe.utils import getdate
+from frappe.model.document import Document
+
+
+class VisitorPass(Document):
+
+    def validate(self):
+        self.validate_issued_date_and_expire_on()
+        self.validate_issued_date_and_returned_date()
+
+    @frappe.whitelist()
+    def validate_issued_date_and_expire_on(self):
+        """
+        Validates that issued_date and expire_on are properly set and checks
+        if issued_date is not later than expire_on.
+        """
+        if not self.issued_date or not self.expire_on:
+            return
+        # Convert dates to proper date objects
+        issued_date = getdate(self.issued_date)
+        expire_on = getdate(self.expire_on)
+
+        if issued_date > expire_on:
+            frappe.throw(
+                msg=_("Issued Date cannot be after Expire On."),
+                title=_("Message")
+            )
+    @frappe.whitelist()
+    def validate_issued_date_and_returned_date(self):
+        """
+        Validates that issued_date and returned_date are properly set and checks
+        if issued_date is not later than returned_date.
+        """
+        if not self.issued_date or not self.returned_date:
+            return
+        # Convert dates to proper date objects
+        issued_date = getdate(self.issued_date)
+        returned_date = getdate(self.returned_date)
+
+        if issued_date > returned_date:
+            frappe.throw(
+                msg=_("Issued Date cannot be after Returned Date."),
+                title=_("Message")
+            )


### PR DESCRIPTION
## Feature description
Created DocType Visitor Pass and its validation

## Solution description
- Created a **DocType "Visitor Pass"** with the following fields: **Inward Register** (Link/Inward Register, mandatory), **Issued Date** (Date, mandatory, default to Today), **Issued Time** (Time, mandatory, default to Now), **Issued To** (Data, fetch Visitor Name from Inward Register), **Expire on** (DateTime), **Returned Date** (Date), and **Returned Time** (Time). This DocType should be submittable.
- Validates that issued_date and expire_on are properly set and checks  if issued_date is not later than expire_on.
- Validates that issued_date and returned_date are properly set and checks if issued_date is not later than returned_date.
- Add a button in Inward Register to create a visitor pass

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/fee78bbc-dee3-4625-b922-aeb304d071d9)
![image](https://github.com/user-attachments/assets/764aced4-45b5-45e6-943f-57d2a42a95f0)
![image](https://github.com/user-attachments/assets/482499f4-26e9-49fd-8f77-d1e1254240c9)
![image](https://github.com/user-attachments/assets/e39d1c9b-1ff7-4b38-8069-04d7b81ce023)
![image](https://github.com/user-attachments/assets/5c18b276-ece0-4677-9697-9bf60a4b1aa6)



## Areas affected and ensured
Visitor Pass Doctype

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - Yes
  - Opera Mini
  - Safari
