### PR TITLE
feat:Create Employee Allocated Asset Report

### DIFF
--- a/beams/beams/doctype/outward_pass/outward_pass.js
+++ b/beams/beams/doctype/outward_pass/outward_pass.js
@@ -1,8 +1,39 @@
 // Copyright (c) 2025, efeone and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Outward Pass", {
-// 	refresh(frm) {
+frappe.ui.form.on("Outward Pass", {
+bundles: function (frm) {
+    if (frm.doc.bundles.length > 0) {
+        let bundle_names = frm.doc.bundles.map((bundle) => bundle.asset_bundle);
+        console.log("Fetching Assets for Bundles:", bundle_names);
 
-// 	},
-// });
+        frappe.call({
+            method: "beams.beams.doctype.outward_pass.outward_pass.bundle_asset_fetch",
+            args: {
+                names: bundle_names,
+            },
+            callback: function (r) {
+                if (r.message) {
+                    let existing_assets = frm.doc.assets || [];
+                    let new_assets = r.message[0];
+                    let merged_assets = mergeArrays(existing_assets, new_assets, "asset")
+                    frm.set_value("assets", merged_assets);
+                    let new_bundles = []
+                    for (var i = 0; i < r.message[1].length; i++) {
+                      new_bundles.push({"asset_bundle":r.message[1][i]})
+                    }
+                    frm.set_value("bundles", new_bundles)
+                }
+            },
+        });
+    }
+},
+});
+
+function mergeArrays(arr1, arr2, key) {
+const merged = [...arr1, ...arr2];
+const unique = merged.filter((obj, index, self) =>
+  index === self.findIndex((o) => o[key] === obj[key])
+);
+return unique;
+}

--- a/beams/beams/doctype/outward_pass/outward_pass.json
+++ b/beams/beams/doctype/outward_pass/outward_pass.json
@@ -6,23 +6,20 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
-  "asset",
   "employee_in_charge",
+  "assets",
+  "column_break_cgmc",
   "posting_date_and_time",
+  "bundles",
+  "section_break_ekgu",
+  "stock_items",
   "amended_from"
  ],
  "fields": [
   {
-   "fieldname": "asset",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "label": "Asset",
-   "options": "Asset",
-   "reqd": 1
-  },
-  {
    "fieldname": "employee_in_charge",
    "fieldtype": "Link",
+   "in_list_view": 1,
    "label": "Employee in Charge",
    "options": "Employee",
    "reqd": 1,
@@ -32,6 +29,7 @@
    "default": "Now",
    "fieldname": "posting_date_and_time",
    "fieldtype": "Datetime",
+   "in_list_view": 1,
    "label": "Posting Date and Time",
    "reqd": 1
   },
@@ -44,11 +42,38 @@
    "print_hide": 1,
    "read_only": 1,
    "search_index": 1
+  },
+  {
+   "fieldname": "assets",
+   "fieldtype": "Table MultiSelect",
+   "label": "Assets",
+   "options": "Assets",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_cgmc",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "bundles",
+   "fieldtype": "Table MultiSelect",
+   "label": "Bundles",
+   "options": "Bundles"
+  },
+  {
+   "fieldname": "section_break_ekgu",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "stock_items",
+   "fieldtype": "Table",
+   "label": "Stock Items",
+   "options": "Asset Bundle Stock Item"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-01-27 10:19:21.596714",
+ "modified": "2025-02-25 11:34:33.159474",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Outward Pass",

--- a/beams/beams/doctype/outward_pass/outward_pass.py
+++ b/beams/beams/doctype/outward_pass/outward_pass.py
@@ -1,9 +1,40 @@
 # Copyright (c) 2025, efeone and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
+import json
 from frappe.model.document import Document
+import os
+import io
+from pyqrcode import create
 
 
 class OutwardPass(Document):
-	pass
+       pass
+
+@frappe.whitelist()
+def bundle_asset_fetch(names):
+    names = json.loads(names)
+    assets = set()
+    processed_bundles = set()
+
+    def get_assets_recursive(bundle_name):
+        if bundle_name in processed_bundles:
+            return
+        processed_bundles.add(bundle_name)
+
+        if not frappe.db.exists("Asset Bundle", bundle_name):
+            frappe.throw(f"Asset Bundle '{bundle_name}' not found during processing.")
+
+        asset_bundle = frappe.get_doc("Asset Bundle", bundle_name)
+        assets.update(asset_bundle.assets)
+
+        for sub_bundle in asset_bundle.bundles:
+            get_assets_recursive(sub_bundle.asset_bundle)
+
+    for name in names:
+        if not frappe.db.exists("Asset Bundle", name):
+            frappe.throw(f"Asset Bundle '{name}' not found. Please check the name.")
+        get_assets_recursive(name)
+
+    return list(assets), list(processed_bundles)

--- a/beams/beams/report/employee_allocated_asset_report/employee_allocated_asset_report.js
+++ b/beams/beams/report/employee_allocated_asset_report/employee_allocated_asset_report.js
@@ -1,0 +1,13 @@
+// Copyright (c) 2025, efeone and contributors
+// For license information, please see license.txt
+
+frappe.query_reports["Employee Allocated Asset Report"] = {
+    "filters": [
+        {
+            "fieldname": "employee",
+            "label": __("Employee"),
+            "fieldtype": "Link",
+            "options": "Employee"
+        }
+    ]
+};

--- a/beams/beams/report/employee_allocated_asset_report/employee_allocated_asset_report.json
+++ b/beams/beams/report/employee_allocated_asset_report/employee_allocated_asset_report.json
@@ -1,0 +1,42 @@
+{
+ "add_total_row": 0,
+ "columns": [],
+ "creation": "2025-02-24 15:48:26.127549",
+ "disabled": 0,
+ "docstatus": 0,
+ "doctype": "Report",
+ "filters": [],
+ "idx": 0,
+ "is_standard": "Yes",
+ "letterhead": null,
+ "modified": "2025-02-24 16:06:00.637750",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "Employee Allocated Asset Report",
+ "owner": "Administrator",
+ "prepared_report": 0,
+ "ref_doctype": "Employee",
+ "report_name": "Employee Allocated Asset Report",
+ "report_type": "Script Report",
+ "roles": [
+  {
+   "role": "HR Manager"
+  },
+  {
+   "role": "HR User"
+  },
+  {
+   "role": "Employee"
+  },
+  {
+   "role": "Employee Self Service"
+  },
+  {
+   "role": "CEO"
+  },
+  {
+   "role": "HOD"
+  }
+ ],
+ "timeout": 0
+}

--- a/beams/beams/report/employee_allocated_asset_report/employee_allocated_asset_report.py
+++ b/beams/beams/report/employee_allocated_asset_report/employee_allocated_asset_report.py
@@ -12,6 +12,8 @@ def get_columns():
     return [
         {"label": "Employee", "fieldname": "employee", "fieldtype": "Link", "options": "Employee", "width": 200},
         {"label": "Asset", "fieldname": "asset", "fieldtype": "Link", "options": "Asset", "width": 200},
+        {"label": "Item Code", "fieldname": "item_code", "fieldtype": "Link", "options": "Item", "width": 150},
+        {"label": "Item Name", "fieldname": "item_name", "fieldtype": "Data", "width": 200},
         {"label": "Location", "fieldname": "location", "fieldtype": "Data", "width": 200},
         {"label": "Total Asset Cost", "fieldname": "total_asset_cost", "fieldtype": "Currency", "width": 150}
     ]
@@ -21,11 +23,18 @@ def get_data(filters):
     asset_filters = {}
 
     if filters.get("employee"):
-        asset_filters["custodian"] = filters["employee"]  
+        asset_filters["custodian"] = filters["employee"]
 
     assets = frappe.get_all(
         "Asset",
-        fields=["custodian as employee", "name as asset", "location", "total_asset_cost"],
+        fields=[
+            "custodian as employee",
+            "name as asset",
+            "item_code",
+            "item_name",
+            "location",
+            "total_asset_cost"
+        ],
         filters=asset_filters if asset_filters else None
     )
 
@@ -33,6 +42,8 @@ def get_data(filters):
         row = {
             "employee": asset["employee"],
             "asset": asset["asset"],
+            "item_code": asset.get("item_code"),
+            "item_name": asset.get("item_name"),
             "location": asset["location"],
             "total_asset_cost": asset["total_asset_cost"]
         }

--- a/beams/beams/report/employee_allocated_asset_report/employee_allocated_asset_report.py
+++ b/beams/beams/report/employee_allocated_asset_report/employee_allocated_asset_report.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2025, efeone and contributors
+# For license information, please see license.txt
+
+import frappe
+
+def execute(filters=None):
+    columns = get_columns()
+    data = get_data(filters)
+    return columns, data
+
+def get_columns():
+    return [
+        {"label": "Employee", "fieldname": "employee", "fieldtype": "Link", "options": "Employee", "width": 200},
+        {"label": "Asset", "fieldname": "asset", "fieldtype": "Link", "options": "Asset", "width": 200},
+        {"label": "Location", "fieldname": "location", "fieldtype": "Data", "width": 200},
+        {"label": "Total Asset Cost", "fieldname": "total_asset_cost", "fieldtype": "Currency", "width": 150}
+    ]
+
+def get_data(filters):
+    data = []
+    asset_filters = {}
+
+    if filters.get("employee"):
+        asset_filters["custodian"] = filters["employee"]  
+
+    assets = frappe.get_all(
+        "Asset",
+        fields=["custodian as employee", "name as asset", "location", "total_asset_cost"],
+        filters=asset_filters if asset_filters else None
+    )
+
+    for asset in assets:
+        row = {
+            "employee": asset["employee"],
+            "asset": asset["asset"],
+            "location": asset["location"],
+            "total_asset_cost": asset["total_asset_cost"]
+        }
+        data.append(row)
+
+    return data


### PR DESCRIPTION
## Feature description
Created Employee Allocated Asset Report

## Solution description
- Adding an employee filter to the get_data function.
- Filtering assets based on the custodian field, ensuring only assets assigned to the selected employee are displayed.
- Maintaining the report structure with fields: Employee, Asset, Location, and Total Asset Cost.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/5ec3b2c6-f24c-4a98-907a-38fe1ed4fbe1)

[Screencast from 24-02-25 04:40:58 PM IST.webm](https://github.com/user-attachments/assets/e7f82ad5-dafe-49db-96e4-60fd9afa411f)
## Areas affected and ensured
- Employees doctype
- Asset doctype

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - yes
  - Opera Mini
  - Safari
