### PR TITLE
feat: Create Journal Entry for Provident Fund (PF) deduction upon submission of Salary Slip

### DIFF
--- a/beams/beams/custom_scripts/salary_slip/salary_slip.py
+++ b/beams/beams/custom_scripts/salary_slip/salary_slip.py
@@ -1,0 +1,68 @@
+import frappe
+from frappe.utils import flt
+
+@frappe.whitelist()
+def create_journal_entry(doc, method):
+    """
+    Create Journal Entry for Provident Fund (PF) deduction upon submission of Salary Slip.
+    """
+
+    pf_deduction = None
+    for deduction in doc.deductions:
+        if deduction.salary_component == "Provident Fund":
+            pf_deduction = deduction
+            break
+
+    if not pf_deduction:
+        return
+
+    pf_amount = pf_deduction.amount
+
+    # Fetch PF Expense Account from Payroll Settings
+    pf_expense_account = frappe.db.get_single_value("Payroll Settings", "pf_expense_account")
+    if not pf_expense_account:
+        frappe.throw(
+            title="Missing Configuration",
+            msg="Please configure the PF Expense Account in Payroll Settings."
+        )
+
+    # Fetch PF Payable Account from the Salary Component for the given company
+    pf_payable_account = frappe.db.get_value(
+        "Salary Component Account",
+        filters={
+            "parentfield": "accounts",
+            "parenttype": "Salary Component",
+            "parent": "Provident Fund",
+            "company": doc.company
+        },
+        fieldname="account"
+    )
+    if not pf_payable_account:
+        frappe.throw(
+            title="Missing Account",
+            msg=f"No PF Payable Account found for the company {doc.company}. Please check the Salary Component configuration."
+        )
+
+    # Step 4: Create the Journal Entry
+    journal_entry = frappe.new_doc("Journal Entry")
+    journal_entry.voucher_type = "Journal Entry"
+    journal_entry.company = doc.company
+    journal_entry.posting_date = doc.posting_date
+    journal_entry.reference_doctype = "Salary Slip"
+    journal_entry.reference_name = doc.name
+
+    # Add debit entry for PF Expense
+    journal_entry.append("accounts", {
+        "account": pf_expense_account,
+        "debit_in_account_currency": pf_amount,
+    })
+
+    # Add credit entry for PF Payable
+    journal_entry.append("accounts", {
+        "account": pf_payable_account,
+        "credit_in_account_currency": pf_amount,
+    })
+
+    # Insert and Submit the Journal Entry
+    journal_entry.insert()
+    journal_entry.submit()

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -288,6 +288,9 @@ doc_events = {
                     "beams.beams.custom_scripts.event.event.validate_event_conflict",
                     "beams.beams.custom_scripts.event.event.validate_event_before_approval"
         ],
+    },
+    "Salary Slip": {
+        "on_submit": "beams.beams.custom_scripts.salary_slip.salary_slip.create_journal_entry"
     }
 }
 


### PR DESCRIPTION
## Feature description
The feature creates a Journal Entry for Provident Fund (PF) deduction when a Salary Slip is submitted. 

## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description
1) Validation:
    -Check for the "Provident Fund" deduction in the deductions child table of the Salary Slip.
2) Fetch Accounts:
    -Retrieve the PF Expense Account from Payroll Settings.
    -Fetch the PF Payable Account from the Salary Component for Provident Fund and ensure it matches the company.
3) Create Journal Entry:
    -Instantiate a new Journal Entry with the following details:
        Debit: PF Expense Account for the deducted amount.
        Credit: PF Payable Account for the same amount.
    -Link the Journal Entry to the Salary Slip.
4) Insert and Submit:
    Save and submit the Journal Entry.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/cd6c4be4-b4eb-4f62-8a49-d01294b8c693)
![image](https://github.com/user-attachments/assets/693a5a2c-7233-4319-ac39-f85b89ed38b5)
![image](https://github.com/user-attachments/assets/ed1df619-be47-40e8-9f7f-53d5f98f72a8)

## Areas affected and ensured
- Salary Slip Submission: Ensures PF deductions trigger Journal Entry creation.
- Payroll Settings: PF Expense Account validation.
- Salary Component: PF Payable Account validation.
- Journal Entry: Creation and submission of entries.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Mozilla Firefox
 