### PR TITLE
TASK-2025-00197:Created Asset Movements and Stock Entries at the "Transfer" Action when moving from Approved to Transferred.

### DIFF
--- a/beams/beams/doctype/asset_return_checklist_template/asset_return_checklist_template.json
+++ b/beams/beams/doctype/asset_return_checklist_template/asset_return_checklist_template.json
@@ -1,6 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
+ "autoname": "field:asset_return_checklist_template",
  "creation": "2025-02-25 16:44:46.464624",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -53,10 +54,11 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-02-25 16:53:55.041102",
+ "modified": "2025-02-26 12:26:10.689803",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Asset Return Checklist Template",
+ "naming_rule": "By fieldname",
  "owner": "Administrator",
  "permissions": [
   {

--- a/beams/beams/doctype/asset_transfer_request/asset_transfer_request.json
+++ b/beams/beams/doctype/asset_transfer_request/asset_transfer_request.json
@@ -6,13 +6,17 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
-  "posting_date",
-  "posting_time",
+  "employee",
+  "location",
   "asset_type",
   "bundle",
-  "assets",
   "asset",
+  "assets",
   "bundles",
+  "column_break_ivnd",
+  "posting_date",
+  "posting_time",
+  "section_break_sesi",
   "items",
   "asset_return_checklist_template",
   "asset_return_checklist",
@@ -44,7 +48,8 @@
    "fieldname": "assets",
    "fieldtype": "Table MultiSelect",
    "label": "Assets",
-   "options": "Assets"
+   "options": "Assets",
+   "read_only": 1
   },
   {
    "depends_on": "eval:doc.asset_type == \"Bundle\"",
@@ -55,14 +60,17 @@
    "read_only": 1
   },
   {
+   "allow_on_submit": 1,
+   "depends_on": "eval:doc.workflow_state == \"Transferred\"",
    "fieldname": "asset_return_checklist_template",
    "fieldtype": "Link",
    "label": "Asset Return Checklist template",
-   "options": "Asset Return Checklist Template",
-   "reqd": 1
+   "mandatory_depends_on": "eval:doc.workflow_state == \"Transferred\"",
+   "options": "Asset Return Checklist Template"
   },
   {
    "allow_on_submit": 1,
+   "depends_on": "eval:doc.asset_return_checklist_template",
    "fieldname": "asset_return_checklist",
    "fieldtype": "Table",
    "label": "Asset Return Checklist",
@@ -83,8 +91,8 @@
    "fieldname": "bundle",
    "fieldtype": "Link",
    "label": "Bundle",
-   "options": "Asset Bundle",
-   "reqd": 1
+   "mandatory_depends_on": "eval:doc.asset_type == \"Bundle\"",
+   "options": "Asset Bundle"
   },
   {
    "depends_on": "eval:doc.asset_type == \"Bundle\"",
@@ -100,12 +108,34 @@
    "fieldtype": "Link",
    "label": "Asset",
    "options": "Asset"
+  },
+  {
+   "fieldname": "employee",
+   "fieldtype": "Link",
+   "label": "Employee",
+   "options": "Employee",
+   "reqd": 1
+  },
+  {
+   "fieldname": "location",
+   "fieldtype": "Link",
+   "label": "Location",
+   "options": "Location",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_ivnd",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_sesi",
+   "fieldtype": "Section Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-02-24 17:05:29.602881",
+ "modified": "2025-02-26 13:08:05.355551",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Asset Transfer Request",

--- a/beams/beams/doctype/asset_transfer_request/asset_transfer_request.py
+++ b/beams/beams/doctype/asset_transfer_request/asset_transfer_request.py
@@ -1,12 +1,12 @@
 # Copyright (c) 2025, efeone and contributors
 # For license information, please see license.txt
 
-
 import frappe
 from frappe.model.document import Document
 from frappe.utils import today
 from frappe import _
 from frappe.utils import now_datetime, get_url_to_form
+from datetime import datetime
 
 
 class AssetTransferRequest(Document):
@@ -18,6 +18,92 @@ class AssetTransferRequest(Document):
         if self.posting_date:
             if self.posting_date > today():
                 frappe.throw(_("Posting Date cannot be set after today's date."))
+
+    def on_update_after_submit(self):
+        '''Ensure that Asset Movement and Stock Entries are created when the workflow state is 'Transferred'.'''
+        if self.workflow_state == 'Transferred':
+            self.create_asset_movement()
+            self.create_stock_entries()
+
+    def create_asset_movement(self):
+        """Create Asset Movement when the workflow state is 'Transferred'."""
+        asset_movement = frappe.new_doc('Asset Movement')
+        asset_movement.purpose = 'Transfer'
+        asset_movement.posting_time = self.posting_time
+        asset_movement.reference_doctype = "Asset Transfer Request"
+        asset_movement.reference_name = self.name
+        posting_datetime_str = f"{self.posting_date} {self.posting_time}"
+        asset_movement.transaction_date = datetime.strptime(posting_datetime_str, "%Y-%m-%d %H:%M:%S")
+
+        if not self.location:
+            frappe.throw(_("Please provide a target location for the asset transfer."))
+
+        if not self.assets and self.asset_type == "Bundle":
+            frappe.throw(_("No assets found to transfer."))
+        elif not self.asset and self.asset_type == "Single Asset":
+            frappe.throw(_("Asset required for transfer."))
+
+        if self.asset_type == "Single Asset":
+            if self.asset:
+                asset_movement.append('assets', {
+                    "asset": self.asset,
+                    "target_location": self.location,
+                })
+        elif self.asset_type == "Bundle":
+
+            for item in self.assets:
+                if item.asset:
+                    asset_movement.append('assets', {
+                        "asset": item.asset,
+                        "target_location": self.location,
+                    })
+
+        asset_movement.insert()
+        asset_movement.submit()
+
+        frappe.msgprint(
+            _('Asset Movement Created: <a href="{0}">{1}</a>').format(get_url_to_form(asset_movement.doctype, asset_movement.name),asset_movement.name),
+            alert=True, indicator='green'
+        )
+
+    def create_stock_entries(self):
+        """Create Stock Entry when the workflow state is 'Transferred'."""
+        if not self.asset_type == "Bundle":
+            return
+
+        if not self.items:
+            return
+
+        source_warehouse = 'Stores - E'
+        if not frappe.db.exists('Warehouse', source_warehouse):
+            frappe.throw(_("Could not find Source Warehouse: {0}".format(source_warehouse)))
+
+        stock_entry = frappe.new_doc('Stock Entry')
+        stock_entry.stock_entry_type = 'Material Issue'
+        stock_entry.purpose = 'Material Issue'
+        stock_entry.from_warehouse = source_warehouse
+        stock_entry.posting_time = self.posting_time
+        stock_entry.set("set_posting_time", 1)
+        stock_entry.posting_date = self.posting_date
+        stock_entry.set("set_posting_time", 1)
+
+        for item in self.items:
+            if item.item:
+                stock_entry.append('items', {
+                    "item_code": item.item,
+                    "qty": item.qty,
+                    "s_warehouse": source_warehouse,
+                })
+
+        if not stock_entry.items:
+            frappe.throw(_("No items found to add to Stock Entry."))
+
+        stock_entry.insert()
+        stock_entry.submit()
+
+        frappe.msgprint(
+            _('Stock Entry Created: <a href="{0}">{1}</a>').format(get_url_to_form(stock_entry.doctype, stock_entry.name),stock_entry.name),
+            alert=True, indicator='green')
 
 @frappe.whitelist()
 def get_stock_items_from_bundle(bundle):

--- a/beams/beams/doctype/beams_admin_settings/beams_admin_settings.json
+++ b/beams/beams/doctype/beams_admin_settings/beams_admin_settings.json
@@ -12,7 +12,9 @@
   "asset_audit_notification",
   "start_notification_from",
   "notifcation_frequency",
-  "notification_template"
+  "notification_template",
+  "column_break_qndy",
+  "asset_transfer_warehouse"
  ],
  "fields": [
   {
@@ -71,12 +73,22 @@
    "fieldtype": "Select",
    "label": "Start Notification From",
    "options": "\nJanuary\nFebruary\nMarch\nApril\nMay\nJune\nJuly\nAugust\nSeptember\nOctober\nNovember\nDecember"
+  },
+  {
+   "fieldname": "column_break_qndy",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "asset_transfer_warehouse",
+   "fieldtype": "Link",
+   "label": "Asset Transfer Warehouse",
+   "options": "Warehouse"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-02-25 11:49:30.547256",
+ "modified": "2025-02-25 17:08:17.611088",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "BEAMS Admin Settings",

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -3737,7 +3737,7 @@ def get_beams_roles():
     '''
         Method to get BEAMS specific roles
     '''
-    return ['Production Manager', 'CEO', 'Company Secretary', 'HOD','Enquiry Officer','Enquiry Manager','Shift Publisher','Program Producer','Operations Head','Operations User','Admin','Driver','Budget User']
+    return ['Production Manager', 'CEO', 'Company Secretary', 'HOD','Enquiry Officer','Enquiry Manager','Shift Publisher','Program Producer','Operations Head','Operations User','Admin','Driver','Budget User','Technical Store Head']
 
 def get_custom_translations():
     '''


### PR DESCRIPTION
## Feature description
Need to: 

- Create Asset Movements and Stock Entries at the "Transfer" Action when moving from Approved to Transferred.
-  Add to Naming Series in Asset Return Checklist Template doctype.
-  Add "Asset Transfer Warehouse" field in Beams Admin Settings Doctype.
- Create Role Technical Store Head through Setup.py
- When Workflow Sate of Asset Transfer Request is Transferred, display the fields Asset Return Checklist Template and     Asset Return Checklist and make it mandatory to be filled in before Return Action.

## Solution description
-  Created Asset Movements and Stock Entries at the "Transfer" Action when moving from Approved to Transferred.
-  Added to Naming Series in Asset Return Checklist Template doctype.
-  Added "Asset Transfer Warehouse" field in Beams Admin Settings Doctype.
- Created  Role Technical Store Head through Setup.py.
-  When Workflow Sate of Asset Transfer Request is Transferred, displayed the fields Asset Return Checklist Template and  Asset Return Checklist and made it mandatory to be filled in before Return Action.

## Output screenshots (optional)
[Screencast from 26-02-25 01:56:30 PM IST.webm](https://github.com/user-attachments/assets/6226d1d5-44f0-42c7-92d4-1e765ee6dd52)
[Screencast from 26-02-25 03:06:30 PM IST.webm](https://github.com/user-attachments/assets/237835b3-07b5-49d9-9933-9d790fe78ff3)

![image](https://github.com/user-attachments/assets/20d095bc-5ad9-43a0-97c9-7e238300f7cd)
![image](https://github.com/user-attachments/assets/696e362c-047f-4edf-a6ef-28198d3b8b15)
![image](https://github.com/user-attachments/assets/7af1a61c-d78d-4e08-b6c2-ba69fcf40686)





## Areas affected and ensured

- Asset Movement Doctype.
- Stock Entry Doctype.
- Beams Admin Settinds Doctype.

## Was this feature tested on the browsers
  - Mozilla Firefox
 
