### PR TITLE
feat:add Posting Date to Asset Auditing doctype

### DIFF
--- a/beams/beams/doctype/asset_auditing/asset_auditing.js
+++ b/beams/beams/doctype/asset_auditing/asset_auditing.js
@@ -10,5 +10,8 @@ frappe.ui.form.on('Asset Auditing', {
                 }
             });
         }
+    },
+    posting_date:function (frm){
+      frm.call("validate_posting_date");
     }
 });

--- a/beams/beams/doctype/asset_auditing/asset_auditing.json
+++ b/beams/beams/doctype/asset_auditing/asset_auditing.json
@@ -15,7 +15,6 @@
   "asset_photos",
   "remarks",
   "has_damage",
-  "damage_remarks",
   "amended_from"
  ],
  "fields": [
@@ -49,6 +48,7 @@
    "reqd": 1
   },
   {
+   "fetch_from": "asset.location",
    "fieldname": "location",
    "fieldtype": "Link",
    "label": "Location",
@@ -74,12 +74,6 @@
    "reqd": 1
   },
   {
-   "depends_on": "\n",
-   "fieldname": "damage_remarks",
-   "fieldtype": "Small Text",
-   "label": "Damage Remarks"
-  },
-  {
    "default": "Now",
    "fieldname": "posting_date",
    "fieldtype": "Date",
@@ -93,7 +87,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-02-18 15:07:48.796779",
+ "modified": "2025-02-18 16:10:52.558484",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Asset Auditing",

--- a/beams/beams/doctype/asset_auditing/asset_auditing.json
+++ b/beams/beams/doctype/asset_auditing/asset_auditing.json
@@ -6,14 +6,17 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
-  "section_break_rev9",
-  "amended_from",
   "asset",
   "employee",
-  "asset_photos",
+  "column_break_bgwn",
+  "posting_date",
   "location",
+  "section_break_rev9",
+  "asset_photos",
   "remarks",
-  "has_damage"
+  "has_damage",
+  "damage_remarks",
+  "amended_from"
  ],
  "fields": [
   {
@@ -69,12 +72,28 @@
    "label": "Employee",
    "options": "Employee",
    "reqd": 1
+  },
+  {
+   "depends_on": "\n",
+   "fieldname": "damage_remarks",
+   "fieldtype": "Small Text",
+   "label": "Damage Remarks"
+  },
+  {
+   "default": "Now",
+   "fieldname": "posting_date",
+   "fieldtype": "Date",
+   "label": "Posting Date"
+  },
+  {
+   "fieldname": "column_break_bgwn",
+   "fieldtype": "Column Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-02-17 11:32:44.935636",
+ "modified": "2025-02-18 15:07:48.796779",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Asset Auditing",

--- a/beams/beams/doctype/asset_auditing/asset_auditing.py
+++ b/beams/beams/doctype/asset_auditing/asset_auditing.py
@@ -3,8 +3,19 @@
 
 import frappe
 from frappe.model.document import Document
+from frappe.utils import today
+from frappe import _
 
 class AssetAuditing(Document):
+    def before_save(self):
+        self.validate_posting_date()
+        
+    @frappe.whitelist()
+    def validate_posting_date(self):
+        if self.posting_date:
+            if self.posting_date > today():
+                frappe.throw(_("Posting Date cannot be set after today's date."))
+
     def before_submit(self):
         if len(self.asset_photos) < 3:
             frappe.msgprint(


### PR DESCRIPTION
## Feature description
- added Posting Date to Asset Auditing doctype

## Solution description
- added Posting Date to Asset Auditing doctype
- add validation for posting date
- fetch location from asset

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/6120b20f-1b20-48ef-ae0e-eed6432fad74)
![image](https://github.com/user-attachments/assets/8f9f0225-308d-4bbc-b5f9-e532391e3659)


## Areas affected and ensured

Asset Auditing


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - yes
  - Opera Mini
  - Safari
