### PR TITLE
fix: Add validation for score field in Interview Feedback dialog

### DIFF
--- a/beams/beams/custom_scripts/interview/interview.js
+++ b/beams/beams/custom_scripts/interview/interview.js
@@ -133,12 +133,10 @@ frappe.ui.form.on('Interview', {
                 let value = parseFloat($(this).val()) || 0;
                 if (value > 10) {
                     frappe.msgprint(__('Score cannot be greater than 10'));
-                    row.score = 10;
                 } else if (value < 0) {
                     frappe.msgprint(__('Score cannot be less than 0'));
-                    row.score = 0;
                 }
-                skill_grid.refresh(); 
+                skill_grid.refresh();
             });
         });
 

--- a/beams/beams/custom_scripts/interview/interview.js
+++ b/beams/beams/custom_scripts/interview/interview.js
@@ -122,7 +122,26 @@ frappe.ui.form.on('Interview', {
                 d.hide();
             }
         });
+
         d.show();
+        frappe.after_ajax(() => {
+            let skill_grid = d.fields_dict.skill_set.grid;
+            skill_grid.wrapper.on('change', 'input[data-fieldname="score"]', function () {
+                let row = skill_grid.get_selected();
+                if (!row) return;
+
+                let value = parseFloat($(this).val()) || 0;
+                if (value > 10) {
+                    frappe.msgprint(__('Score cannot be greater than 10'));
+                    row.score = 10;
+                } else if (value < 0) {
+                    frappe.msgprint(__('Score cannot be less than 0'));
+                    row.score = 0;
+                }
+                skill_grid.refresh(); 
+            });
+        });
+
     },
     get_fields_for_questions: function () {
         return [{


### PR DESCRIPTION
## Feature description
Real-time validation is added to the score field in the feedback dialog to ensure that users cannot enter a score greater than 10.

## Analysis and design (optional)
The score field is validated instantly as the user types, showing an error if it exceeds 10.

## Solution description
- Added an event listener for the score field in the feedback dialog.
- When a score is entered, the script checks if it exceeds the maximum limit of 10. If so, an error message is shown to the user.
- This change ensures that the score validation happens immediately when the user inputs a value, rather than waiting until submission.

## Output screenshots (optional)
[Screencast from 02-04-2025 11:50:56 AM.webm](https://github.com/user-attachments/assets/75f74aff-3afa-4e31-8aa9-a0515a234511)

## Areas affected and ensured
Interview feedback dialog

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Mozilla Firefox
  
