### PR TITLE
fix:Set Job Requisition in Job Opening

### DIFF
--- a/beams/beams/custom_scripts/job_requisition/job_requisition.py
+++ b/beams/beams/custom_scripts/job_requisition/job_requisition.py
@@ -23,7 +23,7 @@ def create_job_opening_from_job_requisition(doc, method):
                     "qualification": qualification.qualification
                 })
             job_opening.min_experience = doc.min_experience
-            job_opening.job_requisition = doc.name
+            job_opening.job_requisition_id_ = doc.name
             job_opening.no_of_positions = doc.no_of_positions
             job_opening.no_of_days_off = doc.no_of_days_off
             job_opening.preffered_location = doc.location


### PR DESCRIPTION
## Feature description
-Job Requisition is not auto setting in Job Opening([ISS-2025-00033])

## Solution description
-Assigned Job Requisition in Job Opening

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/c8713ca3-3b7e-4104-b7cf-31dc1f278f60)

## Is there any existing behavior change of other features due to this code change?
-No.

## Was this feature tested on the browsers?
- Mozilla Firefox
 