### PR TITLE
feat:Added no of in  employees in Technical Request

### DIFF
--- a/beams/beams/custom_scripts/project/project.js
+++ b/beams/beams/custom_scripts/project/project.js
@@ -8,10 +8,10 @@ frappe.ui.form.on('Project', {
             });
         }, __("Create"));
 
-        // Add a button to create an Equipment Hire Request
-        frm.add_custom_button(__('Equipment Hire Request'), function () {
+        // Add a button to create an Equipment Acquiral Request
+        frm.add_custom_button(__('Equipment Acquiral Request'), function () {
             frappe.model.open_mapped_doc({
-                method: "beams.beams.custom_scripts.project.project.map_equipment_hire_request",
+                method: "beams.beams.custom_scripts.project.project.map_equipment_acquiral_request",
                 frm: frm,
             });
         }, __("Create"));
@@ -31,181 +31,6 @@ frappe.ui.form.on('Project', {
                 frm: frm,
             });
         }, __("Create"));
-
-        frm.add_custom_button(__('Assign Equipments'), function () {
-            const dialog = new frappe.ui.Dialog({
-                title: 'Assign Equipments',
-                fields: [
-                    {
-                        label: 'Required From',
-                        fieldtype: 'Datetime',
-                        fieldname: 'required_from',
-                        in_list_view: 1,
-                        reqd: 1
-                    },
-                    {
-                        label: 'Required To',
-                        fieldtype: 'Datetime',
-                        fieldname: 'required_to',
-                        in_list_view: 1,
-                        reqd: 1
-                    },
-                    {
-                        fieldtype: 'Table',
-                        label: 'Equipments',
-                        fieldname: 'equipments',
-                        reqd: 1,
-                        fields: [
-                            {
-                                label: 'Item',
-                                fieldtype: 'Link',
-                                fieldname: 'item',
-                                options: 'Item',
-                                in_list_view: 1,
-                                reqd: 1,
-                                onchange: function() {
-                                  let data = [];
-                                  let promises = [];
-
-                                  dialog.fields_dict.equipments.df.data.forEach((item, i) => {
-                                      let promise = frappe.call({
-                                          method: "beams.beams.custom_scripts.project.project.get_available_quantities",
-                                          args: {
-                                              items: [item.item],
-                                              bureau: frm.doc.bureau
-                                          },
-                                          callback: function(r) {
-                                              if (r.message) {
-                                                  const available_qty = r.message[item.item] || 0;
-                                                  item["available_quantity"] = available_qty;
-                                                  data.push(item);
-                                              }
-                                          }
-                                      });
-
-                                      promises.push(promise);
-                                  });
-
-                                  Promise.all(promises).then(() => {
-                                      dialog.fields_dict.equipments.df.data = data;
-                                      dialog.fields_dict.equipments.grid.refresh();
-                                  });
-                              }
-                            },
-                            {
-                                label: 'Available Quantity',
-                                fieldtype: 'Int',
-                                fieldname: 'available_quantity',
-                                in_list_view: 1,
-                                read_only: 1,
-                                default: 0
-                            },
-                            {
-                                label: 'Required Quantity',
-                                fieldtype: 'Int',
-                                fieldname: 'required_quantity',
-                                in_list_view: 1,
-                                reqd: 1
-                            },
-                        ]
-                    }
-                ],
-                size: 'large',
-                primary_action_label: 'Submit',
-                primary_action(values) {
-                    const equipment_data = values?.equipments || [];
-
-                    if (!equipment_data.length) {
-                        frappe.msgprint(__('Please add at least one equipment row.'));
-                        return;
-                    }
-
-                    const request_data = [];
-                    const hire_request_data = [];
-
-                    for (const row of equipment_data) {
-                        const available_qty = row.available_quantity || 0;
-
-                        if (row.required_quantity <= available_qty) {
-                            request_data.push({
-                                item: row.item,
-                                quantity: row.required_quantity,
-                                available_quantity: available_qty,
-                                required_from: row.required_from,
-                                required_to: row.required_to
-                            });
-                        } else {
-                            if (available_qty > 0) {
-                              request_data.push({
-                                  item: row.item,
-                                  quantity: available_qty,
-                                  available_quantity: available_qty,
-                                  required_from: row.required_from,
-                                  required_to: row.required_to
-                              });
-                            }
-
-                            hire_request_data.push({
-                                item: row.item,
-                                required_quantity: row.required_quantity - available_qty,
-                            });
-                        }
-                    }
-
-                    const create_requests = [];
-
-                    if (request_data.length) {
-                        create_requests.push(
-                            frappe.call({
-                                method: 'beams.beams.custom_scripts.project.project.create_equipment_request',
-                                args: {
-                                    source_name: frm.doc.name,
-                                    equipment_data: JSON.stringify(request_data),
-                                    required_from: values.required_from,
-                                    required_to: values.required_to
-                                }
-                            })
-                        );
-                    }
-
-                    if (hire_request_data.length) {
-                        create_requests.push(
-                            frappe.call({
-                                method: 'beams.beams.custom_scripts.project.project.create_equipment_hire_request',
-                                args: {
-                                    source_name: frm.doc.name,
-                                    equipment_data: JSON.stringify(hire_request_data),
-                                    required_from: values.required_from,
-                                    required_to: values.required_to
-                                }
-                            })
-                        );
-                    }
-
-                    Promise.all(create_requests)
-                        .then(() => {
-                            dialog.hide();
-                            frm.reload_doc();
-                        });
-                }
-            });
-
-            // Set the item filter based on bureau's assets
-            frappe.call({
-                method: "beams.beams.custom_scripts.project.project.get_assets_by_bureau",
-                args: { bureau: frm.doc.bureau },
-                callback: function(r) {
-                    if (r.message?.length) {
-                        dialog.fields_dict.equipments.grid.get_field("item").get_query = () => ({
-                            filters: { name: ["in", r.message] }
-                        });
-                        dialog.show();
-                    } else {
-                        frappe.msgprint(__('No available items found for the selected Bureau.'));
-                    }
-                }
-            });
-        });
 
       // Add "Technical Request" button under the "Create" group
       frm.add_custom_button(__('Technical Request'), function () {
@@ -234,6 +59,12 @@ frappe.ui.form.on('Project', {
                               options: 'Designation',
                               in_list_view: 1,
                               reqd: 1
+                          },
+                          {
+                              label: 'No of Employees',
+                              fieldtype: 'Int',
+                              fieldname: 'no_of_employees',
+                              in_list_view: 1
                           },
                           {
                               label: 'Required From',

--- a/beams/beams/doctype/adhoc_budget/adhoc_budget.json
+++ b/beams/beams/doctype/adhoc_budget/adhoc_budget.json
@@ -49,6 +49,7 @@
    "fieldtype": "Currency",
    "label": "Expected Revenue",
    "precision": "2",
+   "read_only": 1,
    "reqd": 1
   },
   {
@@ -153,7 +154,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-01-28 12:43:05.529583",
+ "modified": "2025-02-01 09:54:43.713123",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Adhoc Budget",

--- a/beams/beams/doctype/employees/employees.json
+++ b/beams/beams/doctype/employees/employees.json
@@ -1,0 +1,33 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-01-31 17:30:40.328297",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "employee"
+ ],
+ "fields": [
+  {
+   "fieldname": "employee",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Employee",
+   "options": "Employee",
+   "reqd": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2025-01-31 17:31:19.633429",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "Employees",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/beams/beams/doctype/employees/employees.py
+++ b/beams/beams/doctype/employees/employees.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class Employees(Document):
+	pass

--- a/beams/beams/doctype/equipment_acquiral_request/equipment_acquiral_request.js
+++ b/beams/beams/doctype/equipment_acquiral_request/equipment_acquiral_request.js
@@ -26,5 +26,8 @@ frappe.ui.form.on("Equipment Acquiral Request", {
     },
     required_to: function (frm) {
         frm.call("validate_required_from_and_required_to");
-    }
+    },
+    posting_date:function (frm){
+      frm.call("validate_posting_date");
+    },
 });

--- a/beams/beams/doctype/equipment_acquiral_request/equipment_acquiral_request.js
+++ b/beams/beams/doctype/equipment_acquiral_request/equipment_acquiral_request.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2025, efeone and contributors
 // For license information, please see license.txt
 
-frappe.ui.form.on("Equipment Hire Request", {
+frappe.ui.form.on("Equipment Acquiral Request", {
     refresh(frm) {
         // Show the 'Purchase Invoice' button only if the document is submitted (docstatus == 1) and approved
         if (frm.doc.docstatus == 1 && frm.doc.workflow_state == 'Approved') {
@@ -12,6 +12,13 @@ frappe.ui.form.on("Equipment Hire Request", {
                 invoice.posting_date = frm.doc.posting_date; // Set posting date from the current document
                 frappe.set_route("form", "Purchase Invoice", invoice.name); // Redirect to the new Purchase Invoice form
             }, __("Create"));
+
+            // Create 'Asset Movement' button
+            frm.add_custom_button(__('Asset Movement'), function () {
+                let asset_movement = frappe.model.get_new_doc("Asset Movement");
+                asset_movement.posting_date = frm.doc.posting_date; // Set posting date from the current document
+                frappe.set_route("form", "Asset Movement", asset_movement.name); // Redirect to the new Asset Movement form
+            }, __("Create"));
         }
     },
     required_from: function (frm) {
@@ -19,8 +26,5 @@ frappe.ui.form.on("Equipment Hire Request", {
     },
     required_to: function (frm) {
         frm.call("validate_required_from_and_required_to");
-    },
-    posting_date:function (frm){
-      frm.call("validate_posting_date");
     }
 });

--- a/beams/beams/doctype/equipment_acquiral_request/equipment_acquiral_request.json
+++ b/beams/beams/doctype/equipment_acquiral_request/equipment_acquiral_request.json
@@ -1,7 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
- "autoname": "format:EHP-{YY}-{####}",
+ "autoname": "format:EAR-{YY}-{####}",
  "creation": "2025-01-18 12:01:22.530499",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -15,7 +15,9 @@
   "required_from",
   "required_to",
   "section_break_ozsg",
-  "required_items"
+  "required_items",
+  "section_break_tmmn",
+  "reason_for_rejection"
  ],
  "fields": [
   {
@@ -27,7 +29,7 @@
    "fieldtype": "Link",
    "label": "Amended From",
    "no_copy": 1,
-   "options": "Equipment Hire Request",
+   "options": "Equipment Acquiral Request",
    "print_hide": 1,
    "read_only": 1,
    "search_index": 1
@@ -35,10 +37,8 @@
   {
    "fieldname": "project",
    "fieldtype": "Link",
-   "in_list_view": 1,
    "label": "Project",
-   "options": "Project",
-   "reqd": 1
+   "options": "Project"
   },
   {
    "fetch_from": "project.bureau",
@@ -76,15 +76,25 @@
    "fieldtype": "Table",
    "label": "Required Items ",
    "options": "Required Hire Items Detail"
+  },
+  {
+   "fieldname": "section_break_tmmn",
+   "fieldtype": "Section Break"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "reason_for_rejection",
+   "fieldtype": "Small Text",
+   "label": "Reason for Rejection"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-02-01 11:03:43.332717",
+ "modified": "2025-01-31 16:12:14.240194",
  "modified_by": "Administrator",
  "module": "BEAMS",
- "name": "Equipment Hire Request",
+ "name": "Equipment Acquiral Request",
  "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [

--- a/beams/beams/doctype/equipment_acquiral_request/equipment_acquiral_request.py
+++ b/beams/beams/doctype/equipment_acquiral_request/equipment_acquiral_request.py
@@ -5,10 +5,12 @@ import frappe
 from frappe.model.document import Document
 from frappe.utils import getdate  # Import getdate function
 from frappe import _  # Import _ for translations
+from frappe.utils import today
 
 class EquipmentAcquiralRequest(Document):
     def validate(self):
         self.validate_required_from_and_required_to()
+        self.validate_posting_date()
 
     @frappe.whitelist()
     def validate_required_from_and_required_to(self):

--- a/beams/beams/doctype/equipment_acquiral_request/equipment_acquiral_request.py
+++ b/beams/beams/doctype/equipment_acquiral_request/equipment_acquiral_request.py
@@ -28,3 +28,10 @@ class EquipmentAcquiralRequest(Document):
                 msg=_('The "Required From" date cannot be after the "Required To" date.'),
                 title=_('Validation Error')
             )
+
+
+    @frappe.whitelist()
+    def validate_posting_date(self):
+        if self.posting_date:
+            if self.posting_date > today():
+                frappe.throw(_("Posting Date cannot be set after today's date."))

--- a/beams/beams/doctype/equipment_acquiral_request/equipment_acquiral_request.py
+++ b/beams/beams/doctype/equipment_acquiral_request/equipment_acquiral_request.py
@@ -4,17 +4,11 @@
 import frappe
 from frappe.model.document import Document
 from frappe.utils import getdate  # Import getdate function
-from frappe.utils import today
 from frappe import _  # Import _ for translations
 
-
-
-class EquipmentHireRequest(Document):
+class EquipmentAcquiralRequest(Document):
     def validate(self):
         self.validate_required_from_and_required_to()
-        
-    def before_save(self):
-        self.validate_posting_date()
 
     @frappe.whitelist()
     def validate_required_from_and_required_to(self):
@@ -34,9 +28,3 @@ class EquipmentHireRequest(Document):
                 msg=_('The "Required From" date cannot be after the "Required To" date.'),
                 title=_('Validation Error')
             )
-
-    @frappe.whitelist()
-    def validate_posting_date(self):
-        if self.posting_date:
-            if self.posting_date > today():
-                frappe.throw(_("Posting Date cannot be set after today's date."))

--- a/beams/beams/doctype/equipment_acquiral_request/test_equipment_acquiral_request.py
+++ b/beams/beams/doctype/equipment_acquiral_request/test_equipment_acquiral_request.py
@@ -5,5 +5,5 @@
 from frappe.tests.utils import FrappeTestCase
 
 
-class TestEquipmentHireRequest(FrappeTestCase):
+class TestEquipmentAcquiralRequest(FrappeTestCase):
 	pass

--- a/beams/beams/doctype/equipment_request/equipment_request.js
+++ b/beams/beams/doctype/equipment_request/equipment_request.js
@@ -4,6 +4,7 @@
 frappe.ui.form.on('Equipment Request', {
     refresh: function (frm) {
         set_item_query(frm)
+
         // Show the 'Asset Movement' button only if the document is submitted (docstatus == 1) and approved
         if (frm.doc.docstatus == 1 && frm.doc.workflow_state == 'Approved') {
             frm.add_custom_button(__('Asset Movement'), function () {
@@ -12,7 +13,16 @@ frappe.ui.form.on('Equipment Request', {
                 frappe.set_route("form", "Asset Movement", asset_movement.name); // Redirect to the new Asset Movement form
             }, __("Create"));
         }
+
+        // Add a button to create an Equipment Acquiral Request
+        frm.add_custom_button(__('Equipment Acquiral Request'), function () {
+            frappe.model.open_mapped_doc({
+                method: "beams.beams.doctype.equipment_request.equipment_request.map_equipment_acquiral_request",
+                frm: frm,
+            });
+        }, __("Create"));
     },
+    
     bureau: function (frm) {
         set_item_query(frm)
     },

--- a/beams/beams/doctype/equipment_request/equipment_request.py
+++ b/beams/beams/doctype/equipment_request/equipment_request.py
@@ -3,8 +3,8 @@
 
 import frappe
 from frappe.model.document import Document
-from frappe.utils import getdate
-from frappe.utils import today
+from frappe.utils import today,getdate
+from frappe.model.mapper import get_mapped_doc
 from frappe import _
 
 class EquipmentRequest(Document):
@@ -30,8 +30,32 @@ class EquipmentRequest(Document):
                 msg=_('The "Required From" date cannot be after the "Required To" date.'),
                 title=_('Validation Error')
             )
+
     @frappe.whitelist()
     def validate_posting_date(self):
         if self.posting_date:
             if self.posting_date > today():
                 frappe.throw(_("Posting Date cannot be set after today's date."))
+
+
+@frappe.whitelist()
+def map_equipment_acquiral_request(source_name, target_doc=None):
+    '''
+    Maps fields from the Equipment Request doctype to the Equipment Acquiral Request doctype.
+    '''
+    return get_mapped_doc(
+        "Equipment Request",
+        source_name,
+        {
+            "Equipment Request": {
+                "doctype": "Equipment Acquiral Request",
+                "field_map": {
+                    "name": "equipment_request",
+                    "expected_start_date": "required_from",
+                    "expected_end_date": "required_to",
+                    "bureau": "bureau"
+                }
+            }
+        },
+        target_doc
+    )

--- a/beams/beams/doctype/external_resource_request/external_resource_request.js
+++ b/beams/beams/doctype/external_resource_request/external_resource_request.js
@@ -1,9 +1,8 @@
-// // Copyright (c) 2025, efeone and contributors
-// // For license information, please see license.txt
+// Copyright (c) 2025, efeone and contributors
+// For license information, please see license.txt
 
 frappe.ui.form.on("External Resource Request", {
     refresh(frm) {
-        // Show the 'Purchase Invoice' button only if the document is submitted (docstatus == 1)
         if (frm.doc.docstatus == 1) {
             frm.add_custom_button(__('Purchase Invoice'), function () {
                 let invoice = frappe.model.get_new_doc("Purchase Invoice");
@@ -12,33 +11,32 @@ frappe.ui.form.on("External Resource Request", {
             }, __("Create"));
         }
     },
+      required_from: function (frm) {
+          frm.call('updated_required_resources',)
+          .then(r => {
+              if (r.message) {
+                  frm.refresh_field("required_resources");
+              }
+          })
+      },
 
-    required_from(frm) {
-        update_required_resources(frm, 'required_from');
-    },
-
-    required_to(frm) {
-        update_required_resources(frm, 'required_to');
-    },
-    required_from: function (frm) {
-        frm.call("validate_required_from_and_required_to");
-    },
-    required_to: function (frm) {
-        frm.call("validate_required_from_and_required_to");
-    }
-});
-
-function update_required_resources(frm, fieldname) {
-    // Ensure at least one row exists in the child table
-    if (!frm.doc.required_resources || frm.doc.required_resources.length === 0) {
-        frappe.model.add_child(frm.doc, 'required_resources');
-    }
-
-    // Update the child table field with the parent field value
-    frm.doc.required_resources.forEach(row => {
-        row[fieldname] = frm.doc[fieldname];
+      required_to: function (frm) {
+        frm.call('updated_required_resources',)
+        .then(r => {
+            if (r.message) {
+                frm.refresh_field("required_resources");
+            }
+        })
+      }
     });
 
-    // Refresh the child table to reflect the changes
-    frm.refresh_field('required_resources');
-}
+    frappe.ui.form.on("External Resources Detail", {
+        required_resources_add: function (frm, cdt, cdn) {
+          frm.call('updated_required_resources',)
+          .then(r => {
+              if (r.message) {
+                  frm.refresh_field("required_resources");
+              }
+          })
+        }
+    });

--- a/beams/beams/doctype/external_resource_request/external_resource_request.py
+++ b/beams/beams/doctype/external_resource_request/external_resource_request.py
@@ -1,9 +1,9 @@
-# Copyright (c) 2025, efeone and contributors
-# For license information, please see license.txt
+# # Copyright (c) 2025, efeone and contributors
+# # For license information, please see license.txt
 
 import frappe
 from frappe.model.document import Document
-from frappe.utils import getdate
+from frappe.utils import today,getdate
 from frappe import _
 
 class ExternalResourceRequest(Document):
@@ -11,22 +11,32 @@ class ExternalResourceRequest(Document):
     def validate(self):
         self.validate_required_from_and_required_to()
 
+    def before_save(self):
+        self.validate_posting_date()
+
     @frappe.whitelist()
     def validate_required_from_and_required_to(self):
-        """
-        Validates that required_from and required_to are properly set and checks
-        if required_from is not later than required_to.
-        """
+        """Validates required_from and required_to dates."""
         if not self.required_from or not self.required_to:
             return
 
-        # Convert dates to proper date objects
         required_from = getdate(self.required_from)
         required_to = getdate(self.required_to)
 
-        # Check if required_from is after required_to
         if required_from > required_to:
             frappe.throw(
                 msg=_('The "Required From" date cannot be after the "Required To" date.'),
                 title=_('Validation Error')
             )
+
+    @frappe.whitelist()
+    def validate_posting_date(self):
+        if self.posting_date:
+            if self.posting_date > today():
+                frappe.throw(_("Posting Date cannot be set after today's date."))
+
+    @frappe.whitelist()
+    def updated_required_resources(self):
+        for req in self.required_resources:
+            req.required_from = self.required_from
+            req.required_to = self.required_to

--- a/beams/beams/doctype/external_resource_request/external_resource_request.py
+++ b/beams/beams/doctype/external_resource_request/external_resource_request.py
@@ -1,5 +1,5 @@
-# # Copyright (c) 2025, efeone and contributors
-# # For license information, please see license.txt
+# Copyright (c) 2025, efeone and contributors
+# For license information, please see license.txt
 
 import frappe
 from frappe.model.document import Document

--- a/beams/beams/doctype/program_request/program_request.json
+++ b/beams/beams/doctype/program_request/program_request.json
@@ -10,6 +10,7 @@
   "program_name",
   "program_type",
   "generates_revenue",
+  "expected_revenue",
   "location",
   "column_break_teaq",
   "posting_date",
@@ -139,12 +140,17 @@
    "fieldname": "estimated_budget",
    "fieldtype": "Currency",
    "label": "Estimated Budget"
+  },
+  {
+   "fieldname": "expected_revenue",
+   "fieldtype": "Float",
+   "label": "Expected Revenue"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-01-18 13:19:00.061148",
+ "modified": "2025-01-31 12:36:15.817621",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Program Request",

--- a/beams/beams/doctype/required_items_detail/required_items_detail.json
+++ b/beams/beams/doctype/required_items_detail/required_items_detail.json
@@ -8,7 +8,8 @@
  "field_order": [
   "required_item",
   "available_item_quantity",
-  "quantity"
+  "quantity",
+  "issued_quantity"
  ],
  "fields": [
   {
@@ -33,12 +34,17 @@
    "in_list_view": 1,
    "label": "Available Quantity",
    "read_only": 1
+  },
+  {
+   "fieldname": "issued_quantity",
+   "fieldtype": "Int",
+   "label": "Issued Quantity"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-01-30 11:29:58.783994",
+ "modified": "2025-01-31 14:48:56.759624",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Required Items Detail",

--- a/beams/beams/doctype/technical_request/technical_request.json
+++ b/beams/beams/doctype/technical_request/technical_request.json
@@ -10,7 +10,8 @@
   "bureau",
   "department",
   "designation",
-  "employee",
+  "no_of_employees",
+  "required_employees",
   "column_break_cgox",
   "posting_date",
   "required_from",
@@ -53,14 +54,6 @@
    "label": "Designation",
    "options": "Designation",
    "reqd": 1
-  },
-  {
-   "allow_on_submit": 1,
-   "fieldname": "employee",
-   "fieldtype": "Link",
-   "label": "Employee ",
-   "mandatory_depends_on": "eval: doc.workflow_state == \"Pending Approval\"",
-   "options": "Employee"
   },
   {
    "fieldname": "column_break_cgox",
@@ -110,12 +103,24 @@
    "print_hide": 1,
    "read_only": 1,
    "search_index": 1
+  },
+  {
+   "fieldname": "no_of_employees",
+   "fieldtype": "Int",
+   "label": "No of Employees"
+  },
+  {
+   "fieldname": "required_employees",
+   "fieldtype": "Table MultiSelect",
+   "label": "Required Employees",
+   "mandatory_depends_on": "eval: doc.workflow_state == \"Pending Approval\"",
+   "options": "Employees"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-01-24 09:48:25.425153",
+ "modified": "2025-02-03 12:44:20.517584",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Technical Request",

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -231,7 +231,7 @@ def get_Project_custom_fields():
                 "label": "Bureau",
                 "fieldtype": "Link",
                 "options":"Bureau",
-                "insert_after": "generates_revenue",
+                "insert_after": "expected_revenue",
                 "fetch_from": "program_request.bureau",
                 "read_only": 1
 
@@ -266,6 +266,14 @@ def get_Project_custom_fields():
                 "insert_after": "program_request"
             },
             {
+                "fieldname": "expected_revenue",
+                "fieldtype": "Float",
+                "label": "Expected Revenue",
+                "read_only": 1,
+                "fetch_from": "program_request.expected_revenue",
+                "insert_after": "generates_revenue"
+            },
+            {
                 "fieldname": "allocated_resources_details_section",
                 "fieldtype": "Section Break",
                 "label": " Allocated Resource Details",
@@ -280,15 +288,6 @@ def get_Project_custom_fields():
                 "insert_after":"allocated_resources_details_section"
             },
             {
-                "fieldname": "estimated_budget",
-                "fieldtype": "Currency",
-                "label": "Estimated Budget",
-                "options":"Estimated Budget",
-                "fetch_from": "program_request.estimated_budget",
-                "insert_after":"generates_revenue",
-                "read_only": 1
-            },
-            {
                 "fieldname": "approved_budget",
                 "fieldtype": "Currency",
                 "label": "Approved Budget",
@@ -296,7 +295,31 @@ def get_Project_custom_fields():
                 "insert_after":"budget_expense_types",
                 "read_only": 1
 
+            },
+            {
+                "fieldname": "estimated_budget",
+                "fieldtype": "Currency",
+                "label": "Estimated Budget",
+                "options":"Estimated Budget",
+                "fetch_from": "program_request.estimated_budget",
+                "insert_after":"approved_budget",
+                "read_only": 1
+            },
+            {
+                "fieldname": "description",
+                "fieldtype": "Small Text",
+                "label": "Description",
+                "fetch_from":"program_request.description",
+                "insert_after": "requirements"
+            },
+            {
+                "fieldname": "requirements",
+                "fieldtype": "Small Text",
+                "label": "Requirements",
+                "fetch_from":"program_request.requirements",
+                "insert_after": "bureau"
             }
+
         ]
     }
 


### PR DESCRIPTION
## Feature description

- [ ] Add functionality that enables number of employees selected for Technical Request.
- [ ] Fetch Description and Remarks from Program Request to Project.
- [ ] Fetch Expected Revenue in Project doctype from program Request.
- [ ] Map External Resource Request from Technical Request. 
- [ ] Populated required resources child table.

## Solution description

- Created a popup in Project that takes inputs to create Technical Request  including no of employees and the technical document created  allows selection from a filtered list based on department and designation and the selection is limitted by the number of employees  specified in the popup.
- Removed assigning Equipments functionality from Project.


Fetched Remarks,Description and expected revenue from Program Request in project.
Created External Resource Request from Technical Request and populated its child table required resources. 


## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/576d2436-28b8-44f6-954c-3f35629616cd)
![image](https://github.com/user-attachments/assets/cc145d2e-7fee-4e67-b98f-90a8f2aa3bd6)
![image](https://github.com/user-attachments/assets/ad31ad4c-0aff-42ad-a83d-9dacc973f228)


## Areas affected and ensured
Technical Request
Equipment Acquiral Request.
External Resource  Request.
Program Request.
Project.

## Is there any existing behavior change of other features due to this code change?
       No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox