### PR TITLE
feat:     TASK-2025-00330 - Apply filter in Training feedback

### DIFF
--- a/beams/beams/custom_scripts/training_feedback/training_feedback.js
+++ b/beams/beams/custom_scripts/training_feedback/training_feedback.js
@@ -1,0 +1,16 @@
+frappe.ui.form.on("Training Feedback", {
+    training_event: function(frm) {
+        if (!frm.doc.training_event) {
+            frm.set_query("employee", () => ({}));
+            frm.set_value("employee", "");
+            frm.refresh_field("employee");
+            return;
+        }
+
+        frappe.db.get_doc("Training Event", frm.doc.training_event).then(event => {
+            let employee_list = (event.employees || []).map(emp => emp.employee);
+            frm.set_query("employee", () => ({ filters: { name: ["in", employee_list] } }));
+            frm.refresh_field("employee");
+        });
+    }
+});

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -58,7 +58,8 @@ doctype_js = {
     "Job Offer": "beams/custom_scripts/job_offer/job_offer.js",
     "Appraisal":"beams/custom_scripts/appraisal/appraisal.js",
     "Project":"beams/custom_scripts/project/project.js",
-    "Asset Movement":"beams/custom_scripts/asset_movement/asset_movement.js"
+    "Asset Movement":"beams/custom_scripts/asset_movement/asset_movement.js",
+    "Training Feedback":"beams/custom_scripts/training_feedback/training_feedback.js"
 }
 doctype_list_js = {
     "Sales Invoice" : "beams/custom_scripts/sales_invoice/sales_invoice_list.js",


### PR DESCRIPTION
## Feature description
Apply filter in Training feedback

## Solution description
- When the Training Event is Cleared

      - The Employee filter is reset (shows all employees).
      - The Employee field is cleared to avoid invalid selections.
- When a Training Event is Selected

- The script fetches employee records from the selected Training Event using frappe.db.get_doc().
    - Extract the Employee IDs from the child table (employees).
     - A filter is applied to show only those employees in the dropdown.

## Out
[Screencast from 07-03-25 12:39:41 PM IST.webm](https://github.com/user-attachments/assets/97eba90e-cbb3-4566-9ae8-0e446f3e44d5)
put screenshots (optional)


## Areas affected and ensured
List out the areas affected by your code changes.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - Yes
  - Opera Mini
  - Safari
