### PR TITLE
TASK-2025-00313:validation for to_date in the Attendance Request doctype

### DIFF
--- a/beams/beams/custom_scripts/attendance_request/attendance_request.py
+++ b/beams/beams/custom_scripts/attendance_request/attendance_request.py
@@ -2,6 +2,7 @@ import frappe
 from frappe import _
 from frappe.utils import format_date, get_link_to_form
 from hrms.hr.doctype.attendance_request.attendance_request import AttendanceRequest
+from frappe.utils import today
 
 
 class AttendanceRequestOverride(AttendanceRequest):
@@ -138,8 +139,12 @@ def get_checkin_time(employee, checkout_record):
 	return checkin_time
 
 
-
-
-
-
-
+@frappe.whitelist()
+def validate_to_date(doc, method):
+    """
+    Validates that the 'to_date' field in the Attendance Regularisation doctype
+    is not set to a future date.
+    """
+    if doc.to_date:
+        if doc.to_date > today():
+            frappe.throw(_("To Date cannot be a Future date"))

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -327,7 +327,10 @@ doc_events = {
     },
     "Budget":{
         "validate":"beams.beams.custom_scripts.budget.budget.update_total_amount"
-    },
+     },
+    "Attendance Request":{
+        "before_save":"beams.beams.custom_scripts.attendance_request.attendance_request.validate_to_date"
+    }
 }
 
 # Scheduled Tasks


### PR DESCRIPTION
## Feature description
Need a validation for the to_date in attendance request doctype


## Solution description
- applied validation that if to_date is cannot be future date always today or before 

## Output screenshots (optional)

![image](https://github.com/user-attachments/assets/2c927e8f-2cff-4969-8ed4-596007e2af1d)

## Areas affected and ensured
Attendence regularisation doectype

## Is there any existing behavior change of other features due to this code change?
 No.
## Was this feature tested on the browsers?
  
  - Mozilla Firefox
 
