### PR TITLE
feat:customize asset doctype

### DIFF
--- a/beams/setup.py
+++ b/beams/setup.py
@@ -591,6 +591,34 @@ def get_asset_custom_fields():
                 "options":"Bureau",
                 "label": "Bureau",
                 "insert_after": "location"
+            },
+            {
+                "fieldname": "in_transit",
+                "fieldtype": "Check",
+                "label": "In Transit",
+                "insert_after": "is_composite_asset",
+                "allow_on_submit": 1,
+                "read_only":1
+
+            },
+            {
+                "fieldname": "warranty_details_section",
+                "fieldtype": "Section Break",
+                "label": "Warranty Details Section",
+                "insert_after": "comprehensive_insurance",
+                "collapsible": 1
+            },
+            {
+                "fieldname": "warranty_reference_no",
+                "fieldtype": "Data",
+                "label": "Warranty Reference No",
+                "insert_after": "warranty_details_section"
+            },
+            {
+                "fieldname": "warranty_till",
+                "fieldtype": "Date",
+                "label": "Warranty Till",
+                "insert_after": "warranty_reference_no"
             }
         ]
     }


### PR DESCRIPTION
## Feature description
customize asset doctype

## Solution description
- add fields in asset 
- Field Name - In Transit, Warranty Reference No ,Warranty Till

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/446a878f-e65e-496e-b317-033772f88cdb)
![image](https://github.com/user-attachments/assets/155a7204-ca66-40b4-8ea7-77199bc78cef)

## Areas affected and ensured
 asset doctype

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox -yes
  - Opera Mini
  - Safari
