### PR TITLE
feat:add full name field in security patrol log doctype

### DIFF
--- a/beams/beams/doctype/security_patrol_log/security_patrol_log.json
+++ b/beams/beams/doctype/security_patrol_log/security_patrol_log.json
@@ -8,6 +8,7 @@
  "field_order": [
   "section_break_ielw",
   "employee",
+  "full_name",
   "patrol_log",
   "remarks",
   "amended_from"
@@ -45,12 +46,19 @@
    "fieldname": "remarks",
    "fieldtype": "Small Text",
    "label": "Remarks"
+  },
+  {
+   "fetch_from": "employee.employee_name",
+   "fieldname": "full_name",
+   "fieldtype": "Data",
+   "label": "Full Name",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-01-27 09:11:22.160164",
+ "modified": "2025-02-28 12:21:30.350671",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Security Patrol Log",


### PR DESCRIPTION
## Feature description
Add a new field 'full name' in security patrol log doctype

## Solution description
Added  new field 'full name' in security patrol log doctype

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/7c3a343c-85f7-49a4-a2fb-951570cbc2ce)


## Areas affected and ensured
List out the areas affected by your code changes. ( security patrol log doctype)

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
