### PR TITLE
Refactor: Simplified logic to conditionally display the 'New Feedback' button in Appraisal

### DIFF
--- a/beams/beams/custom_scripts/appraisal/appraisal.js
+++ b/beams/beams/custom_scripts/appraisal/appraisal.js
@@ -17,9 +17,19 @@ frappe.ui.form.on('Appraisal', {
         frm.set_df_property('final_score', 'hidden', 1);
 
         if (!frm.is_new()) {
-            // Add custom button to trigger the feedback dialog
-            frm.add_custom_button(__('New Feedback'), function () {
-                frm.events.show_feedback_dialog(frm);
+            // Get the logged-in user
+            let user = frappe.session.user;
+
+            // Fetch the logged-in user's linked Employee record
+            frappe.db.get_value('Employee', { 'user_id': user }, 'name').then(r => {
+                let employee = r.message?.name;
+
+                // Add "New Feedback" button only if the logged-in user is NOT the appraised employee
+                if (frm.doc.employee !== employee) {
+                    frm.add_custom_button(__('New Feedback'), function () {
+                        frm.events.show_feedback_dialog(frm);
+                    });
+                }
             });
         }
 


### PR DESCRIPTION
## Feature description
Hide the "New Feedback" button for the employee being appraised in the Appraisal form. Only other users should be able to see the button.
## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description
- Fetched the logged-in user’s linked Employee record.
- Checked if the logged-in user is the same as the employee in the Appraisal form.
- Added the "New Feedback" button only if the logged-in user is not the appraised employee.

## Output screenshots (optional)

- An appraisal is created for employee Diya
 ![image](https://github.com/user-attachments/assets/64f4e1f4-1091-4c92-93ac-837b388f8572)

- when the Employee Diya logged-in,she cannot see New Feedback button
![image](https://github.com/user-attachments/assets/cff12d02-ef81-4172-b1f9-c8431f2c0c82)


## Areas affected and ensured
Appraisal form UI
User session handling (to determine the logged-in employee)
Button visibility logic
## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
