### PR TITLE
fix: Changed label of Budget Accounts in Budget

### DIFF
--- a/beams/setup.py
+++ b/beams/setup.py
@@ -771,7 +771,7 @@ def get_budget_custom_fields():
             {
                 "fieldname": "budget_accounts_hr",
                 "fieldtype": "Table",
-                "label": "Budget Accounts",
+                "label": "Budget Accounts(HR Overheads)",
                 "options": "Budget Account",
                 "insert_after": "budget_accounts_custom"
             },


### PR DESCRIPTION
## Feature description
- Update label of budget accounts.

## Solution description
- Changed Budget Accounts label to Budget Accounts(HR Overheads)

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/8265bc47-7cc9-4142-86c7-ce45c3ef5733)

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox