### PR TITLE
    TASK-2025-00338: changed logic for update status for local enquiry report

### DIFF
--- a/beams/beams/doctype/local_enquiry_report/local_enquiry_report.py
+++ b/beams/beams/doctype/local_enquiry_report/local_enquiry_report.py
@@ -122,15 +122,21 @@ def set_status_to_overdue():
 
     # Fetch Local Enquiry Reports with expected completion date on or before today and status not set to 'Overdue'
     enquiries = frappe.get_all('Local Enquiry Report', filters={
-        'expected_completion_date': ['<=', today_date],
         'status': ['!=', 'Overdue']
-    }, fields=['name', 'expected_completion_date'])
+    }, fields=['name', 'expected_completion_date','enquiry_completion_date'])
+    
 
     if enquiries:
         for enquiry in enquiries:
-            # Check Enquiry Completion date is set or Expected completion date is over
-            if not enquiry.enquiry_completion_date and today_date > getdate(enquiry.expected_completion_date):
+            expected_date = getdate(enquiry.expected_completion_date)if enquiry.expected_completion_date else None
+            completion_date = getdate(enquiry.enquiry_completion_date) if enquiry.enquiry_completion_date else None
+            if not expected_date:
+                continue
+            if completion_date and completion_date > expected_date:
                 frappe.db.set_value('Local Enquiry Report', enquiry.name, 'status', 'Overdue')
+
+
+
 
 
 @frappe.whitelist()


### PR DESCRIPTION
## Issue description

1.need to currently the status of Local Enquiry Report become overdue even if enquiry completion date does not exceed expected completion date


## Solution description
1. change the logic that status become not be overdue even without exceeds the enquiry_completion_date than the expected_completion_date
- status become overdue when only the enquiry_completion_date exceeds the expected_completion_date

## Output screenshots (optional)
[Screencast from 12-03-25 03:04:37 PM IST.webm](https://github.com/user-attachments/assets/9a439ca6-7e13-4958-99c0-eaa0cbfa4121)
[Uploading Screencast from 12-03-25 03:09:01 PM IST.webm…]()



## Areas affected and ensured
local enquiry report

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
 
  - Mozilla Firefox

