### PR TITLE
feat: TASK-2025-00147-Added Validation that Returned Date and Time is filled in before Status becomes Returned

### DIFF
--- a/beams/beams/doctype/visitor_pass/visitor_pass.json
+++ b/beams/beams/doctype/visitor_pass/visitor_pass.json
@@ -68,11 +68,13 @@
    "label": "Expire on "
   },
   {
+   "allow_on_submit": 1,
    "fieldname": "returned_date",
    "fieldtype": "Date",
    "label": "Returned Date "
   },
   {
+   "allow_on_submit": 1,
    "fieldname": "returned_time",
    "fieldtype": "Time",
    "label": "Returned Time "
@@ -85,7 +87,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-01-24 13:32:13.778424",
+ "modified": "2025-01-27 10:15:09.835171",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Visitor Pass",

--- a/beams/beams/doctype/visitor_pass/visitor_pass.py
+++ b/beams/beams/doctype/visitor_pass/visitor_pass.py
@@ -12,6 +12,16 @@ class VisitorPass(Document):
     def validate(self):
         self.validate_issued_date_and_expire_on()
         self.validate_issued_date_and_returned_date()
+        self.validate_returned_date_and_returned_time()
+
+
+    def validate_returned_date_and_returned_time(self):
+            '''
+                Ensure  Returned Date and Time selection based on workflow state
+            '''
+            if self.workflow_state == 'Issued':
+                if not self.returned_date or not self.returned_time:
+                    frappe.throw(_('Please select an Returned Date and Time.'))
 
     @frappe.whitelist()
     def validate_issued_date_and_expire_on(self):


### PR DESCRIPTION


## Feature description
- Added Validation that Returned Date and Time is filled in before Status becomes Returned

## Solution description
- This solution addresses the requirement to ensure that the "Returned Date" and "Returned Time" fields are filled when the workflow state is transitioned to "Issued" in the "Visitor Pass" Doctype.
- A new method **validate_returned_date_and_returned_time**  was added to check the presence of the **returned_date** and  **returned_time** fields when the workflow_state is set to "Issued".

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/10b63cc3-6330-4573-96df-47d30b12ce3e)


## Areas affected and ensured
- Visitor Pass Doctype

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - yes
  - Opera Mini
  - Safari
