### PR TITLE
Fix:Validated the posting date fields

### DIFF
--- a/beams/beams/doctype/inward_register/inward_register.js
+++ b/beams/beams/doctype/inward_register/inward_register.js
@@ -18,5 +18,8 @@ frappe.ui.form.on('Inward Register', {
                 });
             }, __("Create"));
         }
-    }
+    },
+    posting_date:function (frm){
+        frm.call("validate_posting_date");
+      }
 });

--- a/beams/beams/doctype/inward_register/inward_register.py
+++ b/beams/beams/doctype/inward_register/inward_register.py
@@ -5,10 +5,13 @@ from frappe.model.document import Document
 from frappe.utils import nowdate, nowtime
 from frappe.utils.user import get_users_with_role
 from frappe.desk.form.assign_to import add as add_assign
+from frappe.utils import today
+from frappe import _
 
 
 class InwardRegister(Document):
-
+	def before_save(self):
+		self.validate_posting_date()
 
 
 	def on_submit(self, method=None):
@@ -31,3 +34,8 @@ class InwardRegister(Document):
 	                    "name": self.name,
 	                    "description": description
 	                })
+	@frappe.whitelist()
+	def validate_posting_date(self):
+		if self.posting_date:
+			if self.posting_date > today():
+				frappe.throw(_("Posting Date cannot be set after today's date."))

--- a/beams/beams/doctype/outward_register/outward_register.js
+++ b/beams/beams/doctype/outward_register/outward_register.js
@@ -1,8 +1,8 @@
 // Copyright (c) 2025, efeone and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Outward Register", {
-// 	refresh(frm) {
-
-// 	},
-// });
+frappe.ui.form.on("Outward Register", {
+  posting_date:function (frm){
+      frm.call("validate_posting_date");
+    }
+});

--- a/beams/beams/doctype/outward_register/outward_register.py
+++ b/beams/beams/doctype/outward_register/outward_register.py
@@ -1,9 +1,18 @@
 # Copyright (c) 2025, efeone and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
+from frappe.utils import today
+from frappe import _
 
 
 class OutwardRegister(Document):
-	pass
+    def before_save(self):
+        self.validate_posting_date()
+
+    @frappe.whitelist()
+    def validate_posting_date(self):
+        if self.posting_date:
+            if self.posting_date > today():
+                frappe.throw(_("Posting Date cannot be set after today's date."))

--- a/beams/beams/doctype/transportation_request/transportation_request.js
+++ b/beams/beams/doctype/transportation_request/transportation_request.js
@@ -2,16 +2,6 @@
 // For license information, please see license.txt
 frappe.ui.form.on("Transportation Request", {
     refresh: function (frm) {
-        // Show the "Purchase Invoice" button only if the status is "Approved"
-        if (frm.doc.workflow_state === "Approved") {
-            frm.add_custom_button(__('Purchase Invoice'), function () {
-                var invoice = frappe.model.get_new_doc("Purchase Invoice");
-                invoice.posting_date = frm.doc.posting_date;
-                frappe.set_route("form", "Purchase Invoice", invoice.name);
-            }, __("Create"));
-        }
-
-        // Show the "Vehicle Hire Request" button only if the status is "Approved"
         if (frm.doc.workflow_state === "Approved") {
             frm.add_custom_button(__('Vehicle Hire Request'), function () {
                 frappe.model.open_mapped_doc({
@@ -21,15 +11,16 @@ frappe.ui.form.on("Transportation Request", {
             }, __("Create"));
         }
 
-        // Toggle read-only state of "vehicles" child table based on workflow state
         if (frm.doc.workflow_state === "Pending Approval") {
             frm.set_df_property("vehicles", "read_only", false);
         } else {
             frm.set_df_property("vehicles", "read_only", true);
         }
     },
+    posting_date:function (frm){
+        frm.call("validate_posting_date");
+      },
 
-    // Event handlers for the child table "vehicles"
     vehicles_add: function (frm, cdt, cdn) {
         frm.set_value("no_of_own_vehicles", frm.doc.vehicles.length);
     },

--- a/beams/beams/doctype/trip_sheet/trip_sheet.js
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.js
@@ -2,6 +2,9 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Trip Sheet', {
+    posting_date:function (frm){
+        frm.call("validate_posting_date");
+      },
     starting_date_and_time: function(frm) {
         frm.call({
             method: "validate_start_datetime_and_end_datetime",
@@ -41,16 +44,23 @@ frappe.ui.form.on('Trip Sheet', {
     },
 
     refresh: function(frm) {
-        if (!frm.is_new()) {
-            frm.add_custom_button(__('Vehicle Incident Record'), function() {
-                let vehicle_incident_record = frappe.model.get_new_doc("Vehicle Incident Record");
-                vehicle_incident_record.trip_sheet = frm.doc.name;
-                frappe.set_route("form", "Vehicle Incident Record", vehicle_incident_record.name);
-            }, __("Create"));
-        }
-    },
-
-    onload: function(frm) {
+     if (!frm.is_new()) {
+         frm.add_custom_button(__('Vehicle Incident Record'), function() {
+             frappe.call({
+                 method: "beams.beams.doctype.trip_sheet.trip_sheet.create_vehicle_incident_record",
+                 args: {
+                     trip_sheet: frm.doc.name
+                 },
+                 callback: function(r) {
+                     if (r.message) {
+                         frappe.set_route("form", "Vehicle Incident Record", r.message);
+                     }
+                 }
+             });
+         }, __("Create"));
+     }
+ },
+   onload: function(frm) {
         frm.set_query('transportation_requests', function() {
             return {
                 filters: {

--- a/beams/beams/doctype/trip_sheet/trip_sheet.json
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.json
@@ -10,7 +10,7 @@
   "driver",
   "vehicle",
   "column_break_abgb",
-  "date",
+  "posting_date",
   "section_break_ziua",
   "references_column",
   "travel_requests",
@@ -62,14 +62,6 @@
    "in_list_view": 1,
    "label": " Vehicle",
    "options": "Vehicle",
-   "reqd": 1
-  },
-  {
-   "default": "Today",
-   "fieldname": "date",
-   "fieldtype": "Date",
-   "in_list_view": 1,
-   "label": "Date",
    "reqd": 1
   },
   {
@@ -166,19 +158,18 @@
    "fieldname": "final_odometer_reading",
    "fieldtype": "Int",
    "label": "Final Odometer Reading",
-   "reqd": 1
+   "mandatory_depends_on": "eval:doc.docstatus==\"Saved\" "
   },
   {
    "fieldname": "distance_traveledkm",
    "fieldtype": "Float",
    "label": "Distance Traveled(Km)",
-   "reqd": 1
+   "read_only": 1
   },
   {
    "fieldname": "fuel_consumed",
    "fieldtype": "Float",
-   "label": "Fuel Consumed",
-   "reqd": 1
+   "label": "Fuel Consumed"
   },
   {
    "fieldname": "column_break_anpp",
@@ -188,13 +179,21 @@
    "fieldname": "mileage",
    "fieldtype": "Float",
    "label": "Mileage",
+   "read_only": 1
+  },
+  {
+   "default": "Today",
+   "fieldname": "posting_date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "Posting Date",
    "reqd": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-01-27 15:57:44.019794",
+ "modified": "2025-01-31 13:52:37.720123",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Trip Sheet",

--- a/beams/beams/doctype/trip_sheet/trip_sheet.py
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.py
@@ -3,23 +3,25 @@
 import frappe
 from frappe.model.document import Document
 from frappe.utils import get_datetime
-from frappe import _  # Import _ for translation and localization
+from frappe.utils import today
+from frappe import _
 
 class TripSheet(Document):
     def validate(self):
         self.validate_start_datetime_and_end_datetime()
         self.calculate_and_validate_fuel_data()
+    def before_save(self):
+        self.validate_posting_date()
 
     @frappe.whitelist()
     def validate_start_datetime_and_end_datetime(self):
-        """
+        '''
         Validates that starting_datetime and ending_datetime are properly set and checks
         if starting_datetime is not later than ending_datetime.
-        """
+        '''
         if not self.starting_date_and_time or not self.ending_date_and_time:
             return
 
-        # Convert datetimes to proper datetime objects
         starting_date_and_time = get_datetime(self.starting_date_and_time)
         ending_date_and_time = get_datetime(self.ending_date_and_time)
 
@@ -31,25 +33,28 @@ class TripSheet(Document):
 
     @frappe.whitelist()
     def calculate_and_validate_fuel_data(self):
-        """
+        '''
         Validate odometer readings and calculate distance traveled and fuel consumption per km.
         Automatically updates the fields on the same document.
-        """
-        # Validate odometer readings
+        '''
         if self.initial_odometer_reading > self.final_odometer_reading:
             frappe.throw(_("Initial Odometer Reading must be less than  Final Odometer Reading"))
 
-        # Calculate distance traveled
         if self.final_odometer_reading and self.initial_odometer_reading:
             self.distance_traveledkm = self.final_odometer_reading - self.initial_odometer_reading
         else:
             self.distance_traveledkm = 0
 
-        # Calculate fuel consumption per km
         if self.fuel_consumed and self.fuel_consumed != 0 and self.distance_traveledkm:
             self.mileage = self.distance_traveledkm / self.fuel_consumed
         else:
             self.mileage = 0
+
+    @frappe.whitelist()
+    def validate_posting_date(self):
+        if self.posting_date:
+            if self.posting_date > today():
+                frappe.throw(_("Posting Date cannot be set after today's date."))
 
 
 
@@ -58,23 +63,21 @@ def get_last_odometer(vehicle):
     if not vehicle:
         return 0
 
-    # Check if a Trip Sheet exists for the given vehicle
     last_trip_exists = frappe.db.exists(
         "Trip Sheet",
-        {"vehicle": vehicle, "docstatus": 1},  # Only consider submitted Trip Sheets
+        {"vehicle": vehicle, "docstatus": 1},
     )
 
     if last_trip_exists:
-        # Fetch the final_odometer of the last Trip Sheet
         final_odometer = frappe.db.get_value(
             "Trip Sheet",
             {"vehicle": vehicle, "docstatus": 1},
             "final_odometer_reading",
-            order_by="creation desc",  # Ensure the latest trip sheet is fetched
+            order_by="creation desc",
         )
-        return final_odometer or 0  # Return the final odometer or 0 if not found
+        return final_odometer or 0
     else:
-        return 0  # Return 0 if no trip sheet exists for the vehicle
+        return 0
 
 @frappe.whitelist()
 def get_selected_requests(child_table, fieldname):
@@ -98,9 +101,28 @@ def get_selected_requests(child_table, fieldname):
         filters={"parent": ["in", eligible_parents]},
         fields=[fieldname]
     )
-    
+
     for doc in result:
         if doc.get(fieldname):
             selected_requests.append(doc.get(fieldname))
 
     return selected_requests
+
+@frappe.whitelist()
+def create_vehicle_incident_record(trip_sheet):
+    '''
+    Creates a new Vehicle Incident Record for the given Trip Sheet.
+    '''
+    if not trip_sheet:
+        frappe.throw("Trip Sheet is required to create a Vehicle Incident Record.")
+
+    trip_sheet_doc = frappe.get_doc("Trip Sheet", trip_sheet)
+
+    vehicle_incident = frappe.get_doc({
+        "doctype": "Vehicle Incident Record",
+        "trip_sheet": trip_sheet
+    })
+
+    vehicle_incident.insert(ignore_mandatory=True)
+
+    return vehicle_incident.name

--- a/beams/beams/doctype/vehicle_incident_record/vehicle_incident_record.js
+++ b/beams/beams/doctype/vehicle_incident_record/vehicle_incident_record.js
@@ -1,8 +1,8 @@
 // Copyright (c) 2025, efeone and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Vehicle Incident Record", {
-// 	refresh(frm) {
-
-// 	},
-// });
+frappe.ui.form.on("Vehicle Incident Record", {
+  posting_date:function (frm){
+      frm.call("validate_posting_date");
+    }
+});

--- a/beams/beams/doctype/vehicle_incident_record/vehicle_incident_record.json
+++ b/beams/beams/doctype/vehicle_incident_record/vehicle_incident_record.json
@@ -9,12 +9,12 @@
   "section_break_ue5d",
   "trip_sheet",
   "offense_type",
-  "employee",
-  "employee_name",
-  "amended_from",
+  "driver",
+  "driver_name",
   "column_break_hwrj",
   "posting_date",
-  "offense_date_and_time"
+  "offense_date_and_time",
+  "amended_from"
  ],
  "fields": [
   {
@@ -51,7 +51,8 @@
    "default": "Today",
    "fieldname": "posting_date",
    "fieldtype": "Date",
-   "label": "Posting Date "
+   "label": "Posting Date ",
+   "reqd": 1
   },
   {
    "fieldname": "offense_date_and_time",
@@ -60,27 +61,30 @@
    "reqd": 1
   },
   {
-   "fieldname": "employee",
+   "fieldname": "column_break_hwrj",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "trip_sheet.driver",
+   "fieldname": "driver",
    "fieldtype": "Link",
-   "label": "Employee",
-   "options": "Employee",
+   "label": "Driver",
+   "options": "Driver",
    "reqd": 1
   },
   {
-   "fetch_from": "employee.employee_name",
-   "fieldname": "employee_name",
+   "fetch_from": "driver.full_name",
+   "fieldname": "driver_name",
    "fieldtype": "Data",
-   "label": "Employee Name"
-  },
-  {
-   "fieldname": "column_break_hwrj",
-   "fieldtype": "Column Break"
+   "label": "Driver Name",
+   "read_only": 1,
+   "reqd": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-01-23 10:59:07.444716",
+ "modified": "2025-01-31 15:12:22.481381",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Vehicle Incident Record",

--- a/beams/beams/doctype/vehicle_incident_record/vehicle_incident_record.py
+++ b/beams/beams/doctype/vehicle_incident_record/vehicle_incident_record.py
@@ -1,9 +1,14 @@
 # Copyright (c) 2025, efeone and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
-
+from frappe.utils import today
+from frappe import _
 
 class VehicleIncidentRecord(Document):
-	pass
+    @frappe.whitelist()
+    def validate_posting_date(self):
+        if self.posting_date:
+            if self.posting_date > today():
+                frappe.throw(_("Posting Date cannot be set after today's date."))


### PR DESCRIPTION
## Feature description
Need to: 
  Validate the posting date fields in Vehicle Incident Record Doctype, Trip Sheet Doctype and Inward Register Doctype,Outward Register Doctype and Transportation Request Doctype.

  Change the Vehicle Incident Record Doctype like add Driver field.

## Solution description
 Validate the posting date fields in Vehicle Incident Record Doctype, Trip Sheet Doctype and Inward Register Doctype,   Outward Register Doctype and Transportation Request Doctype.

 Change the Vehicle Incident Record Doctype like add Driver field.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/57d69f43-5c4a-4644-91a2-1f8332f2e6ed)
![image](https://github.com/user-attachments/assets/e2167aba-73da-4cc6-b608-70c65e7f8013)
![image](https://github.com/user-attachments/assets/973dfc54-2c67-4d4c-aa2e-d46d3fa1cd67)
![image](https://github.com/user-attachments/assets/15fbffe9-80d8-4a1b-b54c-64d2204d169f)
![image](https://github.com/user-attachments/assets/8a8758b9-543c-4b02-a5fe-1a14315a7f5a)




## Areas affected and ensured
Vehicle Incident Record Doctype, Trip Sheet Doctype and Inward Register Doctype.

## Is there any existing behavior change of other features due to this code change?
No. 

## Was this feature tested on the browsers?
 - Mozilla Firefox
 