### PR TITLE
fix : Issue fixing

### DIFF
--- a/beams/beams/custom_scripts/job_requisition/job_requisition.js
+++ b/beams/beams/custom_scripts/job_requisition/job_requisition.js
@@ -5,8 +5,14 @@ frappe.ui.form.on('Job Requisition', {
             frappe.db.get_value('Employee', { 'user_id': frappe.session.user }, 'name').then(r => {
                 if (r && r.message) {
                     frm.set_value('requested_by', r.message.name);
+
                 }
             });
+        }
+
+        if (frm.doc.request_for === 'Employee Replacement') {
+            frm.set_value('no_of_positions', 1);
+            frm.set_df_property('no_of_positions','read_only',1);
         }
     },
 

--- a/beams/beams/custom_scripts/job_requisition/job_requisition.py
+++ b/beams/beams/custom_scripts/job_requisition/job_requisition.py
@@ -15,8 +15,9 @@ def create_job_opening_from_job_requisition(doc, method):
             job_opening.designation = doc.designation
             job_opening.status = 'Open'
             job_opening.posted_on = now_datetime()
-            job_opening.department = doc.department
+            job_opening.department = frappe.get_value("Employee", doc.requested_by, "department")
             job_opening.employment_type = doc.employment_type
+            job_opening.job_requisition = doc.name
             # Setting Minimum Educational Qualification
             for qualification in doc.min_education_qual:
                 job_opening.append('min_education_qual', {

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -1660,17 +1660,17 @@ def get_job_requisition_custom_fields():
                 "insert_after": "no_of_days_off"
             },
             {
-                "fieldname": "travel_required",
+                "fieldname": "is_work_shift_needed",
                 "fieldtype": "Check",
-                "label": "Travel required for the position",
+                "label": "Is Shift Work Needed",
                 "insert_after": "work_details_column_break",
                 "permlevel": 1
             },
             {
-                "fieldname": "is_work_shift_needed",
+                "fieldname": "travel_required",
                 "fieldtype": "Check",
-                "label": "Is Shift Work Needed",
-                "insert_after": "travel_required",
+                "label": "Travel required for the position",
+                "insert_after": "is_work_shift_needed",
                 "permlevel": 1
             },
             {
@@ -1678,7 +1678,7 @@ def get_job_requisition_custom_fields():
                 "fieldtype": "Check",
                 "label": "Driving License Needed for this Position",
                 "depends_on": "eval:doc.travel_required == 1",
-                "insert_after": "is_work_shift_needed",
+                "insert_after": "travel_required",
                 "permlevel": 1
             },
             {
@@ -1687,6 +1687,7 @@ def get_job_requisition_custom_fields():
                 "label": "License Type",
                 "options": "License Type",
                 "depends_on": "eval:doc.driving_license_needed == 1",
+                "mandatory_depends_on":"eval:doc.driving_license_needed == 1",
                 "insert_after": "driving_license_needed",
                 "permlevel": 1
             },
@@ -2422,7 +2423,7 @@ def get_job_opening_custom_fields():
                 "fieldname": "no_of_positions",
                 "fieldtype": "Int",
                 "label": "No of.Positions",
-                "insert_after": "employment_type"
+                "insert_after": "employment_type",
             },
             {
                 "fieldname": "no_of_days_off",
@@ -3469,7 +3470,7 @@ def get_property_setters():
             "doctype_or_field": "DocField",
             "doc_type": "Job Requisition",
             "field_name": "department",
-            "property": "reqd",
+            "property": "hidden",
             "value": 1
         }
     ]


### PR DESCRIPTION
## Issue description

- Hide field department and remove mandatory
- Fetch the request by department to the job opening department
- Set No of positions as 1 and read only on requested for is for employee replacement
- Set License type as Mandatory
- Rearrange the field Is shift Work Needed
- Create Job opening connection in Job requisition

## Solution description

- The field department set as hidden and removed mandatory
- Department field in job opening is fetched from the department of employee selected in requested by
- No of positions is set as 1 and read only on loading the page with Employee replacement 
- License type set as mandatory
- Is Shift Work Needed
- Job opening connection is set job requisition

## Output screenshots (optional)

[Screencast from 02-03-25 09:16:10 PM IST.webm](https://github.com/user-attachments/assets/c671e69c-6f72-4c99-9f3b-1c76d80e26a9)



