### PR TITLE
fix: Remove permlevel for experience field in Job Applicant

### DIFF
--- a/beams/beams/doctype/local_enquiry_report/local_enquiry_report.json
+++ b/beams/beams/doctype/local_enquiry_report/local_enquiry_report.json
@@ -161,7 +161,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-11-08 09:28:51.283318",
+ "modified": "2025-03-04 11:44:27.596407",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Local Enquiry Report",
@@ -183,5 +183,6 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
- "states": []
+ "states": [],
+ "title_field": "job_applicant_name"
 }

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -1727,7 +1727,7 @@ def get_job_requisition_custom_fields():
             {
                 "fieldname": "min_experience",
                 "fieldtype": "Float",
-                "label": "Minimum Experience Required",
+                "label": "Minimum Experience Required (Years)",
                 "insert_after": "no_of_days_off",
                 "permlevel": 1
             },
@@ -2009,9 +2009,8 @@ def get_job_applicant_custom_fields():
             {
                 "fieldname": "min_experience",
                 "fieldtype": "Float",
-                "label": "Work Experience(in years)",
+                "label": "Work Experience (Years)",
                 "insert_after": "details_column_break",
-                "permlevel": 1
             },
             {
                 "fieldname": "details_column_break",
@@ -2530,7 +2529,7 @@ def get_job_opening_custom_fields():
             {
                 "fieldname": "min_experience",
                 "fieldtype": "Float",
-                "label": "Minimum Experience Required",
+                "label": "Minimum Experience Required (Years)",
                 "insert_after": "is_work_shift_needed"
             },
             {
@@ -3528,7 +3527,7 @@ def get_property_setters():
             "doctype_or_field": "DocType",
             "doc_type": "Job Requisition",
             "property": "field_order",
-            "value": "[\"naming_series\", \"request_for\", \"employee_left\", \"relieving_date\", \"suggested_designation\", \"designation\", \"department\", \"employment_type\", \"location\", \"column_break_qkna\", \"no_of_positions\", \"expected_compensation\", \"reason_for_requesting\", \"column_break_4\", \"company\", \"status\", \"interview\", \"interview_rounds\", \"work_details\", \"no_of_days_off\", \"work_details_column_break\", \"travel_required\", \"is_work_shift_needed\", \"driving_license_needed\", \"license_type\", \"education\", \"min_education_qual\", \"education_column_break\", \"min_experience\", \"reset_column\", \"language_proficiency\", \"skill_proficiency\", \"section_break_7\", \"requested_by\", \"requested_by_name\", \"column_break_10\", \"requested_by_dept\", \"requested_by_designation\", \"timelines_tab\", \"posting_date\", \"completed_on\", \"column_break_15\", \"expected_by\", \"time_to_fill\", \"job_description_tab\", \"job_description_template\", \"job_title\", \"description\", \"suggestions\", \"connections_tab\"]"
+            "value": "[\"naming_series\", \"request_for\", \"employee_left\", \"relieving_date\", \"suggested_designation\", \"designation\", \"department\", \"employment_type\", \"location\", \"column_break_qkna\", \"no_of_positions\", \"expected_compensation\", \"reason_for_requesting\", \"column_break_4\", \"company\", \"status\", \"interview\", \"interview_rounds\", \"work_details\", \"no_of_days_off\", \"work_details_column_break\", \"is_work_shift_needed\", \"travel_required\",  \"driving_license_needed\", \"license_type\", \"education\", \"min_education_qual\", \"education_column_break\", \"min_experience\", \"reset_column\", \"language_proficiency\", \"skill_proficiency\", \"section_break_7\", \"requested_by\", \"requested_by_name\", \"column_break_10\", \"requested_by_dept\", \"requested_by_designation\", \"timelines_tab\", \"posting_date\", \"completed_on\", \"column_break_15\", \"expected_by\", \"time_to_fill\", \"job_description_tab\", \"job_description_template\", \"job_title\", \"description\", \"suggestions\", \"connections_tab\"]"
         }
     ]
 def get_material_request_custom_fields():


### PR DESCRIPTION
## Feature description
- Remove permlevel for experience field in Job Applicant
- Add 'In Years' to field Label 'Experience'
- Put is_work_shift_needed checkbox  before travel_required checkbox in Job Requisition
- Put title for Local Enquiry Report

## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description
Describe your code changes in detail for reviewers.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/306fd322-32f6-44ed-a630-17d7e88a9e21)
## Areas affected and ensured
Job Applicant-permlevel
Job Requisition-field arrangement
## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
