### PR TITLE
TASK-2025-00320:Applied filter for Swapping Employee in Shift Swap Request

### DIFF
--- a/beams/beams/doctype/shift_swap_request/shift_swap_request.js
+++ b/beams/beams/doctype/shift_swap_request/shift_swap_request.js
@@ -7,11 +7,14 @@ frappe.ui.form.on('Shift Swap Request', {
         frm.fields_dict['swap_with_employee'].get_query = function(doc, cdt, cdn) {
             return {
                 filters: {
-                    'department': doc.department // Filter employees based on the department field
+                    'department': doc.department,// Filter employees based on the department field
+                    'name': ['!=', doc.employee] // Prevent selecting the same employee
+
                 }
             };
         };
     },
+  
     onload: function (frm) {
       // Only fetch employee if the field is not set
       if (!frm.doc.employee) {


### PR DESCRIPTION
## Feature description
Apply filter for Swapping Employee in Shift Swap Request as the same employee cannot be selected.

## Solution description

- Added a filter to exclude the current employee from the employee swap options.
- This ensures that users cannot select themselves as the swap partner.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/7baabc66-d3f8-43e6-90b5-74c54f2f51ca)

## Areas affected and ensured
Shift Swap Request

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  
