### PR TITLE
fix: validation for offense date in vehicle incident record , and filter for transferred asset in asset transfer request doctype

### DIFF
--- a/beams/beams/doctype/asset_transfer_request/asset_transfer_request.js
+++ b/beams/beams/doctype/asset_transfer_request/asset_transfer_request.js
@@ -124,6 +124,19 @@ frappe.ui.form.on("Asset Transfer Request", {
                 }
             });
         }
+    },
+    async onload(frm) {
+        let assets_in_transfer = await get_assets_in_transfer();
+        console.log("Filtered Assets:", assets_in_transfer);
+
+        frm.set_query("asset", function() {
+            return {
+                filters: [
+                    ["Asset", "status", "!=", "Transferred"],
+                    ["Asset", "name", "not in", assets_in_transfer]
+                ]
+            };
+        });
     }
 });
 
@@ -195,4 +208,26 @@ function start_qr_scanner(frm, fieldname) {
         }
     });
     scanner.show();
+}
+/**
+ * Fetches a list of assets currently in transfer.
+ * @returns {Promise<Array>} - Returns an array of asset names.
+ */
+async function get_assets_in_transfer() {
+    try {
+        let response = await frappe.db.get_list("Asset Transfer Request", {
+            filters: {
+                workflow_state: ["not in", ["Draft", "Rejected","Pending Approval","Approved","Transferred and Received"]]
+            },
+            fields: ["asset"],
+            limit_page_length: 1000
+        });
+
+        let assets = [...new Set(response.map(entry => entry.asset))];
+        console.log("Assets in transfer:", assets);
+        return assets;
+    } catch (error) {
+        console.error("Error fetching assets in transfer:", error);
+        return [];
+    }
 }

--- a/beams/beams/doctype/vehicle_incident_record/vehicle_incident_record.js
+++ b/beams/beams/doctype/vehicle_incident_record/vehicle_incident_record.js
@@ -4,5 +4,8 @@
 frappe.ui.form.on("Vehicle Incident Record", {
   posting_date:function (frm){
       frm.call("validate_posting_date");
+    },
+  offense_date_and_time: function (frm) {
+      frm.call("validate_offense_date_and_time");
     }
 });

--- a/beams/beams/doctype/vehicle_incident_record/vehicle_incident_record.py
+++ b/beams/beams/doctype/vehicle_incident_record/vehicle_incident_record.py
@@ -12,6 +12,7 @@ class VehicleIncidentRecord(Document):
         if self.posting_date:
             if self.posting_date > today():
                 frappe.throw(_("Posting Date cannot be set after today's date."))
+
     @frappe.whitelist()
     def validate_offense_date_and_time(self):
         if self.offense_date_and_time:

--- a/beams/beams/doctype/vehicle_incident_record/vehicle_incident_record.py
+++ b/beams/beams/doctype/vehicle_incident_record/vehicle_incident_record.py
@@ -12,3 +12,8 @@ class VehicleIncidentRecord(Document):
         if self.posting_date:
             if self.posting_date > today():
                 frappe.throw(_("Posting Date cannot be set after today's date."))
+    @frappe.whitelist()
+    def validate_offense_date_and_time(self):
+        if self.offense_date_and_time:
+            if self.offense_date_and_time > today():
+                frappe.throw(_("Offense Date cannot be set after today's date."))


### PR DESCRIPTION
## Feature description
Add Validation for future dates on offense date in Vehicle Incident Record.
Apply filter for transferred assets in asset transfer request doctype

## Solution description
Added Validation for future dates on offense date in Vehicle Incident Record.
Applied filter for transferred assets in asset transfer request doctype

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/0c8ab5de-a841-40d1-9ba0-4b0b3df5ac14)
![image](https://github.com/user-attachments/assets/3b673b37-6e75-4195-a2b6-7f90c766192d)


## Areas affected and ensured
List out the areas affected by your code changes.( vehicle incident record and asset transfer request doctype)

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
