### PR TITLE
feat: send asset auditing notification to Technical Store Head and Asset owner

### DIFF
--- a/beams/beams/doctype/beams_admin_settings/beams_admin_settings.json
+++ b/beams/beams/doctype/beams_admin_settings/beams_admin_settings.json
@@ -5,7 +5,10 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
-  "default_award_expense_account"
+  "default_award_expense_account",
+  "asset_auditing_notification",
+  "notify_after",
+  "asset_auditing_notification_template"
  ],
  "fields": [
   {
@@ -15,12 +18,34 @@
    "label": " Default Award Expense Account",
    "options": "Account",
    "reqd": 1
+  },
+  {
+   "depends_on": "eval:doc.asset_auditing_notification",
+   "description": "In Days",
+   "fieldname": "notify_after",
+   "fieldtype": "Int",
+   "label": "Notify After",
+   "mandatory_depends_on": "eval:doc.asset_auditing_notification"
+  },
+  {
+   "depends_on": "eval:doc.asset_auditing_notification",
+   "fieldname": "asset_auditing_notification_template",
+   "fieldtype": "Link",
+   "label": "Asset Auditing Notification Template",
+   "mandatory_depends_on": "eval:doc.asset_auditing_notification",
+   "options": "Email Template"
+  },
+  {
+   "default": "0",
+   "fieldname": "asset_auditing_notification",
+   "fieldtype": "Check",
+   "label": "Asset Auditing Notification"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-01-23 16:30:33.927575",
+ "modified": "2025-02-19 12:19:45.614542",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "BEAMS Admin Settings",

--- a/beams/beams/doctype/beams_admin_settings/beams_admin_settings.py
+++ b/beams/beams/doctype/beams_admin_settings/beams_admin_settings.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, efeone and contributors
+# For license information, please see license.txt
 import frappe
 from frappe.utils import nowdate, add_days
 from frappe.model.document import Document
@@ -15,7 +17,7 @@ def send_asset_audit_reminder():
 
     settings = frappe.get_single("BEAMS Admin Settings")
 
-    if settings.asset_auditing_notificaton:
+    if settings.asset_auditing_notification:
         notify_days = settings.notify_after
         template_name = settings.asset_auditing_notification_template
 

--- a/beams/beams/doctype/beams_admin_settings/beams_admin_settings.py
+++ b/beams/beams/doctype/beams_admin_settings/beams_admin_settings.py
@@ -1,9 +1,103 @@
-# Copyright (c) 2025, efeone and contributors
-# For license information, please see license.txt
-
-# import frappe
+import frappe
+from frappe.utils import nowdate, add_days
 from frappe.model.document import Document
-
+from frappe.email.doctype.email_account.email_account import EmailAccount
 
 class BEAMSAdminSettings(Document):
-	pass
+    pass
+
+
+@frappe.whitelist()
+def send_asset_audit_reminder():
+    '''
+    If Asset Auditing Notification is checked, Send Notification to users with "Technical Store Head" role and Current asset owner.
+    '''
+
+    settings = frappe.get_single("BEAMS Admin Settings")
+
+    if settings.asset_auditing_notificaton:
+        notify_days = settings.notify_after
+        template_name = settings.asset_auditing_notification_template
+
+        if not notify_days or not template_name:
+            frappe.log_error("Asset Audit Notification: Configuration missing", "Asset Auditing")
+            return
+
+        # Get Email Template
+        email_template = frappe.get_doc("Email Template", template_name)
+        if not email_template:
+            frappe.log_error("Asset Audit Notification: Email Template not found", "Asset Auditing")
+            return
+
+        audit_due_date = add_days(nowdate(), -notify_days)
+
+        assets = frappe.get_all("Asset Auditing",
+            filters={"posting_date": ["<=", audit_due_date]},
+            fields=["asset", "posting_date"])
+
+        asset_names = list(set([a["asset"] for a in assets]))
+
+        if asset_names:
+            asset_details = frappe.get_all("Asset",
+                filters={"name": ["in", asset_names]},
+                fields=["name", "asset_name", "asset_owner", "company"])
+
+            for asset in asset_details:
+                recipients = get_asset_notification_recipients(asset)
+                if recipients:
+                    subject = f"Asset Audit Reminder: {asset.asset_name}"
+                    message = f"""
+                    <p>Reminder : The asset <b>{asset.asset_name}</b> was last audited on {next(a['posting_date'] for a in assets if a['asset'] == asset['name'])}.<br>
+                    Please ensure it is audited again.</p>
+                    <p>Thank you,<br>
+                    Technical Store Department</p>
+                    """
+                    frappe.sendmail(
+                    recipients=recipients,
+                    subject=subject,
+                    message=message,
+                    )
+
+                    send_inapp_notification(recipients, subject, message)
+
+
+def get_asset_notification_recipients(asset):
+    recipients = set()
+
+    # Get Users with "Technical Store Head" Role
+    it_users = frappe.get_all("User",
+        filters={"enabled": 1},
+        fields=["name", "email"])
+
+    for user in it_users:
+        if frappe.get_all("Has Role", filters={"parent": user.name, "role": "Technical Store Head"}):
+            recipients.add(user.email)
+
+    # Add Asset Owner
+    if asset.asset_owner:
+        recipients.add(asset.asset_owner)
+
+    return list(recipients)
+
+
+def send_inapp_notification(recipients, subject, message):
+    '''
+    Create in-app notifications for recipients
+    '''
+    for email in recipients:
+        user = frappe.get_value("User", {"email": email}, "name")
+
+        if user:
+            notification = frappe.get_doc({
+                "doctype": "Notification Log",
+                "subject": subject,
+                "email_content": message,
+                "for_user": user,
+                "type": "Alert"
+            })
+            notification.insert(ignore_permissions=True)
+
+            # Publish Real-time Notification
+            frappe.publish_realtime(event="msgprint",
+                message=message,
+                user=user)

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -327,7 +327,8 @@ scheduler_events = {
         "beams.beams.doctype.compensatory_leave_log.compensatory_leave_log.expire_leave_allocation",
         "beams.beams.doctype.beams_hr_settings.beams_hr_settings.send_shift_publication_notifications",
         "beams.beams.doctype.beams_hr_settings.beams_hr_settings.send_appraisal_reminders",
-        "beams.beams.custom_scripts.vehicle.vehicle.send_vehicle_document_reminders"
+        "beams.beams.custom_scripts.vehicle.vehicle.send_vehicle_document_reminders",
+        "beams.beams.doctype.beams_admin_settings.beams_admin_settings.send_asset_audit_reminder"
     ],
 # "all": [
 # "beams.tasks.all"


### PR DESCRIPTION
## Feature description
Configure Reminders for Asset Auditing in BEAMS Admin Settings and Send Notification.
If Asset Auditing Notification is checked ,Send Notification to users with "IT" role and Current asset owner


## Solution description
Modify BEAMS Admin Settings:
Added field named  "Asset Auditing Notification" (Check)
Added field named  "Notify After (Days)" (Int) (Display and Mandatory Depends on Asset Auditing Notification check)
Added field named  "Asset Auditing Notification Template" (Link/Email Template) (Display and Mandatory Depends on Asset Auditing Notification check)
If Asset Auditing Notification is checked in BEAMS Admin Settings, send notification based on the configuration. Send Notification to users with "Technical Store Head" role and Current asset owner

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/b7ab5679-1e96-4c7a-b001-ea09d2446fcb)
![image](https://github.com/user-attachments/assets/76b05a5d-3b29-4380-9a18-6c5dff6f30fb)
![image](https://github.com/user-attachments/assets/2495621f-8413-47bc-8c39-a7a5cab0a379)


## Areas affected and ensured
List out the areas affected by your code changes.(BEAMS admin settings)

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Mozilla Firefox
 
