### PR TITLE
fix: handle permission issue for Leave Allocation update

### DIFF
--- a/beams/beams/custom_scripts/appraisal/appraisal.py
+++ b/beams/beams/custom_scripts/appraisal/appraisal.py
@@ -127,9 +127,7 @@ def get_appraisal_summary(appraisal_template, employee_feedback=None):
     final_average_score = total_marks / total_criteria if total_criteria > 0 else 0
 
     if feedback_doc and feedback_doc.appraisal:
-        appraisal_doc = frappe.get_doc("Appraisal", feedback_doc.appraisal)
-        appraisal_doc.final_average_score = final_average_score
-        appraisal_doc.save()
+        frappe.db.set_value("Appraisal", feedback_doc.appraisal, "final_average_score", final_average_score)
 
     # Generate the HTML table
     table_html = """

--- a/beams/beams/custom_scripts/employee_checkin/employee_checkin.py
+++ b/beams/beams/custom_scripts/employee_checkin/employee_checkin.py
@@ -47,6 +47,7 @@ def handle_employee_checkin_out(doc, method):
         if allocation.to_date < end_date:
             allocation.to_date = end_date
         allocation.new_leaves_allocated += 1
+        allocation.flags.ignore_permissions = True
         allocation.save()
     else:
         # Create new Leave Allocation
@@ -58,5 +59,5 @@ def handle_employee_checkin_out(doc, method):
             "to_date": end_date,
             "new_leaves_allocated": 1,
         })
-        leave_allocation_doc.insert()
+        leave_allocation_doc.insert(ignore_permissions=True)
         leave_allocation_doc.submit()


### PR DESCRIPTION
## Feature description
1. When Employees working on a double shift and checking out lack the necessary permissions to create or update their leave allocation, preventing the compensatory leave from being granted.
2. When attempting to save an Appraisal document, a TimestampMismatchError was raised. The error message indicated that the document had been modified after it was loaded into memory:

## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description
- Added ignore_permissions flag while saving Leave Allocation to prevent PermissionError.
- Update only the specific field (final_average_score) directly in the database using frappe.db.set_value, thereby bypassing the full document save and its timestamp check.

## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.

## Areas affected and ensured

- Employee Checkin-processing
- Leave Allocation-creation and updates
- Appraisal 

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  