### PR TITLE
fix: Update resume attachment validation to allow multiple formats

### DIFF
--- a/beams/beams/custom_scripts/job_applicant/job_applicant.js
+++ b/beams/beams/custom_scripts/job_applicant/job_applicant.js
@@ -29,20 +29,21 @@ frappe.ui.form.on('Job Applicant', {
         }
     },
     validate: function (frm) {
-      const resume_attachment = frm.doc.resume_attachment;
-      if (resume_attachment) {
-          const file_extension = resume_attachment.split('.').pop().toLowerCase();
-          if (file_extension !== 'pdf') {
-              frappe.msgprint({
-                  title: __('Validation for Resume '),
-                  message: __('Only PDF files are allowed for Resume Attachment.'),
-                  indicator: 'red'
-              });
-              frappe.validated = false;
-          }
-      }
-  }
+        const resume_attachment = frm.doc.resume_attachment;
+        if (resume_attachment) {
+            const allowed_extensions = ['pdf', 'doc', 'docx', 'xls', 'xlsx'];
+            const file_extension = resume_attachment.split('.').pop().toLowerCase();
 
+            if (!allowed_extensions.includes(file_extension)) {
+                frappe.msgprint({
+                    title: __('Validation for Resume'),
+                    message: __('Only PDF, DOC, DOCX, XLS, and XLSX files are allowed'),
+                    indicator: 'red'
+                });
+                frappe.validated = false;
+            }
+        }
+    }
 });
 
 function handle_custom_buttons(frm) {

--- a/beams/beams/custom_scripts/job_applicant/job_applicant.py
+++ b/beams/beams/custom_scripts/job_applicant/job_applicant.py
@@ -178,15 +178,16 @@ def fetch_department(doc, method):
             doc.department = department
         else:
             frappe.throw(f"Department not found for the selected Job Opening: {doc.job_title}")
+
 def validate_resume_attachment(doc, method):
     if doc.resume_attachment:
         file_doc = frappe.get_doc("File", {"file_url": doc.resume_attachment})
         file_name = file_doc.file_name
-        file_extension = os.path.splitext(file_name)[1].lower()
+        file_extension = os.path.splitext(file_name)[1][1:].lower()  
 
-        if file_extension != '.pdf':
-            frappe.msgprint(
-                msg=_('Only PDF files are allowed for Resume Attachment'),
-                title=_('Validation for Resume'),
-                indicator="red"
+        allowed_extensions = ['pdf', 'doc', 'docx', 'xls', 'xlsx']
+        if file_extension not in allowed_extensions:
+            frappe.throw(
+                _("Only PDF, DOC, DOCX, XLS, and XLSX files are allowed"),
+                title=_("Validation for Resume")
             )


### PR DESCRIPTION
## Feature description
-Update resume attachment validation to allow multiple file formats  
-Allow DOC file upload for resume attachment  
-Applicants should be able to upload files such as PDF, Excel, Word, etc.[ISS-2025-00042]

## Solution description
Updated both client-side and server-side validation to permit PDF, DOC, , XLS, and XLSX file formats for resume attachments.  

## Output screenshots (optional)
[Screencast from 24-02-25 01:21:53 PM IST.webm](https://github.com/user-attachments/assets/cf4958a7-d78f-42ae-856b-f65e341c5dee)


## Areas affected and ensured
-Job Application Doctype

## Is there any existing behavior change of other features due to this code change?
 -Yes 

## Was this feature tested on the browsers?
-Mozilla Firefox
 
