### PR TITLE
 Add Validation in Employee Travel Request Doctype and Calculate Total Days

### DIFF
--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.json
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.json
@@ -111,7 +111,8 @@
   {
    "fieldname": "total_days",
    "fieldtype": "Float",
-   "label": "Total Days "
+   "label": "Total Days ",
+   "read_only": 1
   },
   {
    "fieldname": "source",
@@ -207,7 +208,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-01-23 11:25:45.768338",
+ "modified": "2025-01-30 13:03:14.377232",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Employee Travel Request",

--- a/beams/beams/doctype/reference_document/reference_document.json
+++ b/beams/beams/doctype/reference_document/reference_document.json
@@ -14,21 +14,19 @@
    "fieldname": "remarks",
    "fieldtype": "Small Text",
    "in_list_view": 1,
-   "label": "Remarks",
-   "reqd": 1
+   "label": "Remarks"
   },
   {
    "fieldname": "document",
    "fieldtype": "Attach",
    "in_list_view": 1,
-   "label": "Document",
-   "reqd": 1
+   "label": "Document"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-01-21 16:07:23.243521",
+ "modified": "2025-01-30 11:07:25.369841",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Reference Document",


### PR DESCRIPTION
## Feature description
Add Validation in Employee Travel Request Doctype and Calculate Total Days 
Remove Mandatory field in Reference Document Doctype

## Solution description
Added Validation in Employee Travel Request Doctype and Calculate Total Days 
Total Days field change to Read Only in Employee Travel Request
Removed Mandatory field in Reference Document Doctype

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/9ff1ce2d-360a-450a-92f6-515371f5bff7)

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
 - Mozilla Firefox
 
