### PR TITLE
fix: Update field label from His/Her Name to Related Employee Name

### DIFF
--- a/beams/setup.py
+++ b/beams/setup.py
@@ -1362,8 +1362,8 @@ def get_employee_custom_fields():
                 "insert_after": "places_to_travel"
             },
             {
-                "fieldname": "employee_name",
-                "label": "His/Her Name",
+                "fieldname": "related_employee_name",
+                "label": "Related Employee Name",
                 "fieldtype": "Data",
                 "insert_after": "are_you_related_to_employee",
                 "depends_on": "eval:doc.are_you_related_to_employee == 1",


### PR DESCRIPTION
## Fix description
The Employee DocType already has the field "His/Her Name". Since the same label was used when  Are You Related to Employee(checkbox) was checked, it caused an error.

## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description
Renamed the duplicate "His/Her Name" field to "Related Employee Name" when Are You Related to Employee(checkbox) was checked 

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/cdd75a4b-5d6f-41f5-86f8-f933c953b9a7)

## Areas affected and ensured
Employee

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Mozilla Firefox
  