### PR TITLE
    TASK-2025-00419:Restrict selection of Origin and Destination in Work Detail if not set in Batta Claim.

### DIFF
--- a/beams/beams/doctype/batta_claim/batta_claim.js
+++ b/beams/beams/doctype/batta_claim/batta_claim.js
@@ -275,18 +275,24 @@ function calculate_batta_totals(frm) {
     });
 }
 
+frappe.ui.form.on('Batta Claim', {
+    origin: update_child_table,
+    destination: update_child_table
+});
+
+function update_child_table(frm) {
+    if (!frm.doc.work_detail) return;
+
+    frm.doc.work_detail.forEach(row => {
+        frappe.model.set_value(row.doctype, row.name, 'origin', frm.doc.origin || '');
+        frappe.model.set_value(row.doctype, row.name, 'destination', frm.doc.destination || '');
+    });
+}
 
 frappe.ui.form.on('Work Detail', {
-    distance_travelled_km: function(frm, cdt, cdn) {
-        calculate_total_distance_travelled(frm);
-    },
-
     work_detail_add: function(frm, cdt, cdn) {
-        const { origin, destination } = frm.doc;
-
-           // Set initial values for the new row
-        frappe.model.set_value(cdt, cdn, 'origin', origin);
-        frappe.model.set_value(cdt, cdn, 'destination', destination);
+        frappe.model.set_value(cdt, cdn, 'origin', frm.doc.origin || '');
+        frappe.model.set_value(cdt, cdn, 'destination', frm.doc.destination || '');
     }
 });
 


### PR DESCRIPTION
## Feature description
     Restrict selection of Origin and Destination in Work Detail if not set in Batta Claim.

## Solution description
     Disabled Origin and Destination in Work Detail until they are not set in Batta Claim

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/e18b2e5f-c0ba-46b0-a296-f4b5065a6ca7)

![image](https://github.com/user-attachments/assets/ccb7725f-d6d7-42ee-b3cd-239cf0060caa)


## Is there any existing behavior change of other features due to this code change?
     Yes 

## Was this feature tested on the browsers?
      Mozilla Firefox
