### PR TITLE
TASK-2025-00335:Hide the button when status become completed in Training Event doctype

### DIFF
--- a/beams/beams/custom_scripts/employee/employee.js
+++ b/beams/beams/custom_scripts/employee/employee.js
@@ -43,54 +43,53 @@ frappe.ui.form.on('Employee', {
           frm.set_value('leave_approver', '');
       }
   },
-  refresh: function(frm) {
+  refresh: function(frm){
     if (!frm.is_new() && frappe.user.has_role('HR Manager')) { // Adds the custom button 'Training Request' in the 'Create' section
-      frm.add_custom_button('Training Request', function() {
-        // Call the server-side function to fetch the employee ID for the current user
-        frappe.call({
-          method: "beams.beams.custom_scripts.employee.employee.get_employee_name_for_user",
-          args: {
-            user_id: frappe.session.user
-          },
-          callback: function(response) {
-            if (response.message) {
-              // If employee ID is found, create a new 'Training Request' document
-              frappe.new_doc('Training Request', {
-                employee: frm.doc.name,
-                training_requested_by: response.message // Set training_requested_by to the fetched employee ID
-              });
-            } else {
+		// Check if employee name exists for the logged-in user and add 'Event' button if available
+				frappe.call({
+					method: "beams.beams.custom_scripts.employee.employee.get_employee_name_for_user",
+					args: {
+						user_id: frappe.session.user
+					},
+					callback: function(response) {
+						if (response.message) {
+							frm.add_custom_button(__('Event'), function() {
+								frappe.model.open_mapped_doc({
+									method: "beams.beams.custom_scripts.employee.employee.create_event",
+									frm: frm,
+									args: {
+										"employee_id": frm.doc.name,
+										"hod_user": frappe.session.user
+									}
+								});
+							}, __('Create'));
 
-              // Show a message if no employee record is found for the user
-              frappe.msgprint(__('No employee record found for the current user.'));
-            }
-          }
-        });
-      }, 'Create');
+				      frm.add_custom_button('Training Request', function() {
+				        // Call the server-side function to fetch the employee ID for the current user
+				        frappe.call({
+				          method: "beams.beams.custom_scripts.employee.employee.get_employee_name_for_user",
+				          args: {
+				            user_id: frappe.session.user
+				          },
+				          callback: function(response) {
+				            if (response.message) {
+				              // If employee ID is found, create a new 'Training Request' document
+				              frappe.new_doc('Training Request', {
+				                employee: frm.doc.name,
+				                training_requested_by: response.message // Set training_requested_by to the fetched employee ID
+				              });
+				            } else {
 
-
-      // Check if employee name exists for the logged-in user and add 'Event' button if available
-      frappe.call({
-        method: "beams.beams.custom_scripts.employee.employee.get_employee_name_for_user",
-        args: {
-          user_id: frappe.session.user
-        },
-        callback: function(response) {
-          if (response.message) {
-            frm.add_custom_button(__('Event'), function() {
-              frappe.model.open_mapped_doc({
-                method: "beams.beams.custom_scripts.employee.employee.create_event",
-                frm: frm,
-                args: {
-                  "employee_id": frm.doc.name,
-                  "hod_user": frappe.session.user
-                }
-              });
-            }, __('Create'));
-          }
-        }
-      });
-    }
+				              // Show a message if no employee record is found for the user
+				              frappe.msgprint(__('No employee record found for the current user.'));
+				            }
+				          }
+				        });
+				      }, 'Create');
+						}
+					}
+    	});
+		}
   },
   employment_type: function(frm) {
     frappe.call({

--- a/beams/beams/custom_scripts/employee/employee.js
+++ b/beams/beams/custom_scripts/employee/employee.js
@@ -1,113 +1,113 @@
 frappe.ui.form.on('Employee', {
-  /**
-  * Adds a custom button 'Training Request' for users with 'HOD' role
-  * This button creates a new 'Training Request' document.
-  */
+	/**
+	* Adds a custom button 'Training Request' for users with 'HOD' role
+	* This button creates a new 'Training Request' document.
+	*/
 	job_applicant: function (frm) {
-	    if (frm.doc.job_applicant) {
-	        // Fetch Job Applicant data using frappe.db.get_doc
-	        frappe.db.get_doc('Job Applicant', frm.doc.job_applicant)
-	            .then(job_applicant => {
-	                // Map fields from Job Applicant to Employee
-	                frm.set_value('first_name', job_applicant.applicant_name);
-	                frm.set_value('date_of_birth', job_applicant.date_of_birth);
-	                frm.set_value('gender', job_applicant.gender);
-	                frm.set_value('cell_number', job_applicant.phone_number);
-	                frm.set_value('name_of_father_or_spouse', job_applicant.father_name);
-	                frm.set_value('designation', job_applicant.designation);
-	                frm.set_value('department', job_applicant.department);
-	                frm.set_value('current_address', job_applicant.current_address);
-	                frm.set_value('permanent_address', job_applicant.permanent_address);
-	                frm.set_value('marital_status', job_applicant.marital_status);
+		if (frm.doc.job_applicant) {
+			// Fetch Job Applicant data using frappe.db.get_doc
+			frappe.db.get_doc('Job Applicant', frm.doc.job_applicant)
+			.then(job_applicant => {
+				// Map fields from Job Applicant to Employee
+				frm.set_value('first_name', job_applicant.applicant_name);
+				frm.set_value('date_of_birth', job_applicant.date_of_birth);
+				frm.set_value('gender', job_applicant.gender);
+				frm.set_value('cell_number', job_applicant.phone_number);
+				frm.set_value('name_of_father_or_spouse', job_applicant.father_name);
+				frm.set_value('designation', job_applicant.designation);
+				frm.set_value('department', job_applicant.department);
+				frm.set_value('current_address', job_applicant.current_address);
+				frm.set_value('permanent_address', job_applicant.permanent_address);
+				frm.set_value('marital_status', job_applicant.marital_status);
 
-	                frm.refresh_fields();
-	            });
-	    }
+				frm.refresh_fields();
+			});
+		}
 	},
-  reports_to: function(frm) {
-      if (frm.doc.reports_to) {
-					frappe.db.get_value('Employee', frm.doc.reports_to, 'user_id')
-					.then(r => {
-							if (r.message.user_id) {
-									reports_to_user = r.message.user_id
-									frm.set_value('expense_approver', reports_to_user);
-									frm.set_value('shift_request_approver', reports_to_user);
-									frm.set_value('leave_approver', reports_to_user);
-							}
-					})
-      }
-   else {
-          // Clear approver fields if 'reports_to' is empty
-          frm.set_value('expense_approver', '');
-          frm.set_value('shift_request_approver', '');
-          frm.set_value('leave_approver', '');
-      }
-  },
-  refresh: function(frm){
-    if (!frm.is_new() && frappe.user.has_role('HR Manager')) { // Adds the custom button 'Training Request' in the 'Create' section
+	reports_to: function(frm) {
+		if (frm.doc.reports_to) {
+			frappe.db.get_value('Employee', frm.doc.reports_to, 'user_id')
+			.then(r => {
+				if (r.message.user_id) {
+					reports_to_user = r.message.user_id
+					frm.set_value('expense_approver', reports_to_user);
+					frm.set_value('shift_request_approver', reports_to_user);
+					frm.set_value('leave_approver', reports_to_user);
+				}
+			})
+		}
+		else {
+			// Clear approver fields if 'reports_to' is empty
+			frm.set_value('expense_approver', '');
+			frm.set_value('shift_request_approver', '');
+			frm.set_value('leave_approver', '');
+		}
+	},
+	refresh: function(frm){
+		if (!frm.is_new() && frappe.user.has_role('HR Manager')) { // Adds the custom button 'Training Request' in the 'Create' section
 		// Check if employee name exists for the logged-in user and add 'Event' button if available
-			frappe.call(		{
-				method: "beams.beams.custom_scripts.employee.employee.get_employee_name_for_user",
-				args: {
-					user_id: frappe.session.user
-				},
-				callback: function(response) {
-					if (response.message) {
-						frm.add_custom_button(__('Event'), function() {
-							frappe.model.open_mapped_doc({
-								method: "beams.beams.custom_scripts.employee.employee.create_event",
-								frm: frm,
-								args: {
-									"employee_id": frm.doc.name,
-									"hod_user": frappe.session.user
+		frappe.call(		{
+			method: "beams.beams.custom_scripts.employee.employee.get_employee_name_for_user",
+			args: {
+				user_id: frappe.session.user
+			},
+			callback: function(response) {
+				if (response.message) {
+					frm.add_custom_button(__('Event'), function() {
+						frappe.model.open_mapped_doc({
+							method: "beams.beams.custom_scripts.employee.employee.create_event",
+							frm: frm,
+							args: {
+								"employee_id": frm.doc.name,
+								"hod_user": frappe.session.user
+							}
+						});
+					}, __('Create'));
+
+					frm.add_custom_button('Training Request', function() {
+						// Call the server-side function to fetch the employee ID for the current user
+						frappe.call({
+							method: "beams.beams.custom_scripts.employee.employee.get_employee_name_for_user",
+							args: {
+								user_id: frappe.session.user
+							},
+							callback: function(response) {
+								if (response.message) {
+									// If employee ID is found, create a new 'Training Request' document
+									frappe.new_doc('Training Request', {
+										employee: frm.doc.name,
+										training_requested_by: response.message // Set training_requested_by to the fetched employee ID
+									});
+								} else {
+
+									// Show a message if no employee record is found for the user
+									frappe.msgprint(__('No employee record found for the current user.'));
 								}
-							});
-						}, __('Create'));
-
-			      frm.add_custom_button('Training Request', function() {
-			        // Call the server-side function to fetch the employee ID for the current user
-			        frappe.call({
-			          method: "beams.beams.custom_scripts.employee.employee.get_employee_name_for_user",
-			          args: {
-			            user_id: frappe.session.user
-			          },
-			          callback: function(response) {
-			            if (response.message) {
-			              // If employee ID is found, create a new 'Training Request' document
-			              frappe.new_doc('Training Request', {
-			                employee: frm.doc.name,
-			                training_requested_by: response.message // Set training_requested_by to the fetched employee ID
-			              });
-			            } else {
-
-		              // Show a message if no employee record is found for the user
-		              frappe.msgprint(__('No employee record found for the current user.'));
-		            }
-		          }
-		        });
-		      }, 'Create');
+							}
+						});
+					}, 'Create');
 				}
 			}
-					});
-		}
-  },
-  employment_type: function(frm) {
-    frappe.call({
-      method: "beams.beams.custom_scripts.employee.employee.get_notice_period",
-      args: {
-        employment_type: frm.doc.employment_type,
-        job_applicant: frm.doc.job_applicant
-      },
-      callback: function(response) {
-        if (response.message !== undefined && response.message !== null) {
-          // Update the notice period if it's different or currently None/empty
-          if (response.message !== frm.doc.notice_number_of_days) {
-            frm.set_value('notice_number_of_days', response.message);
-            frm.refresh_field('notice_number_of_days');
-          }
-        }
-      },
+		});
+	}
+},
+employment_type: function(frm) {
+	frappe.call({
+		method: "beams.beams.custom_scripts.employee.employee.get_notice_period",
+		args: {
+			employment_type: frm.doc.employment_type,
+			job_applicant: frm.doc.job_applicant
+		},
+		callback: function(response) {
+			if (response.message !== undefined && response.message !== null) {
+				// Update the notice period if it's different or currently None/empty
+				if (response.message !== frm.doc.notice_number_of_days) {
+					frm.set_value('notice_number_of_days', response.message);
+					frm.refresh_field('notice_number_of_days');
+				}
+			}
+		},
 
-    });
-  }
+	});
+}
 });

--- a/beams/beams/custom_scripts/employee/employee.js
+++ b/beams/beams/custom_scripts/employee/employee.js
@@ -46,49 +46,49 @@ frappe.ui.form.on('Employee', {
   refresh: function(frm){
     if (!frm.is_new() && frappe.user.has_role('HR Manager')) { // Adds the custom button 'Training Request' in the 'Create' section
 		// Check if employee name exists for the logged-in user and add 'Event' button if available
-				frappe.call({
-					method: "beams.beams.custom_scripts.employee.employee.get_employee_name_for_user",
-					args: {
-						user_id: frappe.session.user
-					},
-					callback: function(response) {
-						if (response.message) {
-							frm.add_custom_button(__('Event'), function() {
-								frappe.model.open_mapped_doc({
-									method: "beams.beams.custom_scripts.employee.employee.create_event",
-									frm: frm,
-									args: {
-										"employee_id": frm.doc.name,
-										"hod_user": frappe.session.user
-									}
-								});
-							}, __('Create'));
+			frappe.call(		{
+				method: "beams.beams.custom_scripts.employee.employee.get_employee_name_for_user",
+				args: {
+					user_id: frappe.session.user
+				},
+				callback: function(response) {
+					if (response.message) {
+						frm.add_custom_button(__('Event'), function() {
+							frappe.model.open_mapped_doc({
+								method: "beams.beams.custom_scripts.employee.employee.create_event",
+								frm: frm,
+								args: {
+									"employee_id": frm.doc.name,
+									"hod_user": frappe.session.user
+								}
+							});
+						}, __('Create'));
 
-				      frm.add_custom_button('Training Request', function() {
-				        // Call the server-side function to fetch the employee ID for the current user
-				        frappe.call({
-				          method: "beams.beams.custom_scripts.employee.employee.get_employee_name_for_user",
-				          args: {
-				            user_id: frappe.session.user
-				          },
-				          callback: function(response) {
-				            if (response.message) {
-				              // If employee ID is found, create a new 'Training Request' document
-				              frappe.new_doc('Training Request', {
-				                employee: frm.doc.name,
-				                training_requested_by: response.message // Set training_requested_by to the fetched employee ID
-				              });
-				            } else {
+			      frm.add_custom_button('Training Request', function() {
+			        // Call the server-side function to fetch the employee ID for the current user
+			        frappe.call({
+			          method: "beams.beams.custom_scripts.employee.employee.get_employee_name_for_user",
+			          args: {
+			            user_id: frappe.session.user
+			          },
+			          callback: function(response) {
+			            if (response.message) {
+			              // If employee ID is found, create a new 'Training Request' document
+			              frappe.new_doc('Training Request', {
+			                employee: frm.doc.name,
+			                training_requested_by: response.message // Set training_requested_by to the fetched employee ID
+			              });
+			            } else {
 
-				              // Show a message if no employee record is found for the user
-				              frappe.msgprint(__('No employee record found for the current user.'));
-				            }
-				          }
-				        });
-				      }, 'Create');
-						}
-					}
-    	});
+		              // Show a message if no employee record is found for the user
+		              frappe.msgprint(__('No employee record found for the current user.'));
+		            }
+		          }
+		        });
+		      }, 'Create');
+				}
+			}
+					});
 		}
   },
   employment_type: function(frm) {

--- a/beams/beams/custom_scripts/training_event/training_event.js
+++ b/beams/beams/custom_scripts/training_event/training_event.js
@@ -6,7 +6,7 @@ frappe.ui.form.on('Training Event', {
           frm.remove_custom_button('Training Feedback');
         }, 5);
       }
-        if (!frm.is_new() && frappe.user.has_role("HR Manager")) {
+        if (!frm.is_new() && frappe.user.has_role("HR Manager")&& frm.doc.event_status !== "Completed") {
             // Create the main group button "Training Request"
             frm.add_custom_button("Training Request", () => {
                 show_training_request_dialog(frm);


### PR DESCRIPTION

## Feature description
 Need to arrange the button in create group button in the employee doctype
Need hide the get employees button when the event status become completed the in the Training Event doctype 
 

## Solution description
1. Arranged the button group button create  order the event button is first and Training event in secound . via employee.js 
2. hidden the get employees button inthe training event . if the event status become completed then the get employees button is hidden via training event.js

## Output screenshots (optional)

[Screencast from 10-03-25 04:12:22 PM IST.webm](https://github.com/user-attachments/assets/ecff4764-eb6f-471e-b54f-bb0d979314e8)

![image](https://github.com/user-attachments/assets/4bd86a72-f75c-4f59-9374-316ecfef1a73)



## Areas affected and ensured
employee and training event doctype

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  
  - Mozilla Firefox
  