### PR TITLE
feat:     TASK-2025-00251-Implement Adding Assets and Bundles using QR Code in asset bundle

### DIFF
--- a/beams/beams/doctype/asset_bundle/asset_bundle.js
+++ b/beams/beams/doctype/asset_bundle/asset_bundle.js
@@ -2,14 +2,33 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Asset Bundle", {
-	refresh:function(frm) {
-		frm.fields_dict['stock_items'].grid.get_field('item').get_query = function(doc, cdt, cdn) {
-			return {
-				filters: {
-					is_fixed_asset: 0
-				}
-			};
-		};
+    refresh:function(frm) {
+      // Initialize QR Scanner only once
+      if (!frm._qr_scanner_initialized) {
+          frm._qr_scanner_initialized = true;
+          frm.fields_dict.scan_qr_code.$wrapper.on("click", function() {
+              let scanner = new frappe.ui.Scanner({
+                  multiple: false,
+                  on_success: function(result) {
+                      let scanned_value = result.text.trim();
+                      frm.set_value("scan_qr_code", scanned_value);
+                      frm.trigger("scan_qr_code");  // Trigger processing
+                  },
+                  on_error: function(error) {
+                      frappe.msgprint(__('Failed to scan QR Code. Try again!'));
+                  }
+              });
+              scanner.show();
+          });
+      }
+
+        frm.fields_dict['stock_items'].grid.get_field('item').get_query = function(doc, cdt, cdn) {
+            return {
+                filters: {
+                    is_fixed_asset: 0
+                }
+            };
+        };
         frappe.call({
             method: "beams.beams.doctype.asset_bundle.asset_bundle.get_selected_assets",
             callback: function (response) {
@@ -25,8 +44,7 @@ frappe.ui.form.on("Asset Bundle", {
                 }
             }
         });
-
-				frappe.call({
+        frappe.call({
             method: "beams.beams.doctype.asset_bundle.asset_bundle.get_selected_bundles",
             callback: function (response) {
                 if (response.message) {
@@ -41,13 +59,45 @@ frappe.ui.form.on("Asset Bundle", {
                 }
             }
         });
-	},
-	validate: function(frm) {
-		if (!frm.doc.stock_items?.length && !frm.doc.assets?.length && !frm.doc.bundles?.length) {
-			frappe.msgprint(__('At least one of Stock Items, Assets, or Bundles must be filled in.'));
-			frappe.validated = false;
-		}
-	},
+    },
+    validate: function(frm) {
+        if (!frm.doc.stock_items?.length && !frm.doc.assets?.length && !frm.doc.bundles?.length) {
+            frappe.msgprint(__('At least one of Stock Items, Assets, or Bundles must be filled in.'));
+            frappe.validated = false;
+        }
+    },
+    scan_qr_code: function(frm) {
+    if (!frm.doc.scan_qr_code) return;
+
+    let scanned_value = frm.doc.scan_qr_code.trim();
+
+    frappe.call({
+        method: "frappe.client.get_list",
+        args: {
+            doctype: "Asset",
+            filters: { name: scanned_value },
+            fields: ["name", "asset_name"]
+        },
+        callback: function(r) {
+            if (r.message && r.message.length > 0) {
+                let asset = r.message[0];
+                let existing_asset = (frm.doc.assets || []).find(row => row.asset === asset.name);
+                if (!existing_asset) {
+                    let new_asset = frm.add_child("assets");
+                    new_asset.asset = asset.name;
+                    new_asset.asset_name = asset.asset_name;
+                    frm.refresh_field("assets");
+                } else {
+                    frappe.msgprint(__('Asset is already added!'));
+                }
+            } else {
+                frappe.msgprint(__('No asset found with this QR code!'));
+            }
+            frm.set_value("scan_qr_code", ""); // Clear scan field
+        }
+    });
+    },
+
   bundles: function (frm) {
         if (frm.doc.bundles.length > 0) {
             let bundle_names = frm.doc.bundles.map((bundle) => bundle.asset_bundle);

--- a/beams/beams/doctype/asset_bundle/asset_bundle.json
+++ b/beams/beams/doctype/asset_bundle/asset_bundle.json
@@ -7,6 +7,7 @@
  "engine": "InnoDB",
  "field_order": [
   "assets",
+  "scan_qr_code",
   "column_break_idhv",
   "bundles",
   "section_break_xxjo",
@@ -44,11 +45,17 @@
    "fieldname": "qr_code",
    "fieldtype": "Attach Image",
    "label": "QR Code"
+  },
+  {
+   "fieldname": "scan_qr_code",
+   "fieldtype": "Data",
+   "label": "Scan QR Code",
+   "options": "Barcode"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-02-17 12:12:48.487591",
+ "modified": "2025-02-24 11:55:10.128488",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Asset Bundle",

--- a/beams/beams/doctype/asset_bundle/asset_bundle.json
+++ b/beams/beams/doctype/asset_bundle/asset_bundle.json
@@ -12,7 +12,8 @@
   "bundles",
   "section_break_xxjo",
   "stock_items",
-  "qr_code"
+  "qr_code",
+  "bundle_qr_code"
  ],
  "fields": [
   {
@@ -51,11 +52,16 @@
    "fieldtype": "Data",
    "label": "Scan QR Code",
    "options": "Barcode"
+  },
+  {
+   "fieldname": "bundle_qr_code",
+   "fieldtype": "Attach",
+   "label": "Bundle QR Code"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-02-24 11:55:10.128488",
+ "modified": "2025-03-03 13:32:59.331766",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Asset Bundle",

--- a/beams/beams/doctype/asset_transfer_request/asset_transfer_request.json
+++ b/beams/beams/doctype/asset_transfer_request/asset_transfer_request.json
@@ -14,6 +14,8 @@
   "assets",
   "bundles",
   "received_by",
+  "scan_qr_code",
+  "scan_bundle",
   "column_break_ivnd",
   "posting_date",
   "posting_time",
@@ -150,12 +152,26 @@
    "label": " Received By",
    "mandatory_depends_on": "eval:doc.workflow_state == \"Transferred\"",
    "options": "Employee"
+  },
+  {
+   "depends_on": "eval:doc.asset_type == \"Single Asset\"",
+   "fieldname": "scan_qr_code",
+   "fieldtype": "Data",
+   "label": "Scan Asset",
+   "options": "Barcode"
+  },
+  {
+   "depends_on": "eval:doc.asset_type == \"Bundle\"",
+   "fieldname": "scan_bundle",
+   "fieldtype": "Data",
+   "label": "Scan Bundle",
+   "options": "Barcode"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-02-28 13:46:02.695064",
+ "modified": "2025-03-03 13:58:26.799954",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Asset Transfer Request",

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -314,7 +314,9 @@ doc_events = {
         "before_save": "beams.beams.custom_scripts.asset_movement.asset_movement.before_save"
     },
     "Asset":{
-        "after_insert":"beams.beams.custom_scripts.asset.asset.generate_asset_qr"
+        "after_insert":"beams.beams.custom_scripts.asset.asset.generate_asset_qr",
+        "on_submit":"beams.beams.custom_scripts.asset.asset.generate_asset_details_qr"
+
     },
     "Budget":{
         "validate":"beams.beams.custom_scripts.budget.budget.update_total_amount"

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -630,6 +630,12 @@ def get_asset_custom_fields():
                 "fieldtype": "Attach Image",
                 "label": "QR code",
                 "insert_after": "department"
+            },
+            {
+                "fieldname": "asset_details",
+                "fieldtype": "Attach Image",
+                "label": "Asset Details",
+                "insert_after": "qr_code"
             }
         ]
     }


### PR DESCRIPTION
## Feature description
- Implement Adding Assets and Bundles using QR Code

## Solution description
- Automated QR Code Generation
    - The function generate_asset_qr is triggered when an asset is created.
    - It checks if a QR code already exists; if not, it generates a new one.
- QR Code Scanning for Asset Bundle:
     - Implemented a QR scanner in asset_bundle.js to scan asset QR codes and add them to the asset bundle.
     -  Scanned assets are validated before being added to prevent duplicates.
-  Updated Hooks (hooks.py)
      - Registered generate_asset_qr on after_insert and generate_asset_details_qr on on_submit for the Asset DocType.
- Modified Asset Bundle Doctype (asset_bundle.json)
     -  Added a new field scan_qr_code to facilitate scanning directly from the Asset Bundle form.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/b44b5ba2-aa44-4c3a-a33c-421354f187e2)
![image](https://github.com/user-attachments/assets/b99c1318-7083-425b-9770-57de1d2ae23a)
![Screenshot from 2025-03-03 11-06-16](https://github.com/user-attachments/assets/2b5031e5-fb4e-4dec-a95f-5556a46997e8)


## Areas affected and ensured
- asset
- asset bundle

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - yes
  - Opera Mini
  - Safari
