### PR TITLE
feat:Update related Program Request workflow state to 'Closed' when the Project status becomes 'Completed'.

### DIFF
--- a/beams/beams/custom_scripts/project/project.py
+++ b/beams/beams/custom_scripts/project/project.py
@@ -152,10 +152,3 @@ def update_program_request_status_on_project_completion(doc, method):
             if program_request.workflow_state != "Closed":
                 program_request.workflow_state = "Closed"
                 program_request.save()  # Save the document
-                frappe.db.commit()  # Commit changes to the database
-
-                frappe.msgprint(f"Program Request {request['name']} has been updated to 'Closed' in the workflow.")
-                print(f"Program Request {request['name']} has been updated to 'Closed' in the workflow.")
-
-            else:
-                frappe.msgprint(f"Program Request {request['name']} is already in 'Closed' state.")

--- a/beams/beams/custom_scripts/project/project.py
+++ b/beams/beams/custom_scripts/project/project.py
@@ -130,3 +130,32 @@ def create_technical_support_request(project_id, requirements):
         frappe.msgprint(_("Technical Request created successfully for project: {0}.").format(project.project_name), indicator="green", alert=1)
 
     return
+
+@frappe.whitelist()
+def update_program_request_status_on_project_completion(doc, method):
+    """
+    Update related Program Request workflow state to 'Closed' when the Project status becomes 'Completed'.
+    """
+    if doc.status == "Completed":
+        # Fetch all related Program Requests linked to this Project
+        program_requests = frappe.get_all(
+            "Program Request",
+            filters={"project": doc.name, "workflow_state": ("!=", "Closed")},  # Exclude already "Closed" state
+            fields=["name"]
+        )
+
+        # Update the workflow state of each Program Request to 'Closed'
+        for request in program_requests:
+            program_request = frappe.get_doc("Program Request", request["name"])
+
+            # Update the workflow state to 'Closed' if not already in 'Closed'
+            if program_request.workflow_state != "Closed":
+                program_request.workflow_state = "Closed"
+                program_request.save()  # Save the document
+                frappe.db.commit()  # Commit changes to the database
+
+                frappe.msgprint(f"Program Request {request['name']} has been updated to 'Closed' in the workflow.")
+                print(f"Program Request {request['name']} has been updated to 'Closed' in the workflow.")
+
+            else:
+                frappe.msgprint(f"Program Request {request['name']} is already in 'Closed' state.")

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -291,6 +291,10 @@ doc_events = {
     },
     "Salary Slip": {
         "on_submit": "beams.beams.custom_scripts.salary_slip.salary_slip.create_journal_entry"
+    },
+
+    "Project": {
+         "on_update": "beams.beams.custom_scripts.project.project.update_program_request_status_on_project_completion"
     }
 }
 


### PR DESCRIPTION


## Feature description
Update related Program Request workflow state to 'Closed' when the Project status becomes 'Completed'.

## Solution description
This function, update_program_request_status_on_project_completion, is designed to update the workflow state of all related Program Requests to "Closed" when the status of a Project is updated to "Completed"

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/74ba48c8-5afc-4ebf-aee4-d73201bb68cd)
![image](https://github.com/user-attachments/assets/8156076b-1d5a-4ec6-9116-12cb74930691)


## Areas affected and ensured
List out the areas affected by your code changes.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox-yes
  - Opera Mini
  - Safari
