### PR TITLE
feat: TASK-2025-00281 Created Asset Reservation Log once the equipment request is submitted

### DIFF
--- a/beams/beams/doctype/equipment_request/equipment_request.json
+++ b/beams/beams/doctype/equipment_request/equipment_request.json
@@ -16,8 +16,9 @@
   "required_to",
   "section_break_mztz",
   "required_equipments",
-  "amended_from",
-  "reason_for_rejection"
+  "priority",
+  "reason_for_rejection",
+  "amended_from"
  ],
  "fields": [
   {
@@ -97,12 +98,18 @@
    "fieldtype": "Link",
    "label": "Location",
    "options": "Location"
+  },
+  {
+   "fieldname": "priority",
+   "fieldtype": "Select",
+   "label": "Priority",
+   "options": "Low\nMedium\nHigh"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-02-07 10:59:45.982870",
+ "modified": "2025-02-28 15:28:50.378737",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Equipment Request",


### PR DESCRIPTION

## Feature description
 - Add field Priority in Equipment Request Doctype
 - Create Asset Reservation Log once the document is submitted if the Request is for a future date (Required From > Current Datetime)
## Solution description
- Added field Priority in Equipment Request Doctype
 - Created Asset Reservation Log once the document is submitted if the Request is for a future date (Required From > Current Datetime)

## Output screenshots (optional)
[Screencast from 01-03-25 12:54:36 PM IST.webm](https://github.com/user-attachments/assets/c932252c-4604-47ea-bfc5-0e789081494f)

## Areas affected and ensured
Asset Reservation Log

## Is there any existing behavior change of other features due to this code change?
 No

## Was this feature tested on the browsers?
  - Mozilla Firefox
  
