### PR TITLE
feat:validation for posting date

### DIFF
--- a/beams/beams/doctype/award_expense_detail/award_expense_detail.json
+++ b/beams/beams/doctype/award_expense_detail/award_expense_detail.json
@@ -14,7 +14,7 @@
    "fieldname": "remarks",
    "fieldtype": "Small Text",
    "in_list_view": 1,
-   "label": "Remarks",
+   "label": "Expense Description",
    "reqd": 1
   },
   {
@@ -28,7 +28,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-01-22 10:53:25.929071",
+ "modified": "2025-01-31 10:24:53.135463",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Award Expense Detail",

--- a/beams/beams/doctype/award_record/award_record.js
+++ b/beams/beams/doctype/award_record/award_record.js
@@ -8,6 +8,12 @@ frappe.ui.form.on('Award Record', {
                 create_jv(frm);
             }, __('Create'));
         }
+        // Show button only if workflow_state is "Awarded"
+        if (frm.doc.workflow_state === "Awarded") {
+            frm.add_custom_button(__('Travel Request'), function() {
+                create_travel_request(frm);
+            }, __('Create'));
+        }
     },
     posting_date:function (frm){
       frm.call("validate_posting_date");
@@ -42,6 +48,13 @@ function create_jv(frm) {
         }
     });
 }
+
+function create_travel_request(frm) {
+    frappe.new_doc('Travel Request', {
+        employee: frm.doc.employee  // Prefill the Employee field
+    });
+}
+
 
 frappe.ui.form.on("Award Expense Detail", {
     amount: function (frm) {

--- a/beams/beams/doctype/award_record/award_record.js
+++ b/beams/beams/doctype/award_record/award_record.js
@@ -4,10 +4,13 @@
 frappe.ui.form.on('Award Record', {
     refresh: function (frm) {
         if (!frm.is_new() && frm.doc.total_amount > 0) {
-            frm.add_custom_button(__('Create Journal Voucher'), function () {
+            frm.add_custom_button(__('Journal Voucher'), function () {
                 create_jv(frm);
-            }, __('Actions'));
+            }, __('Create'));
         }
+    },
+    posting_date:function (frm){
+      frm.call("validate_posting_date");
     }
 });
 
@@ -43,5 +46,8 @@ function create_jv(frm) {
 frappe.ui.form.on("Award Expense Detail", {
     amount: function (frm) {
         frm.call("update_total_amount");
+    },
+    expenses_remove: function(frm){
+      frm.call("update_total_amount");
     }
 });

--- a/beams/beams/doctype/award_record/award_record.json
+++ b/beams/beams/doctype/award_record/award_record.json
@@ -29,7 +29,8 @@
    "fetch_from": "employee.first_name",
    "fieldname": "full_name",
    "fieldtype": "Data",
-   "label": "Full Name "
+   "label": "Employee Name",
+   "read_only": 1
   },
   {
    "default": "Today",
@@ -53,7 +54,8 @@
   {
    "fieldname": "total_amount",
    "fieldtype": "Currency",
-   "label": "Total Amount"
+   "label": "Total Amount",
+   "read_only": 1
   },
   {
    "fieldname": "column_break_imvy",
@@ -77,7 +79,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-01-22 14:35:43.757509",
+ "modified": "2025-01-31 10:56:57.949795",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Award Record",

--- a/beams/beams/doctype/award_record/award_record.py
+++ b/beams/beams/doctype/award_record/award_record.py
@@ -3,10 +3,13 @@
 
 import frappe
 from frappe.model.document import Document
+from frappe.utils import today
+from frappe import _ 
 
 class AwardRecord(Document):
     def before_save(self):
         self.update_total_amount()
+        self.validate_posting_date()
 
     @frappe.whitelist()
     def update_total_amount(self):
@@ -20,3 +23,9 @@ class AwardRecord(Document):
 
         # Set the Total Amount field
         self.total_amount = total_amount
+
+    @frappe.whitelist()
+    def validate_posting_date(self):
+        if self.posting_date:
+            if self.posting_date > today():
+                frappe.throw(_("Posting Date cannot be set after today's date."))

--- a/beams/beams/doctype/equipment_hire_request/equipment_hire_request.js
+++ b/beams/beams/doctype/equipment_hire_request/equipment_hire_request.js
@@ -26,5 +26,8 @@ frappe.ui.form.on("Equipment Hire Request", {
     },
     required_to: function (frm) {
         frm.call("validate_required_from_and_required_to");
+    },
+    posting_date:function (frm){
+      frm.call("validate_posting_date");
     }
 });

--- a/beams/beams/doctype/equipment_hire_request/equipment_hire_request.json
+++ b/beams/beams/doctype/equipment_hire_request/equipment_hire_request.json
@@ -37,8 +37,10 @@
   {
    "fieldname": "project",
    "fieldtype": "Link",
+   "in_list_view": 1,
    "label": "Project",
-   "options": "Project"
+   "options": "Project",
+   "reqd": 1
   },
   {
    "fetch_from": "project.bureau",
@@ -91,7 +93,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-01-29 09:42:02.363503",
+ "modified": "2025-02-01 11:03:43.332717",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Equipment Hire Request",

--- a/beams/beams/doctype/equipment_hire_request/equipment_hire_request.py
+++ b/beams/beams/doctype/equipment_hire_request/equipment_hire_request.py
@@ -4,11 +4,17 @@
 import frappe
 from frappe.model.document import Document
 from frappe.utils import getdate  # Import getdate function
+from frappe.utils import today
 from frappe import _  # Import _ for translations
+
+
 
 class EquipmentHireRequest(Document):
     def validate(self):
         self.validate_required_from_and_required_to()
+        
+    def before_save(self):
+        self.validate_posting_date()
 
     @frappe.whitelist()
     def validate_required_from_and_required_to(self):
@@ -28,3 +34,9 @@ class EquipmentHireRequest(Document):
                 msg=_('The "Required From" date cannot be after the "Required To" date.'),
                 title=_('Validation Error')
             )
+
+    @frappe.whitelist()
+    def validate_posting_date(self):
+        if self.posting_date:
+            if self.posting_date > today():
+                frappe.throw(_("Posting Date cannot be set after today's date."))

--- a/beams/beams/doctype/equipment_request/equipment_request.js
+++ b/beams/beams/doctype/equipment_request/equipment_request.js
@@ -13,6 +13,9 @@ frappe.ui.form.on('Equipment Request', {
     },
     required_to: function (frm) {
         frm.call("validate_required_from_and_required_to");
+    },
+    posting_date:function (frm){
+      frm.call("validate_posting_date");
     }
 });
 

--- a/beams/beams/doctype/equipment_request/equipment_request.py
+++ b/beams/beams/doctype/equipment_request/equipment_request.py
@@ -4,11 +4,15 @@
 import frappe
 from frappe.model.document import Document
 from frappe.utils import getdate
+from frappe.utils import today
 from frappe import _
 
 class EquipmentRequest(Document):
     def validate(self):
         self.validate_required_from_and_required_to()
+
+    def before_save(self):
+        self.validate_posting_date()
 
     @frappe.whitelist()
     def validate_required_from_and_required_to(self):
@@ -26,3 +30,8 @@ class EquipmentRequest(Document):
                 msg=_('The "Required From" date cannot be after the "Required To" date.'),
                 title=_('Validation Error')
             )
+    @frappe.whitelist()
+    def validate_posting_date(self):
+        if self.posting_date:
+            if self.posting_date > today():
+                frappe.throw(_("Posting Date cannot be set after today's date."))

--- a/beams/beams/doctype/guest_appointment/guest_appointment.js
+++ b/beams/beams/doctype/guest_appointment/guest_appointment.js
@@ -28,5 +28,8 @@ frappe.ui.form.on('Guest Appointment', {
         });
         }, __("Create"));
         }
-      }
+      },
+      posting_date:function (frm){
+        frm.call("validate_posting_date");
+      }      
 });


### PR DESCRIPTION
## Feature description
validation for posting date


## Solution description
added posting date validation in equipment_hire_request,equipment_request,guest_appointment
## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/c892a033-df37-477c-ae58-97a3a8ea9561)
![image](https://github.com/user-attachments/assets/1c747dc7-584a-4946-9092-ae3075debbdb)
![image](https://github.com/user-attachments/assets/3db902fd-a7f9-4a43-b3b0-bd06caadac6d)


## Areas affected and ensured
- equipment hire request
- equipment request 
- guest appointment

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox-yes
  - Opera Mini
  - Safari
