### PR TITLE
fix: fix check-out failure due to missing Compensatory Leave Type in Beams HR Settings

### DIFF
--- a/beams/beams/custom_scripts/employee_checkin/employee_checkin.py
+++ b/beams/beams/custom_scripts/employee_checkin/employee_checkin.py
@@ -14,7 +14,7 @@ def handle_employee_checkin_out(doc, method):
     # Fetch Compensatory Leave Type
     compensatory_leave_type = frappe.db.get_single_value("Beams HR Settings", "compensatory_leave_type")
     if not compensatory_leave_type:
-        frappe.throw("Compensatory Leave Type is not configured in Beams HR Settings.")
+        return
 
     # Parse time from the Employee Checkin log
     doc_time = datetime.strptime(doc.time, "%Y-%m-%d %H:%M:%S") if isinstance(doc.time, str) else doc.time


### PR DESCRIPTION
## Feature description
Fix the issue where employees with double shift assignment are unable to check out due to the missing "Compensatory Leave Type" configuration in Beams HR Settings. 
## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description
Added a check to allow employees to check out even if the "Compensatory Leave Type" is not set.
If the setting is missing, the function simply returns instead of blocking check-out.

## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.

## Areas affected and ensured
Employee check-in/check-out process
Beams HR Settings 

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
