### PR TITLE
Created a Button External Resource Request in Technical Request Doctype

### DIFF
--- a/beams/beams/doctype/technical_request/technical_request.js
+++ b/beams/beams/doctype/technical_request/technical_request.js
@@ -7,70 +7,85 @@ frappe.ui.form.on('Technical Request', {
         frm.set_df_property("reason_for_rejection", "hidden", true);
         frm.set_df_property("employee", "read_only", false);
         frm.set_df_property("employee", "hidden", false);
-        if (frm.doc.workflow_state === "Pending Approval" || frm.doc.workflow_state =='Draft') {
+
+        if (frm.doc.workflow_state === "Pending Approval" || frm.doc.workflow_state === "Draft") {
             frm.set_df_property("employee", "read_only", false);
         } else {
-            frm.set_df_property('employee', 'read_only', true);
+            frm.set_df_property("employee", "read_only", true);
         }
 
-        set_employee_query(frm)
-
-        // Handle the visibility of the "Reason for Rejection" field
+        set_employee_query(frm);
         toggle_reason_for_rejection_field(frm);
+
+        if (!frm.is_new()) {  
+            frm.add_custom_button("External Resource Request", function() {
+                frappe.new_doc("External Resource Request", {
+                    project: frm.doc.project,
+                    bureau: frm.doc.bureau
+                });
+            }, "Create");
+        }
     },
+
     employee: function(frm) {
-       set_employee_query(frm);
+        set_employee_query(frm);
     },
+
     designation: function(frm) {
-      set_employee_query(frm);
+        set_employee_query(frm);
     },
+
     workflow_state: function(frm) {
         // Trigger visibility logic when the workflow state changes
         toggle_reason_for_rejection_field(frm);
     },
+
     // Trigger validation when the "required_from" field is updated
-    required_from: function (frm) {
+    required_from: function(frm) {
         frm.call("validate_required_from_and_required_to");
     },
-    required_to: function (frm) {
+
+    required_to: function(frm) {
         frm.call("validate_required_from_and_required_to");
     }
 });
 
 function set_employee_query(frm) {
-  frm.set_query('employee', () => {
-      return {
-          filters: {
-            department: frm.doc.department,
-            designation: frm.doc.designation
-          }
-      }
-  })
+    frm.set_query('employee', () => {
+        return {
+            filters: {
+                department: frm.doc.department,
+                designation: frm.doc.designation
+            }
+        };
+    });
 }
 
 function toggle_reason_for_rejection_field(frm) {
+    if (!frm.doc.department) return; // Ensure department is set
+
     // Fetch the HOD for the selected department
-    frappe.db.get_value('Department', frm.doc.department, 'head_of_department', (r) => {
-        if (r && r.head_of_department) {
-            frappe.db.get_value('Employee', {name: r.head_of_department}, 'user_id', (user) => {
-                const hod_user_id = user.user_id;
+    frappe.db.get_value('Department', frm.doc.department, 'head_of_department').then((r) => {
+        if (r && r.message && r.message.head_of_department) {
+            let hod_employee = r.message.head_of_department;
 
-                // Determine if the logged-in user is the HOD
-                const is_hod = frappe.session.user === hod_user_id;
+            frappe.db.get_value('Employee', { name: hod_employee }, 'user_id').then((user) => {
+                if (user && user.message && user.message.user_id) {
+                    const hod_user_id = user.message.user_id;
+                    const is_hod = frappe.session.user === hod_user_id;
 
-                // Always show the "Reason for Rejection" field to the HOD, even before the workflow state is "Rejected"
-                if (is_hod) {
-                    frm.set_df_property("reason_for_rejection", "hidden", false);
-
-                    // Allow only HOD to edit the field
-                    frm.set_df_property("reason_for_rejection", "read_only", false);
-                } else {
-                    // Hide the field for non-HOD users unless the workflow state is "Rejected"
-                    if (frm.doc.workflow_state === "Rejected") {
+                    // Always show the "Reason for Rejection" field to the HOD
+                    if (is_hod) {
                         frm.set_df_property("reason_for_rejection", "hidden", false);
-                        frm.set_df_property("reason_for_rejection", "read_only", true);
+                        frm.set_df_property("reason_for_rejection", "read_only", false);
                     } else {
-                        frm.set_df_property("reason_for_rejection", "hidden", true);
+                        // Hide the field for non-HOD users unless the workflow state is "Rejected"
+                        if (frm.doc.workflow_state === "Rejected") {
+                            frm.set_df_property("reason_for_rejection", "hidden", false);
+                            frm.set_df_property("reason_for_rejection", "read_only", true);
+                        } else {
+                            frm.set_df_property("reason_for_rejection", "hidden", true);
+                        }
                     }
                 }
             });


### PR DESCRIPTION
## Feature description
Need to: Create a Button External Resource Request in Technical Request Doctype

## Solution description
Created a Button External Resource Request in Technical Request Doctype when it is saved. 

## Output screenshots (optional)
[Screencast from 29-01-25 04:38:11 PM IST.webm](https://github.com/user-attachments/assets/6c6d8e2b-82ff-4ccb-83f1-d81dd1c4e73f)

## Areas affected and ensured
Technical Request Doctype

## Is there any existing behavior change of other features due to this code change?
No. 

## Was this feature tested on the browsers?
  - Mozilla Firefox
 
