### PR TITLE
Feat:Created Purchase Order Button from Equipment Acquiral Request Doctype  to Purchase Order Doctype

### DIFF
--- a/beams/beams/doctype/equipment_acquiral_request/equipment_acquiral_request.js
+++ b/beams/beams/doctype/equipment_acquiral_request/equipment_acquiral_request.js
@@ -1,5 +1,6 @@
 // Copyright (c) 2025, efeone and contributors
 // For license information, please see license.txt
+
 frappe.ui.form.on("Equipment Acquiral Request", {
     refresh(frm) {
         if (frm.doc.docstatus === 1 && frm.doc.workflow_state === 'Approved') {

--- a/beams/beams/doctype/equipment_acquiral_request/equipment_acquiral_request.js
+++ b/beams/beams/doctype/equipment_acquiral_request/equipment_acquiral_request.js
@@ -1,33 +1,117 @@
-// Copyright (c) 2025, efeone and contributors
-// For license information, please see license.txt
-
 frappe.ui.form.on("Equipment Acquiral Request", {
     refresh(frm) {
-        // Show the 'Purchase Invoice' button only if the document is submitted (docstatus == 1) and approved
-        if (frm.doc.docstatus == 1 && frm.doc.workflow_state == 'Approved') {
+        if (frm.doc.docstatus === 1 && frm.doc.workflow_state === 'Approved') {
+            frm.add_custom_button(__('Purchase Order'), function() {
+                let dialog = new frappe.ui.Dialog({
+                    title: __('Purchase Order'),
+                    fields: [
+                        {
+                            fieldtype: 'Link',
+                            label: 'Supplier',
+                            fieldname: 'supplier',
+                            options: 'Supplier',
+                            reqd: 1,
+                            in_list_view: 1
+                        },
+                        {
+                            fieldtype: 'Date',
+                            label: 'Required by Date',
+                            fieldname: 'schedule_date',
+                            reqd: 1,
+                            in_list_view: 1
+                        },
+                        {
+                            fieldtype: 'Table',
+                            label: 'Items',
+                            fieldname: 'items',
+                            reqd: 1,
+                            fields: [
+                                {
+                                    fieldtype: 'Link',
+                                    label: 'Item',
+                                    fieldname: 'item_code',
+                                    options: 'Item',
+                                    in_list_view: 1
+                                },
+                                {
+                                    fieldtype: 'Float',
+                                    label: 'Quantity',
+                                    fieldname: 'qty',
+                                    in_list_view: 1
+                                }
+                            ],
+                            data: frm.doc.required_items.map(item => ({
+                                item_code: item.item,
+                                qty: item.quantity,
+                                acquired_qty: item.acquired_qty || 0
+                            }))
+                        }
+                    ],
+                    size: 'large',
+                    primary_action_label: __('Create Purchase Order'),
+                    primary_action: function() {
+                        let values = dialog.get_values();
+                        frappe.model.with_doctype('Purchase Order', function() {
+                            let po = frappe.model.get_new_doc('Purchase Order');
 
-            // Create 'Purchase Invoice' button
-            frm.add_custom_button(__('Purchase Invoice'), function () {
-                let invoice = frappe.model.get_new_doc("Purchase Invoice");
-                invoice.posting_date = frm.doc.posting_date; // Set posting date from the current document
-                frappe.set_route("form", "Purchase Invoice", invoice.name); // Redirect to the new Purchase Invoice form
-            }, __("Create"));
+                            po.posting_date = frm.doc.posting_date;
 
-            // Create 'Asset Movement' button
-            frm.add_custom_button(__('Asset Movement'), function () {
-                let asset_movement = frappe.model.get_new_doc("Asset Movement");
-                asset_movement.posting_date = frm.doc.posting_date; // Set posting date from the current document
-                frappe.set_route("form", "Asset Movement", asset_movement.name); // Redirect to the new Asset Movement form
-            }, __("Create"));
+                            values.items.forEach(item => {
+                                let child = frappe.model.add_child(po, 'Purchase Order Item', 'items');
+                                child.item_code = item.item_code;
+                                child.qty = item.qty;
+                                child.acquired_qty = item.acquired_qty;
+                            });
+
+                            po.supplier = values.supplier;
+
+                            if (!po.supplier) {
+                                frappe.msgprint({
+                                    title: __('Error'),
+                                    indicator: 'red',
+                                    message: __('Please select a supplier')
+                                });
+                                return;
+                            }
+
+                            po.schedule_date = values.schedule_date;
+
+                            if (!po.schedule_date) {
+                                frappe.msgprint({
+                                    title: __('Error'),
+                                    indicator: 'red',
+                                    message: __('Please select a Required by Date')
+                                });
+                                return;
+                            }
+
+                            frappe.db.insert(po)
+                                .then(doc => {
+                                    frappe.show_alert({
+                                        message: __('Purchase Order created'),
+                                        indicator: 'green'
+                                    });
+                                    frappe.set_route('Form', 'Purchase Order', doc.name);
+                                    dialog.hide();
+                                })
+                        });
+                    }
+                });
+
+                dialog.show();
+            }, __('Create'));
         }
     },
+
     required_from: function (frm) {
         frm.call("validate_required_from_and_required_to");
     },
+
     required_to: function (frm) {
         frm.call("validate_required_from_and_required_to");
     },
-    posting_date:function (frm){
-      frm.call("validate_posting_date");
-    },
+
+    posting_date: function (frm) {
+        frm.call("validate_posting_date");
+    }
 });

--- a/beams/beams/doctype/equipment_acquiral_request/equipment_acquiral_request.js
+++ b/beams/beams/doctype/equipment_acquiral_request/equipment_acquiral_request.js
@@ -1,3 +1,5 @@
+// Copyright (c) 2025, efeone and contributors
+// For license information, please see license.txt
 frappe.ui.form.on("Equipment Acquiral Request", {
     refresh(frm) {
         if (frm.doc.docstatus === 1 && frm.doc.workflow_state === 'Approved') {

--- a/beams/beams/doctype/equipment_acquiral_request/equipment_acquiral_request.json
+++ b/beams/beams/doctype/equipment_acquiral_request/equipment_acquiral_request.json
@@ -75,7 +75,7 @@
    "fieldname": "required_items",
    "fieldtype": "Table",
    "label": "Required Items ",
-   "options": "Required Hire Items Detail"
+   "options": "Required Acquiral Items Detail"
   },
   {
    "fieldname": "section_break_tmmn",
@@ -83,15 +83,17 @@
   },
   {
    "allow_on_submit": 1,
+   "depends_on": "eval: doc.workflow_state == \"Pending Approval\" || doc.workflow_state == \"Rejected\";",
    "fieldname": "reason_for_rejection",
    "fieldtype": "Small Text",
-   "label": "Reason for Rejection"
+   "label": "Reason for Rejection",
+   "read_only_depends_on": "eval: doc.workflow_state != \"Pending Approval\";"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-01-31 16:12:14.240194",
+ "modified": "2025-02-05 13:43:31.160610",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Equipment Acquiral Request",

--- a/beams/beams/doctype/equipment_acquiral_request/equipment_acquiral_request.py
+++ b/beams/beams/doctype/equipment_acquiral_request/equipment_acquiral_request.py
@@ -10,6 +10,8 @@ from frappe.utils import today
 class EquipmentAcquiralRequest(Document):
     def validate(self):
         self.validate_required_from_and_required_to()
+
+    def before_save(self):
         self.validate_posting_date()
 
     @frappe.whitelist()
@@ -20,11 +22,9 @@ class EquipmentAcquiralRequest(Document):
         """
         if not self.required_from or not self.required_to:
             return
-        # Convert dates to proper date objects
         required_from = getdate(self.required_from)
         required_to = getdate(self.required_to)
 
-        # Check if required_from is after required_to
         if required_from > required_to:
             frappe.throw(
                 msg=_('The "Required From" date cannot be after the "Required To" date.'),

--- a/beams/beams/doctype/equipment_request/equipment_request.js
+++ b/beams/beams/doctype/equipment_request/equipment_request.js
@@ -5,16 +5,14 @@ frappe.ui.form.on('Equipment Request', {
     refresh: function (frm) {
         set_item_query(frm)
 
-        // Show the 'Asset Movement' button only if the document is submitted (docstatus == 1) and approved
         if (frm.doc.docstatus == 1 && frm.doc.workflow_state == 'Approved') {
             frm.add_custom_button(__('Asset Movement'), function () {
                 let asset_movement = frappe.model.get_new_doc("Asset Movement");
-                asset_movement.posting_date = frm.doc.posting_date; // Set posting date from the current document
-                frappe.set_route("form", "Asset Movement", asset_movement.name); // Redirect to the new Asset Movement form
+                asset_movement.posting_date = frm.doc.posting_date;
+                frappe.set_route("form", "Asset Movement", asset_movement.name);
             }, __("Create"));
         }
 
-        // Add a button to create an Equipment Acquiral Request
         frm.add_custom_button(__('Equipment Acquiral Request'), function () {
             frappe.model.open_mapped_doc({
                 method: "beams.beams.doctype.equipment_request.equipment_request.map_equipment_acquiral_request",
@@ -68,7 +66,6 @@ function validate_dates(frm) {
 
 function set_item_query(frm) {
   if (frm.doc.bureau) {
-      // Fetch all assets with the same bureau
       frappe.call({
           method: 'frappe.client.get_list',
           args: {
@@ -83,7 +80,6 @@ function set_item_query(frm) {
               if (response.message && response.message.length > 0) {
                   const item_codes = response.message.map(asset => asset.item_code);
 
-                  // Set the filter for the child table's Required Item field
                   frm.fields_dict['required_equipments'].grid.get_field('required_item').get_query = function () {
                       return {
                           filters: {

--- a/beams/beams/doctype/equipment_request/equipment_request.py
+++ b/beams/beams/doctype/equipment_request/equipment_request.py
@@ -48,8 +48,12 @@ class EquipmentRequest(Document):
 def map_equipment_acquiral_request(source_name, target_doc=None):
     '''
     Maps fields from the Equipment Request doctype to the Equipment Acquiral Request doctype.
+    Calculates acquired_qty as Required Qty - Issued Qty in the child table.
+    Only maps the required_item (item) to the child table.
     '''
-    return get_mapped_doc(
+    equipment_request = frappe.get_doc("Equipment Request", source_name)
+
+    target_doc = get_mapped_doc(
         "Equipment Request",
         source_name,
         {
@@ -65,3 +69,12 @@ def map_equipment_acquiral_request(source_name, target_doc=None):
         },
         target_doc
     )
+
+    for item in equipment_request.required_equipments:
+        acquired_qty = item.quantity - item.issued_quantity
+        target_item = target_doc.append("required_items", {
+            "item": item.required_item,
+            "quantity": acquired_qty
+        })
+
+    return target_doc

--- a/beams/beams/doctype/required_acquiral_items_detail/required_acquiral_items_detail.json
+++ b/beams/beams/doctype/required_acquiral_items_detail/required_acquiral_items_detail.json
@@ -7,7 +7,8 @@
  "engine": "InnoDB",
  "field_order": [
   "item",
-  "quantity"
+  "quantity",
+  "acquired_qty"
  ],
  "fields": [
   {
@@ -24,15 +25,21 @@
    "in_list_view": 1,
    "label": "Quantity",
    "reqd": 1
+  },
+  {
+   "fieldname": "acquired_qty",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Acquired Quantity"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-01-29 09:53:12.785405",
+ "modified": "2025-02-04 12:38:48.534795",
  "modified_by": "Administrator",
  "module": "BEAMS",
- "name": "Required Hire Items Detail",
+ "name": "Required Acquiral Items Detail",
  "owner": "Administrator",
  "permissions": [],
  "sort_field": "modified",

--- a/beams/beams/doctype/required_acquiral_items_detail/required_acquiral_items_detail.py
+++ b/beams/beams/doctype/required_acquiral_items_detail/required_acquiral_items_detail.py
@@ -5,5 +5,5 @@
 from frappe.model.document import Document
 
 
-class RequiredHireItemsDetail(Document):
+class RequiredAcquiralItemsDetail(Document):
 	pass

--- a/beams/beams/doctype/required_items_detail/required_items_detail.json
+++ b/beams/beams/doctype/required_items_detail/required_items_detail.json
@@ -38,13 +38,14 @@
   {
    "fieldname": "issued_quantity",
    "fieldtype": "Int",
+   "in_list_view": 1,
    "label": "Issued Quantity"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-01-31 14:48:56.759624",
+ "modified": "2025-02-04 12:22:55.172165",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Required Items Detail",

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -3565,7 +3565,7 @@ def get_beams_roles():
     '''
         Method to get BEAMS specific roles
     '''
-    return ['Production Manager', 'CEO', 'Company Secretary', 'HOD','Enquiry Officer','Enquiry Manager','Shift Publisher','Program Producer','Operations Head','Operations User','Admin','Driver']
+    return ['Production Manager', 'CEO', 'Company Secretary', 'HOD','Enquiry Officer','Enquiry Manager','Shift Publisher','Program Producer','Operations Head','Operations User','Admin','Driver','Budget User']
 
 def get_custom_translations():
     '''


### PR DESCRIPTION
## Feature description
Need to: 

- Create Purchase Order Button from Equipment Acquiral Request Doctype  to Purchase Order Doctype.
Showed a dialog box, Items in the form is displayed in the dialog box. Everything editable. on      Primary action, create Purchase Order with the Corresponding Item Row reference in the PO Item Table
- Maps fields from the Equipment Request doctype to the Equipment Acquiral Request doctype.
- Create new Role "Budget User".

## Solution description

- Created Purchase Order Button from Equipment Acquiral Request Doctype  to Purchase Order Doctype.
   Show a dialog box, Items in the form is displayed in the dialog box. Everything editable. on Primary action, create    Purchase Order with the Corresponding Item Row reference in the PO Item Table
- Maps fields from the Equipment Request doctype to the Equipment Acquiral Request doctype.
             - Calculated acquired_qty as Required Qty - Issued Qty in the child table.
            - Only maps the required_item (item) to the child table.

- Created new Role "Budget User".

## Output screenshots (optional)
[Screencast from 05-02-25 02:29:41 PM IST.webm](https://github.com/user-attachments/assets/b7af09b2-69e9-4876-9eaa-4f09fff074d0)

[Screencast from 05-02-25 02:30:54 PM IST.webm](https://github.com/user-attachments/assets/5bf6f768-04f1-44ea-8ea0-22c4c7d91ea3)

## Areas affected and ensured
Acquiral Request Doctype 

## Is there any existing behavior change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?
  - Mozilla Firefox
 
