### PR TITLE
feat: TASK-2025-00271 - added the Assets and items in the Asset Return Checklist

### DIFF
--- a/beams/beams/doctype/asset_return_checklist/asset_return_checklist.json
+++ b/beams/beams/doctype/asset_return_checklist/asset_return_checklist.json
@@ -7,10 +7,17 @@
  "engine": "InnoDB",
  "field_order": [
   "checklist_item",
-  "checked"
+  "checked",
+  "returned",
+  "consumed",
+  "damaged",
+  "missinglost",
+  "reassigned",
+  "remarks"
  ],
  "fields": [
   {
+   "allow_on_submit": 1,
    "fieldname": "checklist_item",
    "fieldtype": "Small Text",
    "in_list_view": 1,
@@ -19,17 +26,66 @@
    "reqd": 1
   },
   {
+   "allow_on_submit": 1,
    "default": "0",
    "fieldname": "checked",
    "fieldtype": "Check",
    "in_list_view": 1,
    "label": "Checked"
+  },
+  {
+   "allow_on_submit": 1,
+   "default": "0",
+   "fieldname": "returned",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Returned"
+  },
+  {
+   "allow_on_submit": 1,
+   "default": "0",
+   "fieldname": "consumed",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Consumed"
+  },
+  {
+   "allow_on_submit": 1,
+   "default": "0",
+   "fieldname": "damaged",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Damaged"
+  },
+  {
+   "allow_on_submit": 1,
+   "default": "0",
+   "fieldname": "missinglost",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Missing/Lost"
+  },
+  {
+   "allow_on_submit": 1,
+   "default": "0",
+   "fieldname": "reassigned",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Reassigned"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "remarks",
+   "fieldtype": "Small Text",
+   "in_list_view": 1,
+   "label": "Remarks",
+   "mandatory_depends_on": "eval:doc.damaged || doc.missinglost\n"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-02-25 16:30:53.043647",
+ "modified": "2025-02-28 16:53:40.989507",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Asset Return Checklist",


### PR DESCRIPTION

## Feature description
- Modify Asset Return Checklist Table in Asset Transfer Request and Added the Assets and items in the Asset Return   Checklist

## Solution description
-  Checkboxes: Returned, Consumed, Damaged, Missing/Lost, Reassigned
  Remarks (Small Text, mandatory for Damaged & Missing/Lost)
  Automated Checklist Population:
  
-  When the status is Transferred, the checklist auto-fills with Assets, Items, and Template Items
   Workflow Validation

## Output screenshots (optional)
/home/avishna/Videos/Screencasts/Screencast from 01-03-25 01:06:16 PM IST.webm
/home/avishna/Videos/Screencasts/Screencast from 01-03-25 01:08:31 PM IST.webm

## Areas affected and ensured
 - Asset Return Checklist

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - yes
  - Opera Mini
  - Safari
