### PR TITLE
feat:Added validation for Offer Dates.

### DIFF
--- a/beams/beams/custom_scripts/employee/employee.py
+++ b/beams/beams/custom_scripts/employee/employee.py
@@ -174,14 +174,6 @@ def validate_offer_dates(doc, method):
 
     today_date = getdate(today())
 
-    # Ensure Offer Date is in the future
-    if doc.scheduled_confirmation_date and getdate(doc.scheduled_confirmation_date) < today_date:
-        frappe.throw(_("Offer Date must be a future date."))
-
-    # Ensure  Confirmation Date is in the future
-    if doc.final_confirmation_date and getdate(doc.final_confirmation_date) < today_date:
-        frappe.throw(_("Confirmation Date must be a future date."))
-
     # Ensure Final Confirmation Date is after Scheduled Confirmation Date
     if doc.scheduled_confirmation_date and doc.final_confirmation_date:
         if getdate(doc.final_confirmation_date) <= getdate(doc.scheduled_confirmation_date):

--- a/beams/beams/custom_scripts/employee/employee.py
+++ b/beams/beams/custom_scripts/employee/employee.py
@@ -3,7 +3,8 @@ from frappe import _
 from frappe.model.naming import make_autoname
 from frappe.model.naming import set_name_by_naming_series
 from frappe.model.mapper import get_mapped_doc
-from frappe.utils import getdate, nowdate, add_days
+from frappe.utils import getdate, nowdate, add_days,today
+
 
 @frappe.whitelist()
 def create_event(employee_id=None, hod_user=None, target_doc=None):
@@ -166,3 +167,22 @@ def get_next_employee_id(department_abbr):
         employee_count = int(employee_id)
         next_employee_id = '{0}{1}'.format(series_prefix, str(employee_count+1))
     return next_employee_id
+
+
+def validate_offer_dates(doc, method):
+    """Validate Employee fields before saving/submitting."""
+
+    today_date = getdate(today())
+
+    # Ensure Offer Date is in the future
+    if doc.scheduled_confirmation_date and getdate(doc.scheduled_confirmation_date) < today_date:
+        frappe.throw(_("Offer Date must be a future date."))
+
+    # Ensure  Confirmation Date is in the future
+    if doc.final_confirmation_date and getdate(doc.final_confirmation_date) < today_date:
+        frappe.throw(_("Confirmation Date must be a future date."))
+
+    # Ensure Final Confirmation Date is after Scheduled Confirmation Date
+    if doc.scheduled_confirmation_date and doc.final_confirmation_date:
+        if getdate(doc.final_confirmation_date) <= getdate(doc.scheduled_confirmation_date):
+            frappe.throw(_("Confirmation Date must be after Offer Date."))

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -266,7 +266,10 @@ doc_events = {
     "Employee" : {
         "autoname": "beams.beams.custom_scripts.employee.employee.autoname",
         "after_insert": "beams.beams.custom_scripts.employee.employee.after_insert",
-        "validate": "beams.beams.custom_scripts.employee.employee.validate"
+        "validate":  [
+            "beams.beams.custom_scripts.employee.employee.validate",
+            "beams.beams.custom_scripts.employee.employee.validate_offer_dates"
+        ],
     },
     "Job Offer" : {
         "on_submit":"beams.beams.custom_scripts.job_offer.job_offer.make_employee"


### PR DESCRIPTION
## Feature description
This Feature validates Offer Date and Confirmation Date such that both these field cannot past date values and also offer date cannot be after Confirmation Date.

## Analysis and design (optional)
Server-side validation to the Employee doctype, ensuring:

-Offer Date must be a future date.
-Confirmation Date must be a future date.
- Confirmation Date must be after Offer Date.

This prevents incorrect or past dates from being saved, ensuring data consistency.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/13d29aff-25f7-468f-bc95-fa71e3936929)
![image](https://github.com/user-attachments/assets/3718f646-e8b4-452b-98a0-5dcc25d028f7)
![image](https://github.com/user-attachments/assets/1286da1f-7fa2-4266-b68b-adc2078f4a68)



## Areas affected and ensured
Employee doctype.

## Is there any existing behavior change of other features due to this code change?
     No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox

