### PR TITLE
fix:Available quantity fetched  from filtered list of items based on location.

### DIFF
--- a/beams/beams/custom_scripts/project/project.js
+++ b/beams/beams/custom_scripts/project/project.js
@@ -8,13 +8,6 @@ frappe.ui.form.on('Project', {
             });
         }, __("Create"));
 
-        // Add a button to create an Equipment Acquiral Request
-        frm.add_custom_button(__('Equipment Acquiral Request'), function () {
-            frappe.model.open_mapped_doc({
-                method: "beams.beams.custom_scripts.project.project.map_equipment_acquiral_request",
-                frm: frm,
-            });
-        }, __("Create"));
 
         // Adds a button to the 'Project' form to create an Transportation Request.
         frm.add_custom_button(__('Transportation Request'), function () {
@@ -131,65 +124,65 @@ frappe.ui.form.on('Project', {
             });
         }, "Create");
 
-                // Add a button to create an Equipment Acquiral Request
-                frm.add_custom_button(__('Equipment Acquiral Request'), function () {
-                    frappe.model.open_mapped_doc({
-                        method: "beams.beams.custom_scripts.project.project.map_equipment_acquiral_request",
-                        frm: frm,
-                    });
-                }, __("Create"));
+        // Add a button to create an Equipment Acquiral Request
+        frm.add_custom_button(__('Equipment Acquiral Request'), function () {
+          frappe.model.open_mapped_doc({
+            method: "beams.beams.custom_scripts.project.project.map_equipment_acquiral_request",
+            frm: frm,
+          });
+        }, __("Create"));
 
-                // Add "Equipment Request" button under the "Create" group
-                frm.add_custom_button(__('Equipment Request'), function () {
-                    const dialog = new frappe.ui.Dialog({
-                        title: 'Equipments',
-                        fields: [
-                            {
-                                label: 'Required From',
-                                fieldtype: 'Datetime',
-                                fieldname: 'required_from',
-                                in_list_view: 1,
-                                reqd: 1
-                            },
-                            {
-                                label: 'Required To',
-                                fieldtype: 'Datetime',
-                                fieldname: 'required_to',
-                                in_list_view: 1,
-                                reqd: 1
-                            },
-                            {
-                                fieldtype: 'Table',
-                                label: 'Equipments',
-                                fieldname: 'equipments',
-                                reqd: 1,
-                                fields: [
-                                    {
-                                        label: 'Item',
-                                        fieldtype: 'Link',
-                                        fieldname: 'item',
-                                        options: 'Item',
-                                        in_list_view: 1,
-                                        reqd: 1,
-                                        onchange: function() {
-                                            let data = [];
-                                            let promises = [];
-
-                                            dialog.fields_dict.equipments.df.data.forEach((item, i) => {
-                                                let promise = frappe.call({
-                                                    method: "beams.beams.custom_scripts.project.project.get_available_quantities",
-                                                    args: {
-                                                        items: [item.item],
-                                                        location: frm.doc.location
-                                                    },
-                                                    callback: function(r) {
-                                                        if (r.message) {
-                                                            const available_qty = r.message[item.item] || 0;
-                                                            item["available_quantity"] = available_qty;
-                                                            data.push(item);
-                                                        }
-                                                    }
-                                                });
+        // Add "Equipment Request" button under the "Create" group
+        frm.add_custom_button(__('Equipment Request'), function () {
+          const dialog = new frappe.ui.Dialog({
+            title: 'Equipments',
+            fields: [
+              {
+                label: 'Required From',
+                fieldtype: 'Datetime',
+                fieldname: 'required_from',
+                in_list_view: 1,
+                reqd: 1
+              },
+              {
+                label: 'Required To',
+                fieldtype: 'Datetime',
+                fieldname: 'required_to',
+                in_list_view: 1,
+                reqd: 1
+              },
+              {
+                fieldtype: 'Table',
+                label: 'Equipments',
+                fieldname: 'equipments',
+                reqd: 1,
+                fields: [
+                  {
+                    label: 'Item',
+                    fieldtype: 'Link',
+                    fieldname: 'item',
+                    options: 'Item',
+                    in_list_view: 1,
+                    reqd: 1,
+                    onchange: function() {
+                      let data = [];
+                      let promises = [];
+                      dialog.fields_dict.equipments.df.data.forEach((item, i) => {
+                      let promise = frappe.call({
+                        method: "beams.beams.custom_scripts.project.project.get_available_quantities",
+                        args: {
+                          items: [item.item],
+                          location: frm.doc.location
+                          },
+                          callback: function(r) {
+                          if (r.message)
+                          {
+                            const available_qty = r.message[item.item] || 0;
+                            item["available_quantity"] = available_qty;
+                            data.push(item);
+                          }
+                  }
+                        });
                                                 promises.push(promise);
                                             });
 
@@ -225,26 +218,23 @@ frappe.ui.form.on('Project', {
                             // Validate required dates
                             const required_from = values.required_from;
                             const required_to = values.required_to;
-
-                            if (!required_from || !required_to) {
-                                frappe.msgprint(__('Both "Required From" and "Required To" are mandatory.'));
+                            if(!required_from || !required_to) {
+                              frappe.msgprint(__('Both "Required From" and "Required To" are mandatory.'));
+                                return;
+                            }
+                            if(required_from >= required_to) {
+                              frappe.msgprint(__('"Required From" date should be earlier than "Required To" date.'));
                                 return;
                             }
 
-                            if (required_from >= required_to) {
-                                frappe.msgprint(__('"Required From" date should be earlier than "Required To" date.'));
+                            if(!equipment_data.length) {
+                              frappe.msgprint(__('Please add at least one equipment row.'));
                                 return;
                             }
-
-                            if (!equipment_data.length) {
-                                frappe.msgprint(__('Please add at least one equipment row.'));
-                                return;
-                            }
-
                             const request_data = [];
 
                             // Loop through equipment data to process requests
-                            for (const row of equipment_data) {
+                            for(const row of equipment_data) {
                                 const available_qty = row.available_quantity || 0;
 
                                 request_data.push({
@@ -257,25 +247,26 @@ frappe.ui.form.on('Project', {
                             }
 
                             // Create the equipment request
-                            frappe.call({
-                                method: 'beams.beams.custom_scripts.project.project.create_equipment_request',
-                                args: {
-                                    source_name: frm.doc.name,
-                                    equipment_data: JSON.stringify(request_data),
-                                    required_from: values.required_from,
-                                    required_to: values.required_to
-                                }
-                            }).then(() => {
-                                dialog.hide();
-                                frm.reload_doc();
-                            });
+                      frappe.call({
+                        method: 'beams.beams.custom_scripts.project.project.create_equipment_request',
+                        args: {
+                          source_name: frm.doc.name,
+                          equipment_data: JSON.stringify(request_data),
+                          required_from: values.required_from,
+                          required_to: values.required_to
+                        }
+                      }).then(() => {
+                        dialog.hide();
+                        frm.reload_doc();
+                      });
                         }
                     });
 
                     // Fetch assets filtered by location
-                    frappe.call({
+                      frappe.call({
                         method: "beams.beams.custom_scripts.project.project.get_assets_by_location",
-                        args: { location: frm.doc.location },
+                        args: {
+                          location: frm.doc.location },
                         callback: function(r) {
                             if (r.message?.length) {
                                 dialog.fields_dict.equipments.grid.get_field("item").get_query = () => ({

--- a/beams/beams/custom_scripts/project/project.js
+++ b/beams/beams/custom_scripts/project/project.js
@@ -131,162 +131,164 @@ frappe.ui.form.on('Project', {
             });
         }, "Create");
 
-        frm.add_custom_button(__('Equipment Request'), function () {
-          const dialog = new frappe.ui.Dialog({
-            title: 'Equipments',
-            fields: [
-              {
-                label: 'Required From',
-                fieldtype: 'Datetime',
-                fieldname: 'required_from',
-                in_list_view: 1,
-                reqd: 1
-              },
-              {
-                label: 'Required To',
-                fieldtype: 'Datetime',
-                fieldname: 'required_to',
-                in_list_view: 1,
-                reqd: 1
-              },
-              {
-                fieldtype: 'Table',
-                label: 'Equipments',
-                fieldname: 'equipments',
-                reqd: 1,
-                fields: [
-                  {
-                    label: 'Item',
-                    fieldtype: 'Link',
-                    fieldname: 'item',
-                    options: 'Item',
-                    in_list_view: 1,
-                    reqd: 1,
-                    onchange: function() {
-                      let data = [];
-                      let promises = [];
-                      dialog.fields_dict.equipments.df.data.forEach((item, i) => {
-                      let promise = frappe.call({
-                        method: "beams.beams.custom_scripts.project.project.get_available_quantities",
-                        args: {
-                          items: [item.item],
-                          bureau: frm.doc.bureau
-                        },
-                        callback: function(r) {
-                          if (r.message) {
-                            const available_qty = r.message[item.item] || 0;
-                            item["available_quantity"] = available_qty;
-                            data.push(item);
-                          }
-                          }
-                        });
-                        promises.push(promise);
-                        });
+                // Add a button to create an Equipment Acquiral Request
+                frm.add_custom_button(__('Equipment Acquiral Request'), function () {
+                    frappe.model.open_mapped_doc({
+                        method: "beams.beams.custom_scripts.project.project.map_equipment_acquiral_request",
+                        frm: frm,
+                    });
+                }, __("Create"));
 
-                      Promise.all(promises).then(() => {
-                        dialog.fields_dict.equipments.df.data = data;
-                        dialog.fields_dict.equipments.grid.refresh();
-                      });
-                    }
-                    },
-                    {
-                      label: 'Available Quantity',
-                      fieldtype: 'Int',
-                      fieldname: 'available_quantity',
-                      in_list_view: 1,
-                      read_only: 1,
-                      default: 0
-                    },
-                    {
-                      label: 'Required Quantity',
-                      fieldtype: 'Int',
-                      fieldname: 'required_quantity',
-                      in_list_view: 1,
-                      reqd: 1
-                    },
-                ]
-            }
-          ],
-          size: 'large',
-          primary_action_label: 'Submit',
-          primary_action(values) {
-            const equipment_data = values?.equipments || [];
+                // Add "Equipment Request" button under the "Create" group
+                frm.add_custom_button(__('Equipment Request'), function () {
+                    const dialog = new frappe.ui.Dialog({
+                        title: 'Equipments',
+                        fields: [
+                            {
+                                label: 'Required From',
+                                fieldtype: 'Datetime',
+                                fieldname: 'required_from',
+                                in_list_view: 1,
+                                reqd: 1
+                            },
+                            {
+                                label: 'Required To',
+                                fieldtype: 'Datetime',
+                                fieldname: 'required_to',
+                                in_list_view: 1,
+                                reqd: 1
+                            },
+                            {
+                                fieldtype: 'Table',
+                                label: 'Equipments',
+                                fieldname: 'equipments',
+                                reqd: 1,
+                                fields: [
+                                    {
+                                        label: 'Item',
+                                        fieldtype: 'Link',
+                                        fieldname: 'item',
+                                        options: 'Item',
+                                        in_list_view: 1,
+                                        reqd: 1,
+                                        onchange: function() {
+                                            let data = [];
+                                            let promises = [];
 
-            // Validate if required dates are provided and if "Required From" is before "Required To"
-            const required_from = values.required_from;
-            const required_to = values.required_to;
+                                            dialog.fields_dict.equipments.df.data.forEach((item, i) => {
+                                                let promise = frappe.call({
+                                                    method: "beams.beams.custom_scripts.project.project.get_available_quantities",
+                                                    args: {
+                                                        items: [item.item],
+                                                        location: frm.doc.location
+                                                    },
+                                                    callback: function(r) {
+                                                        if (r.message) {
+                                                            const available_qty = r.message[item.item] || 0;
+                                                            item["available_quantity"] = available_qty;
+                                                            data.push(item);
+                                                        }
+                                                    }
+                                                });
+                                                promises.push(promise);
+                                            });
 
-            if (!required_from || !required_to) {
-                frappe.msgprint(__('Both "Required From" and "Required To" are mandatory.'));
-                return;
-            }
+                                            Promise.all(promises).then(() => {
+                                                dialog.fields_dict.equipments.df.data = data;
+                                                dialog.fields_dict.equipments.grid.refresh();
+                                            });
+                                        }
+                                    },
+                                    {
+                                        label: 'Available Quantity',
+                                        fieldtype: 'Int',
+                                        fieldname: 'available_quantity',
+                                        in_list_view: 1,
+                                        read_only: 1,
+                                        default: 0
+                                    },
+                                    {
+                                        label: 'Required Quantity',
+                                        fieldtype: 'Int',
+                                        fieldname: 'required_quantity',
+                                        in_list_view: 1,
+                                        reqd: 1
+                                    }
+                                ]
+                            }
+                        ],
+                        size: 'large',
+                        primary_action_label: 'Submit',
+                        primary_action(values) {
+                            const equipment_data = values?.equipments || [];
 
-            if (required_from >= required_to) {
-                frappe.msgprint(__('"Required From" date should be earlier than "Required To" date.'));
-                return;
-            }
+                            // Validate required dates
+                            const required_from = values.required_from;
+                            const required_to = values.required_to;
 
-            if (!equipment_data.length) {
-                frappe.msgprint(__('Please add at least one equipment row.'));
-                return;
-            }
+                            if (!required_from || !required_to) {
+                                frappe.msgprint(__('Both "Required From" and "Required To" are mandatory.'));
+                                return;
+                            }
 
-            const request_data = [];
+                            if (required_from >= required_to) {
+                                frappe.msgprint(__('"Required From" date should be earlier than "Required To" date.'));
+                                return;
+                            }
 
-            // Loop through equipment data to process requests
-            for (const row of equipment_data) {
-                const available_qty = row.available_quantity || 0;
+                            if (!equipment_data.length) {
+                                frappe.msgprint(__('Please add at least one equipment row.'));
+                                return;
+                            }
 
-                request_data.push({
-                    item: row.item,
-                    quantity: row.required_quantity,
-                    available_quantity: available_qty,
-                    required_from: row.required_from,
-                    required_to: row.required_to
-                });
-            }
+                            const request_data = [];
 
-            // Create the equipment request
-            const create_requests = [];
-            if (request_data.length) {
-                create_requests.push(
-                    frappe.call({
-                        method: 'beams.beams.custom_scripts.project.project.create_equipment_request',
-                        args: {
-                            source_name: frm.doc.name,
-                            equipment_data: JSON.stringify(request_data),
-                            required_from: values.required_from,
-                            required_to: values.required_to
+                            // Loop through equipment data to process requests
+                            for (const row of equipment_data) {
+                                const available_qty = row.available_quantity || 0;
+
+                                request_data.push({
+                                    item: row.item,
+                                    required_quantity: row.required_quantity,
+                                    available_quantity: row.available_quantity,
+                                    required_from: row.required_from,
+                                    required_to: row.required_to
+                                });
+                            }
+
+                            // Create the equipment request
+                            frappe.call({
+                                method: 'beams.beams.custom_scripts.project.project.create_equipment_request',
+                                args: {
+                                    source_name: frm.doc.name,
+                                    equipment_data: JSON.stringify(request_data),
+                                    required_from: values.required_from,
+                                    required_to: values.required_to
+                                }
+                            }).then(() => {
+                                dialog.hide();
+                                frm.reload_doc();
+                            });
                         }
-                    })
-                );
-            }
+                    });
 
-            Promise.all(create_requests)
-                .then(() => {
-                    dialog.hide();
-                    frm.reload_doc();
-                });
-        }
-    });
-    // Set the item filter based on bureau's assets
-    frappe.call({
-      method: "beams.beams.custom_scripts.project.project.get_assets_by_bureau",
-      args: { bureau: frm.doc.bureau },
-      callback: function(r) {
-        if (r.message?.length) {
-          dialog.fields_dict.equipments.grid.get_field("item").get_query = () => ({
-            filters: {
-              name: ["in", r.message]
-            }
-          });
-          dialog.show();
-        } else {
-          frappe.msgprint(__('No available items found for the selected Bureau.'));
-            }
-        }
-    });
-    }, __("Create"));
-
-    }
-  });
+                    // Fetch assets filtered by location
+                    frappe.call({
+                        method: "beams.beams.custom_scripts.project.project.get_assets_by_location",
+                        args: { location: frm.doc.location },
+                        callback: function(r) {
+                            if (r.message?.length) {
+                                dialog.fields_dict.equipments.grid.get_field("item").get_query = () => ({
+                                    filters: {
+                                        name: ["in", r.message]
+                                    }
+                                });
+                                dialog.show();
+                            } else {
+                                frappe.msgprint(__('No available items found for the selected Location.'));
+                            }
+                        }
+                    });
+                }, __("Create"));
+              }
+            });

--- a/beams/beams/custom_scripts/project/project.py
+++ b/beams/beams/custom_scripts/project/project.py
@@ -259,7 +259,6 @@ def create_equipment_request(source_name, equipment_data, required_from, require
     })
 
     request_doc.insert(ignore_permissions=True)
-
     project_name = frappe.db.get_value('Project', source_name, 'project_name')
     frappe.msgprint(_("Equipment Request created successfully for project: {}.").format(project_name),indicator="green",alert=1)
     return True

--- a/beams/beams/custom_scripts/project/project.py
+++ b/beams/beams/custom_scripts/project/project.py
@@ -73,7 +73,9 @@ def map_equipment_request(source_name, target_doc=None):
                     "name": "project",
                     "expected_start_date": "required_from",
                     "expected_end_date": "required_to",
-                    "bureau": "bureau"
+                    "bureau": "bureau",
+                    "location": "location"
+
                 }
             }
         },
@@ -154,7 +156,7 @@ def update_program_request_status_on_project_completion(doc, method):
         # Fetch all related Program Requests linked to this Project
         program_requests = frappe.get_all(
             "Program Request",
-            filters={"project": doc.name, "workflow_state": ("!=", "Closed")},  # Exclude already "Closed" state
+            filters={"project": doc.name, "workflow_state": ("!=", "Closed")},
             fields=["name"]
         )
 
@@ -190,47 +192,56 @@ def validate_employee_assignment(doc, method):
             frappe.throw(f"Employee {employee_name} ({row.employee}) is already assigned to another project ({', '.join(overlapping_projects)}) within the same time period.")
 
 @frappe.whitelist()
-def get_available_quantities(items, bureau=None):
+def get_assets_by_location(location):
+    '''Fetch unique item codes of Assets linked to the given Location.'''
+    if not location:
+        frappe.throw(_("Location is required."))
+
+    assets = frappe.get_all(
+        "Asset",
+        filters={"location": location},
+        pluck="item_code",
+        distinct=True
+    )
+
+    return assets or []
+
+@frappe.whitelist()
+def get_available_quantities(items, location):
     '''
-    Get available quantities for items at locations matching the bureau.
+    Get available quantities for specified items at a given location.
     Returns a dictionary with item codes as keys and their available quantities as values.
     '''
     if isinstance(items, str):
         items = json.loads(items)
 
-    available_quantities = {}
+    if not location:
+        frappe.throw(_("Location is required."))
 
-    if bureau:
-        location = frappe.db.get_value("Bureau", bureau, "location")
+    available_quantities = {item: 0 for item in items}
 
-        if location:
-            for item in items:
-                total_quantity = frappe.db.count(
-                    "Asset",
-                    filters={
-                        "item_code": item,
-                        "bureau": bureau,
-                        "location": location
-                    }
-                ) or 0
-                available_quantities[item] = total_quantity
-        else:
-            for item in items:
-                available_quantities[item] = 0
-
-    else:
-        available_quantities = {item: 0 for item in items}
+    # Fetch count of assets matching the given items and location
+    for item in items:
+        total_quantity = frappe.db.count(
+            "Asset",
+            filters={
+                "item_code": item,
+                "location": location
+            }
+        ) or 0
+        available_quantities[item] = total_quantity
 
     return available_quantities
-
 
 @frappe.whitelist()
 def create_equipment_request(source_name, equipment_data, required_from, required_to):
     '''Creates an Equipment Request for a project with multiple items.'''
-    equipment_data = json.loads(equipment_data)
+    request_data = json.loads(equipment_data)
 
     if not frappe.db.exists('Project', source_name):
         frappe.throw(_("Invalid Project ID: {0}").format(source_name))
+
+    print("Request Data:", request_data)
 
     request_doc = frappe.get_doc({
         'doctype': "Equipment Request",
@@ -240,29 +251,15 @@ def create_equipment_request(source_name, equipment_data, required_from, require
         'required_equipments': [
             {
                 'required_item': data['item'],
-                'quantity': data['quantity'],
-                'available_item_quantity': data['available_quantity']
+                'required_quantity': data['required_quantity'],
+                'available_quantity': data['available_quantity']
             }
-            for data in equipment_data
+            for data in request_data
         ]
     })
 
     request_doc.insert(ignore_permissions=True)
+
     project_name = frappe.db.get_value('Project', source_name, 'project_name')
-    frappe.msgprint(_("Equipment Request created successfully for project: {}.").format(project_name), indicator="green", alert=1)
-
+    frappe.msgprint(_("Equipment Request created successfully for project: {}.").format(project_name),indicator="green",alert=1)
     return True
-
-
-@frappe.whitelist()
-def get_assets_by_bureau(bureau):
-    '''Fetch item codes of Assets linked to the given Bureau.'''
-    if not bureau:
-        return []
-
-    return frappe.get_all(
-        "Asset",
-        filters={"bureau": bureau},
-        pluck="item_code",
-        distinct=True
-    ) or []

--- a/beams/beams/doctype/equipment_request/equipment_request.js
+++ b/beams/beams/doctype/equipment_request/equipment_request.js
@@ -48,7 +48,7 @@ frappe.ui.form.on('Required Items Detail', {
             callback: function(r) {
                 if (r.message) {
                     const available_qty = r.message[row.required_item] || 0;
-                    row.available_item_quantity = available_qty;
+                    row.available_quantity = available_qty;
                     frm.refresh_field('required_equipments');
                 }
             }

--- a/beams/beams/doctype/required_items_detail/required_items_detail.json
+++ b/beams/beams/doctype/required_items_detail/required_items_detail.json
@@ -7,8 +7,8 @@
  "engine": "InnoDB",
  "field_order": [
   "required_item",
-  "available_item_quantity",
-  "quantity",
+  "available_quantity",
+  "required_quantity",
   "issued_quantity"
  ],
  "fields": [
@@ -21,32 +21,31 @@
    "reqd": 1
   },
   {
-   "fieldname": "quantity",
+   "fieldname": "issued_quantity",
    "fieldtype": "Int",
    "in_list_view": 1,
-   "label": "Required Quantity",
-   "non_negative": 1,
-   "reqd": 1
+   "label": "Issued Quantity"
   },
   {
-   "fieldname": "available_item_quantity",
+   "fieldname": "available_quantity",
    "fieldtype": "Int",
    "in_list_view": 1,
    "label": "Available Quantity",
    "read_only": 1
   },
   {
-   "allow_on_submit": 1,
-   "fieldname": "issued_quantity",
+   "fieldname": "required_quantity",
    "fieldtype": "Int",
    "in_list_view": 1,
-   "label": "Issued Quantity"
+   "label": "Required Quantity",
+   "non_negative": 1,
+   "reqd": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-02-07 16:44:08.753547",
+ "modified": "2025-02-10 12:10:22.977461",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Required Items Detail",


### PR DESCRIPTION
## Feature description
Modify filtering of item by considering location as the attribute instead of Bureau in Required Item Detail child table.


## Solution description
From Project create Equipment Request button when clicked shows a popup dialog box   Available quantity in require items detail child table  is auto fetched when an item is selected.But the filtering was based on Bureau defined in the Project.Now it is modified as filtering is done based on Location of item.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/6be9e8c3-4bd5-4c99-8e77-ef82115c48bc)
![image](https://github.com/user-attachments/assets/dde603ba-f07a-44ec-801c-efcbb89026bb)


## Areas affected and ensured
Project doctype.
Equipment Request doctype.

## Is there any existing behavior change of other features due to this code change?
       No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
