### PR TITLE
feat:add validation for button Equipment Acquiral Request

### DIFF
--- a/beams/beams/doctype/equipment_request/equipment_request.js
+++ b/beams/beams/doctype/equipment_request/equipment_request.js
@@ -5,13 +5,13 @@ frappe.ui.form.on('Equipment Request', {
     refresh: function (frm) {
         set_item_query(frm)
         if (frm.doc.workflow_state === "Approved"){
-        frm.add_custom_button(__('Equipment Acquiral Request'), function () {
-            frappe.model.open_mapped_doc({
-                method: "beams.beams.doctype.equipment_request.equipment_request.map_equipment_acquiral_request",
-                frm: frm,
-            });
-        }, __("Create"));
-      }
+          frm.add_custom_button(__('Equipment Acquiral Request'), function () {
+              frappe.model.open_mapped_doc({
+                  method: "beams.beams.doctype.equipment_request.equipment_request.map_equipment_acquiral_request",
+                  frm: frm,
+              });
+          }, __("Create"));
+        }
     },
 
     bureau: function (frm) {

--- a/beams/beams/doctype/equipment_request/equipment_request.js
+++ b/beams/beams/doctype/equipment_request/equipment_request.js
@@ -4,13 +4,14 @@
 frappe.ui.form.on('Equipment Request', {
     refresh: function (frm) {
         set_item_query(frm)
-
+        if (frm.doc.workflow_state === "Approved"){
         frm.add_custom_button(__('Equipment Acquiral Request'), function () {
             frappe.model.open_mapped_doc({
                 method: "beams.beams.doctype.equipment_request.equipment_request.map_equipment_acquiral_request",
                 frm: frm,
             });
         }, __("Create"));
+      }
     },
 
     bureau: function (frm) {


### PR DESCRIPTION
## Feature description
- add validation for button Equipment Acquiral Request

## Solution description
- add validation for button Equipment Acquiral Request in Equipment  Request 
- button is only visible when the document's workflow state is "Approved".

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/32e1efd3-68e4-40b1-91d4-8abffd9952cc)
![image](https://github.com/user-attachments/assets/9090ae0b-3fa1-4e28-a581-cb71439bbb3a)


## Areas affected and ensured
Equipment  Request 

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox-yes 
  - Opera Mini
  - Safari
