### PR TITLE
feat:Customise Release Order Doctype

### DIFF
--- a/beams/beams/custom_scripts/quotation/quotation.js
+++ b/beams/beams/custom_scripts/quotation/quotation.js
@@ -1,4 +1,15 @@
 frappe.ui.form.on('Quotation', {
+    party_name: function(frm) {
+        if (frm.doc.party_name) {
+            frappe.db.get_value("Customer", frm.doc.party_name, "region", (r) => {
+                if (r && r.region) {
+                    frm.set_value("region", r.region);
+                }
+            });
+        } else {
+            frm.set_value("region", ""); 
+        }
+    },
     onload: function(frm) {
        if (!frm.doc.executive) {
            // Only fetch if field is empty

--- a/beams/beams/custom_scripts/quotation/quotation.js
+++ b/beams/beams/custom_scripts/quotation/quotation.js
@@ -1,13 +1,13 @@
 frappe.ui.form.on('Quotation', {
     party_name: function(frm) {
-        if (frm.doc.party_name) {
+        if (frm.doc.quotation_to == "Customer" and frm.doc.party_name) {
             frappe.db.get_value("Customer", frm.doc.party_name, "region", (r) => {
                 if (r && r.region) {
                     frm.set_value("region", r.region);
                 }
             });
         } else {
-            frm.set_value("region", ""); 
+            frm.set_value("region", "");
         }
     },
     onload: function(frm) {

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -1064,7 +1064,8 @@ def get_quotation_custom_fields():
                 "fieldtype": "Link",
                 "label": "Region",
                 "insert_after": "customer_name",
-                "options": "Region"
+                "options": "Region",
+                "fetch_from": "party_name.region"
             },
             {
                 "fieldname": "albatross_details_section",
@@ -3582,7 +3583,16 @@ def get_property_setters():
             "property": "label",
             "property_type": "Link",
             "value":"Service Item"
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Quotation",
+            "field_name": "coupon_code",
+            "property": "hidden",
+            "property_type": "Link",
+            "value":1
         }
+
     ]
 
 def get_material_request_custom_fields():

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -1064,8 +1064,7 @@ def get_quotation_custom_fields():
                 "fieldtype": "Link",
                 "label": "Region",
                 "insert_after": "customer_name",
-                "options": "Region",
-                "fetch_from": "party_name.region"
+                "options": "Region"
             },
             {
                 "fieldname": "albatross_details_section",


### PR DESCRIPTION
## Feature description
Customise Release Order Doctype

## Solution description
- Fetch Region In relase Order when selecting customer..
- Hide Coupon Code field in Release Order.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/9766190a-5768-4560-8d64-53688c367766)

![image](https://github.com/user-attachments/assets/190e0500-6e0a-43fc-bc17-71397d48bd54)


## Areas affected and ensured
Release Order.
## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox -Yes
  - Opera Mini
  - Safari
