### PR TITLE
fix:fixed syntax error in Release Order

### DIFF
--- a/beams/beams/custom_scripts/quotation/quotation.js
+++ b/beams/beams/custom_scripts/quotation/quotation.js
@@ -1,6 +1,6 @@
 frappe.ui.form.on('Quotation', {
     party_name: function(frm) {
-        if (frm.doc.quotation_to == "Customer" and frm.doc.party_name) {
+        if (frm.doc.quotation_to == "Customer" && frm.doc.party_name) {
             frappe.db.get_value("Customer", frm.doc.party_name, "region", (r) => {
                 if (r && r.region) {
                     frm.set_value("region", r.region);


### PR DESCRIPTION
## Feature description
fixed syntax error in Release Order

## Solution description
- JavaScript uses && instead of and for logical operations.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/4f92b2f8-afbc-4c1c-9e7f-bf11003a1f13)


## Areas affected and ensured
- Release Order
## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - yes
  - Opera Mini
  - Safari
