### PR TITLE
fix: updated Equipment Request field from issued quantity to acquired quantity

### DIFF
--- a/beams/beams/custom_scripts/purchase_order/purchase_order.py
+++ b/beams/beams/custom_scripts/purchase_order/purchase_order.py
@@ -139,5 +139,5 @@ def update_equipment_quantities(doc, method):
                             er_doc = frappe.get_doc("Equipment Request", equipment_request)
                             for e_item in er_doc.required_equipments:
                                 if e_item.required_item == ea_item:
-                                    e_item.issued_quantity = (e_item.issued_quantity + item.qty)
+                                    e_item.acquired_quantity = (e_item.acquired_quantity + item.qty)
                             er_doc.save()

--- a/beams/beams/doctype/required_items_detail/required_items_detail.json
+++ b/beams/beams/doctype/required_items_detail/required_items_detail.json
@@ -10,6 +10,7 @@
   "available_quantity",
   "required_quantity",
   "issued_quantity",
+  "acquired_quantity",
   "asset_movement"
  ],
  "fields": [
@@ -48,12 +49,20 @@
    "fieldname": "asset_movement",
    "fieldtype": "Button",
    "label": "Asset Movement"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "acquired_quantity",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Acquired Quantity",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-02-12 11:23:47.202723",
+ "modified": "2025-02-13 09:43:47.778466",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Required Items Detail",


### PR DESCRIPTION

## Issue description

1.Need to add  new field in the child table  Required Items Detail doctype
1. Need to  update the value in to acquired quantity in Equipment Request doctype 


## Solution description
1. Added the field called Acquired quantity in the child table Required Items Detail doctype 
2. change updation  of value issue quantity in to the acquired quantity when purchase order is submitted in equipment request


## Output screenshots (optional)
[Screencast from 13-02-25 10:17:30 AM IST.webm](https://github.com/user-attachments/assets/e94a5032-0bdd-4b53-825c-188d28986b70)

## Areas affected and ensured
Equipment Request and Equipment Acquiral Request Doctype

## Is there any existing behavior change of other features due to this code change?
 No

## Was this feature tested on the browsers?
 
  - Mozilla Firefox
  
