### PR TITLE
    TASK-2025-00376: fixed  wrong currency in the field in the project doctype

### DIFF
--- a/beams/setup.py
+++ b/beams/setup.py
@@ -58,6 +58,7 @@ def after_install():
     create_custom_fields(get_asset_movement_custom_fields(),ignore_validate=True)
 
 
+
     #Creating BEAMS specific Property Setters
     create_property_setters(get_property_setters())
 
@@ -125,6 +126,7 @@ def before_uninstall():
     delete_custom_fields(get_asset_movement_custom_fields())
 
 
+
 def delete_custom_fields(custom_fields: dict):
     '''
     Method to Delete custom fields
@@ -166,6 +168,7 @@ def get_shift_assignment_custom_fields():
 
         ]
     }
+
 
 def get_Payroll_Settings_custom_fields():
     '''
@@ -309,7 +312,6 @@ def get_project_custom_fields():
                 "fieldname": "approved_budget",
                 "fieldtype": "Currency",
                 "label": "Approved Budget",
-                "options":"approved_budget",
                 "insert_after":"budget_expense_types",
                 "read_only": 1
 
@@ -318,7 +320,6 @@ def get_project_custom_fields():
                 "fieldname": "estimated_budget",
                 "fieldtype": "Currency",
                 "label": "Estimated Budget",
-                "options":"Estimated Budget",
                 "fetch_from": "program_request.estimated_budget",
                 "insert_after":"approved_budget",
                 "read_only": 1

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -58,7 +58,6 @@ def after_install():
     create_custom_fields(get_asset_movement_custom_fields(),ignore_validate=True)
 
 
-
     #Creating BEAMS specific Property Setters
     create_property_setters(get_property_setters())
 
@@ -126,7 +125,6 @@ def before_uninstall():
     delete_custom_fields(get_asset_movement_custom_fields())
 
 
-
 def delete_custom_fields(custom_fields: dict):
     '''
     Method to Delete custom fields
@@ -168,7 +166,6 @@ def get_shift_assignment_custom_fields():
 
         ]
     }
-
 
 def get_Payroll_Settings_custom_fields():
     '''


### PR DESCRIPTION
## Issue  description
wrong currency appearing in Approved Budget field of Project


## Solution description
- wrong currency is updated in the approved budget field  in project doctype
- removed option for currency field approved budget and estimated_budget

## Output screenshots (optional)

[Screencast from 17-03-25 01:57:00 PM IST.webm](https://github.com/user-attachments/assets/239f6fc1-bdb4-4515-afa8-299931cb5e7b)
![image](https://github.com/user-attachments/assets/2eadfd20-5647-4562-b7e6-c3d1b6cf5bdb)

## Areas affected and ensured List out the areas affected by your code changes.
Project

## Is there any existing behavior change of other features due to this code change?

 No

## Was this feature tested on the browsers?

  - Mozilla Firefox
  
