### PR TITLE
fix: Correct Debit/Credit Entries for Expense & Payable Accounts

### DIFF
--- a/beams/beams/doctype/batta_claim/batta_claim.py
+++ b/beams/beams/doctype/batta_claim/batta_claim.py
@@ -72,15 +72,13 @@ class BattaClaim(Document):
             'account': batta_payable_account,
             'party_type': 'Employee',
             'party': self.employee,
-            'debit_in_account_currency': 0,
-            'credit_in_account_currency': self.total_driver_batta,
+            'debit_in_account_currency': self.total_driver_batta,
+            'credit_in_account_currency': 0,
         })
         journal_entry.append('accounts', {
             'account': batta_expense_account,
-            'party_type': 'Employee',
-            'party': self.employee,
-            'debit_in_account_currency': self.total_driver_batta,
-            'credit_in_account_currency': 0,
+            'debit_in_account_currency': 0,
+            'credit_in_account_currency': self.total_driver_batta,
         })
         journal_entry.insert()
         journal_entry.submit()


### PR DESCRIPTION
## Feature description
Fixed incorrect journal entry postings for Expense and Payable accounts in Batta Claim Approval.
## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description
- Expense account now records the amount in credit.
- Payable account now records the amount in debit.
- remove party and party type from expense account

## Output screenshots (optional)

- created a batta claim and Approved it
- ![image](https://github.com/user-attachments/assets/49003fa3-21cb-48b6-9811-01ac748d8a42)
-Creation of Journal Entry on the approval of batta claim
![image](https://github.com/user-attachments/assets/a6eaf0a5-b0f4-4f70-8906-6da151a9e0ee)


## Areas affected and ensured
Journal Entry creation from batta claim Approval
## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari

