### PR TITLE
fix: Hide Custom Buttons from sales order,sales invoice and Opportunity

### DIFF
--- a/beams/beams/custom_scripts/customer/customer.py
+++ b/beams/beams/custom_scripts/customer/customer.py
@@ -13,3 +13,7 @@ def mark_as_edited_if_approved(doc, method):
         if creation_date != current_date:
             if hasattr(doc, 'is_edited'):
                 doc.is_edited = 1
+
+def duplicate_customer(doc, method):
+    if frappe.db.exists("Customer", {"customer_name": doc.customer_name, "name": ["!=", doc.name]}):
+        frappe.throw(_("A customer with the name '{0}' already exists. Please use a different name.").format(doc.customer_name))

--- a/beams/beams/custom_scripts/lead/lead.js
+++ b/beams/beams/custom_scripts/lead/lead.js
@@ -1,0 +1,7 @@
+frappe.ui.form.on('Lead', {
+    refresh: function(frm) {
+        setTimeout(() => {
+            frm.remove_custom_button('Add to Prospect', 'Action');
+        }, 500);
+    }
+});

--- a/beams/beams/custom_scripts/opportunity/opportunity.js
+++ b/beams/beams/custom_scripts/opportunity/opportunity.js
@@ -1,0 +1,9 @@
+frappe.ui.form.on('Opportunity', {
+    refresh: function(frm) {
+        setTimeout(() => {
+            frm.remove_custom_button('Supplier Quotation', 'Create');
+            frm.remove_custom_button('Request For Quotation', 'Create');
+            frm.remove_custom_button('Release Order', 'Create');
+        }, 500);
+    }
+});

--- a/beams/beams/custom_scripts/sales_invoice/sales_invoice.js
+++ b/beams/beams/custom_scripts/sales_invoice/sales_invoice.js
@@ -2,6 +2,8 @@ frappe.ui.form.on('Sales Invoice', {
   refresh: function(frm) {
     setTimeout(() => {
         frm.remove_custom_button('Delivery', 'Create');
+        frm.remove_custom_button('Timesheet', 'Get Items From');
+        frm.remove_custom_button('Delivery Note', 'Get Items From');
     }, 500);
     set_actual_customer_query(frm);
 

--- a/beams/beams/custom_scripts/sales_order/sales_order.js
+++ b/beams/beams/custom_scripts/sales_order/sales_order.js
@@ -2,6 +2,10 @@ frappe.ui.form.on('Sales Order', {
   refresh: function(frm) {
     setTimeout(() => {
         frm.remove_custom_button('Delivery Note', 'Create');
+        frm.remove_custom_button('Pick List', 'Create');
+        frm.remove_custom_button('Work Order', 'Create');
+        frm.remove_custom_button('Material Request', 'Create');
+        frm.remove_custom_button('Request for Raw Materials', 'Create');
     }, 500);
     set_actual_customer_query(frm);
     frm.dashboard.clear_headline();

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -58,7 +58,9 @@ doctype_js = {
     "Job Offer": "beams/custom_scripts/job_offer/job_offer.js",
     "Appraisal":"beams/custom_scripts/appraisal/appraisal.js",
     "Project":"beams/custom_scripts/project/project.js",
-    "Asset Movement":"beams/custom_scripts/asset_movement/asset_movement.js"
+    "Asset Movement":"beams/custom_scripts/asset_movement/asset_movement.js",
+    "Opportunity":"beams/custom_scripts/opportunity/opportunity.js",
+    "Lead":"beams/custom_scripts/lead/lead.js"
 }
 doctype_list_js = {
     "Sales Invoice" : "beams/custom_scripts/sales_invoice/sales_invoice_list.js",
@@ -178,7 +180,10 @@ doc_events = {
     },
     "Customer": {
         "after_insert": "beams.beams.custom_scripts.account.account.create_todo_on_creation_for_customer",
-        "validate": "beams.beams.custom_scripts.customer.customer.mark_as_edited_if_approved"
+        "validate": [
+            "beams.beams.custom_scripts.customer.customer.mark_as_edited_if_approved",
+            "beams.beams.custom_scripts.customer.customer.duplicate_customer"
+            ]
     },
     "Training Event": {
          "on_update": "beams.beams.custom_scripts.training_event.training_event.on_update",

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -3494,6 +3494,94 @@ def get_property_setters():
             "field_name": "department",
             "property": "reqd",
             "value": 1
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Sales Order",
+            "field_name": "set_warehouse",
+            "property": "hidden",
+            "property_type": "Link",
+            "value":1
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Sales Order",
+            "field_name": "scan_barcode",
+            "property": "hidden",
+            "property_type": "Data",
+            "value":1
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Quotation",
+            "field_name": "quotation_to",
+            "property": "default",
+            "property_type": "Link",
+            "value":"Customer"
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Quotation",
+            "field_name": "quotation_to",
+            "property": "read_only",
+            "property_type": "Link",
+            "value":1
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Quotation",
+            "field_name": "order_type",
+            "property": "default",
+            "property_type": "Link",
+            "value":"Sales"
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Quotation",
+            "field_name": "order_type",
+            "property": "read_only",
+            "property_type": "Link",
+            "value":1
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Quotation Item",
+            "field_name": "shopping_cart_section",
+            "property": "hidden",
+            "property_type": "Section Break",
+            "value":1
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Quotation Item",
+            "field_name": "item_weight_details",
+            "property": "hidden",
+            "property_type": "Section Break",
+            "value":1
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Quotation Item",
+            "field_name": "available_quantity_section",
+            "property": "hidden",
+            "property_type": "Section Break",
+            "value":1
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Quotation Item",
+            "field_name": "gst_details_section",
+            "property": "hidden",
+            "property_type": "Section Break",
+            "value":1
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Quotation Item",
+            "field_name": "item_code",
+            "property": "label",
+            "property_type": "Link",
+            "value":"Service Item"
         }
     ]
 


### PR DESCRIPTION
## Feature description
- Hide Custom Buttons from Opportunity except customer.
- Prevent Duplicate Customer Creation
- Customize Release Order Doctype.
- Change label of Item Code to Service Item in Release Order
- Customize Quotation Item Child table.
- Hide Custom Buttons from Sales Order.
- Customize Sales Order doctype.
- Hide Custom buttons from Sales Invoice.
- Hide Add to prospect button from Lead.

## Solution description
- Custom buttons were hidden from the Opportunity doctype except for the Customer button.
- Duplicate customer creation was prevented.
- The Release Order doctype was customized.
- The label of Item Code was changed to Service Item in the Release Order doctype.
- The Quotation Item child table was customized.
- Custom buttons were hidden from the Sales Order doctype.
- The Sales Order doctype was customized.
- Custom buttons were hidden from the Sales Invoice doctype.
- The Add to Prospect button was hidden from the Lead doctype.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/6d952952-0378-4082-bcf0-7f22a870732e)
[Screencast from 11-03-25 08:24:11 PM IST.webm](https://github.com/user-attachments/assets/c8e09649-d8bd-43e6-9353-70bdec7ccdd8)
![image](https://github.com/user-attachments/assets/f5cbd297-e23a-49aa-975c-9159e31b3325)
![image](https://github.com/user-attachments/assets/ddefd9e1-35a0-4218-920a-d94fc321e5d4)
![image](https://github.com/user-attachments/assets/d771cebb-968b-4e0f-b8fd-187c3cb7fd06)

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox