### PR TITLE
fix: absence reminder logic to use email templates and improve notifcation handling

### DIFF
--- a/beams/beams/custom_scripts/attendance/attendance.py
+++ b/beams/beams/custom_scripts/attendance/attendance.py
@@ -1,38 +1,28 @@
 import frappe
 from frappe.utils import nowdate, add_days, format_date
 
+
 def send_absence_reminder():
     '''
     Send a reminder to the reports_to if an employee was absent but did not apply for leave.
     The reminder is based on the value in Absence Reminder Duration and only if Enable Absence Reminders is checked.
     '''
-    # Fetch HR Settings to check if reminders are enabled
     hr_settings = frappe.get_single("Beams HR Settings")
-
-    # Check if absence reminders are enabled
-    if not hr_settings.enable_absence_reminders:
-        return  # Do nothing if reminders are not enabled
-
-    # Get the absence reminder duration from settings
     absence_reminder_duration = hr_settings.absence_reminder_duration
-
-    # If no duration is set, don't proceed
     if not absence_reminder_duration:
         return
-
-    # Calculate the target date based on the configured duration
+    email_template_name = hr_settings.absence_reminder_template
+    if not email_template_name:
+        return
+    email_template = frappe.get_doc("Email Template", email_template_name)
     target_date = add_days(nowdate(), -absence_reminder_duration)
-
-    # Fetch all absent employees for the calculated target date
     absent_employees = frappe.get_all(
         "Attendance",
         filters={"attendance_date": target_date, "status": "Absent"},
         fields=["employee", "employee_name", "attendance_date"]
     )
-
     if absent_employees:
         for employee in absent_employees:
-            # Check if a leave application exists for the absent date
             leave_exists = frappe.db.exists(
                 "Leave Application",
                 {
@@ -42,8 +32,6 @@ def send_absence_reminder():
                     "docstatus": 1,
                 }
             )
-
-            # If no leave exists, create a leave application
             if not leave_exists:
                 # Fetch the Employment Type for the employee
                 employment_type = frappe.db.get_value(
@@ -70,40 +58,43 @@ def send_absence_reminder():
 
                 leave_application.submit()
 
+
                 # Notify the supervisor
                 reports_to = frappe.db.get_value("Employee", employee["employee"], "reports_to")
                 if reports_to:
                     reports_to_email = frappe.db.get_value("Employee", reports_to, "user_id")
                     if reports_to_email:
-                        subject = f"Reminder: No Leave Application for Absent Employee"
-                        message = f"""
-                        <p>Dear {reports_to},</p>
-                        <p>{employee['employee_name']} ({employee['employee']}) was absent on {employee['attendance_date']}
-                        and has not submitted a leave application.</p>
-                        <p>Please follow up with {employee['employee_name']} for further actions.</p>
-                        <p>Best regards,<br>HR Team</p>
-                        """
+                        context_data = {
+                            "employee_name": employee["employee_name"],
+                            "employee_id": employee["employee"],
+                            "attendance_date": employee["attendance_date"],
+                            "reports_to": reports_to
+                        }
+                        subject = frappe.render_template(email_template.subject, context_data)
+                        message = frappe.render_template(email_template.response, context_data)
                         frappe.sendmail(
-                            recipients=reports_to_email,
+                            recipients=[reports_to_email],
                             subject=subject,
                             message=message
                         )
 
+
 def send_absent_reminder():
     """Send a reminder to employees who were absent but did not apply for leave."""
 
-    # Get the date for yesterday
-    target_date = add_days(nowdate(), -1)  # Yesterday
-
-    # Fetch employees who were absent yesterday
+    hr_settings = frappe.get_single("Beams HR Settings")
+    if not hr_settings.leave_application_reminder_duration:
+        return
+    absence_reminder_duration = hr_settings.leave_application_reminder_duration
+    target_date = add_days(nowdate(), -absence_reminder_duration)
     absent_employees = frappe.get_all(
         "Attendance",
         filters={"attendance_date": target_date, "status": "Absent"},
         fields=["employee", "employee_name", "attendance_date"]
     )
-
     if absent_employees:
         for employee in absent_employees:
+
             # Check if a leave application exists for the absence
             leave_exists = frappe.db.exists(
                 "Leave Application",
@@ -115,21 +106,26 @@ def send_absent_reminder():
                 }
             )
 
-            if not leave_exists:
-                # Send a reminder to the employee who was absent
+            if  not leave_exists:
                 send_reminder_email(employee)
 
 def send_reminder_email(employee):
     """Send an email reminder to the absent employee to submit a leave application."""
+    hr_settings = frappe.get_single("Beams HR Settings")
+    email_template_name = hr_settings.leave_application_template
+    if not email_template_name:
+        return
+    email_template = frappe.get_doc("Email Template", email_template_name)
 
-    # Prepare email content
-    subject = f"Reminder: Submit Leave Application for Absence on {format_date(employee['attendance_date'])}"
-    message = f"""
-    <p>Dear {employee['employee_name']},</p>
-    <p>You were marked as <strong>Absent</strong> on {format_date(employee['attendance_date'])}.
-    Please submit a Leave Application if applicable.</p>
-    <p>Thank you.</p>
-    """
+    # Prepare context data for rendering the template
+    context_data = {
+        "employee_name": employee["employee_name"],
+        "employee_id": employee["employee"],
+        "attendance_date": employee["attendance_date"]
+    }
+
+    subject = frappe.render_template(email_template.subject, context_data)
+    message = frappe.render_template(email_template.response, context_data)
 
     # Get the employee's email (user_id field in the Employee DocType)
     email = frappe.db.get_value("Employee", employee["employee"], "user_id")
@@ -140,10 +136,9 @@ def send_reminder_email(employee):
             recipients=[email],
             subject=subject,
             message=message
-            )
+        )
         frappe.msgprint(f"Reminder email sent to {employee['employee_name']} ({email}).")
     else:
-        # Log an error if no email is found for the employee
         frappe.log_error(
             f"Email not found for employee {employee['employee_name']} ({employee['employee']})",
             "Absence Reminder"

--- a/beams/beams/doctype/beams_hr_settings/beams_hr_settings.json
+++ b/beams/beams/doctype/beams_hr_settings/beams_hr_settings.json
@@ -6,10 +6,16 @@
  "engine": "InnoDB",
  "field_order": [
   "default_local_enquiry_duration",
-  "enable_absence_reminders",
   "absence_reminder_duration",
   "column_break_lmqd",
   "permanent_employment_type",
+  "absence_reminder_template",
+  "column_break_dskf",
+  "enable_absence_reminders",
+  "section_break_mafr",
+  "leave_application_template",
+  "column_break_zilk",
+  "leave_application_reminder_duration",
   "notification_settings_tab",
   "notification_to_admin_department_to_create_id_card_section",
   "notification_to_admin",
@@ -17,7 +23,6 @@
   "column_break_gvvx",
   "notification_to_it",
   "it_hod",
-  "column_break_qbue",
   "tab_3_tab",
   "maternity_leave_type",
   "column_break_pjdi",
@@ -34,9 +39,8 @@
   "send_shift_creation_reminder",
   "shift_creation_reminder_template",
   "appraisal_settings_tab",
-  "appraisal_creation_period",
   "enable_appraisal_reminder",
-  "column_break_rcin",
+  "appraisal_creation_period",
   "appraisal_reminder_template"
  ],
  "fields": [
@@ -81,10 +85,6 @@
   },
   {
    "fieldname": "column_break_gvvx",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "column_break_qbue",
    "fieldtype": "Column Break"
   },
   {
@@ -182,10 +182,6 @@
    "label": " Appraisal Creation Period"
   },
   {
-   "fieldname": "column_break_rcin",
-   "fieldtype": "Column Break"
-  },
-  {
    "depends_on": "eval:doc.enable_appraisal_reminder;",
    "fieldname": "appraisal_reminder_template",
    "fieldtype": "Link",
@@ -199,6 +195,7 @@
    "label": "Enable Appraisal Reminder"
   },
   {
+   "description": "Default Employment Type ",
    "fieldname": "permanent_employment_type",
    "fieldtype": "Link",
    "label": "Permanent Employment Type",
@@ -210,7 +207,7 @@
   },
   {
    "depends_on": "eval:doc.enable_absence_reminders == 1",
-   "description": "Days after absence without leave to notify the Reporting Manager",
+   "description": "Notify Reporting Manager after days of Absence without a Leave Application.",
    "fieldname": "absence_reminder_duration",
    "fieldtype": "Int",
    "label": "Absence Reminder Duration"
@@ -220,12 +217,45 @@
    "fieldname": "enable_absence_reminders",
    "fieldtype": "Check",
    "label": "Absence Reminders"
+  },
+  {
+   "depends_on": "eval:doc.enable_absence_reminders == 1",
+   "description": "Default Template for Absence Notification to the Reporting Manager",
+   "fieldname": "absence_reminder_template",
+   "fieldtype": "Link",
+   "label": "Absence Reminder Template",
+   "options": "Email Template"
+  },
+  {
+   "description": "Notify  Employee after days of Absence without a Leave Application.",
+   "fieldname": "leave_application_reminder_duration",
+   "fieldtype": "Int",
+   "label": "Leave Application Reminder Duration"
+  },
+  {
+   "description": " Default Template for Absence Notification to the Employee",
+   "fieldname": "leave_application_template",
+   "fieldtype": "Link",
+   "label": "Leave Application Template",
+   "options": "Email Template"
+  },
+  {
+   "fieldname": "section_break_mafr",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_zilk",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_dskf",
+   "fieldtype": "Column Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-01-09 11:24:00.923221",
+ "modified": "2025-03-01 16:40:21.223017",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Beams HR Settings",

--- a/beams/beams/doctype/beams_hr_settings/beams_hr_settings.json
+++ b/beams/beams/doctype/beams_hr_settings/beams_hr_settings.json
@@ -227,12 +227,14 @@
    "options": "Email Template"
   },
   {
+   "depends_on": "eval:doc.enable_absence_reminders == 1",
    "description": "Notify  Employee after days of Absence without a Leave Application.",
    "fieldname": "leave_application_reminder_duration",
    "fieldtype": "Int",
    "label": "Leave Application Reminder Duration"
   },
   {
+   "depends_on": "eval:doc.enable_absence_reminders == 1",
    "description": " Default Template for Absence Notification to the Employee",
    "fieldname": "leave_application_template",
    "fieldtype": "Link",
@@ -255,7 +257,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-03-01 16:40:21.223017",
+ "modified": "2025-03-03 09:16:53.713255",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Beams HR Settings",


### PR DESCRIPTION
## Feature description
- Need to change the code logic for email template  and improve notification  handling change .
- Need to add the fields in the beams hr settings also change the allignment and description of fields 

## Solution description
- changed the code logic for email template  and improve notification  handling change .
- change the hard coding email template  to default .
- added the fields in beams hr settings Absence Reminder Template(link-email template),Leave Application Reminder Duration(int)
-Leave Application Template(link-email template),changed the description on Absence Reminder Duration
-notification sent for reporter where employee have absence without leave application it is sended based on  Absence Reminder Template(link-email template), and Absence Reminder Duration 
-notification sent employee for absence without leave application based on Leave Application Reminder Duration(int)
-Leave Application Template(link-email template)
## Output screenshots (optional)
[Screencast from 03-03-25 09:28:27 AM IST.webm](https://github.com/user-attachments/assets/fc0be81e-b9d2-48fb-b2d3-e581f9757d2e)
[Uploading Screencast from 03-03-25 09:28:27 AM IST.webm…]()
![image](https://github.com/user-attachments/assets/7f808bac-fc8a-40e6-953b-bb5457aa0cd9)
![Uploading image.png…]()
![Uploading image.png…]()

## Areas affected and ensured
attendance 

## Is there any existing behavior change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?
 
  - Mozilla Firefox
  
