### PR TITLE
 Removed License Plate field from Required Hired Vehicle Detail Doctype

### DIFF
--- a/beams/beams/doctype/required_hired_vehicle_detail/required_hired_vehicle_detail.json
+++ b/beams/beams/doctype/required_hired_vehicle_detail/required_hired_vehicle_detail.json
@@ -8,7 +8,6 @@
   "section_break_iy51",
   "vehicle_type",
   "no_of_vehicles",
-  "license_plates",
   "amended_from"
  ],
  "fields": [
@@ -35,14 +34,6 @@
    "reqd": 1
   },
   {
-   "allow_on_submit": 1,
-   "fieldname": "license_plates",
-   "fieldtype": "Data",
-   "in_list_view": 1,
-   "label": "License Plate(s)",
-   "reqd": 1
-  },
-  {
    "fieldname": "no_of_vehicles",
    "fieldtype": "Int",
    "in_list_view": 1,
@@ -55,7 +46,7 @@
  "is_submittable": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-01-28 15:26:40.256048",
+ "modified": "2025-01-31 09:41:26.724592",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Required Hired Vehicle Detail",


### PR DESCRIPTION
## Feature description
Remove License Plate field from Required Hired Vehicle Detail

## Solution description
Removed License Plate field from Required Hired Vehicle Detail

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/bbbb07b8-2263-4e19-b7bb-3f85fd1e74c2)


## Is there any existing behavior change of other features due to this code change?
 No

## Was this feature tested on the browsers?
  - Mozilla Firefox
  
