### PR TITLE
Fix:Hide the Reason for Rejection field based on workflow state in Employee Travel  Request Doctype

### DIFF
--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.json
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.json
@@ -144,7 +144,8 @@
    "fieldname": "batta_policy",
    "fieldtype": "Link",
    "label": "Batta Policy",
-   "options": "Batta Policy"
+   "options": "Batta Policy",
+   "read_only": 1
   },
   {
    "fieldname": "mode_of_travel",
@@ -167,6 +168,7 @@
   },
   {
    "default": "0",
+   "description": "To mark Attendance for Travel Days",
    "fieldname": "mark_attendance",
    "fieldtype": "Check",
    "label": "Mark Attendance"
@@ -201,9 +203,11 @@
   },
   {
    "allow_on_submit": 1,
+   "depends_on": "eval: doc.workflow_state == \"Pending\" || doc.workflow_state == \"Rejected\" || doc.workflow_state == \"Approved by HOD\";",
    "fieldname": "reason_for_rejection",
    "fieldtype": "Small Text",
-   "label": "Reason for Rejection "
+   "label": "Reason for Rejection ",
+   "read_only_depends_on": "eval: doc.workflow_state == \"Rejected\";"
   },
   {
    "fieldname": "attendance_request",
@@ -216,7 +220,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-02-03 14:24:57.552521",
+ "modified": "2025-02-04 10:00:59.408535",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Employee Travel Request",


### PR DESCRIPTION
## Feature description

 Need to: 

- Hide the Reason for Rejection field based on workflow state in Employee Travel  Request Doctype.
- Change to Batta Policy field to Read Only 
- Add the description for Mark Attendance Check Box

## Solution description

- Hide the Reason for Rejection field based on workflow state in Employee Travel  Request Doctype.
- Changed to Batta Policy field to Read Only 
-  Added the description for Mark Attendance Check Box

## Output screenshots (optional)
[Screencast from 04-02-25 10:13:46 AM IST.webm](https://github.com/user-attachments/assets/f29f1088-e3cf-4379-af4a-9920010a14ef)


## Areas affected and ensured
Employee Travel  Request Doctype.

## Is there any existing behavior change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?
  - Mozilla Firefox
  
