### PR TITLE
feat: Show/hide budget account child tables based on user roles (HOD & HR Manager)

### DIFF
--- a/beams/beams/custom_scripts/budget/budget.js
+++ b/beams/beams/custom_scripts/budget/budget.js
@@ -6,6 +6,16 @@ frappe.ui.form.on('Budget', {
                 frappe.set_route('Form', 'Budget Tool', 'Budget Tool');
             });
         }
+        if (frappe.user_roles.includes("HOD")) {
+            frm.toggle_display("budget_accounts_custom", true);
+        } else {
+            frm.toggle_display("budget_accounts_custom", false);
+        }
+        if (frappe.user_roles.includes("HR Manager")) {
+            frm.toggle_display("budget_accounts_hr", true);
+        } else {
+            frm.toggle_display("budget_accounts_hr", false);
+        }
     },
     department: function (frm) {
         set_filters(frm);


### PR DESCRIPTION
## Feature description
- Show/hide budget account fields based on user roles (HOD & HR Manager)

## Solution description
- Displayed Budget account child tables based on user roles(HOD & HR Manager)

## Output screenshots (optional)
[Screencast from 17-03-25 10:40:28 AM IST.webm](https://github.com/user-attachments/assets/81f8ee73-5b67-468d-96f6-bb7e9629f4b8)
![image](https://github.com/user-attachments/assets/e7cfc57e-8052-4ec3-80ef-0c9ee9238771)

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox
