### PR TITLE
feat: TASK-2025-00273 Applied Filter to Assets and Bundles in asset Bundle Doctype

### DIFF
--- a/beams/beams/doctype/asset_bundle/asset_bundle.js
+++ b/beams/beams/doctype/asset_bundle/asset_bundle.js
@@ -10,6 +10,40 @@ frappe.ui.form.on("Asset Bundle", {
 				}
 			};
 		};
+        frappe.call({
+            method: "beams.beams.doctype.asset_bundle.asset_bundle.get_selected_assets",
+            callback: function (response) {
+                if (response.message) {
+                    let selected_assets = response.message;
+
+                    frm.fields_dict['assets'].get_query = function () {
+                        return {
+                            filters: [
+                                ['name', 'not in', selected_assets]
+                            ]
+                        };
+                    };
+                }
+            }
+        });
+
+				frappe.call({
+            method: "beams.beams.doctype.asset_bundle.asset_bundle.get_selected_bundles",
+            callback: function (response) {
+                if (response.message) {
+                    let selected_bundles = response.message;
+										console.log('yoyo',selected_bundles)
+
+                    frm.fields_dict['bundles'].get_query = function () {
+                        return {
+                            filters: [
+                                ['name', 'not in', selected_bundles]
+                            ]
+                        };
+                    };
+                }
+            }
+        });
 	},
 	validate: function(frm) {
 		if (!frm.doc.stock_items?.length && !frm.doc.assets?.length && !frm.doc.bundles?.length) {

--- a/beams/beams/doctype/asset_bundle/asset_bundle.js
+++ b/beams/beams/doctype/asset_bundle/asset_bundle.js
@@ -15,7 +15,6 @@ frappe.ui.form.on("Asset Bundle", {
             callback: function (response) {
                 if (response.message) {
                     let selected_assets = response.message;
-
                     frm.fields_dict['assets'].get_query = function () {
                         return {
                             filters: [
@@ -32,8 +31,6 @@ frappe.ui.form.on("Asset Bundle", {
             callback: function (response) {
                 if (response.message) {
                     let selected_bundles = response.message;
-										console.log('yoyo',selected_bundles)
-
                     frm.fields_dict['bundles'].get_query = function () {
                         return {
                             filters: [

--- a/beams/beams/doctype/asset_bundle/asset_bundle.py
+++ b/beams/beams/doctype/asset_bundle/asset_bundle.py
@@ -81,3 +81,22 @@ def bundle_asset_fetch(names):
             frappe.throw(f"Asset Bundle '{name}' not found. Please check the name.")
         get_assets_recursive(name)
     return list(assets), list(processed_bundles)
+
+@frappe.whitelist()
+def get_selected_assets():
+    selected_assets = []
+    asset_entries = frappe.get_all("Assets", fields=["asset", "parent"], filters={"parenttype": "Asset Bundle"})
+
+    for entry in asset_entries:
+        if entry.asset:
+            selected_assets.append(entry.asset)
+    return list(set(selected_assets))
+
+@frappe.whitelist()
+def get_selected_bundles():
+    selected_bundles = set()
+    bundle_entries = frappe.get_all("Bundles", fields=["asset_bundle"])
+
+    for entry in bundle_entries:
+        selected_bundles.add(entry["asset_bundle"])
+    return list(selected_bundles)


### PR DESCRIPTION
## Feature description
 - Assets and Asset Bundles that are already in an Asset Bundle cannot be selected in another
 - Apply filters to the following fields:
 Asset
 Assets
 Bundles

## Solution description
 - Assets and Asset Bundles that are already part of an Asset Bundle cannot be selected for another
 - Applied filters 

## Output screenshots (optional)
[Screencast from 27-02-25 10:50:23 AM IST.webm](https://github.com/user-attachments/assets/8a3f7556-ec65-4b1e-8ad3-91eb11c9ad0f)

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Mozilla Firefox
  
