### PR TITLE
Fix:Hide the Reason for Rejection field based on workflow state in  Transportation Request Doctype

### DIFF
--- a/beams/beams/doctype/transportation_request/transportation_request.json
+++ b/beams/beams/doctype/transportation_request/transportation_request.json
@@ -108,9 +108,11 @@
   },
   {
    "allow_on_submit": 1,
+   "depends_on": "eval: doc.workflow_state == \"Pending Approval\" || doc.workflow_state == \"Rejected\";\n",
    "fieldname": "reason_for_rejection",
    "fieldtype": "Small Text",
-   "label": "Reason for Rejection"
+   "label": "Reason for Rejection",
+   "read_only_depends_on": "eval: doc.workflow_state != \"Pending Approval\";"
   },
   {
    "fieldname": "no_of_hired_vehicles",
@@ -122,7 +124,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-01-29 11:21:41.638300",
+ "modified": "2025-02-03 16:26:21.258105",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Transportation Request",


### PR DESCRIPTION
## Feature description
Need to:  
Hide the Reason for Rejection field based on workflow state in  Transportation Request Doctype

## Solution description
Hide the Reason for Rejection field based on workflow state in  Transportation Request Doctype

## Output screenshots (optional)
[Screencast from 03-02-25 04:49:33 PM IST.webm](https://github.com/user-attachments/assets/22da9437-0b42-4669-8123-5c08ab4e88b7)

## Areas affected and ensured
 Transportation Request Doctype

## Is there any existing behavior change of other features due to this code change?
No. 

## Was this feature tested on the browsers?
 - Mozilla Firefox

