### PR TITLE
feat:Added Validation for Expected By field in Job Requisition

### DIFF
--- a/beams/beams/custom_scripts/job_requisition/job_requisition.js
+++ b/beams/beams/custom_scripts/job_requisition/job_requisition.js
@@ -79,12 +79,4 @@ frappe.ui.form.on('Job Requisition', {
             }
         }
     }
-    
-
 });
-    
-   
-
-    
-    
-    

--- a/beams/beams/custom_scripts/job_requisition/job_requisition.js
+++ b/beams/beams/custom_scripts/job_requisition/job_requisition.js
@@ -66,5 +66,25 @@ frappe.ui.form.on('Job Requisition', {
                 }
             };
         });
+    },
+
+    expected_by: function(frm) {
+        if (frm.doc.expected_by) {
+            let expected_date = frappe.datetime.str_to_obj(frm.doc.expected_by);
+            let today = frappe.datetime.str_to_obj(frappe.datetime.get_today());
+
+            if (expected_date < today) {
+                frappe.msgprint(__('Expected By date must be a future date.'));
+                frm.set_value("expected_by", "");  
+            }
+        }
     }
+    
+
 });
+    
+   
+
+    
+    
+    

--- a/beams/beams/custom_scripts/job_requisition/job_requisition.py
+++ b/beams/beams/custom_scripts/job_requisition/job_requisition.py
@@ -2,6 +2,8 @@ import json
 import frappe
 from frappe.model.mapper import get_mapped_doc
 from frappe.utils import now_datetime, get_url_to_form
+from datetime import datetime,date
+
 
 @frappe.whitelist()
 def create_job_opening_from_job_requisition(doc, method):
@@ -94,3 +96,21 @@ def get_template_content(template_name, doc):
         if description:
             rendered_description = frappe.render_template(description, doc)
     return rendered_description
+
+
+@frappe.whitelist()
+def validate_expected_by(doc, method=None):
+    '''Ensure that 'Expected By' date is today or in the future.'''
+    
+    if doc.expected_by:
+        if isinstance(doc.expected_by, str):
+            expected_date = datetime.strptime(doc.expected_by, "%Y-%m-%d").date()
+        elif isinstance(doc.expected_by, date):
+            expected_date = doc.expected_by
+        else:
+            raise ValueError("Invalid type for expected_by. Expected a string or date object.")
+        
+        today = datetime.today().date()
+        
+        if expected_date < today: 
+            frappe.throw("Expected By date must be a future date.")

--- a/beams/beams/custom_scripts/job_requisition/job_requisition.py
+++ b/beams/beams/custom_scripts/job_requisition/job_requisition.py
@@ -4,7 +4,6 @@ from frappe.model.mapper import get_mapped_doc
 from frappe.utils import now_datetime, get_url_to_form
 from datetime import datetime,date
 
-
 @frappe.whitelist()
 def create_job_opening_from_job_requisition(doc, method):
     '''
@@ -96,7 +95,6 @@ def get_template_content(template_name, doc):
         if description:
             rendered_description = frappe.render_template(description, doc)
     return rendered_description
-
 
 @frappe.whitelist()
 def validate_expected_by(doc, method=None):

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -336,7 +336,6 @@ scheduler_events = {
         "beams.beams.doctype.beams_hr_settings.beams_hr_settings.send_appraisal_reminders",
         "beams.beams.custom_scripts.vehicle.vehicle.send_vehicle_document_reminders",
         "beams.beams.doctype.beams_admin_settings.beams_admin_settings.send_asset_audit_reminder"
-
     ],
 # "all": [
 # "beams.tasks.all"

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -217,8 +217,10 @@ doc_events = {
         "on_update": [
             "beams.beams.custom_scripts.job_requisition.job_requisition.create_job_opening_from_job_requisition",
             "beams.beams.custom_scripts.job_requisition.job_requisition.on_update"
-        ]
+        ],
+        "validate": "beams.beams.custom_scripts.job_requisition.job_requisition.validate_expected_by"
     },
+    
     "Journal Entry": {
         "on_cancel": "beams.beams.custom_scripts.journal_entry.journal_entry.on_cancel"
     },
@@ -334,6 +336,7 @@ scheduler_events = {
         "beams.beams.doctype.beams_hr_settings.beams_hr_settings.send_appraisal_reminders",
         "beams.beams.custom_scripts.vehicle.vehicle.send_vehicle_document_reminders",
         "beams.beams.doctype.beams_admin_settings.beams_admin_settings.send_asset_audit_reminder"
+
     ],
 # "all": [
 # "beams.tasks.all"


### PR DESCRIPTION
## Feature description
Validate Expected By field in Job Requisition such that only future dates can be selected.


## Solution description
Validation added as only future dateds are selected.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/2832404e-656a-4053-a1a4-fa058fe4ceab)

## Areas affected and ensured
Job Requisition.

## Is there any existing behavior change of other features due to this code change?
      No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
