### PR TITLE
TASK-2025-00173:Customized Purchase Order Doctype

### DIFF
--- a/beams/setup.py
+++ b/beams/setup.py
@@ -622,6 +622,23 @@ def get_purchase_order_custom_fields():
                 "depends_on": "eval:doc.is_budget_exceed == 1"
 
             }
+        ],
+        "Purchase Order Item": [
+            {
+                "fieldname": "reference_doctype",
+                "fieldtype": "Link",
+                "label": "Reference DocType",
+                "options":"DocType",
+                "insert_after": "blanket_order_rate"
+            },
+            {
+
+                "fieldname": "reference_document",
+                "fieldtype": "Dynamic Link",
+                "label": "Reference Document",
+                "options":"reference_doctype",
+                "insert_after": "reference_doctype"
+            }
         ]
     }
 


### PR DESCRIPTION
## Feature description
Need to: Customize Purchase Order Doctype. Add following fields in PO Item Table:-
Under References:
- Reference DocType (Link/DocType)
- Reference Document (Dynamic Link/Reference DocType)

## Solution description
Customized Purchase Order Doctype.  Added following fields in Purchase Order  Item Table:-
Under References:
- Reference DocType (Link/DocType)
- Reference Document (Dynamic Link/Reference DocType)

## Output screenshots (optional)
 [Screencast from 04-02-25 01:14:22 PM IST.webm](https://github.com/user-attachments/assets/f39d01dd-89d6-4dd8-84ce-17116be5f7ba)
![image](https://github.com/user-attachments/assets/2544e7c4-1acc-413a-8ec8-12791abfc3ff)

## Areas affected and ensured
Purchase Order Doctype

## Is there any existing behavior change of other features due to this code change?
No. 

## Was this feature tested on the browsers?
  - Mozilla Firefox

