### PR TITLE
    TASK-2025-00154 : Created Workflow for Event doctype

### DIFF
--- a/beams/beams/custom_scripts/event/event.js
+++ b/beams/beams/custom_scripts/event/event.js
@@ -72,7 +72,7 @@ frappe.ui.form.on('Event', {
                 }))
             });
         }, 'Create'); // Add the button under the 'Create' group
-        
+
         if (frm.doc.meeting_room && frm.doc.starts_on && frm.doc.ends_on) {
             // Check for conflicting events with the selected meeting room and date range
             frappe.call({
@@ -90,6 +90,7 @@ frappe.ui.form.on('Event', {
                 },
                 callback: function (response) {
                     if (response.message && response.message.length > 0) {
+                        frm.dashboard.clear_headline()
                         frm.dashboard.set_headline(`The selected Meeting Room <b>${frm.doc.meeting_room}</b> is already assigned to another Event during this time.`, 'red')
                     }
                 }

--- a/beams/beams/custom_scripts/event/event.js
+++ b/beams/beams/custom_scripts/event/event.js
@@ -72,12 +72,7 @@ frappe.ui.form.on('Event', {
                 }))
             });
         }, 'Create'); // Add the button under the 'Create' group
-    },
-
-    /**
-     * Validate before saving the document to check for conflicts
-     */
-    validate: function (frm) {
+        
         if (frm.doc.meeting_room && frm.doc.starts_on && frm.doc.ends_on) {
             // Check for conflicting events with the selected meeting room and date range
             frappe.call({
@@ -95,12 +90,7 @@ frappe.ui.form.on('Event', {
                 },
                 callback: function (response) {
                     if (response.message && response.message.length > 0) {
-                        // There is a conflict
-                        frappe.msgprint({
-                            title: __('Conflict Detected'),
-                            message: __('The selected Service Unit is already assigned to another Event during this time. Please choose a different time or Service Unit.'),
-                            indicator: 'red'
-                        });
+                        frm.dashboard.set_headline(`The selected Meeting Room <b>${frm.doc.meeting_room}</b> is already assigned to another Event during this time.`, 'red')
                     }
                 }
             });

--- a/beams/beams/custom_scripts/event/event.py
+++ b/beams/beams/custom_scripts/event/event.py
@@ -14,24 +14,13 @@ def set_status(doc, method):
         doc.save()
 
 @frappe.whitelist()
-def set_workflowstate_pending(doc, method):
-    '''
-    checks if the document has a meeting room assigned and the
-    workflow state is "Draft". If true, it changes the workflow state to "Pending"
-    and saves the document.
-    '''
-    if doc.meeting_room and doc.workflow_state == 'Draft':
-        doc.workflow_state = "Pending"
-        doc.save()
-
-@frappe.whitelist()
 def validate_event_conflict(doc, method):
     '''
     checks for conflicting events in the same meeting room
     by comparing the event's start and end times. If another event exists
     in the same room during the selected time, it displays a warning message.
     '''
-    if doc.meeting_room and doc.starts_on and doc.ends_on:
+    if doc.meeting_room and doc.starts_on and doc.ends_on and doc.workflow_state == "Draft":
         conflicting_events = frappe.get_all("Event", filters={
             "meeting_room": doc.meeting_room,
             "starts_on": ["<=", doc.ends_on],
@@ -39,7 +28,7 @@ def validate_event_conflict(doc, method):
             "name": ["!=", doc.name]
         }, fields=["name", "starts_on", "ends_on"])
         if conflicting_events:
-            frappe.msgprint(_(f"The selected Service Unit <b>{doc.meeting_room}</b> is already assigned to another Event during this time."), title="Warning", indicator="red")
+            frappe.msgprint(_(f"The selected Service Unit <b>{doc.meeting_room}</b> is already assigned to another Event during this time. Send to Admin for Approval."), title="Warning", indicator="red")
 
 
 @frappe.whitelist()

--- a/beams/beams/custom_scripts/event/event.py
+++ b/beams/beams/custom_scripts/event/event.py
@@ -1,0 +1,74 @@
+import frappe
+from frappe.model.document import Document
+from frappe import _
+
+@frappe.whitelist()
+def set_status(doc, method):
+    '''
+    checks if the workflow state of the document is "Rejected"
+    and the status is not already "Cancelled". If true, it sets the status to
+    "Cancelled" and saves the document.
+    '''
+    if doc.workflow_state == "Rejected" and doc.status != "Cancelled":
+        doc.status = "Cancelled"
+        doc.save()
+
+@frappe.whitelist()
+def set_workflowstate_pending(doc, method):
+    '''
+    checks if the document has a meeting room assigned and the
+    workflow state is "Draft". If true, it changes the workflow state to "Pending"
+    and saves the document.
+    '''
+    if doc.meeting_room and doc.workflow_state == 'Draft':
+        doc.workflow_state = "Pending"
+        doc.save()
+
+@frappe.whitelist()
+def validate_event_conflict(doc, method):
+    '''
+    checks for conflicting events in the same meeting room
+    by comparing the event's start and end times. If another event exists
+    in the same room during the selected time, it displays a warning message.
+    '''
+    if doc.meeting_room and doc.starts_on and doc.ends_on:
+        conflicting_events = frappe.get_all("Event", filters={
+            "meeting_room": doc.meeting_room,
+            "starts_on": ["<=", doc.ends_on],
+            "ends_on": [">=", doc.starts_on],
+            "name": ["!=", doc.name]
+        }, fields=["name", "starts_on", "ends_on"])
+        if conflicting_events:
+            frappe.msgprint(_(f"The selected Service Unit <b>{doc.meeting_room}</b> is already assigned to another Event during this time."), title="Warning", indicator="red")
+
+
+@frappe.whitelist()
+def validate_event_before_approval(doc, method):
+    '''
+    Ensure that before approving an event, no other 'Open' events exist
+    with the same service unit (meeting room) at the same time.
+    '''
+    if doc.workflow_state == "Approved" and doc.status == "Open":
+        conflicting_events = frappe.get_all(
+            "Event",
+            filters={
+                "meeting_room": doc.meeting_room,
+                "starts_on": ["<=", doc.ends_on],
+                "ends_on": [">=", doc.starts_on],
+                "status": "Open",
+                "name": ["!=", doc.name],
+            },
+            fields=["name", "starts_on", "ends_on"]
+        )
+        if conflicting_events:
+            frappe.throw(_("Cannot approve this event because another 'Open' event exists in the same Service Unit at the same time."))
+
+@frappe.whitelist()
+def validate_reason_for_rejection(doc, method):
+    '''
+    checks if the workflow state of the document is "Rejected"
+    and if a reason for rejection has not been provided. If no reason is provided,
+    it raises an error with a message to prompt the user to provide one.
+    '''
+    if doc.workflow_state == "Rejected" and not doc.reason_for_rejection:
+        frappe.throw(_("Provide a Reason for Rejection before Rejecting this Event."))

--- a/beams/beams/custom_scripts/event/event.py
+++ b/beams/beams/custom_scripts/event/event.py
@@ -2,16 +2,6 @@ import frappe
 from frappe.model.document import Document
 from frappe import _
 
-@frappe.whitelist()
-def set_status(doc, method):
-    '''
-    checks if the workflow state of the document is "Rejected"
-    and the status is not already "Cancelled". If true, it sets the status to
-    "Cancelled" and saves the document.
-    '''
-    if doc.workflow_state == "Rejected" and doc.status != "Cancelled":
-        doc.status = "Cancelled"
-        doc.save()
 
 @frappe.whitelist()
 def validate_event_conflict(doc, method):

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -282,14 +282,12 @@ doc_events = {
     },
     "Event" :{
         "on_update":[
-                    "beams.beams.custom_scripts.event.event.set_status",
-                    "beams.beams.custom_scripts.event.event.set_workflowstate_pending",
                     "beams.beams.custom_scripts.event.event.validate_reason_for_rejection"
         ],
         "validate":[
                     "beams.beams.custom_scripts.event.event.validate_event_conflict",
                     "beams.beams.custom_scripts.event.event.validate_event_before_approval"
-        ]
+        ],
     }
 }
 

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -279,6 +279,17 @@ doc_events = {
             "beams.beams.custom_scripts.appraisal.appraisal.validate_appraisal",
             "beams.beams.custom_scripts.appraisal.appraisal.set_category_based_on_marks"
         ]
+    },
+    "Event" :{
+        "on_update":[
+                    "beams.beams.custom_scripts.event.event.set_status",
+                    "beams.beams.custom_scripts.event.event.set_workflowstate_pending",
+                    "beams.beams.custom_scripts.event.event.validate_reason_for_rejection"
+        ],
+        "validate":[
+                    "beams.beams.custom_scripts.event.event.validate_event_conflict",
+                    "beams.beams.custom_scripts.event.event.validate_event_before_approval"
+        ]
     }
 }
 

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -389,6 +389,12 @@ def get_event_custom_fields():
                 "label": "External Participants",
                 "options": "External Participants Detail",
                 "insert_after": "section_break_epd"
+            },
+            {
+                "fieldname": "reason_for_rejection",
+                "fieldtype": "Small Text",
+                "label": "Reason for Rejection",
+                "insert_after": "repeat_this_event"
             }
         ]
     }


### PR DESCRIPTION
## Feature description

1.Need to create workflow for event doctype
2.Need to set status status as cancelled when it is rejected 
3.Need to Set the state as pending if there is a service unit selected in the event
4.Need to validate before approval that there is no event that is open with the same service unit in the same time
5.add  new field Reason for Rejection in event
6 .If a service unit already has a event then no other event should be created with same time period
## Solution description

1.created workflow for event doctype
  -Draft, Pending (if only the event has a service unit),Approved (if only the event has a service unit) ,Rejected (if only the event has a service unit)

2.set the status as cancelled when it is rejected 
-when the workflow state rejected  need to set status become cancelled via event.py

3.Set the state as pending if there is a service unit selected in the event
- when the  service unit is selected  the workflow state become pending form draft via event.py

4.validated before approval that there is no event that is open with the same service unit in the same time
- when the workflow state approved event with open status should prevent for approval event.py

5. Added new field reason for rejection (small text) in event doctype  via setup.py
- add validation that it is filled in before rejection 

6.Once a event is created against a service unit , when a another event of same service unit of same time period is created validation is triggered in server side code via event.py


## Output screenshots (optional)
[Screencast from 27-01-25 08:18:50 PM IST.webm](https://github.com/user-attachments/assets/f97ab885-341b-4613-b1c6-db042cb979a7)

## Areas affected and ensured
event doctype

## Is there any existing behavior change of other features due to this code change?
 No.

## Was this feature tested on the browsers?
 
  - Mozilla Firefox
 
