### PR TITLE
feat: Customize Employee Checkin Permission doctype

### DIFF
--- a/beams/beams/doctype/employee_checkin_permission/employee_checkin_permission.json
+++ b/beams/beams/doctype/employee_checkin_permission/employee_checkin_permission.json
@@ -14,8 +14,12 @@
   "shift_end_time",
   "column_break_iaku",
   "date",
+  "expected_arrival_time",
+  "expected_leaving_time",
   "reason",
-  "amended_from"
+  "amended_from",
+  "section_break_hlte",
+  "reports_to"
  ],
  "fields": [
   {
@@ -46,11 +50,13 @@
    "options": "Shift Type"
   },
   {
+   "fetch_from": "shift.start_time",
    "fieldname": "shift_start_time",
    "fieldtype": "Time",
    "label": "Shift Start Time "
   },
   {
+   "fetch_from": "shift.end_time",
    "fieldname": "shift_end_time",
    "fieldtype": "Time",
    "label": "Shift End Time "
@@ -80,11 +86,37 @@
    "print_hide": 1,
    "read_only": 1,
    "search_index": 1
+  },
+  {
+   "depends_on": "eval:doc.log_type=='OUT'\n",
+   "fieldname": "expected_leaving_time",
+   "fieldtype": "Time",
+   "label": "Expected Leaving Time",
+   "mandatory_depends_on": "eval:doc.log_type=='OUT'\n",
+   "reqd": 1
+  },
+  {
+   "depends_on": "eval:doc.log_type=='IN'\n",
+   "fieldname": "expected_arrival_time",
+   "fieldtype": "Time",
+   "label": "Expected Arrival Time",
+   "mandatory_depends_on": "eval:doc.log_type=='IN'\n",
+   "reqd": 1
+  },
+  {
+   "fieldname": "section_break_hlte",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "reports_to",
+   "fieldtype": "Link",
+   "label": "Reports To",
+   "options": "Employee"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-02-26 10:32:58.526029",
+ "modified": "2025-02-27 15:16:13.200069",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Employee Checkin Permission",


### PR DESCRIPTION
## Feature description
- Fetch Shift start time & shift end time from shift type
- Add fields Expected Arrival Time & Expected Leaving  Time based on Log Type
- Add field Reports To
## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description
![image](https://github.com/user-attachments/assets/b9b96b6d-bf81-4dbd-9d11-4bee063e96b6)
## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.

## Areas affected and ensured
List out the areas affected by your code changes.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
