### PR TITLE
fix:Auto Fetch data  from Training program in training event

### DIFF
--- a/beams/beams/custom_scripts/training_event/training_event.js
+++ b/beams/beams/custom_scripts/training_event/training_event.js
@@ -12,8 +12,31 @@ frappe.ui.form.on('Training Event', {
                 show_training_request_dialog(frm);
             }, "Get Employees");
         }
+    },
+
+    training_program: function(frm) {
+        if (frm.doc.training_program) {
+            frappe.call({
+                method: "frappe.client.get",
+                args: {
+                    doctype: "Training Program",
+                    name: frm.doc.training_program
+                },
+                callback: function(r) {
+                    if (r.message) {
+                        let program = r.message;
+                        frm.set_value("trainer_name", program.trainer_name);
+                        frm.set_value("trainer_email", program.trainer_email);
+                        frm.set_value("contact_number", program.contact_number);
+                        frm.set_value("supplier", program.supplier);
+                    }
+                }
+            });
+        }
     }
 });
+
+
 
 // Function to show the training request dialog
 function show_training_request_dialog(frm) {


### PR DESCRIPTION
## Feature description
Auto Fetch Trainer Name,Trainer Email,Supplier,Contact Number form Training program in training event


## Solution description
When Training Program is selected following fields are populated.
- Trainer Name 
- Trainer Email
- Supplier
- Contact Number

## Output screenshots (optional)

![image](https://github.com/user-attachments/assets/70643331-5410-49b2-b4df-a33001d8d18c)


## Is there any existing behavior change of other features due to this code change?
     No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox

