### PR TITLE
feat: Update Cost Subhead and Budget Template

### DIFF
--- a/beams/beams/custom_scripts/budget/budget.js
+++ b/beams/beams/custom_scripts/budget/budget.js
@@ -77,7 +77,8 @@ function set_filters(frm) {
     frm.set_query('budget_template', function () {
         return {
             filters: {
-                division: frm.doc.division
+                division: frm.doc.division,
+                company: frm.doc.company
             }
         };
     });

--- a/beams/beams/doctype/budget_template/budget_template.js
+++ b/beams/beams/doctype/budget_template/budget_template.js
@@ -12,16 +12,33 @@ frappe.ui.form.on('Budget Template', {
             frm.clear_table('budget_template_item');
             frm.refresh_field('budget_template_item');
         }
+    },
+    company: function (frm) {
+        if (frm.doc.company) {
+            frm.clear_table("budget_template_item");
+            frm.refresh_field("budget_template_item");
+        }
     }
 });
 
 frappe.ui.form.on('Budget Template Item', {
     cost_sub_head: function (frm, cdt, cdn) {
         var row = locals[cdt][cdn];
-        if (row.cost_sub_head) {
-            frappe.db.get_value('Cost Subhead', row.cost_sub_head, 'account').then(r => {
-                frappe.model.set_value(cdt, cdn, 'account', r.message.account);
-            })
+
+        if (row.cost_sub_head && frm.doc.company) {
+            frappe.db.get_doc('Cost Subhead', row.cost_sub_head).then(doc => {
+                if (doc.accounts && doc.accounts.length > 0) {
+                    let account_found = doc.accounts.find(acc => acc.company === frm.doc.company);
+                    if (account_found) {
+                        frappe.model.set_value(cdt, cdn, 'account', account_found.default_account);
+                    } else {
+                        frappe.model.set_value(cdt, cdn, 'account', '');
+                        frappe.msgprint(__('No default account found for the selected Cost Subhead and Company.'));
+                    }
+                } else {
+                    frappe.model.set_value(cdt, cdn, 'account', '');
+                }
+            });
         }
     }
 });

--- a/beams/beams/doctype/budget_template/budget_template.json
+++ b/beams/beams/doctype/budget_template/budget_template.json
@@ -10,6 +10,7 @@
   "department",
   "column_break",
   "division",
+  "company",
   "section_break",
   "budget_template_item"
  ],
@@ -28,6 +29,7 @@
    "unique": 1
   },
   {
+   "depends_on": "eval:doc.company",
    "fieldname": "budget_template_item",
    "fieldtype": "Table",
    "label": "Budget Template Item",
@@ -49,11 +51,18 @@
   {
    "fieldname": "section_break",
    "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "label": "Company",
+   "options": "Company",
+   "reqd": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-02-03 16:06:00.882855",
+ "modified": "2025-02-13 10:50:51.981266",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Budget Template",

--- a/beams/beams/doctype/budget_template/budget_template.py
+++ b/beams/beams/doctype/budget_template/budget_template.py
@@ -4,6 +4,24 @@
 import frappe
 from frappe.model.document import Document
 
-
 class BudgetTemplate(Document):
-	pass
+
+    def set_default_account(self):
+        if not hasattr(self, "budget_template_item") or not self.budget_template_item:
+            return
+
+        for item in self.budget_template_item:
+            if not item.cost_sub_head or not self.company:
+                item.account = ""
+                continue
+
+            cost_subhead_doc = frappe.get_doc("Cost Subhead", item.cost_sub_head)
+
+            if cost_subhead_doc.accounts:
+                account_found = next((acc for acc in cost_subhead_doc.accounts if acc.company == self.company), None)
+                item.account = account_found.default_account if account_found else ""
+            else:
+                item.account = ""
+
+    def before_save(self):
+        self.set_default_account()

--- a/beams/beams/doctype/budget_template_item/budget_template_item.json
+++ b/beams/beams/doctype/budget_template_item/budget_template_item.json
@@ -24,7 +24,8 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Account",
-   "options": "Account"
+   "options": "Account",
+   "read_only": 1
   },
   {
    "fieldname": "cost_category",
@@ -44,7 +45,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-01-28 09:36:11.679656",
+ "modified": "2025-02-13 11:59:51.014980",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Budget Template Item",

--- a/beams/beams/doctype/cost_subhead/cost_subhead.js
+++ b/beams/beams/doctype/cost_subhead/cost_subhead.js
@@ -3,7 +3,7 @@
 
 frappe.ui.form.on("Cost Subhead", {
     refresh(frm) {
-        frm.set_query('account', () => {
+        frm.set_query('default_account','accounts', () => {
             return {
                 filters: {
                     is_group: 0

--- a/beams/beams/doctype/cost_subhead/cost_subhead.json
+++ b/beams/beams/doctype/cost_subhead/cost_subhead.json
@@ -9,7 +9,8 @@
   "section_break_9os0",
   "cost_subhead",
   "cost_head",
-  "account"
+  "account",
+  "accounts"
  ],
  "fields": [
   {
@@ -27,7 +28,6 @@
   {
    "fieldname": "account",
    "fieldtype": "Link",
-   "in_list_view": 1,
    "label": "Account",
    "options": "Account",
    "reqd": 1
@@ -38,11 +38,18 @@
    "label": "Cost Head",
    "options": "Cost Head",
    "reqd": 1
+  },
+  {
+   "fieldname": "accounts",
+   "fieldtype": "Table",
+   "label": "Accounts",
+   "options": "Accounts",
+   "reqd": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-01-27 11:03:53.549279",
+ "modified": "2025-02-13 13:26:53.244996",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Cost Subhead",

--- a/beams/patches.txt
+++ b/beams/patches.txt
@@ -1,6 +1,7 @@
 [pre_model_sync]
 beams.patches.rename_hod_role #30-10-2024
 beams.patches.delete_custom_fields  #26-11-2024-1
+beams.patches.update_account  #13-02-20250
 
 [post_model_sync]
 # Patches added in this section will be executed after doctypes are migrated

--- a/beams/patches/update_account.py
+++ b/beams/patches/update_account.py
@@ -1,0 +1,13 @@
+import frappe
+
+def execute():
+    cost_subheads = frappe.get_all('Cost Subhead', pluck='name')
+    default_company = frappe.db.get_single_value('Global Defaults', 'default_company')
+    for subhead in cost_subheads:
+        cost_subhead_doc = frappe.get_doc('Cost Subhead', subhead)
+        cost_subhead_doc.append('accounts', {
+            'company': default_company,
+            'default_account': cost_subhead_doc.account
+        })
+        cost_subhead_doc.save()
+    frappe.db.commit()

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -3323,7 +3323,15 @@ def get_property_setters():
             "property": "depends_on",
             "property_type": "Code",
             "value": "eval: doc.employee_naming_by_department === 0 "
-        }
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Budget Account",
+            "field_name": "account",
+            "property": "read_only",
+            "property_type": "Link",
+            "value": 1
+        },
     ]
 
 def get_material_request_custom_fields():


### PR DESCRIPTION
## Feature description
- Customize Cost Subhead doctype and Budget Template.
- Apply company filter in Budget Template field of Budget.
- Apply filter in Account field of Cost Subhead.
- Fetch account in Budget template based on selected company.

## Solution description
- Customized Cost Subhead doctype and Budget Template.
- Applied company filter in Budget Template field of Budget.
- Applied filter in Account field of Cost Subhead.
- Fetches account in Budget template based on selected company.
- Set account as read only in both budget and Budget template child table.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/27aafaab-66ef-4656-a508-6f2e73d58f5d)
[Screencast from 13-02-25 03:02:31 PM IST.webm](https://github.com/user-attachments/assets/212851c7-349b-424f-a59d-4202f62afa08)

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox