### PR TITLE
fix: updated  logic for the issue quantity in equipment request 

### DIFF
--- a/beams/beams/custom_scripts/purchase_order/purchase_order.py
+++ b/beams/beams/custom_scripts/purchase_order/purchase_order.py
@@ -131,9 +131,11 @@ def update_equipment_quantities(doc, method):
 					)
 				equipment_a_request = frappe.db.get_value("Required Acquiral Items Detail", item.reference_document, "parent")
 				ea_item = frappe.db.get_value("Required Acquiral Items Detail", item.reference_document, "item")
-				equipment_request = frappe.db.get_value("Equipment Acquiral Request", equipment_a_request, "equipment_request")
-				er_doc = frappe.get_doc("Equipment Request", equipment_request)
-				for e_item in er_doc.required_equipments:
-					if e_item.required_item == ea_item:
-						e_item.issued_quantity = (e_item.issued_quantity + item.qty)
-						e_item.save()
+				if equipment_a_request:
+					equipment_request = frappe.db.get_value("Equipment Acquiral Request", equipment_a_request, "equipment_request")
+					if equipment_request:
+						er_doc = frappe.get_doc("Equipment Request", equipment_request)
+						for e_item in er_doc.required_equipments:
+							if e_item.required_item == ea_item:
+								e_item.issued_quantity = (e_item.issued_quantity + item.qty)
+						er_doc.save()


### PR DESCRIPTION
## Issue description
Need add  logic for updating the issue quantity in equipment request 

## Solution description
updated the logic of code for update the issue quantity in equipment request doctype
- Instead of saving child rows in loop, Save the parent doc  after required actions
## Output screenshots (optional)

[Screencast from 10-02-25 05:36:08 PM IST.webm](https://github.com/user-attachments/assets/1dc292c3-ac28-44c6-8770-f953e4af4e9e)

## Areas affected and ensured
equipment request

## Is there any existing behavior change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?

  - Mozilla Firefox
  
