### PR TITLE
feat:create a service item with the same details and set it in the original item

### DIFF
--- a/beams/beams/custom_scripts/item/item.py
+++ b/beams/beams/custom_scripts/item/item.py
@@ -1,10 +1,9 @@
 import frappe
 
-@frappe.whitelist()
 def before_insert(doc, method):
     """Before inserting an Item, fetch 'Hireable' from Item Group if not set and create a Service Item if required."""
 
-    if not doc.hireable and doc.item_group:
+    if not doc.hireable:
         doc.hireable = frappe.db.get_value("Item Group", doc.item_group, "hireable")
 
     if doc.hireable and "-Service" not in doc.item_code:

--- a/beams/beams/custom_scripts/item/item.py
+++ b/beams/beams/custom_scripts/item/item.py
@@ -1,0 +1,37 @@
+import frappe
+
+@frappe.whitelist()
+def before_insert(doc, method):
+    """Before inserting an Item, fetch 'Hireable' from Item Group if not set and create a Service Item if required."""
+
+    if not doc.hireable and doc.item_group:
+        doc.hireable = frappe.db.get_value("Item Group", doc.item_group, "hireable")
+
+    if doc.hireable and "-Service" not in doc.item_code:
+        service_item = create_service_item(doc)
+        doc.service_item = service_item
+
+def create_service_item(doc):
+    """Creates a Service Item and ensures 'Hireable' is disabled."""
+
+    service_item_code = f"{doc.item_code}-Service"
+    if frappe.db.exists("Item", service_item_code):
+        return service_item_code
+
+
+    service_item = frappe.get_doc({
+        "doctype": "Item",
+        "item_code": service_item_code,
+        "item_name": f"{doc.item_name} (Service)",
+        "description": doc.description,
+        "item_group": doc.item_group,
+        "stock_uom": doc.stock_uom,
+        "is_stock_item": 0,
+        "is_sales_item": 1,
+        "is_service_item": 1,
+        "hireable": 0
+    })
+
+    service_item.insert(ignore_permissions=True)
+    frappe.db.set_value("Item", service_item.name, "hireable", 0)
+    return service_item.name

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -150,7 +150,7 @@ permission_query_conditions = {
 
 override_doctype_class = {
     "Attendance Request": "beams.beams.custom_scripts.attendance_request.attendance_request.AttendanceRequestOverride",
-    "Shift Type": "beams.beams.custom_scripts.shift_type.shift_type.ShiftTypeOverride"
+    "Shift Type": "beams.beams.custom_scripts.shift_type.shift_type.ShiftTypeOverride",
 }
 
 # Document Events
@@ -298,6 +298,11 @@ doc_events = {
     "Project": {
          "on_update": "beams.beams.custom_scripts.project.project.update_program_request_status_on_project_completion",
          "validate":"beams.beams.custom_scripts.project.project.validate_employee_assignment"
+    },
+    "Item": {
+        "before_insert": [
+            "beams.beams.custom_scripts.item.item.before_insert"
+        ]
     }
 }
 

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -150,7 +150,7 @@ permission_query_conditions = {
 
 override_doctype_class = {
     "Attendance Request": "beams.beams.custom_scripts.attendance_request.attendance_request.AttendanceRequestOverride",
-    "Shift Type": "beams.beams.custom_scripts.shift_type.shift_type.ShiftTypeOverride",
+    "Shift Type": "beams.beams.custom_scripts.shift_type.shift_type.ShiftTypeOverride"
 }
 
 # Document Events

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -52,6 +52,7 @@ def after_install():
     create_custom_fields(get_asset_custom_fields(),ignore_validate=True)
     create_custom_fields(get_vehicle_custom_fields(),ignore_validate=True)
     create_custom_fields(get_interview_custom_fields(),ignore_validate=True)
+    create_custom_fields(get_item_group_custom_fields(),ignore_validate=True)
 
 
     #Creating BEAMS specific Property Setters
@@ -115,6 +116,7 @@ def before_uninstall():
     delete_custom_fields(get_asset_custom_fields())
     delete_custom_fields(get_vehicle_custom_fields())
     delete_custom_fields(get_interview_custom_fields())
+    delete_custom_fields(get_item_group_custom_fields())
 
 
 def delete_custom_fields(custom_fields: dict):
@@ -1151,6 +1153,25 @@ def get_supplier_custom_fields():
         ]
     }
 
+def get_item_group_custom_fields():
+    '''
+    Custom fields that need to be added to the Quotation Item Doctype
+    '''
+    return {
+        "Item Group": [
+            {
+                "fieldname": "hireable",
+                "fieldtype": "Check",
+                "label": "Hireable",
+                "fetch_from":"parent_item_group.hireable",
+                "set_only_once":1,
+                "fetch_if_empty":1,
+                "insert_after": "gst_hsn_code"
+            }
+
+        ]
+    }
+
 def get_item_custom_fields():
     '''
     Custom fields that need to be added to the Quotation Item Doctype
@@ -1169,8 +1190,23 @@ def get_item_custom_fields():
                 "label": "Sales Type",
                 "options": "Sales Type",
                 "insert_after": "is_production_item"
+           },
+           {
+               "fieldname": "hireable",
+               "fieldtype": "Check",
+               "label": "Hireable",
+               "fetch_from":"item_group.hireable",
+               "set_only_once":1,
+               "insert_after": "gst_hsn_code"
+           },
+           {
+               "fieldname": "service_item",
+               "fieldtype": "Link",
+               "label": "Service Item",
+               "options": "Item",
+               "read_only":1,
+               "insert_after": "item_group"
            }
-
         ]
     }
 


### PR DESCRIPTION

## Feature description
Customize Item Group:-
- Hireable (check, set only once, fetch from parent item group (fetch only if empty))

Customize Item:-
- Hireable (check, fetch from item group, set only once)
- Service Item (Link, Item)

If an item is created with Hireable checked, create a service item with the same details and set it in the original item

## Solution description
Customized Item Group (added field hireable)
Customized Item (added field hireable and service item)
Created a service item with the same details and set it in the original item when an item created with hireable checked

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/52fbc147-fb02-4081-907e-896ebb7e139d)
![image](https://github.com/user-attachments/assets/f52137d6-ca4a-4407-892c-03bddee5b50d)


## Areas affected and ensured
Item Group
Item

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Mozilla Firefox
  
