### PR TITLE
fix:Refactor status options by removing 'Pending Document Upload

### DIFF
--- a/beams/beams/custom_scripts/job_applicant/job_applicant.js
+++ b/beams/beams/custom_scripts/job_applicant/job_applicant.js
@@ -249,7 +249,7 @@ frappe.ui.form.on('Job Applicant', {
         const magic_link_statuses  = [
             'Interview Completed', 'Local Enquiry Approved', 'Selected',
             'Job Proposal Created', 'Job Proposal Accepted',
-            'Interview Scheduled', 'Interview Ongoing', 'Pending Document Upload'
+            'Interview Scheduled', 'Interview Ongoing'
         ];
 
         if (magic_link_statuses.includes(frm.doc.status)) {


### PR DESCRIPTION
## Feature description
Update interview status options

## Solution description
Show 'Send Magic Link' button after Pending document upload

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/abab66c1-48b5-4ed5-aa3e-33575526e579)

## Areas affected and ensured
Job Applicant Doctype

## Is there any existing behavior change of other features due to this code change?
 Yes 

## Was this feature tested on the browsers?
 
  Mozilla Firefox
 

