### PR TITLE
fix: Ensure shift assignment is swapped upon approval of shift swap request

### DIFF
--- a/beams/beams/doctype/shift_swap_request/shift_swap_request.py
+++ b/beams/beams/doctype/shift_swap_request/shift_swap_request.py
@@ -62,7 +62,7 @@ class ShiftSwapRequest(Document):
         Triggered after the Shift Swap Request is updated.
         Initiates the shift swap if the workflow state is "Approved".
         '''
-        if self.workflow_state == "Approved" and self.get_db_value("workflow_state") == "Pending Approval":
+        if self.workflow_state == "Approved":
             self.swap_shifts()
 
     def swap_shifts(self):

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -3413,6 +3413,20 @@ def get_property_setters():
         },
         {
             "doctype_or_field": "DocField",
+            "doc_type": "Shift Assignment",
+            "field_name": "swap_with_employee",
+            "property": "ignore_user_permissions",
+            "value": 1
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Shift Assignment",
+            "field_name": "employee",
+            "property": "ignore_user_permissions",
+            "value": 1
+        },
+        {
+            "doctype_or_field": "DocField",
             "doc_type": "Job Requisition",
             "field_name": "department",
             "property": "reqd",


### PR DESCRIPTION

## Feature description
Shift Assignments were not swapped upon approval of shift swap request.
## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description
Describe your code changes in detail for reviewers.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/13d45863-360a-4b8c-a7c8-ff981ee85b12)
![image](https://github.com/user-attachments/assets/dd495f8f-a777-4d46-9a9a-12b76659cdba)

## Areas affected and ensured
List out the areas affected by your code changes.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
