### PR TITLE
feat:Validated Received By field In Asset Transfer Request Doctype

### DIFF
--- a/beams/beams/doctype/asset_transfer_request/asset_transfer_request.json
+++ b/beams/beams/doctype/asset_transfer_request/asset_transfer_request.json
@@ -13,9 +13,11 @@
   "asset",
   "assets",
   "bundles",
+  "received_by",
   "column_break_ivnd",
   "posting_date",
   "posting_time",
+  "stock_entry",
   "section_break_sesi",
   "items",
   "asset_return_checklist_template",
@@ -130,12 +132,28 @@
   {
    "fieldname": "section_break_sesi",
    "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "stock_entry",
+   "fieldtype": "Link",
+   "label": "Stock Entry",
+   "options": "Stock Entry",
+   "read_only": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "depends_on": "eval:doc.workflow_state == \"Transferred\"",
+   "fieldname": "received_by",
+   "fieldtype": "Link",
+   "label": " Received By",
+   "mandatory_depends_on": "eval:doc.workflow_state == \"Transferred\"",
+   "options": "Employee"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-02-26 13:08:05.355551",
+ "modified": "2025-02-28 11:58:18.633671",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Asset Transfer Request",

--- a/beams/beams/doctype/asset_transfer_request/asset_transfer_request.json
+++ b/beams/beams/doctype/asset_transfer_request/asset_transfer_request.json
@@ -26,6 +26,7 @@
  ],
  "fields": [
   {
+   "default": "Today",
    "fieldname": "posting_date",
    "fieldtype": "Date",
    "in_list_view": 1,
@@ -33,6 +34,7 @@
    "reqd": 1
   },
   {
+   "default": "Now",
    "fieldname": "posting_time",
    "fieldtype": "Time",
    "label": "Posting Time",
@@ -153,7 +155,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-02-28 11:58:18.633671",
+ "modified": "2025-02-28 13:46:02.695064",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Asset Transfer Request",

--- a/beams/beams/doctype/asset_transfer_request/asset_transfer_request.py
+++ b/beams/beams/doctype/asset_transfer_request/asset_transfer_request.py
@@ -24,8 +24,35 @@ class AssetTransferRequest(Document):
            Mark or unmark 'In Transit' checkbox based on workflow state.'''
 
         if self.workflow_state == 'Transferred':
-            self.create_asset_movement()
-            self.create_stock_entries()
+            # Check if asset movement already exists
+            existing_asset_movement = frappe.db.exists("Asset Movement", {
+                "reference_name": self.name,
+                "reference_doctype": "Asset Transfer Request"
+            })
+
+            # Check if stock entry already exists
+            existing_stock_entry = frappe.db.exists("Stock Entry", {
+                "name": self.stock_entry
+            })
+
+            # Only create if they don't exist
+            if not existing_asset_movement:
+                self.create_asset_movement()
+
+            # Only create stock entry if it does not exist
+            if not existing_stock_entry and not self.stock_entry:
+                self.create_stock_entries()
+
+            # Handle 'in_transit' flag for assets
+            if self.asset_type == 'Single Asset' and self.asset:
+                asset = frappe.get_doc('Asset', self.asset)
+                asset.in_transit = 1 if self.workflow_state == 'Approved' else 0
+                asset.save()
+            elif self.asset_type == 'Bundle':
+                for asset in self.assets:
+                    asset_doc = frappe.get_doc('Asset', asset.asset)
+                    asset_doc.in_transit = 1 if self.workflow_state == 'Approved' else 0
+                    asset_doc.save()
 
         if self.asset_type == 'Single Asset' and self.asset:
             asset = frappe.get_doc('Asset', self.asset)
@@ -36,9 +63,20 @@ class AssetTransferRequest(Document):
                 asset_doc = frappe.get_doc('Asset', asset.asset)
                 asset_doc.in_transit = 1 if self.workflow_state == 'Approved' else 0
                 asset_doc.save()
+        self.validate_recieved_by()
+
+    def validate_recieved_by(self):
+        '''
+            Method triggered after the document is updated.
+            It checks if the workflow state has changed from "Transferred" to "Transferred and Received".
+        '''
+        old_doc = self.get_doc_before_save()
+        if old_doc and old_doc.workflow_state == "Transferred" and self.workflow_state == "Transferred and Received":
+            if not self.received_by:
+                frappe.throw(_("The Received By field must be filled."))
 
     def create_asset_movement(self):
-        """Create Asset Movement when the workflow state is 'Transferred'."""
+        '''Create Asset Movement when the workflow state is 'Transferred'.'''
         asset_movement = frappe.new_doc('Asset Movement')
         asset_movement.purpose = 'Transfer'
         asset_movement.posting_time = self.posting_time
@@ -79,21 +117,22 @@ class AssetTransferRequest(Document):
         )
 
     def create_stock_entries(self):
-        """Create Stock Entry when the workflow state is 'Transferred'."""
+        '''Create Stock Entry when the workflow state is 'Transferred'.'''
         if not self.asset_type == "Bundle":
             return
 
         if not self.items:
             return
 
-        source_warehouse = 'Stores - E'
-        if not frappe.db.exists('Warehouse', source_warehouse):
-            frappe.throw(_("Could not find Source Warehouse: {0}".format(source_warehouse)))
+        warehouse = frappe.db.get_value("Beams Admin Settings", None, "asset_transfer_warehouse")
+
+        if not warehouse:
+            frappe.throw(_("Could not find asset_transfer_warehouse in Beams Admin Settings."))
 
         stock_entry = frappe.new_doc('Stock Entry')
         stock_entry.stock_entry_type = 'Material Issue'
         stock_entry.purpose = 'Material Issue'
-        stock_entry.from_warehouse = source_warehouse
+        stock_entry.from_warehouse = warehouse
         stock_entry.posting_time = self.posting_time
         stock_entry.set("set_posting_time", 1)
         stock_entry.posting_date = self.posting_date
@@ -104,7 +143,7 @@ class AssetTransferRequest(Document):
                 stock_entry.append('items', {
                     "item_code": item.item,
                     "qty": item.qty,
-                    "s_warehouse": source_warehouse,
+                    "s_warehouse": warehouse,
                 })
 
         if not stock_entry.items:
@@ -112,6 +151,8 @@ class AssetTransferRequest(Document):
 
         stock_entry.insert()
         stock_entry.submit()
+
+        self.db_set("stock_entry", stock_entry.name)
 
         frappe.msgprint(
             _('Stock Entry Created: <a href="{0}">{1}</a>').format(get_url_to_form(stock_entry.doctype, stock_entry.name),stock_entry.name),

--- a/beams/beams/doctype/asset_transfer_request/test_asset_transfer_request.py
+++ b/beams/beams/doctype/asset_transfer_request/test_asset_transfer_request.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, efeone and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestAssetTransferRequest(FrappeTestCase):
+	pass


### PR DESCRIPTION
## Feature description
Need to: 
-  Validate Received By field In Asset Transfer Request Doctype.
- Create a Stock Entry Field in Asset Transfer Request Doctype.
- To ensure that a Stock Entry and Asset Movement are created only once,  need to perform a check before creating a  new stock entry and Asset movement.

## Solution description
-  Validated Received By field In Asset Transfer Request Doctype.
-  Created a Stock Entry Field in Asset Transfer Request Doctype.
-  Ensured that a Stock Entry and Asset Movement are created only once,  need to perform a check before creating a  new stock entry and Asset movement.

## Output screenshots (optional)
[Screencast from 28-02-25 01:50:54 PM IST.webm](https://github.com/user-attachments/assets/4ae4842d-2d57-4cf9-96b2-553b4f8bf36c)

## Areas affected and ensured
Asset Transfer Request Doctype 

## Is there any existing behavior change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?
  - Mozilla Firefox
