### PR TITLE
TASK-2025-00193 : QR Code Generation in Asset and Asset Bundle

### DIFF
--- a/beams/beams/custom_scripts/asset/asset.py
+++ b/beams/beams/custom_scripts/asset/asset.py
@@ -1,0 +1,48 @@
+
+
+import frappe
+from frappe.model.document import Document
+import os
+import io
+import json
+from pyqrcode import create
+
+
+@frappe.whitelist()
+def generate_asset_qr(doc,method = None):
+    qr_code = doc.get("qr_code")
+    if qr_code and frappe.db.exists({"doctype": "File", "file_url": qr_code}):
+        return
+    doc_url = get_si_json(doc)
+    qr_image = io.BytesIO()
+    url = create(doc_url, error="L")
+    url.png(qr_image, scale=4, quiet_zone=1)
+    name = frappe.generate_hash(doc.name, 5)
+    filename = f"QRCode-{name}.png".replace(os.path.sep, "__")
+    _file = frappe.get_doc(
+        {
+            "doctype": "File",
+            "file_name": filename,
+            "is_private": 0,
+            "content": qr_image.getvalue(),
+            "attached_to_doctype": doc.get("doctype"),
+            "attached_to_name": doc.get("name"),
+            "attached_to_field": "qr_code",
+        }
+    )
+    _file.save()
+    doc.db_set("qr_code", _file.file_url)
+
+def get_si_json(doc):
+    essential_fields = [
+        "item_code",
+        "asset_name",
+        "location",
+        "asset_owner",
+    ]
+    item_data = {}
+    for field in essential_fields:
+        value = doc.get(field)
+        item_data[field] = value
+    json_data = json.dumps(item_data, indent=4)
+    return json_data

--- a/beams/beams/doctype/asset_bundle/asset_bundle.py
+++ b/beams/beams/doctype/asset_bundle/asset_bundle.py
@@ -3,9 +3,67 @@
 
 import frappe
 from frappe.model.document import Document
+import os
+import io
+from pyqrcode import create
+import json
 
 
 class AssetBundle(Document):
 	def before_save(self):
 		if not(self.assets or self.bundles or self.stock_items):
 			frappe.throw("At least one of Stock Items, Assets, or Bundles must be filled in.")
+
+	def after_insert(self):
+		self.generate_asset_bundle_qr()
+
+	def generate_asset_bundle_qr(self):
+		qr_code = self.get("qr_code")
+		if qr_code and frappe.db.exists({"doctype": "File", "file_url": qr_code}):
+			return
+
+		doc_url = self.get_si_json()
+		qr_image = io.BytesIO()
+		url = create(doc_url, error="L")
+		url.png(qr_image, scale=4, quiet_zone=1)
+		name = frappe.generate_hash(self.name, 5)
+		filename = f"QRCode-{name}.png".replace(os.path.sep, "__")
+		_file = frappe.get_doc(
+			{
+				"doctype": "File",
+				"file_name": filename,
+				"is_private": 0,
+				"content": qr_image.getvalue(),
+				"attached_to_doctype": self.get("doctype"),
+				"attached_to_name": self.get("name"),
+				"attached_to_field": "qr_code",
+			}
+		)
+		_file.save()
+		self.db_set("qr_code", _file.file_url)
+
+	def get_si_json(self):
+		essential_fields = ["assets", "bundles","stock_items"]
+		item_data = {}
+		for field in essential_fields:
+			if not field in ["assets", "bundles","stock_items"]:
+				value = self.get(field)
+			else:
+				values = []
+				for row in self.get(field):
+					row_data = {}
+					if field == "assets":
+						row_data["asset"] = row.asset
+						values.append(row_data)
+					elif field == "bundles":
+						row_data["asset_bundle"] = row.asset_bundle
+						values.append(row_data)
+					elif field == "stock_items":
+						row_data["item"] = row.item
+						row_data["uom"] = row.uom
+						row_data["qty"] = row.qty
+						values.append(row_data)
+				value = values
+			item_data[field] = value
+		json_data = json.dumps(item_data, indent=4)
+		return json_data

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -313,7 +313,10 @@ doc_events = {
         "on_submit": [
             "beams.beams.custom_scripts.asset_movement.asset_movement.update_issued_quantity"
             ]
-    }
+    },
+    "Asset":{
+        "after_insert":"beams.beams.custom_scripts.asset.asset.generate_asset_qr"
+    },
 }
 
 # Scheduled Tasks

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -621,6 +621,12 @@ def get_asset_custom_fields():
                 "fieldtype": "Date",
                 "label": "Warranty Till",
                 "insert_after": "warranty_reference_no"
+            },
+            {
+                "fieldname": "qr_code",
+                "fieldtype": "Attach Image",
+                "label": "QR code",
+                "insert_after": "department"
             }
         ]
     }


### PR DESCRIPTION
## Feature description
-Need to add a new field in asset 
-Add script to Generate QR code on creation of asset
-Add script to Generate QR code on creation of asset bundle

## Solution description
1. added new field qr code in the asset doctype
2. added script generate qr code after insert of the asset  via hooks.py and asset.py
3. added script generate qr code after insert of the asset bundle via asset bundle .py

## Output screenshots (optional)
 asset qr code:
[Screencast from 19-02-25 10:17:17 AM IST.webm](https://github.com/user-attachments/assets/8eff6f0a-3e41-42e9-984a-8da3c202d7b8) 
![image](https://github.com/user-attachments/assets/e4330b6b-d950-4765-9338-8f82a4abb042)
asset bundle qr code :
[Screencast from 19-02-25 10:20:34 AM IST.webm](https://github.com/user-attachments/assets/f936e418-7649-4fa5-8cbb-cd810bdb544f)
![image](https://github.com/user-attachments/assets/9d97160a-8d31-4d6c-8c28-f98138da11e3)

## Areas affected and ensured
asset and asset bundle doctype

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  
  - Mozilla Firefox

