### PR TITLE
feat:Created a Damage History Report for Assets

### DIFF
--- a/beams/beams/report/damage_history_report_for_assets/damage_history_report_for_assets.js
+++ b/beams/beams/report/damage_history_report_for_assets/damage_history_report_for_assets.js
@@ -1,0 +1,42 @@
+// Copyright (c) 2025, efeone and contributors
+// For license information, please see license.txt
+
+frappe.query_reports["Damage History Report for Assets"] = {
+	"filters": [
+				{
+						fieldname: "asset",
+						label: __("Asset"),
+						fieldtype: "Link",
+						options: "Asset"
+				},
+				{
+						fieldname: "location",
+						label: __("Location"),
+						fieldtype: "Data",
+				},
+				{
+						fieldname: "audit_id",
+						label: __("Audit ID"),
+						fieldtype: "Link",
+						options: "Asset Auditing",
+				},
+				{
+						fieldname: "repair_status",
+						label: __("Repair Status"),
+						fieldtype: "Select",
+						options: ["", "Pending", "Completed", "cancelled"],
+				},
+				{
+						fieldname: "repair_id",
+						label: __("Asset Repair ID"),
+						fieldtype: "Link",
+						options: "Asset Repair",
+				},
+				{
+						fieldname: "employee",
+						label: __("Employee"),
+						fieldtype: "Link",
+						options: "Employee",
+				}
+	]
+};

--- a/beams/beams/report/damage_history_report_for_assets/damage_history_report_for_assets.json
+++ b/beams/beams/report/damage_history_report_for_assets/damage_history_report_for_assets.json
@@ -1,0 +1,31 @@
+{
+ "add_total_row": 0,
+ "columns": [],
+ "creation": "2025-02-18 09:48:38.685999",
+ "disabled": 0,
+ "docstatus": 0,
+ "doctype": "Report",
+ "filters": [],
+ "idx": 0,
+ "is_standard": "Yes",
+ "json": "{}",
+ "letterhead": null,
+ "modified": "2025-02-18 16:31:13.743513",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "Damage History Report for Assets",
+ "owner": "Administrator",
+ "prepared_report": 0,
+ "ref_doctype": "Asset",
+ "report_name": "Damage History Report for Assets",
+ "report_type": "Script Report",
+ "roles": [
+  {
+   "role": "Accounts User"
+  },
+  {
+   "role": "Quality Manager"
+  }
+ ],
+ "timeout": 0
+}

--- a/beams/beams/report/damage_history_report_for_assets/damage_history_report_for_assets.py
+++ b/beams/beams/report/damage_history_report_for_assets/damage_history_report_for_assets.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2025, efeone and contributors
+# For license information, please see license.txt
+
+import frappe
+
+def execute(filters=None):
+    columns = get_columns()
+    data = get_data(filters)
+    return columns, data
+
+def get_columns():
+    return [
+        {"label": "Asset", "fieldname": "asset", "fieldtype": "Link", "options": "Asset", "width": 200},
+        {"label": "Location", "fieldname": "location", "fieldtype": "Data", "width": 200},
+        {"label": "Audit ID", "fieldname": "audit_id", "fieldtype": "Link", "options": "Asset Auditing", "width": 150},
+        {"label": "Has Damage", "fieldname": "has_damage", "fieldtype": "Data", "width": 100},
+        {"label": "Remarks", "fieldname": "remarks", "fieldtype": "Data", "width": 300},
+        {"label": "Employee", "fieldname": "employee", "fieldtype": "Link", "options": "Employee", "width": 200},
+        {"label": "Posting Date", "fieldname": "posting_date", "fieldtype": "Date", "width": 200},
+        {"label": "Asset Repair ID", "fieldname": "repair_id", "fieldtype": "Link", "options": "Asset Repair", "width": 150},  # New column
+        {"label": "Description", "fieldname": "description", "fieldtype": "Data", "width": 250},
+        {"label": "Repair Cost", "fieldname": "repair_cost", "fieldtype": "Currency", "width": 150},
+        {"label": "Failure Date", "fieldname": "failure_date", "fieldtype": "Date", "width": 150},
+        {"label": "Repair Status", "fieldname": "repair_status", "fieldtype": "Select", "width": 150}
+    ]
+	
+def get_data(filters):
+    data = []
+    asset_filters = {}
+    if filters.get("asset"):
+        asset_filters["name"] = filters["asset"]
+    if filters.get("location"):
+        asset_filters["location"] = filters["location"]
+    asset_auditing_filters = {}
+    if filters.get("employee"):
+        asset_auditing_filters["employee"] = filters["employee"]
+    if filters.get("audit_id"):
+        asset_auditing_filters["name"] = filters["audit_id"]
+    repair_filters = {}
+    if filters.get("repair_status"):
+        repair_filters["repair_status"] = filters["repair_status"]
+    if filters.get("repair_id"):
+        repair_filters["name"] = filters["repair_id"]
+    assets = frappe.get_all("Asset", fields=["name as asset", "location"], filters=asset_filters if asset_filters else None)
+    for asset in assets:
+        audits = frappe.get_all(
+            "Asset Auditing",
+            filters={"asset": asset["asset"], **asset_auditing_filters},
+            fields=["name as audit_id", "has_damage", "remarks", "employee", "posting_date"]
+        )
+        repairs = frappe.get_all(
+            "Asset Repair",
+            filters={"asset": asset["asset"], **repair_filters},
+            fields=["name as repair_id", "description", "repair_cost", "failure_date", "repair_status"]
+        )
+        if not audits:
+            audits = [{"audit_id": None, "has_damage": None, "remarks": None, "employee": None, "posting_date": None}]
+        if not repairs:
+            repairs = [{"repair_id": None, "description": None, "repair_cost": None, "failure_date": None, "repair_status": None}]
+        for audit in audits:
+            for repair in repairs:
+                row = {
+                    "asset": asset["asset"],
+                    "location": asset["location"],
+                    "audit_id": audit["audit_id"],
+                    "has_damage": "Yes" if audit["has_damage"] else "No" if audit["has_damage"] is not None else None,
+                    "remarks": audit["remarks"],
+                    "employee": audit["employee"],
+                    "posting_date": audit["posting_date"],
+                    "repair_id": repair.get("repair_id"),
+                    "description": repair.get("description"),
+                    "repair_cost": repair.get("repair_cost"),
+                    "failure_date": repair.get("failure_date"),
+                    "repair_status": repair.get("repair_status")
+                }
+                if (filters.get("repair_id") and not row["repair_id"]) or \
+                   (filters.get("repair_status") and not row["repair_status"]) or \
+				   (filters.get("employee") and not row["employee"]) or \
+                   (filters.get("audit_id") and not row["audit_id"]):
+                    continue
+                data.append(row)
+
+    return data


### PR DESCRIPTION
## Feature description
Created a Damage History Report for Assets

## Solution description
- Asset details such as location, assigned employee, and audit records.
- Repair details like description, cost, failure date, and repair status.
- Filters to refine results based on asset, location, audit ID, employee, repair ID, and repair status.
- A structured approach to merging audit and repair data, ensuring comprehensive asset tracking.
## Output screenshots (optional)

![image](https://github.com/user-attachments/assets/0dc2fbec-40a0-47c2-8a8b-b186448b61c5)

![image](https://github.com/user-attachments/assets/66a22f67-df84-438c-99b2-4caa737418b2)

[Screencast from 19-02-25 10:24:30 AM IST.webm](https://github.com/user-attachments/assets/bd2c12a0-7311-4e20-8453-fa1e0f162741)

## Areas affected and ensured
Damage History Report for Assets  report

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - yes
  - Opera Mini
  - Safari
