### PR TITLE
feat:Exclude job applicants already linked to an employee or onboarding

### DIFF
--- a/beams/beams/custom_scripts/employee_onboarding/employee_onboarding.js
+++ b/beams/beams/custom_scripts/employee_onboarding/employee_onboarding.js
@@ -35,41 +35,58 @@ frappe.ui.form.on('Employee Onboarding', {
                 }
             }
         });
+
+        // Fetch excluded job applicants and set filter for job_applicant field
+        frappe.call({
+            method: "beams.beams.custom_scripts.employee_onboarding.employee_onboarding.get_job_applicants_with_employee_and_onboarding",
+            callback: function (r) {
+                if (r.message) {
+                    let excluded_applicants = r.message;
+                    frm.fields_dict["job_applicant"].get_query = function () {
+                        return {
+                            filters: {
+                                name: ["not in", " "]
+                            }
+                        };
+                    };
+                }
+            }
+        });
     },
 
-  employee: function(frm) {
-    // If employee is selected, fetch employee details
-    if (frm.doc.employee) {
-      frappe.call({
-        method: 'beams.beams.custom_scripts.employee_onboarding.employee_onboarding.get_employee_details',
-        args: {
-          employee_id: frm.doc.employee
-        },
-        callback: function(response) {
-          if (response.message) {
-            let employee = response.message;
-            // Set the fetched values in the Employee Onboarding form
-            frm.set_value('department', employee.department);
-            frm.set_value('designation', employee.designation);
-            frm.set_value('date_of_joining', employee.date_of_joining);
-            frm.set_value('holiday_list', employee.holiday_list);
-            frm.set_value('employee_grade', employee.employee_grade);
-            frm.refresh_fields();
-          }
+    employee: function(frm) {
+        // If employee is selected, fetch employee details
+        if (frm.doc.employee) {
+            frappe.call({
+                method: 'beams.beams.custom_scripts.employee_onboarding.employee_onboarding.get_employee_details',
+                args: {
+                    employee_id: frm.doc.employee
+                },
+                callback: function(response) {
+                    if (response.message) {
+                        let employee = response.message;
+                        // Set the fetched values in the Employee Onboarding form
+                        frm.set_value('department', employee.department);
+                        frm.set_value('designation', employee.designation);
+                        frm.set_value('date_of_joining', employee.date_of_joining);
+                        frm.set_value('holiday_list', employee.holiday_list);
+                        frm.set_value('employee_grade', employee.employee_grade);
+                        frm.refresh_fields();
+                    }
+                }
+            });
         }
-      });
-    }
-  },
+    },
 
-  job_applicant: function(frm) {
-    if (frm.doc.job_applicant) {
-      frappe.db.get_value('Job Offer', { 'job_applicant': frm.doc.job_applicant }, 'name', function(value) {
-      if (value) {
-        // If the value is returned, set the job_offer field with the name of the job offer
-        frm.set_value('job_offer', value.name);
-        frm.refresh_fields();
-          }
-        });
+    job_applicant: function(frm) {
+        if (frm.doc.job_applicant) {
+            frappe.db.get_value('Job Offer', { 'job_applicant': frm.doc.job_applicant }, 'name', function(value) {
+                if (value) {
+                    // If the value is returned, set the job_offer field with the name of the job offer
+                    frm.set_value('job_offer', value.name);
+                    frm.refresh_fields();
+                }
+            });
         }
-      }
+    }
 });

--- a/beams/beams/custom_scripts/employee_onboarding/employee_onboarding.js
+++ b/beams/beams/custom_scripts/employee_onboarding/employee_onboarding.js
@@ -45,7 +45,7 @@ frappe.ui.form.on('Employee Onboarding', {
                     frm.fields_dict["job_applicant"].get_query = function () {
                         return {
                             filters: {
-                                name: ["not in", " "]
+                                name: ["not in", excluded_applicants]
                             }
                         };
                     };

--- a/beams/beams/custom_scripts/employee_onboarding/employee_onboarding.py
+++ b/beams/beams/custom_scripts/employee_onboarding/employee_onboarding.py
@@ -49,3 +49,21 @@ def get_employee_details(employee_id):
             'holiday_list': employee.holiday_list,
             'employee_grade': employee.grade
         }
+
+@frappe.whitelist()
+def get_job_applicants_with_employee_and_onboarding():
+    job_applicants_with_employees = frappe.get_all(
+        "Employee",
+        filters={"job_applicant": ["!=", ""]},
+        pluck="job_applicant"
+    )
+
+    job_applicants_with_onboarding = frappe.get_all(
+        "Employee Onboarding",
+        filters={"docstatus": ["!=", 2]},
+        pluck="job_applicant"
+    )
+
+    excluded_applicants = list(set(job_applicants_with_employees + job_applicants_with_onboarding))
+
+    return excluded_applicants if excluded_applicants else []


### PR DESCRIPTION
## Feature description
  -Exclude job applicants linked to employees or onboarding  

## Solution description
- Implemented a server-side function to fetch job applicants linked to employees or ongoing onboarding.  
- Updated form script to exclude these applicants from the selection dropdown.  
- Ensures that only unassigned job applicants can be chosen in Employee Onboarding.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/2b01f616-4f03-4b8d-ad2f-3327ed5fe737)
![image](https://github.com/user-attachments/assets/d9aaf2fa-4a57-468b-b062-8fe8726bf5ac)



## Is there any existing behavior change of other features due to this code change?
 No.

## Was this feature tested on the browsers?
- Mozilla Firefox
 