### PR TITLE
TASK-2025-00377: Changed Required Employee field to not editable

### DIFF
--- a/beams/beams/doctype/technical_request/technical_request.json
+++ b/beams/beams/doctype/technical_request/technical_request.json
@@ -115,7 +115,8 @@
    "fieldtype": "Table MultiSelect",
    "label": "Required Employees",
    "mandatory_depends_on": "eval: doc.workflow_state == \"Pending Approval\"",
-   "options": "Employees"
+   "options": "Employees",
+   "read_only_depends_on": "eval:doc.workflow_state == \"Approved\""
   },
   {
    "fetch_from": "project.location",
@@ -129,7 +130,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-02-14 12:02:09.724554",
+ "modified": "2025-03-17 10:19:31.385542",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Technical Request",


### PR DESCRIPTION
## Feature description
Change Required Employee field to not editable when workflow state goes to Approved

## Solution description
Changed Required Employee field to not editable when workflow state goes to Approved

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/7e62f9b6-6e6e-457d-a24c-32be08b3c2b4)


## Is there any existing behavior change of other features due to this code change?
 No

## Was this feature tested on the browsers?
  - Mozilla Firefox
  
