### PR TITLE
Fix:Hide the Reason for Rejection field based on workflow state in Equipment Request Doctype

### DIFF
--- a/beams/beams/doctype/equipment_request/equipment_request.json
+++ b/beams/beams/doctype/equipment_request/equipment_request.json
@@ -83,15 +83,17 @@
   },
   {
    "allow_on_submit": 1,
+   "depends_on": "eval: doc.workflow_state == \"Pending Approval\" || doc.workflow_state == \"Rejected\";\n",
    "fieldname": "reason_for_rejection",
    "fieldtype": "Small Text",
-   "label": "Reason for Rejection"
+   "label": "Reason for Rejection",
+   "read_only_depends_on": "eval: doc.workflow_state != \"Pending Approval\";"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-02-01 13:23:41.358161",
+ "modified": "2025-02-04 13:32:15.483347",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Equipment Request",

--- a/beams/beams/doctype/equipment_request/equipment_request.py
+++ b/beams/beams/doctype/equipment_request/equipment_request.py
@@ -8,11 +8,19 @@ from frappe.model.mapper import get_mapped_doc
 from frappe import _
 
 class EquipmentRequest(Document):
+    
+    def on_cancel(self):
+        # Validate that "Reason for Rejection" is provided if the status is "Rejected"
+        if self.workflow_state == "Rejected" and not self.reason_for_rejection:
+            frappe.throw("Please provide a Reason for Rejection before rejecting this request.")
+
     def validate(self):
         self.validate_required_from_and_required_to()
 
     def before_save(self):
         self.validate_posting_date()
+
+
 
     @frappe.whitelist()
     def validate_required_from_and_required_to(self):

--- a/beams/beams/doctype/equipment_request/equipment_request.py
+++ b/beams/beams/doctype/equipment_request/equipment_request.py
@@ -8,7 +8,7 @@ from frappe.model.mapper import get_mapped_doc
 from frappe import _
 
 class EquipmentRequest(Document):
-    
+
     def on_cancel(self):
         # Validate that "Reason for Rejection" is provided if the status is "Rejected"
         if self.workflow_state == "Rejected" and not self.reason_for_rejection:
@@ -19,8 +19,6 @@ class EquipmentRequest(Document):
 
     def before_save(self):
         self.validate_posting_date()
-
-
 
     @frappe.whitelist()
     def validate_required_from_and_required_to(self):


### PR DESCRIPTION
## Feature description
Need to: Hide the Reason for Rejection field based on workflow state in Equipment Request Doctype

## Solution description
Hide the Reason for Rejection field based on workflow state in Equipment Request Doctype

## Output screenshots (optional)
[Screencast from 04-02-25 03:43:38 PM IST.webm](https://github.com/user-attachments/assets/6d0238fd-8ef3-49f0-a5a3-badea566cd95)

## Areas affected and ensured
Equipment Request Doctype


## Is there any existing behavior change of other features due to this code change?
 No.
 
## Was this feature tested on the browsers?
  - Mozilla Firefox
 
