### PR TITLE
    TASK-2025-00309:validation for Question Assessment in Interview Feedback

### DIFF
--- a/beams/beams/custom_scripts/interview/interview.js
+++ b/beams/beams/custom_scripts/interview/interview.js
@@ -73,13 +73,11 @@ frappe.ui.form.on('Interview', {
             if (frm.doc.scheduled_on && frm.doc.scheduled_on < today) {
                 frappe.throw(__("Interview date cannot be in the past."));
             }
-
             if (to_time <= from_time) {
                 frappe.throw(__("End Time (To Time) must be greater than Start Time (From Time)."));
             }
         }
     },
-
 
     show_custom_feedback_dialog: function (frm, data, question_data, feedback_exists) {
         let fields = frm.events.get_fields_for_custom_feedback();
@@ -182,8 +180,6 @@ frappe.ui.form.on('Interview', {
             }
         });
     },
-
-
 
     get_fields_for_questions: function () {
         return [

--- a/beams/beams/custom_scripts/interview/interview.js
+++ b/beams/beams/custom_scripts/interview/interview.js
@@ -67,19 +67,19 @@ frappe.ui.form.on('Interview', {
             // Convert time strings into Date objects for proper comparison
             let from_time = new Date(`${scheduled_on}T${frm.doc.from_time}`);
             let to_time = new Date(`${scheduled_on}T${frm.doc.to_time}`);
-            
+
             let today = frappe.datetime.get_today();
 
             if (frm.doc.scheduled_on && frm.doc.scheduled_on < today) {
                 frappe.throw(__("Interview date cannot be in the past."));
             }
-            
+
             if (to_time <= from_time) {
                 frappe.throw(__("End Time (To Time) must be greater than Start Time (From Time)."));
             }
         }
     },
-    
+
 
     show_custom_feedback_dialog: function (frm, data, question_data, feedback_exists) {
         let fields = frm.events.get_fields_for_custom_feedback();
@@ -164,8 +164,26 @@ frappe.ui.form.on('Interview', {
                 }
                 skill_grid.refresh();
             });
+
+            if (d.fields_dict.questions) {
+                let question_grid = d.fields_dict.questions.grid;
+                question_grid.wrapper.on('change', 'input[data-fieldname="score"]', function () {
+                    let row = question_grid.get_selected();
+                    if (!row) return;
+
+                    let value = parseFloat($(this).val()) || 0;
+                    if (value > 10) {
+                        frappe.msgprint(__('Score cannot be greater than 10'));
+                    } else if (value < 0) {
+                        frappe.msgprint(__('Score cannot be less than 0'));
+                    }
+                    question_grid.refresh();
+                });
+            }
         });
     },
+
+
 
     get_fields_for_questions: function () {
         return [

--- a/beams/beams/custom_scripts/interview_feedback/interview_feedback.py
+++ b/beams/beams/custom_scripts/interview_feedback/interview_feedback.py
@@ -19,6 +19,14 @@ def validate(doc, method):
             rating = float(row.score) / 10
         row.rating = rating
 
+    for row in doc.interview_question_result:
+        rating = 0
+        if row.score:
+            if row.score > 10 or row.score < 0:
+                frappe.throw(_("Score for question {0} must be a number between 0 and 10.").format(frappe.bold(row.question)))
+            rating = float(row.score) / 10
+        row.rating = rating
+
 def on_interview_feedback_creation(doc):
     '''
         Update the Job Applicant's status to 'Interview Ongoing'


### PR DESCRIPTION
## Feature description
   -Add validation for questions table 

## Solution description
   - Validate that the score in the `questions` table is between 0 and 10.  
   - Ensure `rating` is calculated as `score / 10`, similar to `skill_assessment`.  
   - Raise an error if an invalid score is entered.  

## Output screenshots (optional)

![image](https://github.com/user-attachments/assets/5619fd86-789d-4332-ac35-e5db48dcae83)

![image](https://github.com/user-attachments/assets/1f468446-b9b9-479f-bd1b-c0a4a9c106fb)


## Areas affected and ensured
   -Interview Doctype
   -Interview Feedback Doctype

## Is there any existing behavior change of other features due to this code change
    -No.

## Was this feature tested on the browsers?
   - Mozilla Firefox
 