### PR TITLE
TASK-2025-00422:Validated multiple account selection for the same company.

### DIFF
--- a/beams/beams/custom_scripts/voucher_entry_type/voucher_entry_type.py
+++ b/beams/beams/custom_scripts/voucher_entry_type/voucher_entry_type.py
@@ -1,0 +1,10 @@
+import frappe
+from frappe import _
+
+@frappe.whitelist()
+def validate_repeating_companies(doc, method=None):
+    """Error when the same Company is entered multiple times in accounts"""
+    companies = [entry.company for entry in doc.accounts]
+
+    if len(companies) != len(set(companies)):
+        frappe.throw(_("Same Company is entered mutiple times in Accounts"))

--- a/beams/beams/custom_scripts/voucher_entry_type/voucher_entry_type.py
+++ b/beams/beams/custom_scripts/voucher_entry_type/voucher_entry_type.py
@@ -7,4 +7,7 @@ def validate_repeating_companies(doc, method=None):
     companies = [entry.company for entry in doc.accounts]
 
     if len(companies) != len(set(companies)):
-        frappe.throw(_("Same Company is entered mutiple times in Accounts"))
+        frappe.throw(
+            _("Same Company is entered multiple times in Accounts"), 
+            title=_("Duplicate Company Entry")
+        )

--- a/beams/beams/doctype/batta_claim/batta_claim.json
+++ b/beams/beams/doctype/batta_claim/batta_claim.json
@@ -232,7 +232,7 @@
    "label": "Is Overnight Stay"
   },
   {
-   "depends_on": "eval: doc.batta_type == 'Internal'",
+   "depends_on": "eval: (doc.batta_type == 'Internal' && doc.is_overnight_stay ==1);",
    "fieldname": "room_criteria",
    "fieldtype": "Table MultiSelect",
    "label": "Room Criteria",
@@ -290,7 +290,7 @@
    "link_fieldname": "batta_claim_reference"
   }
  ],
- "modified": "2025-03-19 19:53:17.013025",
+ "modified": "2025-03-21 11:38:27.414706",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Batta Claim",

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -326,6 +326,9 @@ doc_events = {
         "validate":"beams.beams.custom_scripts.budget.budget.beams_budget_validate",
         "before_validate":"beams.beams.custom_scripts.budget.budget.populate_og_accounts"
     },
+    "Voucher Entry Type": {
+        "validate" :"beams.beams.custom_scripts.voucher_entry_type.voucher_entry_type.validate_repeating_companies"
+    }
 }
 
 # Scheduled Tasks

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -3793,7 +3793,16 @@ def get_property_setters():
             "property": "default",
             "property_type": "Link",
             "value":"Employee"
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Voucher Entry",
+            "field_name": "bureau",
+            "property": "in_standard_filter",
+            "property_type": "Check",
+            "value":1
         }
+
 
     ]
 


### PR DESCRIPTION
## Feature description
Restrict Multiple Accounts selection for a Single Company in Voucher Entry Type.

## Analysis and design (optional)
This update ensures that a company in Voucher Entry can have multiple accounts, but the same account cannot be assigned more than once to the same company.

## Solution description
Added validation function:
-     Uses a dictionary to track accounts for each company.
-     Throws an error if the same account is added twice for the same company.
Updated hooks.py to call this function during validation.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/d0daac50-818e-4991-84f3-038ad6034c5d)


## Areas affected and ensured
Voucher Entry Type

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox

