### PR TITLE
 Hided Insurance Details Section Break, Added Fields in Vehicle Documents Doctype

### DIFF
--- a/beams/beams/doctype/vehicle_documents/vehicle_documents.json
+++ b/beams/beams/doctype/vehicle_documents/vehicle_documents.json
@@ -7,7 +7,9 @@
  "engine": "InnoDB",
  "field_order": [
   "document",
-  "expiry_date"
+  "reference_no",
+  "expiry_date",
+  "remarks"
  ],
  "fields": [
   {
@@ -15,7 +17,8 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Document",
-   "options": "Vehicle Document"
+   "options": "Vehicle Document",
+   "reqd": 1
   },
   {
    "default": "Today",
@@ -24,12 +27,26 @@
    "in_list_view": 1,
    "label": "Expiry Date",
    "reqd": 1
+  },
+  {
+   "fieldname": "reference_no",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Reference No",
+   "non_negative": 1,
+   "reqd": 1
+  },
+  {
+   "fieldname": "remarks",
+   "fieldtype": "Small Text",
+   "in_list_view": 1,
+   "label": "Remarks"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-01-27 14:05:20.746137",
+ "modified": "2025-01-31 12:28:36.819061",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Vehicle Documents",

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -3179,6 +3179,14 @@ def get_property_setters():
             "property": "reqd",
             "property_type": "Check",
             "value": 0
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Vehicle",
+            "field_name": "insurance_details",
+            "property": "hidden",
+            "property_type": "Section Break",
+            "value": 1
         }
     ]
 


### PR DESCRIPTION
## Feature description
 Hide Insurance Details Section Break, Add  Fields ' Reference No, Remarks'  in Vehicle Documents Doctype

## Solution description
 Hided Insurance Details Section Break, Added  Fields ' Reference No, Remarks'  in Vehicle Documents Doctype

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/e27a6ec7-2c95-4023-8023-462ed245a6c0)


## Is there any existing behavior change of other features due to this code change?
 No

## Was this feature tested on the browsers?
  - Mozilla Firefox
