### PR TITLE
TASK-2025-00172:Equipment Request created from Project

### DIFF
--- a/beams/beams/custom_scripts/project/project.js
+++ b/beams/beams/custom_scripts/project/project.js
@@ -16,13 +16,13 @@ frappe.ui.form.on('Project', {
             });
         }, __("Create"));
 
-        // Add a button to create an Equipment Request
-        frm.add_custom_button(__('Equipment Request'), function () {
-            frappe.model.open_mapped_doc({
-                method: "beams.beams.custom_scripts.project.project.map_equipment_request",
-                frm: frm,
-            });
-        }, __("Create"));
+        // // Add a button to create an Equipment Request
+        // frm.add_custom_button(__('Equipment Request'), function () {
+        //     frappe.model.open_mapped_doc({
+        //         method: "beams.beams.custom_scripts.project.project.map_equipment_request",
+        //         frm: frm,
+        //     });
+        // }, __("Create"));
 
         // Adds a button to the 'Project' form to create an Transportation Request.
         frm.add_custom_button(__('Transportation Request'), function () {
@@ -139,5 +139,163 @@ frappe.ui.form.on('Project', {
             });
         }, "Create");
 
-     }
+        frm.add_custom_button(__('Equipment Request'), function () {
+    const dialog = new frappe.ui.Dialog({
+        title: 'Equipments',
+        fields: [
+            {
+                label: 'Required From',
+                fieldtype: 'Datetime',
+                fieldname: 'required_from',
+                in_list_view: 1,
+                reqd: 1
+            },
+            {
+                label: 'Required To',
+                fieldtype: 'Datetime',
+                fieldname: 'required_to',
+                in_list_view: 1,
+                reqd: 1
+            },
+            {
+                fieldtype: 'Table',
+                label: 'Equipments',
+                fieldname: 'equipments',
+                reqd: 1,
+                fields: [
+                    {
+                        label: 'Item',
+                        fieldtype: 'Link',
+                        fieldname: 'item',
+                        options: 'Item',
+                        in_list_view: 1,
+                        reqd: 1,
+                        onchange: function() {
+                            let data = [];
+                            let promises = [];
+
+                            dialog.fields_dict.equipments.df.data.forEach((item, i) => {
+                                let promise = frappe.call({
+                                    method: "beams.beams.custom_scripts.project.project.get_available_quantities",
+                                    args: {
+                                        items: [item.item],
+                                        bureau: frm.doc.bureau
+                                    },
+                                    callback: function(r) {
+                                        if (r.message) {
+                                            const available_qty = r.message[item.item] || 0;
+                                            item["available_quantity"] = available_qty;
+                                            data.push(item);
+                                        }
+                                    }
+                                });
+
+                                promises.push(promise);
+                            });
+
+                            Promise.all(promises).then(() => {
+                                dialog.fields_dict.equipments.df.data = data;
+                                dialog.fields_dict.equipments.grid.refresh();
+                            });
+                        }
+                    },
+                    {
+                        label: 'Available Quantity',
+                        fieldtype: 'Int',
+                        fieldname: 'available_quantity',
+                        in_list_view: 1,
+                        read_only: 1,
+                        default: 0
+                    },
+                    {
+                        label: 'Required Quantity',
+                        fieldtype: 'Int',
+                        fieldname: 'required_quantity',
+                        in_list_view: 1,
+                        reqd: 1
+                    },
+                ]
+            }
+        ],
+        size: 'large',
+        primary_action_label: 'Submit',
+        primary_action(values) {
+            const equipment_data = values?.equipments || [];
+
+            // Validate if required dates are provided and if "Required From" is before "Required To"
+            const required_from = values.required_from;
+            const required_to = values.required_to;
+
+            if (!required_from || !required_to) {
+                frappe.msgprint(__('Both "Required From" and "Required To" are mandatory.'));
+                return;
+            }
+
+            if (required_from >= required_to) {
+                frappe.msgprint(__('"Required From" date should be earlier than "Required To" date.'));
+                return;
+            }
+
+            if (!equipment_data.length) {
+                frappe.msgprint(__('Please add at least one equipment row.'));
+                return;
+            }
+
+            const request_data = [];
+
+            // Loop through equipment data to process requests
+            for (const row of equipment_data) {
+                const available_qty = row.available_quantity || 0;
+
+                request_data.push({
+                    item: row.item,
+                    quantity: row.required_quantity,
+                    available_quantity: available_qty,
+                    required_from: row.required_from,
+                    required_to: row.required_to
+                });
+            }
+
+            // Create the equipment request
+            const create_requests = [];
+            if (request_data.length) {
+                create_requests.push(
+                    frappe.call({
+                        method: 'beams.beams.custom_scripts.project.project.create_equipment_request',
+                        args: {
+                            source_name: frm.doc.name,
+                            equipment_data: JSON.stringify(request_data),
+                            required_from: values.required_from,
+                            required_to: values.required_to
+                        }
+                    })
+                );
+            }
+
+            Promise.all(create_requests)
+                .then(() => {
+                    dialog.hide();
+                    frm.reload_doc();
+                });
+        }
+    });
+
+    // Set the item filter based on bureau's assets
+    frappe.call({
+        method: "beams.beams.custom_scripts.project.project.get_assets_by_bureau",
+        args: { bureau: frm.doc.bureau },
+        callback: function(r) {
+            if (r.message?.length) {
+                dialog.fields_dict.equipments.grid.get_field("item").get_query = () => ({
+                    filters: { name: ["in", r.message] }
+                });
+                dialog.show();
+            } else {
+                frappe.msgprint(__('No available items found for the selected Bureau.'));
+            }
+        }
+    });
+    }, __("Create"));
+
+    }
   });

--- a/beams/beams/custom_scripts/project/project.js
+++ b/beams/beams/custom_scripts/project/project.js
@@ -16,14 +16,6 @@ frappe.ui.form.on('Project', {
             });
         }, __("Create"));
 
-        // // Add a button to create an Equipment Request
-        // frm.add_custom_button(__('Equipment Request'), function () {
-        //     frappe.model.open_mapped_doc({
-        //         method: "beams.beams.custom_scripts.project.project.map_equipment_request",
-        //         frm: frm,
-        //     });
-        // }, __("Create"));
-
         // Adds a button to the 'Project' form to create an Transportation Request.
         frm.add_custom_button(__('Transportation Request'), function () {
             frappe.model.open_mapped_doc({

--- a/beams/beams/doctype/equipment_request/equipment_request.js
+++ b/beams/beams/doctype/equipment_request/equipment_request.js
@@ -22,7 +22,7 @@ frappe.ui.form.on('Equipment Request', {
             });
         }, __("Create"));
     },
-    
+
     bureau: function (frm) {
         set_item_query(frm)
     },


### PR DESCRIPTION
## Feature description
-  Add Button  in Project to create equipment request which will open a popup with table for entering data:-
- When an item is selected in the table, available qty should be fetched in required qty can be entered.
- Upon primary action of popup, create equipment request

## Analysis and design (optional)
When Equipment Request button is clicked a popup dialog box appears.This has item field that shows filtered list of items in a particular Bureau.Available quantity is fetched by checking availability of the item.
 validation logic for the "Required From" and "Required To" fields in the Equipment Request popup.
Upon Submission Equipment Request is created.

## Output screenshots (optional)

![image](https://github.com/user-attachments/assets/26fd541f-ca87-441d-9f00-cde0bea95a7a)
![image](https://github.com/user-attachments/assets/e92630c9-1518-4be2-bb44-d31619aaf090)



## Is there any existing behavior change of other features due to this code change?
      No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox

