### PR TITLE
feat:Add a button to the 'Project' form to create an External Resource Request

### DIFF
--- a/beams/beams/custom_scripts/project/project.js
+++ b/beams/beams/custom_scripts/project/project.js
@@ -126,5 +126,14 @@ frappe.ui.form.on('Project', {
           });
           dialog.show();
         }, __("Create"));
+
+        // Add a button to the 'Project' form to create an External Resource Request
+        frm.add_custom_button("External Resource Request", function() {
+            frappe.new_doc("External Resource Request", {
+                project: frm.doc.name,  // Auto-fill Project
+                bureau: frm.doc.bureau  // Auto-fill Bureau (assuming it exists)
+            });
+        }, "Create");  // Group under "Create" button
+
      }
   });

--- a/beams/beams/custom_scripts/project_dashboard/project_dashboard.py
+++ b/beams/beams/custom_scripts/project_dashboard/project_dashboard.py
@@ -15,7 +15,7 @@ def get_data(data=None):
 			{"label": _("Sales"), "items": ["Sales Order", "Delivery Note", "Sales Invoice"]},
 			{"label": _("Purchase"), "items": ["Purchase Order", "Purchase Receipt", "Purchase Invoice"]},
 			{"label": _("Budgets"), "items": ["Budget", "Adhoc Budget"]},
-			{"label": _("Programs"), "items": ["Equipment Hire Request", "Equipment Request", "Transportation Request", "Technical Request"]},
+			{"label": _("Programs"), "items": ["Equipment Hire Request", "Equipment Request", "Transportation Request", "Technical Request","External Resource Request"]},
 
 		],
 	}


### PR DESCRIPTION

## Feature description
Add a button to the 'Project' form to create an External Resource Request

## Solution description
✅ Creates a "External Resource Request" button inside the Project form.
✅ On Click, it opens a new External Resource Request form.
✅ Automatically fills in the Project and Bureau fields from the current Project document.
✅ Groups the button under the "Create" dropdown (optional).
✅ Add "External Resource Request"  into connection

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/d2166b31-8206-4e81-a50f-3a28300cc8a6)
![image](https://github.com/user-attachments/assets/3fcc2e56-b36a-44b8-877e-6fab3834a06a)



## Areas affected and ensured
Project and External Resource Request doctype

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox-yes
  - Opera Mini
  - Safari
