### PR TITLE
Updated 'Issued To' Field in Visitor Pass Doctype Fetch from Inward Register field 'Visitor Name'

### DIFF
--- a/beams/beams/doctype/visitor_pass/visitor_pass.json
+++ b/beams/beams/doctype/visitor_pass/visitor_pass.json
@@ -57,7 +57,7 @@
    "reqd": 1
   },
   {
-   "fetch_from": "inward_register.vistor_name",
+   "fetch_from": "inward_register.visitor_name",
    "fieldname": "issued_to",
    "fieldtype": "Data",
    "label": "Issued To"
@@ -87,7 +87,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-01-27 10:15:09.835171",
+ "modified": "2025-01-29 11:23:46.427372",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Visitor Pass",


### PR DESCRIPTION
## Feature description
Update 'Issued To' Field in Visitor Pass Doctype Fetch from Inward Register Doctype field 'Visitor Name' 

## Solution description
Updated 'Issued To' Field in Visitor Pass Doctype Fetch from Inward Register Doctype field 'Visitor Name'

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/d37de543-3191-4e6c-892f-4dd99f9ab431)


## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Mozilla Firefox
