### PR TITLE
 Refactor: Simplified logic to conditionally display the "New Feedback" button in Appraisal.

### DIFF
--- a/beams/beams/custom_scripts/appraisal/appraisal.js
+++ b/beams/beams/custom_scripts/appraisal/appraisal.js
@@ -44,7 +44,11 @@ frappe.ui.form.on('Appraisal', {
                                 },
                                 callback: function (r) {
                                     if (r.message) {
-                                        $(frm.fields_dict['appraisal_summary'].wrapper).html(r.message);
+                                        $(frm.fields_dict['appraisal_summary'].wrapper).html(r.message[0]);
+                                        if (frm.doc.final_average_score != r.message[1]) {
+                                          frm.set_value("final_average_score", r.message[1])
+                                          frm.refresh_field("final_average_score")
+                                        }
                                     }
                                 }
                             });

--- a/beams/beams/custom_scripts/appraisal/appraisal.js
+++ b/beams/beams/custom_scripts/appraisal/appraisal.js
@@ -17,9 +17,19 @@ frappe.ui.form.on('Appraisal', {
         frm.set_df_property('final_score', 'hidden', 1);
 
         if (!frm.is_new()) {
-            // Add custom button to trigger the feedback dialog
-            frm.add_custom_button(__('New Feedback'), function () {
-                frm.events.show_feedback_dialog(frm);
+            // Get the logged-in user
+            let user = frappe.session.user;
+
+            // Fetch the logged-in user's linked Employee record
+            frappe.db.get_value('Employee', { 'user_id': user }, 'name').then(r => {
+                let employee = r.message?.name;
+
+                // Add "New Feedback" button only if the logged-in user is NOT the appraised employee
+                if (frm.doc.employee !== employee) {
+                    frm.add_custom_button(__('New Feedback'), function () {
+                        frm.events.show_feedback_dialog(frm);
+                    });
+                }
             });
         }
 

--- a/beams/beams/custom_scripts/appraisal/appraisal.py
+++ b/beams/beams/custom_scripts/appraisal/appraisal.py
@@ -128,9 +128,6 @@ def get_appraisal_summary(appraisal_template, employee_feedback=None):
     total_criteria_count = len(key_results)
     final_average_score = round(total_marks / total_criteria if total_criteria > 0 else 0, 3)
 
-    # if feedback_doc and feedback_doc.appraisal:
-    #     frappe.db.set_value("Appraisal", feedback_doc.appraisal, "final_average_score", final_average_score)
-
     # Generate the HTML table
     table_html = """
         <table class="table table-bordered" style="width:100%;">

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -2924,7 +2924,7 @@ def get_appraisal_custom_fields():
         	{
 				"fieldname": "category_based_on_marks",
 				"fieldtype": "Link",
-                "options": "Category",
+                "options": "Appraisal Category",
 				"label": "Category based on marks",
 				"insert_after": "category_html",
                 "read_only": 1
@@ -3005,7 +3005,8 @@ def get_appraisal_custom_fields():
                 "fieldname": "final_average_score",
                 "fieldtype": "Float",
                 "label": "Final Average Score",
-                "insert_after": "employee_image"
+                "insert_after": "employee_image",
+                "precision": 3
             }
         ]
     }
@@ -3681,7 +3682,7 @@ def get_property_setters():
             "doc_type": "Job Requisition",
             "property": "field_order",
             "value": '["basic_details_tab", "basic_information", "employee", "naming_series", "salutation", "first_name", "middle_name", "last_name", "bureau", "stringer_type", "employee_name", "column_break_9", "gender", "date_of_birth", "name_of_father", "name_of_spouse", "column_break1", "date_of_joining", "date_of_appointment", "image", "status", "training_status", "erpnext_user", "user_id", "create_user", "create_user_permission", "company_details_section", "company", "department", "employee_number", "column_break_25", "designation", "reports_to", "column_break_18", "branch", "grade", "employment_details", "job_applicant", "scheduled_confirmation_date", "column_break_32", "final_confirmation_date", "contract_end_date", "col_break_22", "notice_number_of_days", "date_of_retirement", "contact_details", "cell_number", "company_number", "column_break_40", "personal_email", "company_email", "column_break4", "prefered_contact_email", "prefered_email", "unsubscribed", "address_section", "pincode", "current_address", "landmark", "current_accommodation_type", "column_break_46", "permanent_address", "landmark_per", "permanent_accommodation_type", "emergency_contact_details", "person_to_be_contacted", "emergency_contact_name", "column_break_55", "emergency_phone_number", "emergency_phone", "column_break_19", "relation", "relation_emergency", "attendance_and_leave_details", "attendance_device_id", "leave_policy", "leave_policy_name", "column_break_44", "holiday_list", "default_shift", "approvers_section", "expense_approver", "leave_approver", "column_break_45", "shift_request_approver", "leave_approver_name", "expense_approver_name", "salary_information", "ctc", "salary_currency", "salary_mode", "salary_cb", "payroll_cost_center", "pan_number", "provident_fund_account", "bank_details_section", "bank_name", "column_break_heye", "bank_ac_no", "bank_cb", "ifsc_code", "micr_code", "iban", "nominee_details_section", "nominee_details", "personal_details", "marital_status", "aadhar_id", "no_of_children", "family_background", "column_break6", "blood_group", "health_details", "health_insurance_section", "health_insurance_provider", "health_insurance_no", "passport_details_section", "passport_number", "valid_upto", "column_break_73", "date_of_issue", "place_of_issue", "additional_information_section", "physical_disabilities", "disabilities", "marital_indebtness", "court_proceedings", "court_proceedings_details", "column_break_travel", "are_you_willing_to_travel", "in_india", "abroad", "state_restrictions_problems", "places_to_travel", "are_you_related_to_employee", "related_employee_name", "profile_tab", "bio", "educational_qualification", "education", "previous_work_experience", "external_work_history", "history_in_company", "internal_work_history", "documents_tab", "employee_documents", "exit", "resignation_letter_date", "relieving_date", "exit_interview_details", "held_on", "new_workplace", "column_break_99", "leave_encashed", "encashment_date", "feedback_section", "reason_for_leaving", "column_break_104", "feedback", "lft", "rgt", "old_parent", "connections_tab"]'
-            
+
         }
 
     ]


### PR DESCRIPTION
## Feature description
Hide the "New Feedback" button for the employee being appraised in the Appraisal form. Only other users should be able to see the button.
## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description
- Fetched the logged-in user’s linked Employee record.
- Checked if the logged-in user is the same as the employee in the Appraisal form.
- Added the "New Feedback" button only if the logged-in user is not the appraised employee.

## Output screenshots (optional)

- An appraisal is created for employee Diya
 ![image](https://github.com/user-attachments/assets/64f4e1f4-1091-4c92-93ac-837b388f8572)

- when the Employee Diya logged-in,she cannot see New Feedback button
![image](https://github.com/user-attachments/assets/cff12d02-ef81-4172-b1f9-c8431f2c0c82)


## Areas affected and ensured
Appraisal form UI
User session handling (to determine the logged-in employee)
Button visibility logic
## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
