### PR TITLE
fix: Technical Request form not saved unless the Employee field is filled

### DIFF
--- a/beams/beams/doctype/technical_request/technical_request.js
+++ b/beams/beams/doctype/technical_request/technical_request.js
@@ -33,6 +33,7 @@ frappe.ui.form.on('Technical Request', {
             }, "Create");
         }
       },
+
     posting_date:function (frm){
         frm.call("validate_posting_date");
       },
@@ -58,6 +59,12 @@ frappe.ui.form.on('Technical Request', {
 
     required_to: function(frm) {
         frm.call("validate_required_from_and_required_to");
+    },
+
+    validate: function(frm) {
+        if (!frm.doc.required_employees || frm.doc.required_employees.length === 0) {
+            frappe.throw(__('Required Employees field cannot be empty.'));
+        }
     }
 });
 


### PR DESCRIPTION
## Feature description
Technical Request form won't be saved unless the Employee field is filled

## Solution description
Technical Request form not saved unless the Employee field is filled

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/194eea11-696d-43f4-9ab9-9d6de52cedb7)


## Is there any existing behavior change of other features due to this code change?
 No

## Was this feature tested on the browsers?
  - Mozilla Firefox
