### PR TITLE
Refactor: Improve Leave Application script with medical certificate validation and date checks

### DIFF
--- a/beams/beams/custom_scripts/leave_application/leave_application.js
+++ b/beams/beams/custom_scripts/leave_application/leave_application.js
@@ -1,35 +1,12 @@
 frappe.ui.form.on('Leave Application', {
     leave_type: function(frm) {
         validate_from_date(frm);
-        if (frm.doc.leave_type) {
-            frappe.db.get_value('Leave Type', frm.doc.leave_type,['is_proof_document', 'medical_leave_required'], function(value) {
-                if (value.is_proof_document && frm.doc.from_date && frm.doc.to_date) {
-                    var duration = frappe.datetime.get_diff(frm.doc.to_date, frm.doc.from_date) + 1;
-                    if (value.medical_leave_required && duration > value.medical_leave_required) {
-                        frm.set_df_property('medical_certificate', 'hidden', false);
-                        frm.set_df_property('medical_certificate', 'reqd', true);
-                    } else {
-                        frm.set_df_property('medical_certificate', 'hidden', false);
-                        frm.set_df_property('medical_certificate', 'reqd', false);
-                    }
-                } else {
-                    frm.set_df_property('medical_certificate', 'hidden', true);
-                    frm.set_df_property('medical_certificate', 'reqd', false);
-                }
-                frm.refresh_field('medical_certificate');
-            });
-        } else {
-            frm.set_df_property('medical_certificate', 'hidden', true);
-            frm.set_df_property('medical_certificate', 'reqd', false);
-            frm.refresh_field('medical_certificate');
-        }
+        validate_medical_certificate(frm);
     },
-
     from_date: function(frm) {
         validate_from_date(frm);
         frm.trigger('leave_type');
     },
-
     to_date: function(frm) {
         frm.trigger('leave_type');
     }
@@ -52,4 +29,53 @@ function validate_from_date(frm) {
             }
         }
     });
+}
+
+function validate_medical_certificate(frm) {
+    if (!frm.doc.leave_type || !frm.doc.from_date || !frm.doc.to_date) {
+        hide_medical_certificate(frm);
+        return;
+    }
+
+    frappe.db.get_value('Leave Type', frm.doc.leave_type, ['is_proof_document', 'medical_leave_required'])
+        .then(r => {
+            let value = r.message || {};
+
+            if (!value.is_proof_document) {
+                hide_medical_certificate(frm);
+                return;
+            }
+
+            let from_date = frappe.datetime.str_to_obj(frm.doc.from_date);
+            let to_date = frappe.datetime.str_to_obj(frm.doc.to_date);
+
+            if (!from_date || !to_date) {
+                hide_medical_certificate(frm);
+                return;
+            }
+
+            let duration = frappe.datetime.get_day_diff(to_date, from_date) + 1;
+            let medical_leave_required = parseInt(value.medical_leave_required) || 0;
+
+            if (medical_leave_required > 0 && duration > medical_leave_required) {
+                show_medical_certificate(frm);
+            } else {
+                hide_medical_certificate(frm);
+            }
+        })
+        .catch(err => {
+            hide_medical_certificate(frm);
+        });
+}
+
+function show_medical_certificate(frm) {
+    frm.set_df_property('medical_certificate', 'hidden', false);
+    frm.set_df_property('medical_certificate', 'reqd', true);
+    frm.refresh_field('medical_certificate');
+}
+
+function hide_medical_certificate(frm) {
+    frm.set_df_property('medical_certificate', 'hidden', true);
+    frm.set_df_property('medical_certificate', 'reqd', false);
+    frm.refresh_field('medical_certificate');
 }


### PR DESCRIPTION
## Feature description
The issue was that the Medical Certificate field in Leave Application was being shown for all leave applications where is_proof_document(checkbox) was enabled in the Leave Type, regardless of whether the leave duration exceeded the Medical Leave Required value configured in the Leave Type. The check for leave duration was not correctly ensuring that the Medical Certificate field would appear only when the leave duration was greater than the Medical Leave Required value.

## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description
Refactored validation logic for Medical certificate field.
Ensured proper field visibility based on leave type and leave duration.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/e001d9bd-60f1-4c06-b250-0469a39028f5)
[Screencast from 02-07-2025 11:20:10 AM.webm](https://github.com/user-attachments/assets/d7135140-aed0-4291-9b6f-87012e5abed1)

## Areas affected and ensured
Leave Application form validation

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Mozilla Firefox
