### PR TITLE
    ISS-2025-00029:Refactor One-to-One Meeting button and add event reference

### DIFF
--- a/beams/beams/custom_scripts/appraisal/appraisal.py
+++ b/beams/beams/custom_scripts/appraisal/appraisal.py
@@ -277,6 +277,15 @@ def map_appraisal_to_event(source_name):
         raise frappe.exceptions.ValidationError(f"Error: {str(e)}")
 
 @frappe.whitelist()
+def check_existing_event(appraisal_reference):
+    """
+    Check if an Event exists for the given Appraisal.
+
+    """
+    event = frappe.db.get_value("Event", {"appraisal_reference": appraisal_reference}, "name")
+    return event if event else None
+
+@frappe.whitelist()
 def assign_tasks_sequentially(doc=None, method=None):
     """
     Assign tasks sequentially to assessment officers listed in the Appraisal Template,

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -2759,13 +2759,6 @@ def get_appraisal_custom_fields():
                 "read_only": 1
 			},
             {
-                "fieldname": "event_reference",
-                "fieldtype": "Link",
-                "label": "Event Reference",
-                "insert_after": "appraisal_cycle",
-                "options": "Event"
-            },
-            {
                 "fieldname": "employee_self_kra_rating",
                 "fieldtype": "Table",
                 "label": "Employee Rating",


### PR DESCRIPTION
## Feature description
✅ Implement logic to display "View Event" button if an existing event is linked to the Appraisal.
✅ "Remove 'Event Reference' field from appraisal form

## Solution description
✅ Add "View Event" button to Appraisal form when an event is linked.
✅ Removed 'Event Reference' field from appraisal form

## Output screenshots (optional)

[Screencast from 18-02-25 11:08:25 AM IST.webm](https://github.com/user-attachments/assets/812506b1-e5e9-420c-b070-ba8d0756d45b)


## Is there any existing behavior change of other features due to this code change?
✅ No. 
## Was this feature tested on the browsers?
✅ Mozilla Firefox
