### PR TITLE
feat: validation for 'reason for rejection' in all doctypes

### DIFF
--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.py
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.py
@@ -44,9 +44,6 @@ class EmployeeTravelRequest(Document):
             self.total_days = date_diff(self.end_date, self.start_date)
 
     def on_update_after_submit(self):
-        if self.workflow_state == "Approved" and self.reason_for_rejection:
-            frappe.throw("You cannot approve this request if 'Reason for Rejection' is filled.")
-
         """
         Create an Attendance Regularization record in 'Draft' when mark_attendance is checked.
         """
@@ -66,6 +63,9 @@ class EmployeeTravelRequest(Document):
                     alert=True, indicator="green"
                 )
 
+        # Validate that 'Reason for Rejection' is not filled if the status is 'Approved'
+        if self.workflow_state == "Approved" and self.reason_for_rejection:
+            frappe.throw("You cannot approve this request if 'Reason for Rejection' is filled.")
 
     @frappe.whitelist()
     def validate_posting_date(self):

--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.py
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.py
@@ -65,7 +65,7 @@ class EmployeeTravelRequest(Document):
 
         # Validate that 'Reason for Rejection' is not filled if the status is 'Approved'
         if self.workflow_state == "Approved" and self.reason_for_rejection:
-            frappe.throw("You cannot approve this request if 'Reason for Rejection' is filled.")
+            frappe.throw(title="Approval Error", msg="You cannot approve this request if 'Reason for Rejection' is filled.")
 
     @frappe.whitelist()
     def validate_posting_date(self):

--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.py
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.py
@@ -44,6 +44,9 @@ class EmployeeTravelRequest(Document):
             self.total_days = date_diff(self.end_date, self.start_date)
 
     def on_update_after_submit(self):
+        if self.workflow_state == "Approved" and self.reason_for_rejection:
+            frappe.throw("You cannot approve this request if 'Reason for Rejection' is filled.")
+
         """
         Create an Attendance Regularization record in 'Draft' when mark_attendance is checked.
         """

--- a/beams/beams/doctype/equipment_acquiral_request/equipment_acquiral_request.py
+++ b/beams/beams/doctype/equipment_acquiral_request/equipment_acquiral_request.py
@@ -14,6 +14,10 @@ class EquipmentAcquiralRequest(Document):
     def before_save(self):
         self.validate_posting_date()
 
+    def on_update_after_submit(self):
+        if self.workflow_state == "Approved" and self.reason_for_rejection:
+            frappe.throw("You cannot approve this request if 'Reason for Rejection' is filled.")
+
     @frappe.whitelist()
     def validate_required_from_and_required_to(self):
         """

--- a/beams/beams/doctype/equipment_acquiral_request/equipment_acquiral_request.py
+++ b/beams/beams/doctype/equipment_acquiral_request/equipment_acquiral_request.py
@@ -15,6 +15,7 @@ class EquipmentAcquiralRequest(Document):
         self.validate_posting_date()
 
     def on_update_after_submit(self):
+        # Validate that 'Reason for Rejection' is not filled if the status is 'Approved'
         if self.workflow_state == "Approved" and self.reason_for_rejection:
             frappe.throw("You cannot approve this request if 'Reason for Rejection' is filled.")
 

--- a/beams/beams/doctype/equipment_acquiral_request/equipment_acquiral_request.py
+++ b/beams/beams/doctype/equipment_acquiral_request/equipment_acquiral_request.py
@@ -17,7 +17,7 @@ class EquipmentAcquiralRequest(Document):
     def on_update_after_submit(self):
         # Validate that 'Reason for Rejection' is not filled if the status is 'Approved'
         if self.workflow_state == "Approved" and self.reason_for_rejection:
-            frappe.throw("You cannot approve this request if 'Reason for Rejection' is filled.")
+            frappe.throw(title="Approval Error", msg="You cannot approve this request if 'Reason for Rejection' is filled.")
 
     @frappe.whitelist()
     def validate_required_from_and_required_to(self):

--- a/beams/beams/doctype/equipment_request/equipment_request.py
+++ b/beams/beams/doctype/equipment_request/equipment_request.py
@@ -10,6 +10,9 @@ from datetime import datetime
 
 class EquipmentRequest(Document):
     def on_update_after_submit(self):
+        if self.workflow_state == "Approved" and self.reason_for_rejection:
+            frappe.throw("You cannot approve this request if 'Reason for Rejection' is filled.")
+
         if self.workflow_state == 'Approved':
             required_from = (
                 self.required_from.date()

--- a/beams/beams/doctype/equipment_request/equipment_request.py
+++ b/beams/beams/doctype/equipment_request/equipment_request.py
@@ -12,7 +12,7 @@ class EquipmentRequest(Document):
     def on_update_after_submit(self):
         # Validate that 'Reason for Rejection' is not filled if the status is 'Approved'
         if self.workflow_state == "Approved" and self.reason_for_rejection:
-            frappe.throw("You cannot approve this request if 'Reason for Rejection' is filled.")
+            frappe.throw(title="Approval Error", msg="You cannot approve this request if 'Reason for Rejection' is filled.")
 
         if self.workflow_state == 'Approved':
             required_from = (

--- a/beams/beams/doctype/equipment_request/equipment_request.py
+++ b/beams/beams/doctype/equipment_request/equipment_request.py
@@ -10,6 +10,7 @@ from datetime import datetime
 
 class EquipmentRequest(Document):
     def on_update_after_submit(self):
+        # Validate that 'Reason for Rejection' is not filled if the status is 'Approved'
         if self.workflow_state == "Approved" and self.reason_for_rejection:
             frappe.throw("You cannot approve this request if 'Reason for Rejection' is filled.")
 

--- a/beams/beams/doctype/technical_request/technical_request.py
+++ b/beams/beams/doctype/technical_request/technical_request.py
@@ -18,6 +18,7 @@ class TechnicalRequest(Document):
             frappe.throw("Please provide a Reason for Rejection before rejecting this request.")
 
     def on_update_after_submit(self):
+        # Validate that 'Reason for Rejection' is not filled if the status is 'Approved'
         if self.workflow_state == "Approved" and self.reason_for_rejection:
             frappe.throw("You cannot approve this request if 'Reason for Rejection' is filled.")
 

--- a/beams/beams/doctype/technical_request/technical_request.py
+++ b/beams/beams/doctype/technical_request/technical_request.py
@@ -20,7 +20,7 @@ class TechnicalRequest(Document):
     def on_update_after_submit(self):
         # Validate that 'Reason for Rejection' is not filled if the status is 'Approved'
         if self.workflow_state == "Approved" and self.reason_for_rejection:
-            frappe.throw("You cannot approve this request if 'Reason for Rejection' is filled.")
+            frappe.throw(title="Approval Error", msg="You cannot approve this request if 'Reason for Rejection' is filled.")
 
     def validate(self):
         self.validate_required_from_and_required_to()

--- a/beams/beams/doctype/technical_request/technical_request.py
+++ b/beams/beams/doctype/technical_request/technical_request.py
@@ -17,6 +17,10 @@ class TechnicalRequest(Document):
         if self.workflow_state == "Rejected" and not self.reason_for_rejection:
             frappe.throw("Please provide a Reason for Rejection before rejecting this request.")
 
+    def on_update_after_submit(self):
+        if self.workflow_state == "Approved" and self.reason_for_rejection:
+            frappe.throw("You cannot approve this request if 'Reason for Rejection' is filled.")
+
     def validate(self):
         self.validate_required_from_and_required_to()
 
@@ -37,7 +41,7 @@ class TechnicalRequest(Document):
                 msg=_("Required From cannot be after Required To."),
                 title=_("Message")
             )
-            
+
     @frappe.whitelist()
     def validate_posting_date(self):
         if self.posting_date:

--- a/beams/beams/doctype/transportation_request/transportation_request.py
+++ b/beams/beams/doctype/transportation_request/transportation_request.py
@@ -18,6 +18,10 @@ class TransportationRequest(Document):
     def before_update_after_submit(self):
         self.update_no_of_own_vehicles()
 
+    def on_update_after_submit(self):
+        if self.workflow_state == "Approved" and self.reason_for_rejection:
+            frappe.throw("You cannot approve this request if 'Reason for Rejection' is filled.")
+
     def update_no_of_own_vehicles(self):
         '''
         Calculate the total number of rows in the "Vehicles" child table

--- a/beams/beams/doctype/transportation_request/transportation_request.py
+++ b/beams/beams/doctype/transportation_request/transportation_request.py
@@ -21,7 +21,7 @@ class TransportationRequest(Document):
     def on_update_after_submit(self):
         # Validate that 'Reason for Rejection' is not filled if the status is 'Approved'
         if self.workflow_state == "Approved" and self.reason_for_rejection:
-            frappe.throw("You cannot approve this request if 'Reason for Rejection' is filled.")
+            frappe.throw(title="Approval Error", msg="You cannot approve this request if 'Reason for Rejection' is filled.")
 
     def update_no_of_own_vehicles(self):
         '''

--- a/beams/beams/doctype/transportation_request/transportation_request.py
+++ b/beams/beams/doctype/transportation_request/transportation_request.py
@@ -19,6 +19,7 @@ class TransportationRequest(Document):
         self.update_no_of_own_vehicles()
 
     def on_update_after_submit(self):
+        # Validate that 'Reason for Rejection' is not filled if the status is 'Approved'
         if self.workflow_state == "Approved" and self.reason_for_rejection:
             frappe.throw("You cannot approve this request if 'Reason for Rejection' is filled.")
 


### PR DESCRIPTION
## Feature description
Validate the Reason for Rejection is not filled in when approving and it is filled in when rejecting wherever necessary in BEAMS


## Solution description
The method checks if the document's workflow state is set to "Approved" and if the field reason_for_rejection is filled.
If both conditions are true, the system raises an error using frappe.throw(), preventing the document from being approved while a rejection reason exists.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/05b1f6a8-215b-4848-a945-f2bf4d7f78be)


## Areas affected and ensured
List out the areas affected by your code changes.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
