### PR TITLE
fix: applied validation and minor fixes in adhoc budget

### DIFF
--- a/beams/beams/custom_scripts/project/project.py
+++ b/beams/beams/custom_scripts/project/project.py
@@ -3,6 +3,7 @@ from frappe.model.mapper import get_mapped_doc
 import json
 from frappe import _
 from frappe.utils import nowdate
+from erpnext.accounts.utils import get_fiscal_year
 
 @frappe.whitelist()
 def create_adhoc_budget(source_name, target_doc=None):
@@ -11,6 +12,7 @@ def create_adhoc_budget(source_name, target_doc=None):
     selected values from the 'budget_expense_types' field into the child table 'Budget Expense'.
     """
     project_doc = frappe.get_doc('Project', source_name)
+    fiscal_year = get_fiscal_year()["name"]
     adhoc_budget = get_mapped_doc("Project", source_name, {
         "Project": {
                 "doctype": "Adhoc Budget",
@@ -22,7 +24,8 @@ def create_adhoc_budget(source_name, target_doc=None):
                 }
             }
     }, target_doc)
-
+    if fiscal_year:
+        adhoc_budget.fiscal_year = fiscal_year
     for expense_type in project_doc.budget_expense_types:
         adhoc_budget.append('budget_expense', {
             'budget_expense_type': expense_type.budget_expense_type

--- a/beams/beams/doctype/adhoc_budget/adhoc_budget.js
+++ b/beams/beams/doctype/adhoc_budget/adhoc_budget.js
@@ -53,12 +53,21 @@
 
           // Refresh the field to apply the filter
           frm.fields_dict['budget_expense'].grid.refresh_field('budget_expense_type');
+      },
+      expected_start_date: function (frm) {
+          frm.call("validate_start_date_and_end_dates");
+      },
+      expected_end_date: function (frm) {
+          frm.call("validate_start_date_and_end_dates");
       }
   });
 
   frappe.ui.form.on('Budget Expense', {
       budget_amount: function(frm, cdt, cdn) {
           calculate_total_budget_amount(frm);
+      },
+      budget_expense_remove: function(frm) {
+        calculate_total_budget_amount(frm);
       }
   });
 

--- a/beams/beams/doctype/adhoc_budget/adhoc_budget.js
+++ b/beams/beams/doctype/adhoc_budget/adhoc_budget.js
@@ -5,6 +5,12 @@
             // Set the posting date to today if not already set
               frm.set_value('posting_date', frappe.datetime.nowdate());
           }
+          frm.call('get_fiscal_year_for_adhoc_budget',)
+          .then(r => {
+              if (r.message) {
+                frm.set_value('fiscal_year', r.message);
+                frm.refresh_field('fiscal_year');}
+          })
       },
       refresh: function(frm) {
           if (!frm.doc.posting_date) {

--- a/beams/beams/doctype/adhoc_budget/adhoc_budget.py
+++ b/beams/beams/doctype/adhoc_budget/adhoc_budget.py
@@ -4,7 +4,7 @@ from frappe.desk.form.assign_to import add as add_assign
 from frappe.model.document import Document
 from frappe.utils.user import get_users_with_role
 from frappe.utils import getdate
-
+from erpnext.accounts.utils import get_fiscal_year
 
 
 class AdhocBudget(Document):
@@ -172,3 +172,11 @@ class AdhocBudget(Document):
                 msg=_("Start Date cannot be after End Date."),
                 title=_("Validation Error")
             )
+
+    @frappe.whitelist()
+    def get_fiscal_year_for_adhoc_budget(self):
+        """
+        Fetches the current fiscal year name.
+        """
+        fiscal_year = get_fiscal_year()["name"]
+        return fiscal_year


### PR DESCRIPTION
## issue  description

1. Need add validation on the expected start date and expected end date 
2.  Need fetch the default  fiscal_year in adhoc budget from project 
3. need to update  total budget amount when removing a Budget Expense row in Adhoc Budget
4.  need to Validate 'expected_revenue' only when 'generates_revenue' is set in Adhoc Budget

## Solution description

1. added  validation on the expected start date and expected end date 
- validation applied  that expected end date should greater than expected start date via project.py
2.  fetched the default  fiscal_year in adhoc budget from project
- mapped the fiscal year from the project to adhoc budget as default via project.py
3.  updated   total budget amount when removing a Budget Expense row in Adhoc Budget
- updated the total budget amount  after deleting row from budget expense  via adhoc budget.js
4.Validated 'expected_revenue' only when 'generates_revenue' is set in Adhoc Budget
- add condition where the generates_revenue checkbox is checked for validation via adhoc budget.py

##Output screenshots (optional)

[Screencast from 29-01-25 11:20:23 AM IST.webm](https://github.com/user-attachments/assets/0d6c4d93-b79f-4074-a525-7c8f47e253f6)
 [Uploading Screencast from 29-01-25 11:24:35 AM IST.webm…]()


## Areas affected and ensured
adhoc budget doctype

## Is there any existing behavior change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?
 
  - Mozilla Firefox
  
