### PR TITLE
TASK-2025-00291:Override Interview class to hide a message.

### DIFF
--- a/beams/beams/custom_scripts/interview/interview.js
+++ b/beams/beams/custom_scripts/interview/interview.js
@@ -152,7 +152,7 @@ frappe.ui.form.on('Interview', {
             { fieldtype: 'Data', fieldname: 'answer', label: __('Answer') },
             { fieldtype: 'Float', fieldname: 'weight', label: __('Weight') },
             { fieldtype: 'Data', fieldname: 'applicant_answer', label: __('Applicant Answer'), in_list_view: 1, reqd: 1 },
-            { fieldtype: 'Float', fieldname: 'score', label: __('Score'), in_list_view: 1, reqd: 1 },
+            { fieldtype: 'Float', fieldname: 'score', label: __('Score(Out of 10)'), in_list_view: 1, reqd: 1 },
             { fieldtype: 'Data', fieldname: 'parent', hidden: 1, label: __('Parent') },
             { fieldtype: 'Data', fieldname: 'name', hidden: 1, label: __('Name') }
         ];
@@ -161,7 +161,7 @@ frappe.ui.form.on('Interview', {
     get_fields_for_custom_feedback: function () {
         return [
             { fieldtype: 'Link', fieldname: 'skill', label: __('Skill'), options: 'Skill', in_list_view: 1, reqd: 1 },
-            { fieldtype: 'Float', fieldname: 'score', label: __('Score'), in_list_view: 1, reqd: 1 },
+            { fieldtype: 'Float', fieldname: 'score', label: __('Score(Out of 10)'), in_list_view: 1, reqd: 1 },
             { fieldtype: 'Small Text', fieldname: 'remarks', label: __('Remarks') }
         ];
     }

--- a/beams/beams/custom_scripts/interview/interview.js
+++ b/beams/beams/custom_scripts/interview/interview.js
@@ -152,7 +152,7 @@ frappe.ui.form.on('Interview', {
             { fieldtype: 'Data', fieldname: 'answer', label: __('Answer') },
             { fieldtype: 'Float', fieldname: 'weight', label: __('Weight') },
             { fieldtype: 'Data', fieldname: 'applicant_answer', label: __('Applicant Answer'), in_list_view: 1, reqd: 1 },
-            { fieldtype: 'Float', fieldname: 'score', label: __('Score(Out of 10)'), in_list_view: 1, reqd: 1 },
+            { fieldtype: 'Float', fieldname: 'score', label: __('Score (Out of 10)'), in_list_view: 1, reqd: 1 },
             { fieldtype: 'Data', fieldname: 'parent', hidden: 1, label: __('Parent') },
             { fieldtype: 'Data', fieldname: 'name', hidden: 1, label: __('Name') }
         ];
@@ -161,7 +161,7 @@ frappe.ui.form.on('Interview', {
     get_fields_for_custom_feedback: function () {
         return [
             { fieldtype: 'Link', fieldname: 'skill', label: __('Skill'), options: 'Skill', in_list_view: 1, reqd: 1 },
-            { fieldtype: 'Float', fieldname: 'score', label: __('Score(Out of 10)'), in_list_view: 1, reqd: 1 },
+            { fieldtype: 'Float', fieldname: 'score', label: __('Score (Out of 10)'), in_list_view: 1, reqd: 1 },
             { fieldtype: 'Small Text', fieldname: 'remarks', label: __('Remarks') }
         ];
     }

--- a/beams/beams/custom_scripts/interview/interview.py
+++ b/beams/beams/custom_scripts/interview/interview.py
@@ -3,10 +3,9 @@ import frappe
 from frappe import _
 from six import string_types
 from frappe.utils import get_link_to_form
-from frappe.model.document import Document
-from hrms.hr.doctype.interview.interview import DuplicateInterviewRoundError, get_recipients
+from hrms.hr.doctype.interview.interview import Interview
 
-class InterviewOverride(Document):
+class InterviewOverride(Interview):
       def on_submit(self):
             if self.status not in ["Cleared", "Rejected"]:
                   frappe.throw(

--- a/beams/beams/custom_scripts/interview/interview.py
+++ b/beams/beams/custom_scripts/interview/interview.py
@@ -3,6 +3,16 @@ import frappe
 from frappe import _
 from six import string_types
 from frappe.utils import get_link_to_form
+from frappe.model.document import Document
+from hrms.hr.doctype.interview.interview import DuplicateInterviewRoundError, get_recipients
+
+class InterviewOverride(Document):
+      def on_submit(self):
+            if self.status not in ["Cleared", "Rejected"]:
+                  frappe.throw(
+                        _("Only Interviews with Cleared or Rejected status can be submitted."),
+                        title=_("Not Allowed"),
+                	)
 
 @frappe.whitelist()
 def get_interview_skill_and_question_set(interview_round, interviewer=False, interview_name=False):

--- a/beams/beams/doctype/interview_question_result/interview_question_result.json
+++ b/beams/beams/doctype/interview_question_result/interview_question_result.json
@@ -21,11 +21,6 @@
    "reqd": 1
   },
   {
-   "fieldname": "weight",
-   "fieldtype": "Float",
-   "label": "Weight"
-  },
-  {
    "fieldname": "answer",
    "fieldtype": "Small Text",
    "label": "Answer"
@@ -33,18 +28,23 @@
   {
    "fieldname": "score",
    "fieldtype": "Float",
-   "label": "Score"
+   "label": "Score(Out of 10)"
   },
   {
    "fieldname": "applicant_answer",
    "fieldtype": "Small Text",
    "label": "Applicant Answer"
+  },
+  {
+   "fieldname": "weight",
+   "fieldtype": "Float",
+   "label": "Weight"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-11-19 18:18:32.235947",
+ "modified": "2025-03-03 17:09:11.999490",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Interview Question Result",

--- a/beams/beams/doctype/interview_question_result/interview_question_result.json
+++ b/beams/beams/doctype/interview_question_result/interview_question_result.json
@@ -9,8 +9,8 @@
   "question",
   "answer",
   "applicant_answer",
-  "weight",
-  "score"
+  "score",
+  "weight"
  ],
  "fields": [
   {
@@ -28,7 +28,7 @@
   {
    "fieldname": "score",
    "fieldtype": "Float",
-   "label": "Score(Out of 10)"
+   "label": "Score (Out of 10)"
   },
   {
    "fieldname": "applicant_answer",
@@ -44,7 +44,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-03-03 17:09:11.999490",
+ "modified": "2025-03-05 10:50:59.442015",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Interview Question Result",

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -152,7 +152,8 @@ permission_query_conditions = {
 
 override_doctype_class = {
     "Attendance Request": "beams.beams.custom_scripts.attendance_request.attendance_request.AttendanceRequestOverride",
-    "Shift Type": "beams.beams.custom_scripts.shift_type.shift_type.ShiftTypeOverride"
+    "Shift Type": "beams.beams.custom_scripts.shift_type.shift_type.ShiftTypeOverride",
+    "Interview": "beams.beams.custom_scripts.interview.interview.InterviewOverride"
 }
 
 # Document Events

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -3786,7 +3786,7 @@ def get_skill_assessment_custom_fields():
             {
                 "fieldname": "score",
                 "fieldtype": "Float",
-                "label": "Score(Out of 10)",
+                "label": "Score (Out of 10)",
                 "reqd": 1,
                 "insert_after":"skill",
                 "in_list_view": 1

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -1647,7 +1647,17 @@ def get_interview_custom_fields():
                 "insert_after": "job_applicant",
                 "fetch_from": "job_applicant.applicant_name",
                 "read_only": 1
+            
+            },
+            {
+                "fieldname": "applicant_email",
+                "fieldtype": "Data",
+                "label": "Applicant Email ID",
+                "insert_after": "job_applicant",
+                "fetch_from": "job_applicant.email_id",
+                "hidden": 1
             }
+
         ]
     }
 
@@ -3519,6 +3529,13 @@ def get_property_setters():
         {
             "doctype_or_field": "DocField",
             "doc_type": "Job Requisition",
+            "field_name": "department",
+            "property": "reqd",
+            "value": 0
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Job Requisition",
             "field_name": "section_break_7",
             "property": "collapsible",
             "property_type": "Check",
@@ -3532,10 +3549,17 @@ def get_property_setters():
             "value": "eval: !(doc.workflow_state == 'Draft' && doc.request_for == 'New Vacancy')"
         },
         {
-            "doctype_or_field": "DocType",
+            "doctype_or_field": "DocField",
             "doc_type": "Job Requisition",
             "property": "field_order",
             "value": "[\"naming_series\", \"request_for\", \"employee_left\", \"relieving_date\", \"suggested_designation\", \"designation\", \"department\", \"employment_type\", \"location\", \"column_break_qkna\", \"no_of_positions\", \"expected_compensation\", \"reason_for_requesting\", \"column_break_4\", \"company\", \"status\", \"interview\", \"interview_rounds\", \"work_details\", \"no_of_days_off\", \"work_details_column_break\", \"is_work_shift_needed\", \"travel_required\",  \"driving_license_needed\", \"license_type\", \"education\", \"min_education_qual\", \"education_column_break\", \"min_experience\", \"reset_column\", \"language_proficiency\", \"skill_proficiency\", \"section_break_7\", \"requested_by\", \"requested_by_name\", \"column_break_10\", \"requested_by_dept\", \"requested_by_designation\", \"timelines_tab\", \"posting_date\", \"completed_on\", \"column_break_15\", \"expected_by\", \"time_to_fill\", \"job_description_tab\", \"job_description_template\", \"job_title\", \"description\", \"suggestions\", \"connections_tab\"]"
+        },
+        {
+            "doctype_or_field": "DocType",
+            "doc_type": "Job Applicant",
+            "property": "show_title_field_in_link",
+            "property_type" : "Check",
+            "value": 1
         }
     ]
 def get_material_request_custom_fields():
@@ -3762,7 +3786,7 @@ def get_skill_assessment_custom_fields():
             {
                 "fieldname": "score",
                 "fieldtype": "Float",
-                "label": "Score",
+                "label": "Score(Out of 10)",
                 "reqd": 1,
                 "insert_after":"skill",
                 "in_list_view": 1
@@ -3779,6 +3803,7 @@ def get_skill_assessment_custom_fields():
                 "label": "Weight",
                 "insert_after":"remarks"
             }
+
         ]
     }
 


### PR DESCRIPTION
## Feature description
- [ ] Add a field for Job Applicant Email id in Interview doctype & make it hidden
- [ ] Hide the 'Mark as Accepted' message that appears after submitting interview

## Analysis and design (optional)

Added a field for Job Applicant Email id in Interview doctype & made it hidden.
Hidden  'Mark as Accepted' message that appears after submitting interview.
Modified Score field as Score (Out of 10) in feedback dialog box.

## Areas affected and ensured
Interview doctype
Job Applicant doctype

## Is there any existing behavior change of other features due to this code change?
       No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
