### PR TITLE
feat: Issued Qty updated once asset movement is submitted

### DIFF
--- a/beams/beams/custom_scripts/asset_movement/asset_movement.js
+++ b/beams/beams/custom_scripts/asset_movement/asset_movement.js
@@ -1,0 +1,11 @@
+frappe.ui.form.on('Asset Movement', {
+    onload: function(frm) {
+        frm.set_query('reference_doctype', function() {
+            return { filters: {} };
+        });
+
+        frm.set_query('reference_name', function() {
+            return { filters: {} };
+        });
+    }
+});

--- a/beams/beams/custom_scripts/asset_movement/asset_movement.py
+++ b/beams/beams/custom_scripts/asset_movement/asset_movement.py
@@ -1,0 +1,14 @@
+import frappe
+
+def update_issued_quantity(doc, method):
+    """ Update Issued Quantity in Equipment Request's Required Items Detail child table """
+
+    # Ensure reference doctype is "Equipment Request"
+    if doc.reference_doctype != "Required Items Detail":
+        return
+    # Check if the referenced Required Items Detail exists
+    if not frappe.db.exists("Required Items Detail", doc.reference_name):
+        frappe.throw("Referenced Required Items Detail Not Found")
+
+    issued_qty = frappe.db.get_value("Required Items Detail", doc.reference_name, "issued_quantity") or 0
+    frappe.db.set_value("Required Items Detail", doc.reference_name, "issued_quantity", issued_qty + 1)

--- a/beams/beams/doctype/equipment_request/equipment_request.js
+++ b/beams/beams/doctype/equipment_request/equipment_request.js
@@ -85,23 +85,24 @@ frappe.ui.form.on('Required Items Detail', {
                        }
                    }
                ],
-               function(values) {
-                   // Call backend method to map the asset movement
-                   frappe.model.open_mapped_doc({
-                       method: "beams.beams.doctype.equipment_request.equipment_request.map_asset_movement",
-                       frm: frm,
-                       args: {
-                         to_employee: values.employee,
-           							 asset: values.asset
-           						}
-                   });
-               }, __('Asset Movement'), __('Create'));
-           } else {
-               frappe.msgprint(__('Invalid required item selected.'));
-           }
-       });
+               function (values) {
+                      frappe.model.open_mapped_doc({
+                          method: "beams.beams.doctype.equipment_request.equipment_request.map_asset_movement",
+                          frm: frm,
+                          args: {
+                              to_employee: values.employee,
+                              asset: values.asset,
+                              ref_type: row["doctype"],
+                              ref_name: row["name"]
+                          }
+                      });
+                  }, __('Asset Movement'), __('Create'));
+              } else {
+                  frappe.msgprint(__('Invalid required item selected.'));
+              }
+          });
       }
-    });
+  });
 
 function validate_dates(frm) {
     if (frm.doc.required_from && frm.doc.required_to) {

--- a/beams/beams/doctype/equipment_request/equipment_request.py
+++ b/beams/beams/doctype/equipment_request/equipment_request.py
@@ -85,6 +85,9 @@ def map_equipment_acquiral_request(source_name, target_doc=None):
 def map_asset_movement(source_name, target_doc=None):
     to_employee = frappe.flags.get("args", {}).get("to_employee", '')
     asset = frappe.flags.get("args", {}).get("asset", '')
+    ref_type = frappe.flags.get("args", {}).get("ref_type", '')
+    ref_name = frappe.flags.get("args", {}).get("ref_name", '')
+    print(ref_type, ref_name)
     asset_movement = get_mapped_doc("Equipment Request", source_name, {
         "Equipment Request": {
             "doctype": "Asset Movement",
@@ -98,6 +101,8 @@ def map_asset_movement(source_name, target_doc=None):
             'asset': asset,
             'to_employee': to_employee
         })
+    asset_movement.reference_doctype = ref_type
+    asset_movement.reference_name = ref_name
     asset_movement.flags.ignore_mandatory = True
     asset_movement.save(ignore_permissions=True)
     return asset_movement

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -57,7 +57,8 @@ doctype_js = {
     "Leave Application":"beams/custom_scripts/leave_application/leave_application.js",
     "Job Offer": "beams/custom_scripts/job_offer/job_offer.js",
     "Appraisal":"beams/custom_scripts/appraisal/appraisal.js",
-    "Project":"beams/custom_scripts/project/project.js"
+    "Project":"beams/custom_scripts/project/project.js",
+    "Asset Movement":"beams/custom_scripts/asset_movement/asset_movement.js"
 }
 doctype_list_js = {
     "Sales Invoice" : "beams/custom_scripts/sales_invoice/sales_invoice_list.js",
@@ -306,6 +307,11 @@ doc_events = {
         "before_insert": [
             "beams.beams.custom_scripts.item.item.before_insert"
         ]
+    },
+    "Asset Movement": {
+        "on_submit": [
+            "beams.beams.custom_scripts.asset_movement.asset_movement.update_issued_quantity"
+            ]
     }
 }
 


### PR DESCRIPTION
## Feature description
Issued Qty will be updated once asset movement is submitted

## Solution description
Issued Qty updated once asset movement is submitted

## Output screenshots (optional)
[Screencast from 12-02-25 04:52:26 PM IST.webm](https://github.com/user-attachments/assets/fcd15a53-b48e-4b2b-9b54-6b79463ef4f2)


## Areas affected and ensured
Equipment Request

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Mozilla Firefox
  
