### PR TITLE
TASK-2025-00383: create asset transfer request form the employee onboarding doctype

### DIFF
--- a/beams/beams/custom_scripts/employee_onboarding/employee_onboarding.js
+++ b/beams/beams/custom_scripts/employee_onboarding/employee_onboarding.js
@@ -1,5 +1,13 @@
 frappe.ui.form.on('Employee Onboarding', {
     refresh: function(frm) {
+        if (frm.doc.docstatus === 1 && frm.doc.employee) {
+            frappe.call({
+                method: "beams.beams.custom_scripts.employee_onboarding.employee_onboarding.after_submit",
+                args: { "doc_name": frm.doc.name },
+                callback: function(response) {
+                }
+            });
+        }
         // Check if CPAL already exists for the employee
         frappe.call({
             method: "frappe.client.get_list",

--- a/beams/beams/doctype/asset_transfer_request/asset_transfer_request.json
+++ b/beams/beams/doctype/asset_transfer_request/asset_transfer_request.json
@@ -46,7 +46,7 @@
    "fieldname": "asset_type",
    "fieldtype": "Select",
    "label": "Asset Type",
-   "options": "Single Asset\nBundle",
+   "options": "\nSingle Asset\nBundle",
    "reqd": 1
   },
   {
@@ -171,7 +171,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-03-03 13:58:26.799954",
+ "modified": "2025-03-17 15:10:36.965694",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Asset Transfer Request",

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -56,6 +56,7 @@ def after_install():
     create_custom_fields(get_hr_settings_custom_fields(),ignore_validate=True)
     create_custom_fields(get_asset_category_custom_fields(),ignore_validate=True)
     create_custom_fields(get_asset_movement_custom_fields(),ignore_validate=True)
+    create_custom_fields(get_employee_onboarding_custom_fields(),ignore_validate=True)
 
 
     #Creating BEAMS specific Property Setters
@@ -123,6 +124,7 @@ def before_uninstall():
     delete_custom_fields(get_hr_settings_custom_fields())
     delete_custom_fields(get_asset_category_custom_fields())
     delete_custom_fields(get_asset_movement_custom_fields())
+    delete_custom_fields(get_employee_onboarding_custom_fields())
 
 
 def delete_custom_fields(custom_fields: dict):
@@ -164,6 +166,46 @@ def get_shift_assignment_custom_fields():
 
             }
 
+        ]
+    }
+
+def get_employee_onboarding_custom_fields():
+    '''
+    Custom fields that need to be added to the Employment Onboarding DocType
+    '''
+    return {
+        "Employee Onboarding": [
+            {
+                "fieldname": "section_break_onboard",
+                "fieldtype": "Section Break",
+                "label": " ",
+                "insert_after": "activities"
+            },
+            {
+                "fieldname": "assigned_assets",
+                "fieldtype": "Table MultiSelect",
+                "label": "Assigned Assets",
+                "options": "Assets",
+                "insert_after": "section_break_onboard"
+            },
+            {
+                "fieldname": "column_break_onboarding",
+                "fieldtype": "Column Break",
+                "insert_after": "assigned_assets"
+            },
+            {
+                "fieldname": "assigned_bundles",
+                "fieldtype": "Table MultiSelect",
+                "label": "Assigned bundles",
+                "options": "Bundles",
+                "insert_after": "column_break_onboarding"
+            },
+            {
+                "fieldname": "onboarding_asset_section_break",
+                "fieldtype": "Section Break",
+                "label": "",
+                "insert_after": "assigned_bundles"
+            }
         ]
     }
 


### PR DESCRIPTION
## Feature description
1.  need  to created asset transfer request from asset and bundle in the employee onboarding 
2. need remove default value in the asset type field in the asset transfer request 
3. customization on the employee onboarding doctype

## Solution description
1.  Created asset transfer request from asset and bundle in the employee onboarding
- after the submission if employee has value only create asset transfer requests from the employee onboarding and the
- also Bureau field have value asset transfer request is created in background via employee onboarding.py and employee_onboarding .js 
- 2. removed default asset type in the asset transfer request 
- customized the assigned_assets(multiselcet) and assigned_bundles (multiselcet) in the employee onboarding 

## Output screenshots (optional)
.[Screencast from 18-03-25 01:21:08 PM IST.webm](https://github.com/user-attachments/assets/96ddb452-31e7-4de4-9716-6bfb04f06de6)

## Areas affected and ensured
employee onboarding and asset transfer request doctype

## Is there any existing behavior change of other features due to this code change?
 No.

## Was this feature tested on the browsers?
  - Mozilla Firefox