### PR TITLE
fix: Required Employee Field editable in Technical Request Doctype

### DIFF
--- a/beams/beams/doctype/technical_request/technical_request.json
+++ b/beams/beams/doctype/technical_request/technical_request.json
@@ -110,6 +110,7 @@
    "label": "No of Employees"
   },
   {
+   "allow_on_submit": 1,
    "fieldname": "required_employees",
    "fieldtype": "Table MultiSelect",
    "label": "Required Employees",
@@ -128,7 +129,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-02-13 12:53:13.499201",
+ "modified": "2025-02-14 12:02:09.724554",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Technical Request",


### PR DESCRIPTION
## Feature description
Change Required Employee Field editable in Technical Request Doctype when workflow state Pending Approval

## Solution description
Required Employee Field editable in Technical Request Doctype when workflow state Pending Approval

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/2f67f250-e66e-408c-8d2e-fe4e92f3ac97)


## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Mozilla Firefox
