### PR TITLE
ISS-2025-00155:Made Expected Revenue mandatory when Generates Revenue is checked

### DIFF
--- a/beams/beams/doctype/program_request/program_request.js
+++ b/beams/beams/doctype/program_request/program_request.js
@@ -7,5 +7,11 @@ frappe.ui.form.on('Program Request', {
     },
     end_date: function (frm) {
         frm.call("validate_start_date_and_end_dates");
-    }
+    },
+    validate: function(frm) {
+       if (frm.doc.generates_revenue && frm.doc.expected_revenue <= 0) {
+           frappe.msgprint(__('Expected Revenue must be greater than 0.'));
+           frappe.validated = false;  // Prevents form submission
+       }
+   }
 });

--- a/beams/beams/doctype/program_request/program_request.json
+++ b/beams/beams/doctype/program_request/program_request.json
@@ -145,13 +145,14 @@
   {
    "fieldname": "expected_revenue",
    "fieldtype": "Float",
-   "label": "Expected Revenue"
+   "label": "Expected Revenue",
+   "mandatory_depends_on": "eval:doc.generates_revenue == 1\n"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-02-07 09:55:16.690563",
+ "modified": "2025-03-19 12:18:37.206677",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Program Request",


### PR DESCRIPTION
## Feature description
Need to: Make Expected Revenue mandatory when Generates Revenue is checked in Program Request Doctype

## Solution description
Made Expected Revenue mandatory when Generates Revenue is checked  in Program Request Doctype and it is Validated before save using js code.

## Output screenshots (optional)
[Screencast from 19-03-25 12:47:58 PM IST.webm](https://github.com/user-attachments/assets/fb1db4d7-64db-4205-8b92-7c3721c30abe)

## Areas affected and ensured
Program Request Doctype

## Is there any existing behavior change of other features due to this code change?
No. 

## Was this feature tested on the browsers?
  - Mozilla Firefox
 