### PR TITLE
feat:Added field Relieving Date in Job Requisition

### DIFF
--- a/beams/beams/doctype/employee_checkin_permission/employee_checkin_permission.json
+++ b/beams/beams/doctype/employee_checkin_permission/employee_checkin_permission.json
@@ -108,6 +108,7 @@
    "fieldtype": "Section Break"
   },
   {
+   "fetch_from": "employee.reports_to",
    "fieldname": "reports_to",
    "fieldtype": "Link",
    "label": "Reports To",
@@ -116,7 +117,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-02-27 15:16:13.200069",
+ "modified": "2025-03-01 12:27:22.637469",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Employee Checkin Permission",

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -1678,7 +1678,7 @@ def get_job_requisition_custom_fields():
                 "fieldtype": "Check",
                 "label": "Driving License Needed for this Position",
                 "depends_on": "eval:doc.travel_required == 1",
-                "insert_after": "is_work_shift_needed",
+                "insert_after": "min_experience",
                 "permlevel": 1
             },
             {
@@ -1761,6 +1761,15 @@ def get_job_requisition_custom_fields():
                 "options": "Employee",
                 "insert_after": "request_for",
                 "depends_on": "eval:doc.request_for == 'Employee Replacement'"
+            },
+            {
+                "fieldname": "relieving_date",
+                "fieldtype": "Date",
+                "label": "Relieving Date",
+                "insert_after": "employee_left",
+                "fetch_from":"employee_left.relieving_date",
+                "depends_on":"eval:doc.request_for == 'Employee Replacement'",
+                "read_only": 1
             },
             {
                 "fieldname": "interview",
@@ -2494,7 +2503,7 @@ def get_job_opening_custom_fields():
                 "fieldname": "min_experience",
                 "fieldtype": "Float",
                 "label": "Minimum Experience Required",
-                "insert_after": "qualification_details_column_break"
+                "insert_after": "is_work_shift_needed"
             },
             {
                 "fieldname": "proficiency_break",


### PR DESCRIPTION
## Feature description
The 'Minimum Experience Required' field should be relocated from the 'Education and Qualification Details' section into Work Details section
The 'Relieving Date' should be displayed for the employee selected when the 'Request For' is set to 'Employee Replacement

## Solution description
 'Minimum Experience Required' field  relocated from the 'Education and Qualification Details' section into Work Details section
Added field Relieving Date that is set when request for is Employee Replacement.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/2141aa96-0477-4b76-ad51-9f3c7b302ffe)


## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox

