### PR TITLE
feat: add validation for end date in  Employee Travel Request

### DIFF
--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.js
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.js
@@ -52,6 +52,9 @@ frappe.ui.form.on('Employee Travel Request', {
     },
     posting_date:function (frm){
       frm.call("validate_posting_date");
+    },
+    end_date:function (frm){
+    frm.call("validate_dates");
     }
 });
 

--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.js
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.js
@@ -54,7 +54,7 @@ frappe.ui.form.on('Employee Travel Request', {
       frm.call("validate_posting_date");
     },
     end_date:function (frm){
-    frm.call("validate_dates");
+      frm.call("validate_dates");
     }
 });
 

--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.json
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.json
@@ -225,6 +225,7 @@
    "options": "Dynamic Link"
   },
   {
+   "collapsible": 1,
    "fieldname": "section_break_fdom",
    "fieldtype": "Section Break",
    "label": "Links"
@@ -233,7 +234,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-02-07 10:36:23.805117",
+ "modified": "2025-02-07 15:07:23.281161",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Employee Travel Request",

--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.py
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.py
@@ -30,6 +30,8 @@ class EmployeeTravelRequest(Document):
         batta_policy = get_batta_policy(self.requested_by)
         if batta_policy:
             self.batta_policy = batta_policy.get("name")
+
+    @frappe.whitelist()
     def validate_dates(self):
         if self.start_date and self.end_date:
             if self.start_date > self.end_date:


### PR DESCRIPTION
## Feature description
add validation for end date in the Employee Travel Request

## Solution description
add validation for end date in the Employee Travel Request
Collapsible set true in section break in Employee Travel Request

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/5ead19a8-3d53-481c-bef4-7b08807c10bc)
![image](https://github.com/user-attachments/assets/d44d5242-b93a-418f-a4c2-4a3a05f25dca)

## Areas affected and ensured
Employee Travel Request

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - yes
  - Opera Mini
  - Safari
