### PR TITLE
feat:Add No of Positions field to Job Opening doctype and job portal

### DIFF
--- a/beams/setup.py
+++ b/beams/setup.py
@@ -2385,6 +2385,12 @@ def get_job_opening_custom_fields():
                 "insert_after": "location"
             },
             {
+                "fieldname": "no_of_positions",
+                "fieldtype": "Int",
+                "label": "No of.Positions",
+                "insert_after": "employment_type"
+            },
+            {
                 "fieldname": "no_of_days_off",
                 "fieldtype": "Int",
                 "label": "Number of Days Off",

--- a/beams/www/job_portal/job.html
+++ b/beams/www/job_portal/job.html
@@ -32,6 +32,7 @@
                 {%- if job.employment_type -%}
                 <p><i class="fas fa-briefcase"></i> Employment type: {{ job.employment_type }} </p>
                 {%- endif -%}
+                <p><i class="fas fa-users"></i> Openings: {{ job.no_of_positions }} </p>
                 {%- if job.posted_on -%}
                 <p><i class="far fa-calendar-alt"></i> Published date: {{ frappe.utils.getdate(job.posted_on) }} </p>
                 {%- endif -%}


### PR DESCRIPTION
## Feature description
  -Added "No of Positions" field to Job doctype and displayed it in job portal  
  -Applicants should be able to see the number of vacancies available(ISS-2025-00042)

## Solution description
  - Added "no_of_positions" field (Int) after employment_type in Job Opening doctype 
  - Updated job.html to show openings 

## Output screenshots (optional)

[Screencast from 24-02-25 03:53:13 PM IST.webm](https://github.com/user-attachments/assets/f8d840fa-454a-49ec-b311-5a9cc94158e9)


## Is there any existing behavior change of other features due to this code change?
  -Yes 

## Was this feature tested on the browsers?
 - Mozilla Firefox
  