### PR TITLE
TASK-2025-00252 : Prevents updating an Asset Bundle if it is currently in a  non Returned Asset Transfer Request

### DIFF
--- a/beams/beams/doctype/asset_bundle/asset_bundle.py
+++ b/beams/beams/doctype/asset_bundle/asset_bundle.py
@@ -59,26 +59,26 @@ class AssetBundle(Document):
 	    """
 	    Prevents updating an Asset Bundle if it is currently in a Returned Asset Transfer Request.
 	    """
-	    returned_request_names = frappe.get_all(
+	    non_returned_request_names = frappe.get_all(
 	        "Asset Transfer Request",
-	        filters={"workflow_state": "Returned"},
+	        filters={"workflow_state":["!=", "Returned"]},
 	        pluck="name"
 	    )
-	    if not returned_request_names:
+	    if not non_returned_request_names:
 	        return
-	    returned_bundles = frappe.get_all(
+	    non_returned_bundles = frappe.get_all(
 	        "Bundles",
-	        filters={"parent": ["in", returned_request_names]},
+	        filters={"parent": ["in", non_returned_request_names]},
 	        pluck="asset_bundle"
 	    )
 	    directly_assigned_bundles = frappe.get_all(
 	        "Asset Transfer Request",
-	        filters={"name": ["in", returned_request_names]},
+	        filters={"name": ["in", non_returned_request_names]},
 	        pluck="bundle"
 	    )
-	    returned_bundles_set = set(returned_bundles) | set(directly_assigned_bundles)
-	    if self.name in returned_bundles_set:
-	        frappe.throw(f"Cannot update Asset Bundle '{self.name}' as it is in a Returned Asset Transfer Request")
+	    non_returned_bundles_set = set(non_returned_bundles) | set(directly_assigned_bundles)
+	    if self.name in non_returned_bundles_set:
+	        frappe.throw(f"Cannot update Asset Bundle '{self.name}' as it is in a non Returned Asset Transfer Request")
 
 
 @frappe.whitelist()

--- a/beams/beams/doctype/asset_bundle/asset_bundle.py
+++ b/beams/beams/doctype/asset_bundle/asset_bundle.py
@@ -55,6 +55,31 @@ class AssetBundle(Document):
 	        item_data[field] = values
 	    return json.dumps(item_data, indent=4)
 
+	def on_update(self):
+	    """
+	    Prevents updating an Asset Bundle if it is currently in a Returned Asset Transfer Request.
+	    """
+	    returned_request_names = frappe.get_all(
+	        "Asset Transfer Request",
+	        filters={"workflow_state": "Returned"},
+	        pluck="name"
+	    )
+	    if not returned_request_names:
+	        return
+	    returned_bundles = frappe.get_all(
+	        "Bundles",
+	        filters={"parent": ["in", returned_request_names]},
+	        pluck="asset_bundle"
+	    )
+	    directly_assigned_bundles = frappe.get_all(
+	        "Asset Transfer Request",
+	        filters={"name": ["in", returned_request_names]},
+	        pluck="bundle"
+	    )
+	    returned_bundles_set = set(returned_bundles) | set(directly_assigned_bundles)
+	    if self.name in returned_bundles_set:
+	        frappe.throw(f"Cannot update Asset Bundle '{self.name}' as it is in a Returned Asset Transfer Request")
+
 
 @frappe.whitelist()
 def bundle_asset_fetch(names):


### PR DESCRIPTION
## Feature description
Need to Prevent updating an Asset Bundle if it is currently in a  non Returned Asset Transfer Request

## Solution description
- Need to Prevent updating an Asset Bundle if it is currently in a non Returned Asset Transfer Request
  validation  applied non returned asset bundle asset transfer request only update the  returned asset transfer request via asset bundle.py



## Output screenshots (optional)
[Uploading Screencast from 28-02-25 10:29:40 AM IST.webm…]()

## Areas affected and ensured
asset bundle and asset transfer request doctype
## Is there any existing behavior change of other features due to this code change?
No 

## Was this feature tested on the browsers?
  
  - Mozilla Firefox
  