### PR TITLE
TASK-2025-00402: feat: Project Modified

### DIFF
--- a/beams/beams/custom_scripts/project/project.js
+++ b/beams/beams/custom_scripts/project/project.js
@@ -9,105 +9,20 @@ frappe.ui.form.on('Project', {
             });
         }, __("Create"));
 
-        // Add "Technical Request" button under the "Create" group
+
         frm.add_custom_button(__('Technical Request'), function () {
-            // Open a dialog with the specified fields
-            let dialog = new frappe.ui.Dialog({
-                title: 'Technical Request',
-                fields: [
-                    {
-                        fieldtype: 'Table',
-                        label: 'Requirements',
-                        fieldname: 'requirements',
-                        reqd: 1,
-                        fields: [
-                            {
-                                label: 'Department',
-                                fieldtype: 'Link',
-                                fieldname: 'department',
-                                options: 'Department',
-                                in_list_view: 1,
-                                reqd: 1
-                            },
-                            {
-                                label: 'Designation',
-                                fieldtype: 'Link',
-                                fieldname: 'designation',
-                                options: 'Designation',
-                                in_list_view: 1,
-                                reqd: 1
-                            },
-                            {
-                                label: 'No of Employees',
-                                fieldtype: 'Int',
-                                fieldname: 'no_of_employees',
-                                in_list_view: 1
-                            },
-                            {
-                                label: 'Required From',
-                                fieldtype: 'Datetime',
-                                fieldname: 'required_from',
-                                in_list_view: 1,
-                                reqd: 1
-                            },
-                            {
-                                label: 'Required To',
-                                fieldtype: 'Datetime',
-                                fieldname: 'required_to',
-                                in_list_view: 1,
-                                reqd: 1
-                            },
-                            {
-                                label: 'Remarks',
-                                fieldtype: 'Small Text',
-                                fieldname: 'remarks',
-                                in_list_view: 1
-                            }
-                        ]
-                    }
-                ],
-                size: 'large',
-                primary_action_label: 'Submit',
-                primary_action: function () {
-                    let values = dialog.get_values();
-                    if (values && values.requirements) {
-                        // Perform validation for each row
-                        for (let i = 0; i < values.requirements.length; i++) {
-                            let row = values.requirements[i];
-
-                            if (!row.required_from || !row.required_to) {
-                                frappe.msgprint({
-                                    title: __('Validation Error'),
-                                    message: __('Please fill both "Required From" and "Required To" in #row  {0}.', [i + 1]),
-                                    indicator: 'red'
-                                });
-                                return;
-                            }
-
-                            // Ensure Required To is later than Required From
-                            if (row.required_to <= row.required_from) {
-                                frappe.msgprint({
-                                    title: __('Validation Error'),
-                                    message: __('"Required To" must be later than "Required From" in # row {0}.', [i + 1]),
-                                    indicator: 'red'
-                                });
-                                return;
-                            }
-                        }
-
-                        frappe.call({
-                            method: 'beams.beams.custom_scripts.project.project.create_technical_support_request',
-                            args: {
-                                project_id: frm.doc.name,
-                                requirements: JSON.stringify(values.requirements)
-                            },
-                        });
-                        dialog.hide();
-                    }
-                }
-            });
-            dialog.show();
-          }, __("Create"));
+         frappe.call({
+             method: "beams.beams.custom_scripts.project.project.create_technical_request",
+             args: {
+                 project_id: frm.doc.name  
+             },
+             callback: function (r) {
+                 if (r.message) {
+                     frappe.set_route("Form", "Technical Request", r.message);
+                 }
+             }
+         });
+     }, __("Create"));
 
         // Add "Equipment Request" button under the "Create" group
         frm.add_custom_button(__('Equipment Request'), function () {

--- a/beams/beams/doctype/allocated_resource_detail/allocated_resource_detail.json
+++ b/beams/beams/doctype/allocated_resource_detail/allocated_resource_detail.json
@@ -6,10 +6,11 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
+  "department",
   "designation",
-  "assigned_from",
-  "assigned_to",
-  "employee"
+  "employee",
+  "hired_personnel",
+  "hired_personnel_contact_info"
  ],
  "fields": [
   {
@@ -20,29 +21,36 @@
    "options": "Designation"
   },
   {
-   "fieldname": "assigned_from",
-   "fieldtype": "Datetime",
-   "in_list_view": 1,
-   "label": "Assigned From"
-  },
-  {
-   "fieldname": "assigned_to",
-   "fieldtype": "Datetime",
-   "in_list_view": 1,
-   "label": "Assigned To"
-  },
-  {
    "fieldname": "employee",
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Employee",
    "options": "Employee"
+  },
+  {
+   "fieldname": "department",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Department",
+   "options": "Department"
+  },
+  {
+   "fieldname": "hired_personnel",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Hired Personnel"
+  },
+  {
+   "fieldname": "hired_personnel_contact_info",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Hired Personnel Contact Info"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-01-18 12:19:31.195378",
+ "modified": "2025-03-19 14:32:56.747852",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Allocated Resource Detail",

--- a/beams/beams/doctype/external_resource_request/external_resource_request.py
+++ b/beams/beams/doctype/external_resource_request/external_resource_request.py
@@ -6,6 +6,7 @@ from frappe.model.document import Document
 from frappe.utils import today,getdate
 from frappe import _
 from frappe.utils import today
+from frappe.utils import get_datetime
 
 class ExternalResourceRequest(Document):
 
@@ -14,6 +15,33 @@ class ExternalResourceRequest(Document):
 
     def before_save(self):
         self.validate_posting_date()
+
+    def on_submit(self):
+        self.update_external_resources_project_allocated_resources()
+
+    def update_external_resources_project_allocated_resources(self):
+        """Update the allocated_resources_details table in Project when a External Resource Request is Submitted."""
+        if not frappe.db.exists('Project', self.project):
+            frappe.throw(_("Invalid Project ID: {0}").format(self.project))
+
+        project = frappe.get_doc('Project', self.project)
+
+        allocated_resources = [
+            {
+                "department": req.department,
+                "designation": req.designation,
+                "assigned_from": get_datetime(req.required_from) if req.required_from else None,
+                "assigned_to": get_datetime(req.required_to) if req.required_to else None,
+                "hired_personnel": req.hired_personnel,
+                "hired_personnel_contact_info": req.contact_number
+            }
+            for req in self.get("required_resources", [])
+        ]
+
+        if allocated_resources:
+            project.extend("allocated_resources_details", allocated_resources)
+            project.save(ignore_permissions=True)
+
 
     @frappe.whitelist()
     def validate_required_from_and_required_to(self):

--- a/beams/beams/doctype/external_resources_detail/external_resources_detail.json
+++ b/beams/beams/doctype/external_resources_detail/external_resources_detail.json
@@ -6,6 +6,7 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
+  "department",
   "designation",
   "required_from",
   "required_to",
@@ -45,12 +46,19 @@
    "fieldtype": "Phone",
    "in_list_view": 1,
    "label": "Contact Number "
+  },
+  {
+   "fieldname": "department",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Department",
+   "options": "Department"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-01-18 12:01:57.703122",
+ "modified": "2025-03-19 16:02:33.883488",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "External Resources Detail",

--- a/beams/beams/doctype/required_manpower_details/required_manpower_details.json
+++ b/beams/beams/doctype/required_manpower_details/required_manpower_details.json
@@ -19,6 +19,7 @@
    "fieldname": "department",
    "fieldtype": "Link",
    "ignore_user_permissions": 1,
+   "in_list_view": 1,
    "label": "Department",
    "options": "Department"
   },
@@ -26,29 +27,34 @@
    "fieldname": "designation",
    "fieldtype": "Link",
    "ignore_user_permissions": 1,
+   "in_list_view": 1,
    "label": "Designation",
    "options": "Designation"
   },
   {
    "fieldname": "required_from",
    "fieldtype": "Datetime",
+   "in_list_view": 1,
    "label": "Required From"
   },
   {
    "fieldname": "required_to",
    "fieldtype": "Datetime",
+   "in_list_view": 1,
    "label": "Required To"
   },
   {
    "default": "0",
    "fieldname": "allocated",
    "fieldtype": "Check",
+   "in_list_view": 1,
    "label": "Allocated"
   },
   {
    "default": "0",
    "fieldname": "hired",
    "fieldtype": "Check",
+   "in_list_view": 1,
    "label": "Hired"
   },
   {
@@ -59,7 +65,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-03-19 11:39:42.226881",
+ "modified": "2025-03-19 14:33:36.895152",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Required Manpower Details",

--- a/beams/beams/doctype/technical_request/technical_request.js
+++ b/beams/beams/doctype/technical_request/technical_request.js
@@ -18,17 +18,17 @@ frappe.ui.form.on('Technical Request', {
         if (!frm.is_new() && frm.doc.workflow_state === "Approved") {
             frm.add_custom_button("External Resource Request", function() {
                 frappe.call({
-                    method: "beams.beams.doctype.technical_request.technical_request.map_external_resource_request",
+                    method: "beams.beams.doctype.technical_request.technical_request.create_external_resource_request",
                     args: {
-                        "technical_request": frm.doc.name
-                    },
-                    callback: function(response) {
-                        if (response.message) {
-                            frappe.set_route("Form", "External Resource Request", response.message);
-                        }
-                    },
-                });
-            }, "Create");
+                          technical_request: frm.doc.name
+                      },
+                      callback: function(response) {
+                          if (response.message) {
+                              frappe.set_route("Form", "External Resource Request", response.message);
+                          }
+                      }
+                  });
+              }, __("Create"));
         }
       },
     posting_date:function (frm){

--- a/beams/beams/doctype/technical_request/technical_request.py
+++ b/beams/beams/doctype/technical_request/technical_request.py
@@ -7,6 +7,7 @@ from frappe.utils import getdate,format_date
 from frappe import _
 from frappe.model.mapper import get_mapped_doc
 from frappe.utils import today
+from frappe.utils import get_datetime
 
 class TechnicalRequest(Document):
     def before_save(self):
@@ -21,22 +22,35 @@ class TechnicalRequest(Document):
         # Validate that 'Reason for Rejection' is not filled if the status is 'Approved'
         if self.workflow_state == "Approved" and self.reason_for_rejection:
             frappe.throw(title="Approval Error", msg="You cannot approve this request if 'Reason for Rejection' is filled.")
+        if self.workflow_state == "Approved" and self.project:
+            self.update_project_allocated_resources()
 
     def validate(self):
         self.validate_required_from_and_required_to()
 
-    def on_update_after_submit(self):
-        old_doc = self.get_doc_before_save()
-        for row in self.required_employees:
-            for old_row in old_doc.required_employees:
-                if (row.employee != old_row.employee) and (row.idx == old_row.idx) and not (not row.employee and not old_row.employee):
-                    hod = frappe.db.get_value("Department", row.department, "head_of_department")
-                    hod_user = frappe.db.get_value("Employee", hod, "user_id")
-                    if hod_user != frappe.session.user:
-                        frappe.throw(f"You do not have permission to select/change the employee at row #{row.idx}")
-            if old_doc.workflow_state == "Pending Approval" and self.workflow_state in ["Approved" , "Rejected"] :
-                if not row.employee:
-                    frappe.throw("Cannot Approve/Reject Technical Request without Assigning Employees")
+    def update_project_allocated_resources(self):
+        """Update the allocated_resources_details table in Project when a Technical Request is Approved."""
+        if not frappe.db.exists('Project', self.project):
+            frappe.throw(_("Invalid Project ID: {0}").format(self.project))
+
+        project = frappe.get_doc('Project', self.project)
+
+        allocated_resources = [
+            {
+                "department": emp.department,
+                "designation": emp.designation,
+                "employee": emp.employee,
+                "assigned_from": get_datetime(emp.required_from) if emp.required_from else None,
+                "assigned_to": get_datetime(emp.required_to) if emp.required_to else None,
+                "hired_personnel": "",
+                "hired_personnel_contact": ""
+            }
+            for emp in self.get("required_employees", []) if emp.employee
+        ]
+
+        if allocated_resources:
+            project.extend("allocated_resources_details", allocated_resources)
+            project.save(ignore_permissions=True)
 
     @frappe.whitelist()
     def validate_required_from_and_required_to(self):
@@ -62,37 +76,30 @@ class TechnicalRequest(Document):
             if self.posting_date > today():
                 frappe.throw(_("Posting Date cannot be set after today's date."))
 
-
 @frappe.whitelist()
-def map_external_resource_request(technical_request):
-    """
-    Map Technical Request to External Resource Request and manually add a child table row.
-    """
-    mapped_doc = get_mapped_doc(
-        "Technical Request",
-        technical_request,
-        {
-            "Technical Request": {
-                "doctype": "External Resource Request",
-                "field_map": {
-                    "name": "technical_request",
-                    "project": "project",
-                    "bureau": "bureau",
-                    "designation": "designation",
-                    "required_from": "required_from",
-                    "required_to": "required_to"
-                }
-            }
-        }
-    )
+def create_external_resource_request(technical_request):
+    tech_req = frappe.get_doc("Technical Request", technical_request)
 
-    mapped_doc.append("required_resources", {
-        "designation": mapped_doc.designation,
-        "required_from": mapped_doc.required_from,
-        "required_to": mapped_doc.required_to
-        })
+    # Create new External Resource Request
+    external_req = frappe.get_doc({
+        "doctype": "External Resource Request",
+        "project": tech_req.project,
+        "bureau": tech_req.bureau,
+        "location": tech_req.location,
+        "posting_date": tech_req.posting_date,
+        "required_from": tech_req.required_from,
+        "required_to": tech_req.required_to,
+        "required_resources": []
+    })
 
-    new_doc = frappe.get_doc(mapped_doc)
-    new_doc.insert(ignore_permissions=True)
+    for emp in tech_req.required_employees:
+        if not emp.employee:
+            external_req.append("required_resources", {
+                "department": emp.department,
+                "designation": emp.designation,
+                "required_from": emp.required_from,
+                "required_to": emp.required_to
+            })
 
-    return new_doc.name
+    external_req.insert(ignore_permissions=True)  
+    return external_req.name


### PR DESCRIPTION
## Feature description
 - Create Technical Request based on details in required Manpower Details, Only map rows with Allocated and Hired unchecked
 - Modify Allocated Resources Detail with custom fields
 - Fetch the data from the child table of project to the Technical request 
 - Remove Dailog box for Technical Request
 - Fetch the row in Technical Request where Employee field is empty to External Resource Doctype
 - Once Technical Request and External Resource Requstis approved, update Allocated Resource Details with the approved data

## Solution description
  - Created Technical Request based on details in required Manpower Details, Only map rows with Allocated and Hired unchecked
 - Modified Allocated Resources Detail with custom fields
 - Fetched the data from the child table of project to the Technical request 
 - Removed Dailog box for Technical Request
 - Fetched the row in Technical Request where Employee field is empty to External Resource Doctype
 - Once Technical Request and External Resource Requstis approved, update Allocated Resource Details with the approved data


## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/9def7023-8a12-401a-9cf1-a65a5a2a640b)





## Is there any existing behavior change of other features due to this code change?
 No

## Was this feature tested on the browsers?
  - Mozilla Firefox
 
