### PR TITLE
feat:Create Workflow for Equipment Request

### DIFF
--- a/beams/beams/doctype/equipment_hire_request/equipment_hire_request.js
+++ b/beams/beams/doctype/equipment_hire_request/equipment_hire_request.js
@@ -12,13 +12,6 @@ frappe.ui.form.on("Equipment Hire Request", {
                 invoice.posting_date = frm.doc.posting_date; // Set posting date from the current document
                 frappe.set_route("form", "Purchase Invoice", invoice.name); // Redirect to the new Purchase Invoice form
             }, __("Create"));
-
-            // Create 'Asset Movement' button
-            frm.add_custom_button(__('Asset Movement'), function () {
-                let asset_movement = frappe.model.get_new_doc("Asset Movement");
-                asset_movement.posting_date = frm.doc.posting_date; // Set posting date from the current document
-                frappe.set_route("form", "Asset Movement", asset_movement.name); // Redirect to the new Asset Movement form
-            }, __("Create"));
         }
     },
     required_from: function (frm) {

--- a/beams/beams/doctype/equipment_hire_request/equipment_hire_request.json
+++ b/beams/beams/doctype/equipment_hire_request/equipment_hire_request.json
@@ -15,9 +15,7 @@
   "required_from",
   "required_to",
   "section_break_ozsg",
-  "required_items",
-  "section_break_tmmn",
-  "reason_for_rejection"
+  "required_items"
  ],
  "fields": [
   {
@@ -76,22 +74,12 @@
    "fieldtype": "Table",
    "label": "Required Items ",
    "options": "Required Hire Items Detail"
-  },
-  {
-   "fieldname": "section_break_tmmn",
-   "fieldtype": "Section Break"
-  },
-  {
-   "allow_on_submit": 1,
-   "fieldname": "reason_for_rejection",
-   "fieldtype": "Small Text",
-   "label": "Reason for Rejection"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-01-29 09:42:02.363503",
+ "modified": "2025-01-31 11:00:37.894591",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Equipment Hire Request",

--- a/beams/beams/doctype/equipment_request/equipment_request.js
+++ b/beams/beams/doctype/equipment_request/equipment_request.js
@@ -4,6 +4,14 @@
 frappe.ui.form.on('Equipment Request', {
     refresh: function (frm) {
         set_item_query(frm)
+        // Show the 'Asset Movement' button only if the document is submitted (docstatus == 1) and approved
+        if (frm.doc.docstatus == 1 && frm.doc.workflow_state == 'Approved') {
+            frm.add_custom_button(__('Asset Movement'), function () {
+                let asset_movement = frappe.model.get_new_doc("Asset Movement");
+                asset_movement.posting_date = frm.doc.posting_date; // Set posting date from the current document
+                frappe.set_route("form", "Asset Movement", asset_movement.name); // Redirect to the new Asset Movement form
+            }, __("Create"));
+        }
     },
     bureau: function (frm) {
         set_item_query(frm)

--- a/beams/beams/doctype/equipment_request/equipment_request.json
+++ b/beams/beams/doctype/equipment_request/equipment_request.json
@@ -15,7 +15,8 @@
   "required_to",
   "section_break_mztz",
   "required_equipments",
-  "amended_from"
+  "amended_from",
+  "reason_for_rejection"
  ],
  "fields": [
   {
@@ -78,12 +79,18 @@
    "print_hide": 1,
    "read_only": 1,
    "search_index": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "reason_for_rejection",
+   "fieldtype": "Small Text",
+   "label": "Reason for Rejection"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-01-29 11:05:30.542836",
+ "modified": "2025-01-31 10:39:23.412156",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Equipment Request",

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -401,7 +401,6 @@ def get_event_custom_fields():
         ]
     }
 
-
 def get_leave_application_custom_fields():
     '''
     Custom fields that need to be added to the Leave Application  Doctype


### PR DESCRIPTION
## Feature description
     ✅ Create approval workflow for Equipment Request
     ✅ Automatically generates an Asset Movement upon approval
     ✅ Validate the reason for rejection before submission

## Solution description
     ✅ Equipment Request workflow is implemented
     ✅ Approval automatically creates Asset Movement
     ✅ Rejection requires a reason

## Output screenshots (optional)

[Screencast from 31-01-25 11:28:53 AM IST.webm](https://github.com/user-attachments/assets/3cb07d0a-0d6b-4da7-886e-4b5d44c3ed40)


## Areas affected and ensured
     ✅ Equipment Request Doctype 

## Is there any existing behavior change of other features due to this code change?
     ✅  No.

## Was this feature tested on the browsers?
     ✅ Mozilla Firefox
  