### PR TITLE
fix: Update fields in Job Requisition

### DIFF
--- a/beams/setup.py
+++ b/beams/setup.py
@@ -3361,6 +3361,63 @@ def get_property_setters():
             "property_type": "Link",
             "value": 1
         },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Job Requisition",
+            "field_name": "no_of_positions",
+            "property": "reqd",
+            "property_type": "Check",
+            "value": 0
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Job Requisition",
+            "field_name": "expected_compensation",
+            "property": "reqd",
+            "value": 0
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Job Requisition",
+            "field_name": "expected_compensation",
+            "property": "default",
+            "value": 0.0
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Job Requisition",
+            "field_name": "expected_compensation",
+            "property": "mandatory_depends_on",
+            "value": "eval: frappe.user_roles.includes('HR Manager')"
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Job Requisition",
+            "field_name": "expected_compensation",
+            "property": "depends_on",
+            "value": "eval: frappe.user_roles.includes('HR Manager')"
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Job Requisition",
+            "field_name": "employee_left",
+            "property": "ignore_user_permissions",
+            "value": 1
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Job Requisition",
+            "field_name": "requested_by",
+            "property": "ignore_user_permissions",
+            "value": 1
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Job Requisition",
+            "field_name": "department",
+            "property": "reqd",
+            "value": 1
+        },
     ]
 
 def get_material_request_custom_fields():


### PR DESCRIPTION
## Feature description
This feature improves field behavior and permissions in the Job Requisition DocType by making certain fields mandatory or optional based on user roles and adjusting user permissions.
## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description
->The following changes were applied to the Job Requisition DocType:

Field Requirement Changes:
-     no_of_positions → Made Optional
-     expected_compensation → Made Optional, with a default value of 0.0
-     department → Made Mandatory

Dynamic Field Visibility & Mandatory Conditions:
-  expected_compensation:Mandatory only for HR Managers

Permission Changes:
- employee_left → Ignore User Permissions (Accessible to all users)
- requested_by → Ignore User Permissions (Accessible to all users)

## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.

## Areas affected and ensured
List out the areas affected by your code changes.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
