### PR TITLE
    TASK-2025-00331:Validation in ctc in the job offer doctype

### DIFF
--- a/beams/beams/custom_scripts/job_offer/job_offer.js
+++ b/beams/beams/custom_scripts/job_offer/job_offer.js
@@ -22,6 +22,12 @@ frappe.ui.form.on("Job Offer", {
             });
         }
     },
+    validate: function(frm) {
+        if (frm.doc.ctc < 0) {
+            frappe.msgprint(__('CTC cannot be a Negative Value'));
+            frappe.validated = false
+        }
+    }
 });
 
 function make_employee(frm) {

--- a/beams/beams/custom_scripts/job_offer/job_offer.py
+++ b/beams/beams/custom_scripts/job_offer/job_offer.py
@@ -84,4 +84,4 @@ def validate_ctc(doc,method):
         Validate that the  CTC value is not negative.
         """
         if doc.ctc < 0:
-            frappe.throw(" CTC cannot be a Negative Value")
+            frappe.throw("CTC cannot be a Negative Value")

--- a/beams/beams/custom_scripts/job_offer/job_offer.py
+++ b/beams/beams/custom_scripts/job_offer/job_offer.py
@@ -8,7 +8,7 @@ def make_employee(source_name, target_doc=None):
         email, name = frappe.db.get_value(
             "Job Applicant", source.job_applicant, ["email_id", "applicant_name"]
         ) or (None, None)
-        
+
         if email:
             target.personal_email = email
         if name:
@@ -28,7 +28,7 @@ def make_employee(source_name, target_doc=None):
     else:
         target_doc = {}
 
-    
+
     try:
         doc = get_mapped_doc(
             "Job Offer",
@@ -46,14 +46,14 @@ def make_employee(source_name, target_doc=None):
             set_missing_values,
         )
 
-        
+
         job_offer = frappe.get_doc("Job Offer", source_name)
-        
+
         # Only proceed if Job Applicant exists
         if job_offer.job_applicant:
             applicant_data = frappe.get_doc("Job Applicant", job_offer.job_applicant)
-            
-            
+
+
             mapping = {
                 "gender": applicant_data.get("gender"),
                 "date_of_birth": applicant_data.get("date_of_birth"),
@@ -76,3 +76,12 @@ def make_employee(source_name, target_doc=None):
     except Exception as e:
         frappe.log_error(message=f"Error in make_employee: {str(e)}")
         frappe.throw(f"An error occurred while creating employee: {str(e)}")
+
+
+@frappe.whitelist()
+def validate_ctc(doc,method):
+        """
+        Validate that the  CTC value is not negative.
+        """
+        if doc.ctc < 0:
+            frappe.throw(" CTC cannot be a Negative Value")

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -272,7 +272,8 @@ doc_events = {
         ],
     },
     "Job Offer" : {
-        "on_submit":"beams.beams.custom_scripts.job_offer.job_offer.make_employee"
+        "on_submit":"beams.beams.custom_scripts.job_offer.job_offer.make_employee",
+        "validate":"beams.beams.custom_scripts.job_offer.job_offer.validate_ctc"
     },
     "Employee Separation": {
         "on_submit": "beams.beams.custom_scripts.employee_separation.employee_separation.create_exit_clearance"


### PR DESCRIPTION
## Feature description
- Need to apply validation on the field ctc in the job offer doctype

## Solution description

-Applied validation on the field ctc where cannot be save a  Negative Value in job offer doctype via hooks.py and job offer.py job offer.js

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/8b74b2ee-be9a-45a2-9eaa-98c84b54e5d9)
![image](https://github.com/user-attachments/assets/b94e7feb-dd2e-40f0-b0db-139f74102004)


## Areas affected and ensured
job offer doctype

## Is there any existing behavior change of other features due to this code change?
No. 

## Was this feature tested on the browsers?
 
  - Mozilla Firefox
