### PR TITLE
fix:Changes in Sprint Review

### DIFF
--- a/beams/beams/custom_scripts/project/project.js
+++ b/beams/beams/custom_scripts/project/project.js
@@ -16,6 +16,14 @@ frappe.ui.form.on('Project', {
             });
         }, __("Create"));
 
+        // Add a button to create an Equipment Request
+        frm.add_custom_button(__('Equipment Request'), function () {
+            frappe.model.open_mapped_doc({
+                method: "beams.beams.custom_scripts.project.project.create_equipment_request",
+                frm: frm,
+            });
+        }, __("Create"));
+
         // Adds a button to the 'Project' form to create an Transportation Request.
         frm.add_custom_button(__('Transportation Request'), function () {
             frappe.model.open_mapped_doc({

--- a/beams/beams/custom_scripts/project/project.py
+++ b/beams/beams/custom_scripts/project/project.py
@@ -70,6 +70,23 @@ def create_transportation_request(source_name, target_doc=None):
     }, target_doc)
     return transportation_request
 
+
+@frappe.whitelist()
+def create_equipment_request(source_name, target_doc=None):
+    """
+    Maps fields from the Equipment Request doctype to the Project doctype'.
+    """
+    equipment_request = get_mapped_doc("Project", source_name, {
+        "Project": {
+                "doctype": "Equipment Request",
+                "field_map": {
+                    "name": "project",
+                    "bureau": "bureau"
+                }
+            }
+    }, target_doc)
+    return equipment_request
+
 @frappe.whitelist()
 def create_technical_support_request(project_id, requirements):
     ''' Create Technical Request document '''

--- a/beams/beams/doctype/adhoc_budget/adhoc_budget.json
+++ b/beams/beams/doctype/adhoc_budget/adhoc_budget.json
@@ -146,13 +146,14 @@
    "default": "0",
    "fieldname": "generates_revenue",
    "fieldtype": "Check",
-   "label": "Generates Revenue"
+   "label": "Generates Revenue",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-01-14 14:25:27.931877",
+ "modified": "2025-01-28 12:43:05.529583",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Adhoc Budget",

--- a/beams/beams/doctype/required_items_detail/required_items_detail.json
+++ b/beams/beams/doctype/required_items_detail/required_items_detail.json
@@ -6,7 +6,8 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "required_item"
+  "required_item",
+  "quantity"
  ],
  "fields": [
   {
@@ -15,12 +16,18 @@
    "in_list_view": 1,
    "label": "Required Item",
    "options": "Item"
+  },
+  {
+   "fieldname": "quantity",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Quantity"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-01-20 08:37:49.987479",
+ "modified": "2025-01-28 12:50:59.652614",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Required Items Detail",

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -292,7 +292,9 @@ def get_Project_custom_fields():
                 "fieldtype": "Currency",
                 "label": "Approved Budget",
                 "options":"approved_budget",
-                "insert_after":"budget_expense_types"
+                "insert_after":"budget_expense_types",
+                "read_only": 1
+
             }
         ]
     }


### PR DESCRIPTION
## Feature description

- Make Approved Budget field in Project doctype read only.
- Make Generates Revenue field read only  in Adhoc Budget doctype.
- Create Button in Project to create Equipment Request.


## Solution description
The specified fields were made read only a button was created to create Equipment Request document.


## Areas affected and ensured
Project doctype and Adhoc Budget doctype.

## Is there any existing behavior change of other features due to this code change?
       No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
 
