### PR TITLE
Validated Multiple account selection in Voucher Entry Type

### DIFF
--- a/beams/beams/custom_scripts/voucher_entry_type/voucher_entry_type.py
+++ b/beams/beams/custom_scripts/voucher_entry_type/voucher_entry_type.py
@@ -1,0 +1,12 @@
+
+
+import frappe
+from frappe import _
+
+@frappe.whitelist()
+def validate_repeating_companies(doc, method=None):
+    """Error when the same Company is entered multiple times in accounts"""
+    companies = [entry.company for entry in doc.accounts]
+
+    if len(companies) != len(set(companies)):
+        frappe.throw(_("Same Company is entered mutiple times in Accounts"))

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -324,6 +324,13 @@ doc_events = {
     "Budget":{
         "validate":"beams.beams.custom_scripts.budget.budget.update_total_amount"
     },
+    "Attendance Request":{
+        "before_save":"beams.beams.custom_scripts.attendance_request.attendance_request.validate_to_date"
+    },
+    "Voucher Entry Type":{
+        "validate":"beams.beams.custom_scripts.voucher_entry_type.voucher_entry_type.validate_repeating_companies"
+    }
+        
 }
 
 # Scheduled Tasks


### PR DESCRIPTION
## Feature description
Restrict Multiple Accounts selection for a Single Company in Voucher Entry Type.

## Analysis and design (optional)
This update ensures that a company in Voucher Entry can have multiple accounts, but the same account cannot be assigned more than once to the same company.

## Solution description
Added validation function:
-     Uses a dictionary to track accounts for each company.
-     Throws an error if the same account is added twice for the same company.
Updated hooks.py to call this function during validation.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/d0daac50-818e-4991-84f3-038ad6034c5d)


## Areas affected and ensured
Voucher Entry Type

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox

