### PR TITLE
    TASK-2025-00254 :Asset Auditing Periodic Notification

### DIFF
--- a/beams/beams/custom_scripts/asset/asset.py
+++ b/beams/beams/custom_scripts/asset/asset.py
@@ -7,6 +7,7 @@ import os
 import io
 import json
 from pyqrcode import create
+from frappe.utils import getdate, add_months, nowdate
 
 
 @frappe.whitelist()
@@ -47,3 +48,61 @@ def get_si_json(doc):
         item_data[field] = value
     json_data = json.dumps(item_data, indent=4)
     return json_data
+
+@frappe.whitelist()
+def asset_notifications():
+    """Send asset notifications based on the selected frequency and start month."""
+    today = getdate(nowdate())
+    current_month = today.month
+    current_year = today.year
+    beams_settings = frappe.get_single("BEAMS Admin Settings")
+    default_notification_enabled = beams_settings.asset_audit_notification
+    default_frequency = beams_settings.notifcation_frequency
+    default_email_template = beams_settings.notification_template
+    default_start_month = beams_settings.start_notification_from
+    month_map = {
+        "January": 1, "February": 2, "March": 3, "April": 4, "May": 5, "June": 6,
+        "July": 7, "August": 8, "September": 9, "October": 10, "November": 11, "December": 12
+    }
+    global_start_month_num = month_map.get(default_start_month, None)
+    assets = frappe.get_all("Asset", fields=["name", "item_code", "custodian"])
+    for asset in assets:
+        item = frappe.db.get_value(
+            "Item", asset.item_code,
+            ["item_audit_notification", "item_notification_frequency", "item_notification_template", "start_notification_from"],
+            as_dict=True
+        ) if asset.item_code else {}
+        notify_enabled = item.get("item_audit_notification") or default_notification_enabled
+        frequency = item.get("item_notification_frequency") or default_frequency
+        email_template = item.get("item_notification_template") or default_email_template
+        item_start_month = item.get("start_notification_from")
+        item_start_month_num = month_map.get(item_start_month, None)
+        if not notify_enabled or not email_template:
+            continue
+        start_month_num = item_start_month_num if item_start_month_num else global_start_month_num
+        if not start_month_num:
+            continue
+        send_notification = False
+        if frequency == "Monthly":
+            send_notification = True
+        elif frequency == "Trimonthly":
+            send_notification = (current_month - start_month_num) % 3 == 0 if current_month >= start_month_num else (start_month_num - current_month) % 3 == 0
+        elif frequency == "Quarterly":
+            send_notification = (current_month - start_month_num) % 4 == 0 if current_month >= start_month_num else (start_month_num - current_month) % 4 == 0
+        elif frequency == "Half Yearly":
+            send_notification = (current_month - start_month_num) % 6 == 0 if current_month >= start_month_num else (start_month_num - current_month) % 6 == 0
+        elif frequency == "Yearly":
+            send_notification = current_month == start_month_num
+        if not send_notification:
+            continue
+        recipient = frappe.db.get_value("Employee", asset.custodian, "user_id")
+        if not recipient:
+            continue
+        email_template_doc = frappe.get_doc("Email Template", email_template)
+        message = frappe.render_template(email_template_doc.response, {"asset": asset})
+        frappe.sendmail(
+            recipients=[recipient],
+            subject=email_template_doc.subject,
+            message=message
+        )
+        frappe.db.set_value("Asset", asset.name, "modified", today)

--- a/beams/beams/custom_scripts/asset/asset.py
+++ b/beams/beams/custom_scripts/asset/asset.py
@@ -105,4 +105,3 @@ def asset_notifications():
             subject=email_template_doc.subject,
             message=message
         )
-        frappe.db.set_value("Asset", asset.name, "modified", today)

--- a/beams/beams/doctype/beams_admin_settings/beams_admin_settings.json
+++ b/beams/beams/doctype/beams_admin_settings/beams_admin_settings.json
@@ -8,7 +8,11 @@
   "default_award_expense_account",
   "asset_auditing_notification",
   "notify_after",
-  "asset_auditing_notification_template"
+  "asset_auditing_notification_template",
+  "asset_audit_notification",
+  "start_notification_from",
+  "notifcation_frequency",
+  "notification_template"
  ],
  "fields": [
   {
@@ -40,12 +44,39 @@
    "fieldname": "asset_auditing_notification",
    "fieldtype": "Check",
    "label": "Asset Auditing Notification"
+  },
+  {
+   "default": "0",
+   "fieldname": "asset_audit_notification",
+   "fieldtype": "Check",
+   "label": "Periodic Notification for Asset Auditing "
+  },
+  {
+   "depends_on": "eval:doc.asset_audit_notification",
+   "fieldname": "notifcation_frequency",
+   "fieldtype": "Select",
+   "label": "Notifcation Frequency",
+   "options": "\nMonthly\nTrimonthly\nQuarterly\nHalf Yearly\nYearly"
+  },
+  {
+   "depends_on": "eval:doc.asset_audit_notification",
+   "fieldname": "notification_template",
+   "fieldtype": "Link",
+   "label": "Notification Template",
+   "options": "Email Template"
+  },
+  {
+   "depends_on": "eval:doc.asset_audit_notification",
+   "fieldname": "start_notification_from",
+   "fieldtype": "Select",
+   "label": "Start Notification From",
+   "options": "\nJanuary\nFebruary\nMarch\nApril\nMay\nJune\nJuly\nAugust\nSeptember\nOctober\nNovember\nDecember"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-02-19 12:19:45.614542",
+ "modified": "2025-02-25 11:49:30.547256",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "BEAMS Admin Settings",

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -345,9 +345,9 @@ scheduler_events = {
 # "weekly": [
 # "beams.tasks.weekly"
 # ],
-# "monthly": [
-# "beams.tasks.monthly"
-# ],
+    "monthly": [
+        "beams.beams.custom_scripts.asset.asset.asset_notifications"
+    ],
   }
 
 # Testing

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -1278,6 +1278,37 @@ def get_item_custom_fields():
                "options": "Item",
                "read_only":1,
                "insert_after": "item_group"
+           },
+           {
+               "fieldname": "item_audit_notification",
+               "fieldtype": "Check",
+               "label": "Periodic Notification for Asset Auditing ",
+               "depends_on": "eval:doc.is_fixed_asset == 1",
+               "insert_after": "asset_category"
+           },
+           {
+               "fieldname": "item_notification_frequency",
+               "fieldtype": "Select",
+               "label": "Notification Frequency",
+               "options":"\nMonthly\nTrimonthly\nQuarterly\nHalf Yearly\nYearly",
+               "depends_on": "eval:doc.item_audit_notification == 1",
+               "insert_after": "item_audit_notification"
+           }   ,
+           {
+               "fieldname": "item_notification_template",
+               "fieldtype": "Link",
+               "label": "Notification Template",
+               "options":"Email Template",
+               "depends_on": "eval:doc.item_audit_notification == 1",
+               "insert_after": "item_notification_frequency"
+           },
+           {
+               "fieldname": "start_notification_from",
+               "fieldtype": "Select",
+               "label": "Start Notification From",
+               "options":"\nJanuary\nFebruary\nMarch\nApril\nMay\nJune\nJuly\nAugust\nSeptember\nOctober\nNovember\nDecember",
+               "depends_on": "eval:doc.item_audit_notification == 1",
+               "insert_after": "item_audit_notification"
            }
         ]
     }


### PR DESCRIPTION
## Feature description
-Need to Add fields Beams Admin Settings
-Need To Add Fields  Item 
- Send Notifications for Asset Auditing as set in BEAMS Admin Settings, overrided by individual settings in Items

## Solution description
-Added fields are  in beams admin settings  doctype
fields are asset_audit_notification (check),notifcation_frequency(Select),notification_template(Link),start_notification_from(Select)
-Add fields in item doctype
fields are asset_audit_notification (check),notifcation_frequency(Select),notification_template(Link),start_notification_from(Select
-Implement asset notification system with item-specific and default beam admin  settings
-Notification  sented the basics of notifcation_frequency(Select) and start_notification_from(select)


## Output screenshots (optional)
[Screencast from 25-02-25 02:37:10 PM IST.webm](https://github.com/user-attachments/assets/9d9a57af-08d6-40c7-bdb8-78018591a9ef)
![image](https://github.com/user-attachments/assets/fc6db62d-2143-4351-b360-6c499df8bebb)


## Areas affected and ensured
asset and beam admin settings 

## Is there any existing behavior change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?
  
  - Mozilla Firefox
 
