### PR TITLE
fix: hide asset movement button in project

### DIFF
--- a/beams/beams/custom_scripts/project/project.js
+++ b/beams/beams/custom_scripts/project/project.js
@@ -1,5 +1,6 @@
 frappe.ui.form.on('Project', {
     refresh(frm) {
+      hide_asset_movement_field(frm);
       //function adds a button to the 'Project' form to create an Adhoc Budget.
         frm.add_custom_button(__('Adhoc Budget'), function () {
             frappe.model.open_mapped_doc({
@@ -292,6 +293,19 @@ frappe.ui.form.on('Project', {
         };
       }
     });
+
+    function hide_asset_movement_field(frm) {
+        /**
+         * Dynamically hides the "asset_movement" field in the "Required Items"
+         * child table within the relevant doctype.
+         */
+        ["required_items"].forEach(table_name => {
+            if (frm.fields_dict[table_name]) {
+                frm.fields_dict[table_name].grid.update_docfield_property("asset_movement", "hidden", 1);
+                frm.fields_dict[table_name].grid.refresh();
+            }
+        });
+    }
 
     // Apply filter dynamically when Designation field changes in child table
   frappe.ui.form.on('Allocated Resource Detail', {


### PR DESCRIPTION
## Feature description
Need to Hide the Asset Movement Button in the Required Items child table in project doctype

## Solution description
This function hides the asset_movement button in the required_items child table by dynamically updating its hidden property and refreshing the grid to apply the change

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/c5e42993-c972-423d-a4f3-aeab6aff7bf9)


## Areas affected and ensured
List out the areas affected by your code changes.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
