### PR TITLE
feat:Exclude active employees with onboarding from job applicant field

### DIFF
--- a/beams/beams/custom_scripts/employee_onboarding/employee_onboarding.js
+++ b/beams/beams/custom_scripts/employee_onboarding/employee_onboarding.js
@@ -36,19 +36,19 @@ frappe.ui.form.on('Employee Onboarding', {
             }
         });
 
-        // Fetch excluded job applicants and set filter for job_applicant field
         frappe.call({
-            method: "beams.beams.custom_scripts.employee_onboarding.employee_onboarding.get_job_applicants_with_employee_and_onboarding",
+            method: "beams.beams.custom_scripts.employee_onboarding.employee_onboarding.get_excluded_job_applicants",
             callback: function (r) {
                 if (r.message) {
                     let excluded_applicants = r.message;
-                    frm.fields_dict["job_applicant"].get_query = function () {
+
+                    frm.set_query("job_applicant", function () {
                         return {
                             filters: {
                                 name: ["not in", excluded_applicants]
                             }
                         };
-                    };
+                    });
                 }
             }
         });

--- a/beams/beams/custom_scripts/employee_onboarding/employee_onboarding.py
+++ b/beams/beams/custom_scripts/employee_onboarding/employee_onboarding.py
@@ -51,19 +51,22 @@ def get_employee_details(employee_id):
         }
 
 @frappe.whitelist()
-def get_job_applicants_with_employee_and_onboarding():
-    job_applicants_with_employees = frappe.get_all(
+def get_excluded_job_applicants():
+    # Get job applicants linked to active employees
+    job_applicants_with_active_employees = frappe.get_all(
         "Employee",
-        filters={"job_applicant": ["!=", ""]},
+        filters={"status": "Active", "job_applicant": ["!=", ""]},
         pluck="job_applicant"
     )
 
+    # Get job applicants linked to Employee Onboarding (excluding canceled)
     job_applicants_with_onboarding = frappe.get_all(
         "Employee Onboarding",
         filters={"docstatus": ["!=", 2]},
         pluck="job_applicant"
     )
 
-    excluded_applicants = list(set(job_applicants_with_employees + job_applicants_with_onboarding))
+    # Get applicants who satisfy **both** conditions
+    excluded_applicants = list(set(job_applicants_with_active_employees) & set(job_applicants_with_onboarding))
 
     return excluded_applicants if excluded_applicants else []


### PR DESCRIPTION
## Feature description
     -Incorrect filter on Employee onboarding
     -exclude active employees with onboarding from job applicant field

## Solution description
     -Updated filtering logic to exclude job applicants who are linked to active employees and have an Employee Onboarding record.
     -Ensured that other job applicants remain visible in the dropdown.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/3c2ed711-16cd-4875-bfb1-220c373b159a)
![image](https://github.com/user-attachments/assets/343df39a-6fd0-4972-9d3b-c69c3235ee0f)
![image](https://github.com/user-attachments/assets/29ea97f1-5bf4-4b54-a7ca-f227de4b80fc)


## Is there any existing behavior change of other features due to this code change?
      -No

## Was this feature tested on the browsers?
     -Mozilla Firefox
  