### PR TITLE
feat: Notification to Custodian for Asset Movement

### DIFF
--- a/beams/beams/custom_scripts/asset_movement/asset_movement.py
+++ b/beams/beams/custom_scripts/asset_movement/asset_movement.py
@@ -12,3 +12,13 @@ def update_issued_quantity(doc, method):
 
     issued_qty = frappe.db.get_value("Required Items Detail", doc.reference_name, "issued_quantity") or 0
     frappe.db.set_value("Required Items Detail", doc.reference_name, "issued_quantity", issued_qty + 1)
+
+def before_save(doc, method):
+    if doc.assets:
+        first_asset = doc.assets[0]
+        if first_asset.to_employee:
+            doc.new_custodian = first_asset.to_employee
+
+            new_custodian_doc = frappe.get_doc("Employee", doc.new_custodian)
+            if new_custodian_doc.user_id:
+                doc.user_id = new_custodian_doc.user_id

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -310,9 +310,8 @@ doc_events = {
         ]
     },
     "Asset Movement": {
-        "on_submit": [
-            "beams.beams.custom_scripts.asset_movement.asset_movement.update_issued_quantity"
-            ]
+        "on_submit": "beams.beams.custom_scripts.asset_movement.asset_movement.update_issued_quantity",
+        "before_save": "beams.beams.custom_scripts.asset_movement.asset_movement.before_save"
     },
     "Asset":{
         "after_insert":"beams.beams.custom_scripts.asset.asset.generate_asset_qr"

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -55,6 +55,7 @@ def after_install():
     create_custom_fields(get_item_group_custom_fields(),ignore_validate=True)
     create_custom_fields(get_hr_settings_custom_fields(),ignore_validate=True)
     create_custom_fields(get_asset_category_custom_fields(),ignore_validate=True)
+    create_custom_fields(get_asset_movement_custom_fields(),ignore_validate=True)
 
 
     #Creating BEAMS specific Property Setters
@@ -121,6 +122,8 @@ def before_uninstall():
     delete_custom_fields(get_item_group_custom_fields())
     delete_custom_fields(get_hr_settings_custom_fields())
     delete_custom_fields(get_asset_category_custom_fields())
+    delete_custom_fields(get_asset_movement_custom_fields())
+
 
 
 def delete_custom_fields(custom_fields: dict):
@@ -3812,7 +3815,30 @@ def get_hr_settings_custom_fields():
             }
         ]
     }
-
+def get_asset_movement_custom_fields():
+    '''
+        Custom fields that need to be added to the Asset Movement DocType
+    '''
+    return {
+        "Asset Movement": [
+            {
+                "fieldname": "new_custodian",
+                "fieldtype": "Link",
+                "label": "New Custodian",
+                "options": "Employee",
+                "insert_after": "assets",
+                "read_only": 1
+            },
+            {
+                "fieldname": "user_id",
+                "label": "User ID",
+                "fieldtype": "Data",
+                "insert_after": "new_custodian",
+                "options": "Email",
+                "read_only": 1
+            }
+        ]
+    }
 def get_asset_category_custom_fields():
     '''
         Custom fields that need to be added to the Asset Category DocType


### PR DESCRIPTION
## Feature description
Send notification to custodian for asset movement


## Solution description
Added new user id field and custodian field in asset movement doctype.
Setup notification (email notification &system notification) to new custodian when an asset movement  submitted.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/130e1194-b323-4540-9f51-3d990c980e78)
![image](https://github.com/user-attachments/assets/253dea0b-a7c0-4b97-93c7-05d35d511984)
![image](https://github.com/user-attachments/assets/40895fc8-b858-4f38-bee9-cf4d1b04203f)
![image](https://github.com/user-attachments/assets/96d47b17-7ac1-4c2d-9540-749b1a6470da)


## Areas affected and ensured
List out the areas affected by your code changes.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
 
