### PR TITLE
feat: Add Patches to set company in Budget Template

### DIFF
--- a/beams/patches.txt
+++ b/beams/patches.txt
@@ -5,3 +5,4 @@ beams.patches.delete_custom_fields  #26-11-2024-1
 [post_model_sync]
 # Patches added in this section will be executed after doctypes are migrated
 beams.patches.set_account_in_cost_subhead  #14-02-20250
+beams.patches.set_company_in_budget_template  #20-02-2025

--- a/beams/patches/set_account_in_cost_subhead.py
+++ b/beams/patches/set_account_in_cost_subhead.py
@@ -9,5 +9,6 @@ def execute():
             'company': default_company,
             'default_account': cost_subhead_doc.account
         })
+        cost_subhead_doc.flags.ignore_mandatory = True
         cost_subhead_doc.save()
     frappe.db.commit()

--- a/beams/patches/set_company_in_budget_template.py
+++ b/beams/patches/set_company_in_budget_template.py
@@ -1,0 +1,13 @@
+import frappe
+
+def execute():
+    budget_templates = frappe.get_all('Budget Template', pluck='name')
+    default_company = frappe.db.get_single_value('Global Defaults', 'default_company')
+
+    for budget_template in budget_templates:
+        budget_template_doc = frappe.get_doc('Budget Template', budget_template)
+        if not budget_template_doc.company:
+            budget_template_doc.company = default_company
+            budget_template_doc.flags.ignore_mandatory = True
+            budget_template_doc.save()
+    frappe.db.commit()


### PR DESCRIPTION
## Feature description
- Add patches to set company in Budget Template.

## Solution description
- Added patches to set company in Budget Template.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/bf3be31c-b158-40d0-8d88-4409e1a3b7ba)

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox
