### PR TITLE
feat:  Created Asset Movement Button should map details for asset movement against the asset of the selected item

### DIFF
--- a/beams/beams/doctype/equipment_request/equipment_request.py
+++ b/beams/beams/doctype/equipment_request/equipment_request.py
@@ -79,3 +79,25 @@ def map_equipment_acquiral_request(source_name, target_doc=None):
         })
 
     return target_doc
+
+
+@frappe.whitelist()
+def map_asset_movement(source_name, target_doc=None):
+    to_employee = frappe.flags.get("args", {}).get("to_employee", '')
+    asset = frappe.flags.get("args", {}).get("asset", '')
+    asset_movement = get_mapped_doc("Equipment Request", source_name, {
+        "Equipment Request": {
+            "doctype": "Asset Movement",
+            "field_map": {
+
+            }
+        }
+    }, target_doc)
+    asset_movement.purpose = 'Issue'
+    asset_movement.append('assets', {
+            'asset': asset,
+            'to_employee': to_employee
+        })
+    asset_movement.flags.ignore_mandatory = True
+    asset_movement.save(ignore_permissions=True)
+    return asset_movement

--- a/beams/beams/doctype/required_items_detail/required_items_detail.json
+++ b/beams/beams/doctype/required_items_detail/required_items_detail.json
@@ -9,7 +9,8 @@
   "required_item",
   "available_quantity",
   "required_quantity",
-  "issued_quantity"
+  "issued_quantity",
+  "asset_movement"
  ],
  "fields": [
   {
@@ -40,12 +41,18 @@
    "label": "Required Quantity",
    "non_negative": 1,
    "reqd": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "asset_movement",
+   "fieldtype": "Button",
+   "label": "Asset Movement"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-02-10 12:10:22.977461",
+ "modified": "2025-02-12 11:23:47.202723",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Required Items Detail",


### PR DESCRIPTION
## Feature description
Create Asset Movement Button should map details for asset movement against the asset of the selected item

## Solution description
Created Asset Movement Button should map details for asset movement against the asset of the selected item

## Output screenshots (optional)

[Screencast from 12-02-25 11:38:00 AM IST.webm](https://github.com/user-attachments/assets/b2d95aee-f806-4145-b1a0-d774f2ba2969)

## Areas affected and ensured
Asset Movement

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Mozilla Firefox
  
