### PR TITLE
 TASK-2025-00289 : Added the fields in job requistion

### DIFF
--- a/beams/beams/custom_scripts/job_requisition/job_requisition.py
+++ b/beams/beams/custom_scripts/job_requisition/job_requisition.py
@@ -28,7 +28,7 @@ def create_job_opening_from_job_requisition(doc, method):
             job_opening.no_of_positions = doc.no_of_positions
             job_opening.no_of_days_off = doc.no_of_days_off
             job_opening.preffered_location = doc.location
-            job_opening.publish = 1
+            job_opening.publish = doc.publish_on_job_opening
             #Setting Skill Proficiency
             for skill in doc.skill_proficiency:
                 job_opening.append('skill_proficiency', {
@@ -99,7 +99,7 @@ def get_template_content(template_name, doc):
 @frappe.whitelist()
 def validate_expected_by(doc, method=None):
     '''Ensure that 'Expected By' date is today or in the future.'''
-    
+
     if doc.expected_by:
         if isinstance(doc.expected_by, str):
             expected_date = datetime.strptime(doc.expected_by, "%Y-%m-%d").date()
@@ -107,8 +107,8 @@ def validate_expected_by(doc, method=None):
             expected_date = doc.expected_by
         else:
             raise ValueError("Invalid type for expected_by. Expected a string or date object.")
-        
+
         today = datetime.today().date()
-        
-        if expected_date < today: 
+
+        if expected_date < today:
             frappe.throw("Expected By date must be a future date.")

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -1662,7 +1662,7 @@ def get_job_requisition_custom_fields():
                 "fieldname": "no_of_days_off",
                 "fieldtype": "Int",
                 "label": "Number of Days Off",
-                "description": " Number Of Days Off Within a 30-day Period",
+                "description": " Number Of Days Off within a 30-day Period",
                 "insert_after": "work_details",
                 "permlevel": 1
             },

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -125,7 +125,6 @@ def before_uninstall():
     delete_custom_fields(get_asset_movement_custom_fields())
 
 
-
 def delete_custom_fields(custom_fields: dict):
     '''
     Method to Delete custom fields
@@ -340,6 +339,7 @@ def get_project_custom_fields():
 
         ]
     }
+
 
 def get_employment_type_custom_fields():
     '''
@@ -1824,6 +1824,20 @@ def get_job_requisition_custom_fields():
                 "insert_after": "description",
                 "permlevel": 3
             },
+            {
+                "fieldname": "publish_on_job_section",
+                "fieldtype": "Section Break",
+                "label": "",
+                "insert_after": "requested_by_designation"
+            },
+            {
+                "fieldname": "publish_on_job_opening",
+                "fieldtype": "Check",
+                "default": "1",
+                "label": "Publish on Job Opening",
+                "insert_after": "publish_on_job_section",
+                "permlevel":4
+            }
         ]
     }
 
@@ -1849,7 +1863,7 @@ def get_job_applicant_custom_fields():
             {
                 "fieldname": "willing_to_work_on_location",
                 "fieldtype": "Check",
-                "label": "Willing to work on the selected location?",
+                "label": "Willing to Work in the Selected Location?",
                 "insert_after": "country"
             },
             {
@@ -2131,7 +2145,7 @@ def get_job_applicant_custom_fields():
             {
                 "fieldname": "reference_taken",
                 "fieldtype": "Select",
-                "label": "Can a reference taken now?",
+                "label": "Can i take Reference Now?",
                 "options": "\nYes\nNo",
                 "insert_after": "current_designation"
             },
@@ -2189,7 +2203,7 @@ def get_job_applicant_custom_fields():
             {
                 "fieldname": "agency_details",
                 "fieldtype": "Small Text",
-                "label": "Agency Details(if temporary or contractual)",
+                "label": "Agency Details  (if temporary or contractual)",
                 "insert_after": "reason_for_leaving"
             },
             {
@@ -3504,7 +3518,7 @@ def get_property_setters():
             "value": "eval: !(doc.workflow_state == 'Draft' && doc.request_for == 'New Vacancy')"
         },
         {
-            "doctype_or_field": "DocField",
+            "doctype_or_field": "DocType",
             "doc_type": "Job Requisition",
             "property": "field_order",
             "value": "[\"naming_series\", \"request_for\", \"employee_left\", \"relieving_date\", \"suggested_designation\", \"designation\", \"department\", \"employment_type\", \"location\", \"column_break_qkna\", \"no_of_positions\", \"expected_compensation\", \"reason_for_requesting\", \"column_break_4\", \"company\", \"status\", \"interview\", \"interview_rounds\", \"work_details\", \"no_of_days_off\", \"work_details_column_break\", \"travel_required\", \"is_work_shift_needed\", \"driving_license_needed\", \"license_type\", \"education\", \"min_education_qual\", \"education_column_break\", \"min_experience\", \"reset_column\", \"language_proficiency\", \"skill_proficiency\", \"section_break_7\", \"requested_by\", \"requested_by_name\", \"column_break_10\", \"requested_by_dept\", \"requested_by_designation\", \"timelines_tab\", \"posting_date\", \"completed_on\", \"column_break_15\", \"expected_by\", \"time_to_fill\", \"job_description_tab\", \"job_description_template\", \"job_title\", \"description\", \"suggestions\", \"connections_tab\"]"

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -1662,7 +1662,7 @@ def get_job_requisition_custom_fields():
                 "fieldname": "no_of_days_off",
                 "fieldtype": "Int",
                 "label": "Number of Days Off",
-                "description": " Number Of Days Off within a 30-day Period",
+                "description": "Number Of Days Off within a 30-day Period",
                 "insert_after": "work_details",
                 "permlevel": 1
             },

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -2145,7 +2145,7 @@ def get_job_applicant_custom_fields():
             {
                 "fieldname": "reference_taken",
                 "fieldtype": "Select",
-                "label": "Can i take Reference Now?",
+                "label": "Can I take Reference Now?",
                 "options": "\nYes\nNo",
                 "insert_after": "current_designation"
             },
@@ -2203,7 +2203,7 @@ def get_job_applicant_custom_fields():
             {
                 "fieldname": "agency_details",
                 "fieldtype": "Small Text",
-                "label": "Agency Details  (if temporary or contractual)",
+                "label": "Agency Details  (if Temporary or Contractual)",
                 "insert_after": "reason_for_leaving"
             },
             {


### PR DESCRIPTION
## Feature description
- Added a new fields in job requisition and that field is should be traversed to Job Opening.doctype
- changed the label names in the job applicant  doctype


## Solution description
1. added field Publish on Job Opening   permlevel is setted to hr manager and ceo in job requistion doctype traversed in to job opening 
2. changed the label names in job applicant fields are Willing to Work in the Selected Location?,Can i take Reference Now?,Agency Details  (if temporary or contractual)"
## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/4497bb52-ba3b-4b50-914a-9a1306b475f0)
[Screencast from 03-03-25 01:55:28 PM IST.webm](https://github.com/user-attachments/assets/7649941f-af71-42c5-812e-bdd791d15621)
[Screencast from 03-03-25 02:00:12 PM IST.webm](https://github.com/user-attachments/assets/bd2b55db-ce5e-4c48-a1c9-31d10541b94c)



## Areas affected and ensured
job applicant,  job requsition and job opening doctype

## Is there any existing behavior change of other features due to this code change?
No. 

## Was this feature tested on the browsers?
 
  - Mozilla Firefox

