### PR TITLE
TASK-2025-00381:Created Service Purchase Order from External Resource Request

### DIFF
--- a/beams/beams/doctype/external_resource_request/external_resource_request.js
+++ b/beams/beams/doctype/external_resource_request/external_resource_request.js
@@ -18,8 +18,100 @@ frappe.ui.form.on("External Resource Request", {
                 frm.refresh_field("required_resources");
             }
         })
-      }
+      },
+        refresh: function (frm) {
+            if (!frm.is_new()) {
+                frm.add_custom_button(__('Service Purchase Order'), function () {
+                    let dialog = new frappe.ui.Dialog({
+                        title: __('Create Service Purchase Order'),
+                        fields: [
+                            {
+                                fieldtype: 'Link',
+                                label: 'Supplier',
+                                fieldname: 'supplier',
+                                options: 'Supplier',
+                                reqd: 1
+                            },
+                            {
+                                fieldtype: 'Date',
+                                label: 'Required by Date',
+                                fieldname: 'schedule_date',
+                                default: frappe.datetime.nowdate(),
+                                reqd: 1
+                            },
+                            {
+                                fieldtype: 'Link',
+                                label: 'Service Item',
+                                fieldname: 'service_item',
+                                options: 'Item',
+                                reqd: 1,
+                                get_query: function () {
+                                    return {
+                                        filters: {
+                                            hireable: 1 
+                                        }
+                                    };
+                                }
+                            },
+                            {
+                                fieldtype: 'Float',
+                                label: 'Quantity',
+                                fieldname: 'qty',
+                                default: 1,
+                                reqd: 1
+                            },
+                            {
+                                fieldtype: 'Currency',
+                                label: 'Rate',
+                                fieldname: 'rate',
+                                reqd: 1
+                            }
+                        ],
+                        primary_action_label: __('Create Purchase Order'),
+                        primary_action: function () {
+                            let values = dialog.get_values();
+    
+                            if (!values.supplier || !values.schedule_date || !values.service_item || !values.qty || !values.rate) {
+                                frappe.msgprint(__('All fields are required!'));
+                                return;
+                            }
+    
+                            frappe.call({
+                                method: "frappe.client.insert",
+                                args: {
+                                    doc: {
+                                        doctype: "Purchase Order",
+                                        supplier: values.supplier,
+                                        transaction_date: frappe.datetime.nowdate(),
+                                        schedule_date: values.schedule_date,
+                                        items: [
+                                            {
+                                                item_code: values.service_item,
+                                                qty: values.qty,
+                                                rate: values.rate,
+                                                amount: values.qty * values.rate,
+                                                uom: "Nos"
+                                            }
+                                        ]
+                                    }
+                                },
+                                callback: function (response) {
+                                    if (response.message) {
+                                        frappe.set_route('Form', 'Purchase Order', response.message.name);
+                                    }
+                                }
+                            });
+    
+                            dialog.hide();
+                        }
+                    });
+    
+                    dialog.show();
+                }, __("Create"));
+            }
+        }
     });
+    
 
     frappe.ui.form.on("External Resources Detail", {
         required_resources_add: function (frm, cdt, cdn) {


### PR DESCRIPTION
## Feature description
Create Service Purchase order from External Resource Request.

## Solution description
Added a button in External Resource Request to  Create Service Purchase Order and on action of this button    dialog box appears and on submission of this popup Service Purchase Order is created.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/cade2e28-be90-4bb5-a985-97bd5394e105)
![image](https://github.com/user-attachments/assets/bff082c0-bc3e-4b25-9bcb-0ff28d8b249a)


## Areas affected and ensured
External Resource Request
Purchase Order 

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox

