### PR TITLE
feat: TASK-2025-00299 - Updates the Job Applicant's applicant_interview_rounds table when a new Interview is created

### DIFF
--- a/beams/beams/custom_scripts/interview/interview.py
+++ b/beams/beams/custom_scripts/interview/interview.py
@@ -190,3 +190,24 @@ def get_permission_query_conditions(user):
         return conditions
 
     return None
+
+
+def update_applicant_interview_rounds(doc, method):
+    """
+    Update the Job Applicant's applicant_interview_rounds table when a new Interview is created.
+    """
+    if not doc.job_applicant:
+        return
+
+    job_applicant = frappe.get_doc("Job Applicant", doc.job_applicant)
+    existing_rounds = {row.interview_round for row in job_applicant.applicant_interview_rounds}
+
+    if doc.interview_round in existing_rounds:
+        return
+
+    job_applicant.append("applicant_interview_rounds", {
+        "interview_round": doc.interview_round,
+        "interview_status": doc.status
+    })
+
+    job_applicant.save(ignore_permissions=True)

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -220,7 +220,7 @@ doc_events = {
         ],
         "validate": "beams.beams.custom_scripts.job_requisition.job_requisition.validate_expected_by"
     },
-    
+
     "Journal Entry": {
         "on_cancel": "beams.beams.custom_scripts.journal_entry.journal_entry.on_cancel"
     },
@@ -239,7 +239,10 @@ doc_events = {
                         "beams.beams.custom_scripts.interview.interview.mark_interview_completed",
                         "beams.beams.custom_scripts.interview.interview.update_job_applicant_status"
                     ],
-        "after_insert": "beams.beams.custom_scripts.interview.interview.on_interview_creation",
+        "after_insert": [
+            "beams.beams.custom_scripts.interview.interview.on_interview_creation",
+            "beams.beams.custom_scripts.interview.interview.update_applicant_interview_rounds"
+        ],
         "on_update": "beams.beams.custom_scripts.interview.interview.update_applicant_interview_round"
     },
     "Interview Feedback": {


### PR DESCRIPTION
## Feature description
- Updates the Job Applicant's applicant_interview_rounds table when a new Interview is created

## Solution description


-  **Ensures Automatic Update**: Updates the `applicant_interview_rounds` table in the **Job Applicant** Doctype when a new **Interview** is created.  

-  **Checks for Linked Job Applicant**: If the Interview is not linked to a **Job Applicant**, the function exits early.  

-  **Prevents Duplicate Rounds**: Fetches existing interview rounds and skips adding if the round already exists.  

 -  **Appends New Interview Round**: Adds the new **interview round** and its **status** to the Job Applicant’s record.  

 -  **Saves Changes**: Updates the Job Applicant document while **ignoring permission restrictions**.

## Output screenshots (optional)
[Screencast from 04-03-25 01:21:17 PM IST.webm](https://github.com/user-attachments/assets/88c1babb-4d4b-47a6-b6e0-ae82a9153d6c)


## Areas affected and ensured
- 
Job Applicant

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - yes
  - Opera Mini
  - Safari
