### PR TITLE
feat:add validation for external resource request button in technical request doctype

### DIFF
--- a/beams/beams/doctype/technical_request/technical_request.js
+++ b/beams/beams/doctype/technical_request/technical_request.js
@@ -17,7 +17,7 @@ frappe.ui.form.on('Technical Request', {
         set_employee_query(frm);
         toggle_reason_for_rejection_field(frm);
 
-        if (!frm.is_new()) {
+        if (!frm.is_new() && frm.doc.workflow_state === "Approved") {
             frm.add_custom_button("External Resource Request", function() {
                 frappe.call({
                     method: "beams.beams.doctype.technical_request.technical_request.map_external_resource_request",


### PR DESCRIPTION
## Feature description
Add validation for 'external resource request ' button in technical request doctype


## Solution description
Added validation for 'external resource request ' button in technical request doctype ( shows 'external resource request ' button only when workflow state is approved) 

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/db3f9fac-6989-454f-b56f-58b562f45e27)


## Areas affected and ensured
List out the areas affected by your code changes. (technical request doctype)

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Mozilla Firefox
 
