### PR TITLE
feat: Create Doctype Finance Group

### DIFF
--- a/beams/beams/custom_scripts/budget/budget.js
+++ b/beams/beams/custom_scripts/budget/budget.js
@@ -84,7 +84,8 @@ function set_filters(frm) {
     frm.set_query('department', function () {
         return {
             filters: {
-                company: frm.doc.company
+                company: frm.doc.company,
+                finance_group: frm.doc.finance_group
             }
         };
     });

--- a/beams/beams/doctype/finance_group/finance_group.js
+++ b/beams/beams/doctype/finance_group/finance_group.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, efeone and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Finance Group", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/beams/beams/doctype/finance_group/finance_group.json
+++ b/beams/beams/doctype/finance_group/finance_group.json
@@ -1,0 +1,44 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:finance_group",
+ "creation": "2025-03-05 10:56:14.289286",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "finance_group"
+ ],
+ "fields": [
+  {
+   "fieldname": "finance_group",
+   "fieldtype": "Data",
+   "label": "Finance Group",
+   "unique": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2025-03-05 10:57:25.327813",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "Finance Group",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/beams/beams/doctype/finance_group/finance_group.py
+++ b/beams/beams/doctype/finance_group/finance_group.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class FinanceGroup(Document):
+	pass

--- a/beams/beams/doctype/finance_group/test_finance_group.py
+++ b/beams/beams/doctype/finance_group/test_finance_group.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, efeone and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestFinanceGroup(FrappeTestCase):
+	pass

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -564,6 +564,13 @@ def get_department_custom_fields():
                 "fieldtype": "Float",
                 "label": "Threshold Amount",
                 "insert_after": "parent_department"
+            },
+            {
+                "fieldname": "finance_group",
+                "fieldtype": "Link",
+                "label": "Finance Group",
+                "options":"Finance Group",
+                "insert_after": "company"
             }
         ]
     }
@@ -706,7 +713,7 @@ def get_budget_custom_fields():
                 "label": "Department",
                 "options":"Department",
                 "reqd": 1,
-                "insert_after": "company"
+                "insert_after": "finance_group"
             },
             {
                 "fieldname": "division",
@@ -744,6 +751,14 @@ def get_budget_custom_fields():
                 "label": "Total Amount",
                 "read_only": 1,
                 "insert_after": "region"
+            },
+            {
+                "fieldname": "finance_group",
+                "fieldtype": "Link",
+                "label": "Finance Group",
+                "options":"Finance Group",
+                "reqd": 1,
+                "insert_after": "company"
             },
         ],
         "Budget Account": [


### PR DESCRIPTION
## Feature description
- Create doctype Finance group.
- Add Finance group in Department and Budget.

## Solution description
- Created Finance Group doctype.
- Added Finance Group In budget and department.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/55e29053-0e78-4266-8120-b47ad0c452ed)

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox