### PR TITLE
feat: Applied validation for employee is not assigned to multiple projects

### DIFF
--- a/beams/beams/custom_scripts/project/project.py
+++ b/beams/beams/custom_scripts/project/project.py
@@ -157,11 +157,13 @@ def update_program_request_status_on_project_completion(doc, method):
                 program_request.save()  # Save the document
 
 @frappe.whitelist()
-def validate_employee_assignment(doc,method):
+def validate_employee_assignment(doc, method):
     """
     Validate that an employee is not assigned to multiple projects during the same time period.
     """
     for row in doc.allocated_resources_details:
+        if not row.employee:
+            continue
         overlapping_projects = frappe.get_all(
             "Allocated Resource Detail",
             filters={
@@ -175,4 +177,3 @@ def validate_employee_assignment(doc,method):
         if overlapping_projects:
             employee_name = frappe.get_value("Employee", row.employee, "employee_name")
             frappe.throw(f"Employee {employee_name} ({row.employee}) is already assigned to another project ({', '.join(overlapping_projects)}) within the same time period.")
-            

--- a/beams/beams/custom_scripts/project/project.py
+++ b/beams/beams/custom_scripts/project/project.py
@@ -155,3 +155,24 @@ def update_program_request_status_on_project_completion(doc, method):
             if program_request.workflow_state != "Closed":
                 program_request.workflow_state = "Closed"
                 program_request.save()  # Save the document
+
+@frappe.whitelist()
+def validate_employee_assignment(doc,method):
+    """
+    Validate that an employee is not assigned to multiple projects during the same time period.
+    """
+    for row in doc.allocated_resources_details:
+        overlapping_projects = frappe.get_all(
+            "Allocated Resource Detail",
+            filters={
+                "employee": row.employee,
+                "parent": ["!=", doc.name],
+                "assigned_from": ["<=", row.assigned_to],
+                "assigned_to": [">=", row.assigned_from]
+            },
+            pluck="parent"
+        )
+        if overlapping_projects:
+            employee_name = frappe.get_value("Employee", row.employee, "employee_name")
+            frappe.throw(f"Employee {employee_name} ({row.employee}) is already assigned to another project ({', '.join(overlapping_projects)}) within the same time period.")
+            

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -294,7 +294,8 @@ doc_events = {
     },
 
     "Project": {
-         "on_update": "beams.beams.custom_scripts.project.project.update_program_request_status_on_project_completion"
+         "on_update": "beams.beams.custom_scripts.project.project.update_program_request_status_on_project_completion",
+         "validate":"beams.beams.custom_scripts.project.project.validate_employee_assignment"
     }
 }
 


### PR DESCRIPTION

## Feature description

1.Need to apply validation on the project when the employee is not assigned to multiple projects during the same time period.

## Solution description

Added validation to ensure an employee is not assigned to multiple projects during overlapping time periods.
via project.py 

## Output screenshots (optional)

[Screencast from 30-01-25 01:28:00 PM IST.webm](https://github.com/user-attachments/assets/c85b6aee-ce1f-4555-9fba-a1c407fa2531)
## Areas affected and ensured
project doctype

## Is there any existing behavior change of other features due to this code change?
no

## Was this feature tested on the browsers?
  - Mozilla Firefox
  
