### PR TITLE
feat:mapping from award record to employee travel request

### DIFF
--- a/beams/beams/doctype/award_record/award_record.js
+++ b/beams/beams/doctype/award_record/award_record.js
@@ -1,6 +1,3 @@
-// Copyright (c) 2025, efeone and contributors
-// For license information, please see license.txt
-//
 
 frappe.ui.form.on('Award Record', {
     refresh: function (frm) {

--- a/beams/beams/doctype/award_record/award_record.js
+++ b/beams/beams/doctype/award_record/award_record.js
@@ -1,3 +1,5 @@
+// Copyright (c) 2025, efeone and contributors
+// For license information, please see license.txt
 
 frappe.ui.form.on('Award Record', {
     refresh: function (frm) {

--- a/beams/beams/doctype/award_record/award_record.js
+++ b/beams/beams/doctype/award_record/award_record.js
@@ -1,5 +1,6 @@
 // Copyright (c) 2025, efeone and contributors
 // For license information, please see license.txt
+//
 
 frappe.ui.form.on('Award Record', {
     refresh: function (frm) {
@@ -8,15 +9,17 @@ frappe.ui.form.on('Award Record', {
                 create_jv(frm);
             }, __('Create'));
         }
-        // Show button only if workflow_state is "Awarded"
-        if (frm.doc.workflow_state === "Awarded") {
-            frm.add_custom_button(__('Travel Request'), function() {
+
+        // Show button only if workflow_state is "Awarded", "Applied", or "Nominated"
+        if (["Awarded", "Applied", "Nominated"].includes(frm.doc.workflow_state)) {
+            frm.add_custom_button(__('Employee Travel Request'), function() {
                 create_travel_request(frm);
             }, __('Create'));
         }
     },
-    posting_date:function (frm){
-      frm.call("validate_posting_date");
+
+    posting_date: function (frm) {
+        frm.call("validate_posting_date");
     }
 });
 
@@ -50,17 +53,18 @@ function create_jv(frm) {
 }
 
 function create_travel_request(frm) {
-    frappe.new_doc('Travel Request', {
-        employee: frm.doc.employee  // Prefill the Employee field
-    });
-}
+  frappe.model.open_mapped_doc({
+          method: "beams.beams.doctype.award_record.award_record.map_award_record_to_travel_request",
+          frm: frm,
+  });
 
+}
 
 frappe.ui.form.on("Award Expense Detail", {
     amount: function (frm) {
         frm.call("update_total_amount");
     },
-    expenses_remove: function(frm){
-      frm.call("update_total_amount");
+    expenses_remove: function(frm) {
+        frm.call("update_total_amount");
     }
 });

--- a/beams/beams/doctype/award_record/award_record.py
+++ b/beams/beams/doctype/award_record/award_record.py
@@ -4,7 +4,9 @@
 import frappe
 from frappe.model.document import Document
 from frappe.utils import today
-from frappe import _ 
+from frappe import _
+import json
+from frappe.model.mapper import get_mapped_doc
 
 class AwardRecord(Document):
     def before_save(self):
@@ -29,3 +31,36 @@ class AwardRecord(Document):
         if self.posting_date:
             if self.posting_date > today():
                 frappe.throw(_("Posting Date cannot be set after today's date."))
+
+@frappe.whitelist()
+def map_award_record_to_travel_request(source_name, target_doc=None):
+    """
+    Map fields from Award Record DocType to Employee Travel Request DocType
+    """
+
+    def set_missing_values(source, target):
+        target.requested_by = source.employee
+
+    target_doc = get_mapped_doc(
+        "Award Record",
+        source_name,
+        {
+            "Award Record": {
+                "doctype": "Employee Travel Request",
+                "field_map": {"requested_by": "employee"},
+            },
+        },
+        target_doc,
+        set_missing_values,
+    )
+
+    if target_doc and source_name:
+        target_doc.append(
+            "dynamic_link",
+            {
+                "link_doctype": "Award Record",
+                "link_name": source_name
+            },
+        )
+
+    return target_doc

--- a/beams/beams/doctype/award_record/award_record.py
+++ b/beams/beams/doctype/award_record/award_record.py
@@ -1,11 +1,8 @@
-# Copyright (c) 2025, efeone and contributors
-# For license information, please see license.txt
 
 import frappe
 from frappe.model.document import Document
 from frappe.utils import today
 from frappe import _
-import json
 from frappe.model.mapper import get_mapped_doc
 
 class AwardRecord(Document):

--- a/beams/beams/doctype/award_record/award_record.py
+++ b/beams/beams/doctype/award_record/award_record.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2025, efeone and contributors
+# For license information, please see license.txt
 
 import frappe
 from frappe.model.document import Document

--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.json
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.json
@@ -33,6 +33,8 @@
   "mark_attendance",
   "attendance_request",
   "reference_documents",
+  "section_break_fdom",
+  "dynamic_link",
   "reason_for_rejection"
  ],
  "fields": [
@@ -215,12 +217,22 @@
    "label": "Attendance Request",
    "options": "Attendance Request",
    "read_only": 1
+  },
+  {
+   "fieldname": "dynamic_link",
+   "fieldtype": "Table",
+   "label": "Dynamic Link",
+   "options": "Dynamic Link"
+  },
+  {
+   "fieldname": "section_break_fdom",
+   "fieldtype": "Section Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-02-04 10:00:59.408535",
+ "modified": "2025-02-06 10:35:30.732459",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Employee Travel Request",

--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.json
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.json
@@ -226,13 +226,14 @@
   },
   {
    "fieldname": "section_break_fdom",
-   "fieldtype": "Section Break"
+   "fieldtype": "Section Break",
+   "label": "Links"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-02-06 10:35:30.732459",
+ "modified": "2025-02-07 10:36:23.805117",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Employee Travel Request",


### PR DESCRIPTION
## Feature description
Add travel request button for 'nominated' and 'applied' workflow states in Award record doctype.
Add dynamic link child table to employee travel request doctype.
Map from award record to employee travel request doctype.


## Solution description
Added travel request button for 'nominated' and 'applied' workflow states in Award record doctype.
Added dynamic link child table to employee travel request doctype.
Mapped from award record to employee travel request doctype.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/fae25b47-7128-4d88-9b7f-6de86bcc8610)
![image](https://github.com/user-attachments/assets/86ca3e4f-a075-4f09-94d5-408bd0b79b51)

![image](https://github.com/user-attachments/assets/be4a8119-8737-469b-90f6-282c6947e605)
![image](https://github.com/user-attachments/assets/2557424b-379d-4982-ab9a-e65ec52796c2)


## Areas affected and ensured
List out the areas affected by your code changes.( award record, employee travel request doctype)

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Mozilla Firefox
 
