### PR TITLE
Fix:Validated the required _from and required_to in External Resource Request Doctype

### DIFF
--- a/beams/beams/doctype/external_resource_request/external_resource_request.js
+++ b/beams/beams/doctype/external_resource_request/external_resource_request.js
@@ -19,6 +19,12 @@ frappe.ui.form.on("External Resource Request", {
 
     required_to(frm) {
         update_required_resources(frm, 'required_to');
+    },
+    required_from: function (frm) {
+        frm.call("validate_required_from_and_required_to");
+    },
+    required_to: function (frm) {
+        frm.call("validate_required_from_and_required_to");
     }
 });
 

--- a/beams/beams/doctype/external_resource_request/external_resource_request.json
+++ b/beams/beams/doctype/external_resource_request/external_resource_request.json
@@ -7,7 +7,6 @@
  "engine": "InnoDB",
  "field_order": [
   "section_break_ed5d",
-  "amended_from",
   "project",
   "bureau",
   "column_break_fhpe",
@@ -15,7 +14,8 @@
   "required_from",
   "required_to",
   "section_break_ihzk",
-  "required_resources"
+  "required_resources",
+  "amended_from"
  ],
  "fields": [
   {
@@ -40,6 +40,7 @@
    "options": "Project"
   },
   {
+   "fetch_from": "project.bureau",
    "fieldname": "bureau",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -47,6 +48,7 @@
    "options": "Bureau"
   },
   {
+   "default": "Today",
    "fieldname": "posting_date",
    "fieldtype": "Date",
    "in_list_view": 1,
@@ -56,13 +58,15 @@
    "fieldname": "required_from",
    "fieldtype": "Datetime",
    "in_list_view": 1,
-   "label": "Required From"
+   "label": "Required From",
+   "reqd": 1
   },
   {
    "fieldname": "required_to",
    "fieldtype": "Datetime",
    "in_list_view": 1,
-   "label": "Required To "
+   "label": "Required To ",
+   "reqd": 1
   },
   {
    "fieldname": "section_break_ihzk",
@@ -72,7 +76,8 @@
    "fieldname": "required_resources",
    "fieldtype": "Table",
    "label": "Required Resources",
-   "options": "External Resources Detail"
+   "options": "External Resources Detail",
+   "reqd": 1
   },
   {
    "fieldname": "column_break_fhpe",
@@ -82,7 +87,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-01-18 13:59:53.829300",
+ "modified": "2025-01-29 15:23:11.280247",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "External Resource Request",

--- a/beams/beams/doctype/external_resource_request/external_resource_request.py
+++ b/beams/beams/doctype/external_resource_request/external_resource_request.py
@@ -1,9 +1,32 @@
 # Copyright (c) 2025, efeone and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
-
+from frappe.utils import getdate
+from frappe import _
 
 class ExternalResourceRequest(Document):
-	pass
+
+    def validate(self):
+        self.validate_required_from_and_required_to()
+
+    @frappe.whitelist()
+    def validate_required_from_and_required_to(self):
+        """
+        Validates that required_from and required_to are properly set and checks
+        if required_from is not later than required_to.
+        """
+        if not self.required_from or not self.required_to:
+            return
+
+        # Convert dates to proper date objects
+        required_from = getdate(self.required_from)
+        required_to = getdate(self.required_to)
+
+        # Check if required_from is after required_to
+        if required_from > required_to:
+            frappe.throw(
+                msg=_('The "Required From" date cannot be after the "Required To" date.'),
+                title=_('Validation Error')
+            )


### PR DESCRIPTION
## Feature description
Need to: Fetch Bureau field from Project Doctype, Validate the required_from and required_to and Change some fields to mandatory in  External Resource Request Doctype" 

## Solution description
Fetched Bureau field from Project Doctype, Validated the required_from and required_to and Changed some fields to mandatory in  External Resource Request Doctype" 

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/6899ddbc-ce00-4020-8283-25678fae78d2)

## Areas affected and ensured
 External Resource Request Doctype

## Is there any existing behavior change of other features due to this code change?
No. 

## Was this feature tested on the browsers?
  
 - Mozilla Firefox
