### PR TITLE
feat:Remove prospect dialog box that appears when Oppurtunity created from Lead.

### DIFF
--- a/beams/beams/custom_scripts/lead/lead.js
+++ b/beams/beams/custom_scripts/lead/lead.js
@@ -1,7 +1,30 @@
-frappe.ui.form.on('Lead', {
-    refresh: function(frm) {
+frappe.ui.form.on("Lead", {
+    refresh: function (frm) {
+        // Remove "Add to Prospect" button under "Action"
         setTimeout(() => {
-            frm.remove_custom_button('Add to Prospect', 'Action');
+            frm.remove_custom_button("Add to Prospect", "Action");
         }, 500);
+
+        // Override Opportunity button
+        if (!frm.is_new()) {
+            override_make_opportunity(frm);
+        }
     }
 });
+
+function override_make_opportunity(frm) {
+    // Remove default "Opportunity" button
+    frm.remove_custom_button("Opportunity", "Create");
+
+    // Add custom "Opportunity" button without a dialog
+    frm.add_custom_button(
+        __("Opportunity"),
+        function () {
+            frappe.model.open_mapped_doc({
+                method: "erpnext.crm.doctype.lead.lead.make_opportunity",
+                frm: frm
+            });
+        },
+        __("Create")
+    );
+}


### PR DESCRIPTION
## Feature description
Remove the  prospect dialog box that appears when Oppurtunity created from Lead.

## Solution description
The default button was removed and added a new button under Create group in Led that maps to Oppurtunity.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/cb03161f-72a2-406d-8f15-144e3e67dc69)
![image](https://github.com/user-attachments/assets/10f0c93b-d5ca-46dc-9836-25b418082c7a)


## Areas affected and ensured
Lead doctype.

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
 
