### PR TITLE
TASK-2025-00420: Fixed the issue "No of Days is not reflecting when Batta Type is External in Batta Claim".

### DIFF
--- a/beams/beams/doctype/batta_claim/batta_claim.js
+++ b/beams/beams/doctype/batta_claim/batta_claim.js
@@ -223,6 +223,7 @@ function calculate_hours_and_totals(frm, cdt, cdn) {
                         row.number_of_days = Math.ceil(row.total_hours / 24);
                         row.daily_batta = row.number_of_days * frm.doc.batta;
                     } else if (frm.doc.batta_based_on === 'Hours') {
+                        row.number_of_days = Math.ceil(row.total_hours / 24);
                         row.daily_batta = (row.total_hours - row.ot_hours) * frm.doc.batta;
                     }
 


### PR DESCRIPTION
## Feature description
Need to: Fix the issue "No of Days is not reflecting when Batta Type is External in Batta Claim".

## Solution description
Fixed the issue "No of Days is not reflecting when Batta Type is External in Batta Claim".

## Output screenshots (optional)

[Screencast from 20-03-25 02:10:35 PM IST.webm](https://github.com/user-attachments/assets/84751f0f-53c9-490c-9217-c99a4b68d0f4)

## Areas affected and ensured
Batta Claim Doctype

## Is there any existing behavior change of other features due to this code change?
Yes 

## Was this feature tested on the browsers?
 - Mozilla Firefox

