### PR TITLE
fix: Restrict interview visibility to assigned interviewers only

### DIFF
--- a/beams/beams/custom_scripts/interview/interview.py
+++ b/beams/beams/custom_scripts/interview/interview.py
@@ -175,7 +175,7 @@ def get_permission_query_conditions(user):
     user_roles = frappe.get_roles(user)
 
     # Allow Administrator to see all interviews
-    if "Administrator" in user_roles:
+    if "System Manager" in user_roles:
         return None
 
     # Restrict Interviewers to see only scheduled interviews where they are assigned

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -138,6 +138,7 @@ before_uninstall = "beams.setup.before_uninstall"
 
 permission_query_conditions = {
 "Job Applicant": "beams.beams.custom_scripts.job_applicant.job_applicant.get_permission_query_conditions",
+"Interview": "beams.beams.custom_scripts.interview.interview.get_permission_query_conditions"
 }
 
 # has_permission = {


### PR DESCRIPTION
## Feature description
Restricts interview visibility for users with the "Interviewer" role to only those interviews they are assigned to

## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description
- Modified the get_permission_query_conditions method to ensure that only users with the "Interviewer" role can see interviews where they are assigned as an interviewer.
- The query checks the Interview Details table to match the logged-in user with the interviewer field.
- Administrators have unrestricted access to all interviews.

## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.

## Areas affected and ensured
- Interview DocType permissions
- Interview Details table functionality for filtering interviews by interviewer

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
