### PR TITLE
feat:     TASK-2025-00382 - added Required Items in Project

### DIFF
--- a/beams/beams/custom_scripts/asset_movement/asset_movement.py
+++ b/beams/beams/custom_scripts/asset_movement/asset_movement.py
@@ -1,17 +1,29 @@
 import frappe
 
 def update_issued_quantity(doc, method):
-    """ Update Issued Quantity in Equipment Request's Required Items Detail child table """
+    """
+    Update Issued Quantity in Equipment Request's Required Items Detail child table and Project
+    """
+    if frappe.db.exists("Required Items Detail", doc.reference_name):
+        issued_qty = frappe.db.get_value("Required Items Detail", doc.reference_name, "issued_quantity") or 0
+        frappe.db.set_value("Required Items Detail", doc.reference_name, "issued_quantity", issued_qty + 1)
 
-    # Ensure reference doctype is "Equipment Request"
-    if doc.reference_doctype != "Required Items Detail":
-        return
-    # Check if the referenced Required Items Detail exists
-    if not frappe.db.exists("Required Items Detail", doc.reference_name):
-        frappe.throw("Referenced Required Items Detail Not Found")
+        equipment_request = frappe.db.get_value("Required Items Detail", doc.reference_name, "parent")
+        if equipment_request:
+            project_name = frappe.db.get_value("Equipment Request", equipment_request, "project")
 
-    issued_qty = frappe.db.get_value("Required Items Detail", doc.reference_name, "issued_quantity") or 0
-    frappe.db.set_value("Required Items Detail", doc.reference_name, "issued_quantity", issued_qty + 1)
+            if project_name and frappe.db.exists("Project", project_name):
+                project_doc = frappe.get_doc("Project", project_name)
+                updated = False
+                required_item_value = frappe.db.get_value("Required Items Detail", doc.reference_name, "required_item")
+
+                for item in project_doc.required_items:
+                    if item.required_item == required_item_value:
+                        item.issued_quantity += 1
+                        updated = True
+
+                if updated:
+                    project_doc.save()
 
 def before_save(doc, method):
     if doc.assets:

--- a/beams/beams/custom_scripts/project/project.js
+++ b/beams/beams/custom_scripts/project/project.js
@@ -237,6 +237,26 @@ frappe.ui.form.on('Project', {
                       });
                         }
                     });
+                    // **Auto-fill table with items from Required Items**
+                    let equipments_data = frm.doc.required_items.map(item => ({
+                      item: item.required_item, // Ensure this matches the Required Items table
+                      available_quantity: item.available_quantity || 0,
+                      required_quantity: item.required_quantity || 1
+                    }));
+
+                    // **Populate Table in the Dialog**
+                    dialog.fields_dict.equipments.df.data = equipments_data;
+                    dialog.fields_dict.equipments.grid.refresh();
+
+                    // **Filter the Item Field to Remove Already Selected Items**
+                    dialog.fields_dict.equipments.grid.get_field('item').get_query = function () {
+                      let selected_items = dialog.fields_dict.equipments.df.data.map(row => row.item);
+                      return {
+                        filters: {
+                          name: ['in', frm.doc.required_items.map(item => item.required_item).filter(item => !selected_items.includes(item))]
+                        }
+                      };
+                    };
                     dialog.show();
                 }, __("Create"));
 

--- a/beams/beams/custom_scripts/purchase_order/purchase_order.py
+++ b/beams/beams/custom_scripts/purchase_order/purchase_order.py
@@ -114,7 +114,7 @@ def fetch_department_from_cost_center(doc, method):
 @frappe.whitelist()
 def update_equipment_quantities(doc, method):
     """
-    Update the 'acquired_quantity' field in the 'Required Acquiral Items' child table
+    Update the 'acquired_quantity' field in the 'Required Acquiral Items' child table and project
     of the linked Equipment Acquiral Request when the Purchase Order is submitted.
     """
     old_doc = doc.get_doc_before_save()
@@ -141,3 +141,13 @@ def update_equipment_quantities(doc, method):
                                 if e_item.required_item == ea_item:
                                     e_item.acquired_quantity = (e_item.acquired_quantity + item.qty)
                             er_doc.save()
+
+                            project = frappe.db.get_value("Equipment Request", equipment_request, "project")
+                            if project:
+                                project_doc = frappe.get_doc("Project", project)
+
+                                for p_item in project_doc.required_items:
+                                    if p_item.required_item == ea_item:
+                                        p_item.acquired_quantity += item.qty
+
+                                project_doc.save()

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -345,6 +345,20 @@ def get_project_custom_fields():
                 "fetch_from":"program_request.location",
                 "insert_after": "department",
                 "fetch_on_save_if_empty":1
+            },
+            {
+                "fieldname": "required_items_details",
+                "fieldtype": "Section Break",
+                "label": "Required Items Details",
+                "collapsible": 1,
+                "insert_after": "estimated_budget"
+            },
+            {
+                "fieldname": "required_items",
+                "fieldtype": "Table",
+                "label": "Required Items",
+                "options": "Required Items Detail",
+                "insert_after": "required_items_details"
             }
 
         ]


### PR DESCRIPTION
## Feature description
- added Required Items child table  in Project

## Solution description
- added Required Items child table  in Project
- The "Item" field in the dialog only shows items that are listed in the required_items table
- Add a table in Project to Required Items in Project. (Use the same table as in the equipment request.)
- Only items from required_items are selectable.
- Once an item is selected, it will no longer be available in the dropdown.
- If an item is removed from the table, it becomes available again.
- update Required Items Detail in project when Purchase Order and asset movement is submitted
- changed issued quantity and acquired quantity

## Output screenshots (optional)

[Screencast from 18-03-25 11:40:46 AM IST.webm](https://github.com/user-attachments/assets/3de3dd24-0b28-4cd3-b490-6a01101daac4)

[Screencast from 17-03-25 01:40:44 PM IST.webm](https://github.com/user-attachments/assets/35d087c2-0e08-4f0b-9e7a-017b71a8ac28)


## Areas affected and ensured
Project

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - yes
  - Opera Mini
  - Safari
