### PR TITLE
    TASK-2025-00346:Fetch and set Executive field for Employee users in Release Order

### DIFF
--- a/beams/beams/custom_scripts/quotation/quotation.js
+++ b/beams/beams/custom_scripts/quotation/quotation.js
@@ -1,4 +1,20 @@
 frappe.ui.form.on('Quotation', {
+    onload: function(frm) {
+       if (!frm.doc.executive) {
+           // Only fetch if field is empty
+           let user_roles = frappe.user_roles;
+           // Get roles of the logged-in user
+           if (user_roles.includes("Employee")) {
+                frappe.db.get_value("Employee", { user_id: frappe.session.user }, "name")
+                    .then(r => {
+                        if (r && r.message && r.message.name) {
+                          frm.set_value("executive", r.message.name);
+                      }
+                });
+           }
+       }
+    },
+
     refresh: function(frm) {
         if (frm.doc.docstatus == 1) {
             // Check if the is_barter checkbox is checked and show the Purchase Invoice button


### PR DESCRIPTION
## Feature description
     -Set Executive field if user has Employee role

## Solution description
     -Assign the "executive" field if it is empty
     -Fetch the Employee name based on the logged-in user.
     -Ensure the user has the "Employee" role before fetching

## Output screenshots 


[Screencast from 12-03-25 09:58:18 AM IST.webm](https://github.com/user-attachments/assets/777ca529-bbbb-4c39-9fa2-b7c4782dffc9)



[Screencast from 12-03-25 10:00:39 AM IST.webm](https://github.com/user-attachments/assets/635d9b6c-bc21-473b-a424-0b804ed7730d)


## Areas affected and ensured
    -Release Order

## Is there any existing behavior change of other features due to this code change?
    - No. 

## Was this feature tested on the browsers?
     -Mozilla Firefox
 