### PR TITLE
feat: make posting date read only in shift swap request

### DIFF
--- a/beams/beams/doctype/shift_swap_request/shift_swap_request.json
+++ b/beams/beams/doctype/shift_swap_request/shift_swap_request.json
@@ -33,6 +33,7 @@
    "fieldtype": "Date",
    "in_list_view": 1,
    "label": "Posting Date",
+   "read_only": 1,
    "reqd": 1
   },
   {
@@ -129,7 +130,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-02-06 10:54:36.961648",
+ "modified": "2025-03-05 16:29:17.794563",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Shift Swap Request",


### PR DESCRIPTION
## Feature description
make posting field read only to prevent entering future dates
## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description
Describe your code changes in detail for reviewers.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/3f81263d-d435-4428-a98d-914dfe74eebf)

## Areas affected and ensured
shift swap request
## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
