### PR TITLE
TASK-2025-00441 : Type Error in Trip Sheet when string is entered in Final Odome…

### DIFF
--- a/beams/beams/doctype/trip_sheet/trip_sheet.py
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.py
@@ -8,8 +8,20 @@ from frappe import _
 
 class TripSheet(Document):
     def validate(self):
+        # Ensure the final_odometer_reading is not None and is an integer
+        if self.final_odometer_reading is None:
+            frappe.throw("Please enter an integer value for Final Odometer Reading.")
+
+        if not isinstance(self.final_odometer_reading, int):
+            frappe.throw("Please enter an integer value for Final Odometer Reading.")
+            
+        if not self.travel_requests and not self.transportation_requests:
+            frappe.throw("Please provide at least one of Travel Requests or Transportation Requests.")
+
         self.validate_start_datetime_and_end_datetime()
         self.calculate_and_validate_fuel_data()
+
+
     def before_save(self):
         self.validate_posting_date()
 


### PR DESCRIPTION
## Feature description

- Type Error in Trip Sheet when string is entered in Final Odometer Reading
-  Validate one of the field travel request or transportation request is mandatory

## Solution description
- If the field final odometer reading is empty or entered wrong data then frappe throw
- validated that one of the field travel or transportation request is mandatory

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/64c3d3e4-a031-4db3-8588-9d689c1ab6bf)
![image](https://github.com/user-attachments/assets/2b44e936-7037-4520-a4fb-92a7d3debea5)
![image](https://github.com/user-attachments/assets/d092cbb8-7414-4403-92e8-2dff0ead6778)



