### PR TITLE
Fix:Arranged the buttons on group button in Project Doctype

### DIFF
--- a/beams/beams/custom_scripts/project/project.js
+++ b/beams/beams/custom_scripts/project/project.js
@@ -8,129 +8,105 @@ frappe.ui.form.on('Project', {
             });
         }, __("Create"));
 
+        // Add "Technical Request" button under the "Create" group
+        frm.add_custom_button(__('Technical Request'), function () {
+            // Open a dialog with the specified fields
+            let dialog = new frappe.ui.Dialog({
+                title: 'Technical Request',
+                fields: [
+                    {
+                        fieldtype: 'Table',
+                        label: 'Requirements',
+                        fieldname: 'requirements',
+                        reqd: 1,
+                        fields: [
+                            {
+                                label: 'Department',
+                                fieldtype: 'Link',
+                                fieldname: 'department',
+                                options: 'Department',
+                                in_list_view: 1,
+                                reqd: 1
+                            },
+                            {
+                                label: 'Designation',
+                                fieldtype: 'Link',
+                                fieldname: 'designation',
+                                options: 'Designation',
+                                in_list_view: 1,
+                                reqd: 1
+                            },
+                            {
+                                label: 'No of Employees',
+                                fieldtype: 'Int',
+                                fieldname: 'no_of_employees',
+                                in_list_view: 1
+                            },
+                            {
+                                label: 'Required From',
+                                fieldtype: 'Datetime',
+                                fieldname: 'required_from',
+                                in_list_view: 1,
+                                reqd: 1
+                            },
+                            {
+                                label: 'Required To',
+                                fieldtype: 'Datetime',
+                                fieldname: 'required_to',
+                                in_list_view: 1,
+                                reqd: 1
+                            },
+                            {
+                                label: 'Remarks',
+                                fieldtype: 'Small Text',
+                                fieldname: 'remarks',
+                                in_list_view: 1
+                            }
+                        ]
+                    }
+                ],
+                size: 'large',
+                primary_action_label: 'Submit',
+                primary_action: function () {
+                    let values = dialog.get_values();
+                    if (values && values.requirements) {
+                        // Perform validation for each row
+                        for (let i = 0; i < values.requirements.length; i++) {
+                            let row = values.requirements[i];
 
-        // Adds a button to the 'Project' form to create an Transportation Request.
-        frm.add_custom_button(__('Transportation Request'), function () {
-            frappe.model.open_mapped_doc({
-                method: "beams.beams.custom_scripts.project.project.create_transportation_request",
-                frm: frm,
+                            if (!row.required_from || !row.required_to) {
+                                frappe.msgprint({
+                                    title: __('Validation Error'),
+                                    message: __('Please fill both "Required From" and "Required To" in #row  {0}.', [i + 1]),
+                                    indicator: 'red'
+                                });
+                                return;
+                            }
+
+                            // Ensure Required To is later than Required From
+                            if (row.required_to <= row.required_from) {
+                                frappe.msgprint({
+                                    title: __('Validation Error'),
+                                    message: __('"Required To" must be later than "Required From" in # row {0}.', [i + 1]),
+                                    indicator: 'red'
+                                });
+                                return;
+                            }
+                        }
+
+                        frappe.call({
+                            method: 'beams.beams.custom_scripts.project.project.create_technical_support_request',
+                            args: {
+                                project_id: frm.doc.name,
+                                requirements: JSON.stringify(values.requirements)
+                            },
+                        });
+                        dialog.hide();
+                    }
+                }
             });
-        }, __("Create"));
-
-      // Add "Technical Request" button under the "Create" group
-      frm.add_custom_button(__('Technical Request'), function () {
-          // Open a dialog with the specified fields
-          let dialog = new frappe.ui.Dialog({
-              title: 'Technical Request',
-              fields: [
-                  {
-                      fieldtype: 'Table',
-                      label: 'Requirements',
-                      fieldname: 'requirements',
-                      reqd: 1,
-                      fields: [
-                          {
-                              label: 'Department',
-                              fieldtype: 'Link',
-                              fieldname: 'department',
-                              options: 'Department',
-                              in_list_view: 1,
-                              reqd: 1
-                          },
-                          {
-                              label: 'Designation',
-                              fieldtype: 'Link',
-                              fieldname: 'designation',
-                              options: 'Designation',
-                              in_list_view: 1,
-                              reqd: 1
-                          },
-                          {
-                              label: 'No of Employees',
-                              fieldtype: 'Int',
-                              fieldname: 'no_of_employees',
-                              in_list_view: 1
-                          },
-                          {
-                              label: 'Required From',
-                              fieldtype: 'Datetime',
-                              fieldname: 'required_from',
-                              in_list_view: 1,
-                              reqd: 1
-                          },
-                          {
-                              label: 'Required To',
-                              fieldtype: 'Datetime',
-                              fieldname: 'required_to',
-                              in_list_view: 1,
-                              reqd: 1
-                          },
-                          {
-                              label: 'Remarks',
-                              fieldtype: 'Small Text',
-                              fieldname: 'remarks',
-                              in_list_view: 1
-                          }
-                      ]
-                  }
-              ],
-              size: 'large',
-              primary_action_label: 'Submit',
-              primary_action: function () {
-                  let values = dialog.get_values();
-                  if (values && values.requirements) {
-                      // Perform validation for each row
-                      for (let i = 0; i < values.requirements.length; i++) {
-                          let row = values.requirements[i];
-
-                          if (!row.required_from || !row.required_to) {
-                              frappe.msgprint({
-                                  title: __('Validation Error'),
-                                  message: __('Please fill both "Required From" and "Required To" in #row  {0}.', [i + 1]),
-                                  indicator: 'red'
-                              });
-                              return;
-                          }
-
-                          // Ensure Required To is later than Required From
-                          if (row.required_to <= row.required_from) {
-                              frappe.msgprint({
-                                  title: __('Validation Error'),
-                                  message: __('"Required To" must be later than "Required From" in # row {0}.', [i + 1]),
-                                  indicator: 'red'
-                              });
-                              return;
-                          }
-                      }
-
-                      frappe.call({
-                          method: 'beams.beams.custom_scripts.project.project.create_technical_support_request',
-                          args: {
-                              project_id: frm.doc.name,
-                              requirements: JSON.stringify(values.requirements)
-                          },
-                      });
-                      dialog.hide();
-                  }
-              }
-          });
-          dialog.show();
-        }, __("Create"));
-
-        frm.add_custom_button("External Resource Request", function() {
-            frappe.new_doc("External Resource Request", {
-                project: frm.doc.name,
-                bureau: frm.doc.bureau
-            });
-        }, "Create");
-
-        // Add a button to create an Equipment Acquiral Request
-        frm.add_custom_button(__('Equipment Acquiral Request'), function () {
-          frappe.model.open_mapped_doc({
-            method: "beams.beams.custom_scripts.project.project.map_equipment_acquiral_request",
-            frm: frm,
-          });
-        }, __("Create"));
+            dialog.show();
+          }, __("Create"));
 
         // Add "Equipment Request" button under the "Create" group
         frm.add_custom_button(__('Equipment Request'), function () {
@@ -263,33 +239,55 @@ frappe.ui.form.on('Project', {
                     });
                     dialog.show();
                 }, __("Create"));
-                // Ensure filtering is applied when form loads
-                frm.fields_dict.allocated_resources_details.grid.get_field("employee").get_query = function(doc, cdt, cdn) {
-                    let row = locals[cdt][cdn];
-                    return {
-                        filters: {
-                            designation: row.designation || ""
-                        }
-                    };
-                };
-              }
-            });
 
-            // Apply filter dynamically when Designation field changes in child table
-          frappe.ui.form.on('Allocated Resource Detail', {
-              designation: function(frm, cdt, cdn) {
-                  let row = locals[cdt][cdn];
-                  frappe.model.set_value(cdt, cdn, 'employee', '');
-                  if (row.designation) {
-                      frm.fields_dict.allocated_resources_details.grid.get_field("employee").get_query = function(doc, cdt, cdn) {
-                          let child_row = locals[cdt][cdn];
-                          return {
-                              filters: {
-                                  designation: child_row.designation
-                              }
-                          };
-                      };
-                  }
-                  frm.refresh_field("allocated_resources_details");
-              }
+        // Add a button to create an Equipment Acquiral Request
+        frm.add_custom_button(__('Equipment Acquiral Request'), function () {
+          frappe.model.open_mapped_doc({
+            method: "beams.beams.custom_scripts.project.project.map_equipment_acquiral_request",
+            frm: frm,
           });
+        }, __("Create"));
+
+        frm.add_custom_button("External Resource Request", function() {
+            frappe.new_doc("External Resource Request", {
+                project: frm.doc.name,
+                bureau: frm.doc.bureau
+            });
+        }, "Create");
+        // Adds a button to the 'Project' form to create an Transportation Request.
+        frm.add_custom_button(__('Transportation Request'), function () {
+            frappe.model.open_mapped_doc({
+                method: "beams.beams.custom_scripts.project.project.create_transportation_request",
+                frm: frm,
+            });
+        }, __("Create"));
+        // Ensure filtering is applied when form loads
+        frm.fields_dict.allocated_resources_details.grid.get_field("employee").get_query = function(doc, cdt, cdn) {
+            let row = locals[cdt][cdn];
+            return {
+                filters: {
+                    designation: row.designation || ""
+                }
+            };
+        };
+      }
+    });
+
+    // Apply filter dynamically when Designation field changes in child table
+  frappe.ui.form.on('Allocated Resource Detail', {
+      designation: function(frm, cdt, cdn) {
+          let row = locals[cdt][cdn];
+          frappe.model.set_value(cdt, cdn, 'employee', '');
+          if (row.designation) {
+              frm.fields_dict.allocated_resources_details.grid.get_field("employee").get_query = function(doc, cdt, cdn) {
+                  let child_row = locals[cdt][cdn];
+                  return {
+                      filters: {
+                          designation: child_row.designation
+                      }
+                  };
+              };
+          }
+          frm.refresh_field("allocated_resources_details");
+      }
+  });

--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.json
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.json
@@ -234,7 +234,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-02-07 15:07:23.281161",
+ "modified": "2025-02-12 17:16:14.451010",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Employee Travel Request",
@@ -255,6 +255,7 @@
    "write": 1
   }
  ],
+ "search_fields": "requested_by",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/beams/beams/doctype/transportation_request/transportation_request.json
+++ b/beams/beams/doctype/transportation_request/transportation_request.json
@@ -133,7 +133,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-02-07 11:00:58.239108",
+ "modified": "2025-02-12 17:13:10.350245",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Transportation Request",
@@ -153,6 +153,7 @@
    "write": 1
   }
  ],
+ "search_fields": "project",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -316,7 +316,7 @@ def get_Project_custom_fields():
             },
             {
                 "fieldname": "requirements",
-                "fieldtype": "Small Text",
+                "fieldtype": "Text Editor",
                 "label": "Requirements",
                 "fetch_from":"program_request.requirements",
                 "insert_after": "bureau"
@@ -324,7 +324,7 @@ def get_Project_custom_fields():
             {
                 "fieldname": "location",
                 "fieldtype": "Link",
-                "label": "location",
+                "label": "Location",
                 "options":"Location",
                 "fetch_from":"program_request.location",
                 "insert_after": "department",

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -312,14 +312,14 @@ def get_Project_custom_fields():
                 "fieldtype": "Small Text",
                 "label": "Description",
                 "fetch_from":"program_request.description",
-                "insert_after": "requirements"
+                "insert_after": "bureau"
             },
             {
                 "fieldname": "requirements",
                 "fieldtype": "Text Editor",
                 "label": "Requirements",
                 "fetch_from":"program_request.requirements",
-                "insert_after": "bureau"
+                "insert_after": "description"
             },
             {
                 "fieldname": "location",


### PR DESCRIPTION
## Feature description
Nedd to: 
     

- Arrange the button on group button in project.
-  Add search fields in Transportation Request Doctype and Travel Request Doctype
-  Change the field name of Requirements fields in Project Doctype.

## Solution description

-  Arrange the button on group button in Project Doctype.
-  Add search fields in Transportation Request Doctype and Travel Request Doctype.
-  Change the field name of Requirements fields in Project Doctype.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/62303b4f-4e03-4d70-b70b-11d491788fd8)
![image](https://github.com/user-attachments/assets/bae34093-5961-435e-9e2c-04cbb09991b8)
![image](https://github.com/user-attachments/assets/9a452a84-931a-42be-8b2d-137278e90feb)



## Areas affected and ensured

- Project Doctype
- Transportation Request Doctype
- Travel Request Doctype.

## Is there any existing behavior change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?
  - Mozilla Firefox
 