### PR TITLE
fix: Fields changed to Read only

### DIFF
--- a/beams/beams/doctype/required_items_detail/required_items_detail.json
+++ b/beams/beams/doctype/required_items_detail/required_items_detail.json
@@ -27,7 +27,8 @@
    "fieldname": "issued_quantity",
    "fieldtype": "Int",
    "in_list_view": 1,
-   "label": "Issued Quantity"
+   "label": "Issued Quantity",
+   "read_only": 1
   },
   {
    "fieldname": "available_quantity",
@@ -62,7 +63,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-02-13 09:43:47.778466",
+ "modified": "2025-03-04 11:33:44.518997",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Required Items Detail",

--- a/beams/beams/doctype/transportation_request/transportation_request.json
+++ b/beams/beams/doctype/transportation_request/transportation_request.json
@@ -66,6 +66,7 @@
    "reqd": 1
   },
   {
+   "default": "1",
    "fieldname": "noof_travallers",
    "fieldtype": "Int",
    "label": "No.of Travallers"
@@ -109,10 +110,11 @@
   },
   {
    "allow_on_submit": 1,
-   "depends_on": "eval: doc.workflow_state == \"Pending Approval\" || doc.workflow_state == \"Rejected\";\n",
+   "depends_on": "eval: doc.workflow_state == \"Pending Approval\" || doc.workflow_state == \"Rejected\";",
    "fieldname": "reason_for_rejection",
    "fieldtype": "Small Text",
    "label": "Reason for Rejection",
+   "read_only": 1,
    "read_only_depends_on": "eval: doc.workflow_state != \"Pending Approval\";"
   },
   {
@@ -133,7 +135,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-02-12 17:13:10.350245",
+ "modified": "2025-03-04 11:50:41.274550",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Transportation Request",


### PR DESCRIPTION
## Feature description
Issued Quantity in Equipment Request change to read only
Reason for rejection change to read only in Transportation Request

## Solution description
Issued Quantity in Equipment Request changed to read only
Reason for rejection change to read only in Transportation Request
No.of travallers default set to one

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/1523aa24-f950-4799-a472-99f6292ecff1)
![image](https://github.com/user-attachments/assets/1fceb6e3-4cd2-4aa9-9ec1-ce320e10eba4)

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Mozilla Firefox
  