### PR TITLE
fix: Validated the expected checkin time and expected checkout time in employee travel request

### DIFF
--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.js
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.js
@@ -45,6 +45,13 @@ frappe.ui.form.on('Employee Travel Request', {
     },
     end_date:function (frm){
       frm.call("validate_dates");
+       calculateTotalDays(frm);
+    },
+    validate:function(frm){
+      frm.call("validate_expected_time");
+    },
+    start_date:function(frm){
+      calculateTotalDays(frm);
     }
 });
 
@@ -86,4 +93,15 @@ function set_mode_of_travel_filter(frm) {
           })
       },
   });
+}
+
+function calculateTotalDays(frm) {
+    if (frm.doc.start_date && frm.doc.end_date) {
+        let start = new Date(frm.doc.start_date);
+        let end = new Date(frm.doc.end_date);
+        let diff = frappe.datetime.get_day_diff(end, start);
+        frm.set_value('total_days', diff > 0 ? diff : 1);
+    } else {
+        frm.set_value('total_days', null);
+    }
 }

--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.py
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.py
@@ -21,6 +21,8 @@ class EmployeeTravelRequest(Document):
     def validate(self):
         self.validate_dates()
         self.calculate_total_days()
+        self.validate_expected_time()
+        self.total_days_calculate()
 
     def before_save(self):
         self.validate_posting_date()
@@ -73,6 +75,20 @@ class EmployeeTravelRequest(Document):
         if self.posting_date:
             if self.posting_date > today():
                 frappe.throw(_("Posting Date cannot be set after today's date."))
+
+    @frappe.whitelist()
+    def validate_expected_time(self):
+        """Ensure Expected Check-out Time is not earlier than Expected Check-in Time."""
+        if self.expected_check_in_time and self.expected_check_out_time:
+            if self.expected_check_out_time < self.expected_check_in_time:
+                frappe.throw("Expected Check-out Time cannot be earlier than Expected Check-in Time.")
+
+    def total_days_calculate(self):
+        """Calculate the total number of travel days, ensuring at least one day."""
+        if self.start_date and self.end_date:
+            start_date = datetime.strptime(self.start_date, "%Y-%m-%d %H:%M:%S").date()
+            end_date = datetime.strptime(self.end_date, "%Y-%m-%d %H:%M:%S").date()
+            self.total_days = 1 if start_date == end_date else (end_date - start_date).days + 1
 
 @frappe.whitelist()
 def get_batta_policy(requested_by):

--- a/beams/beams/doctype/transportation_request/transportation_request.json
+++ b/beams/beams/doctype/transportation_request/transportation_request.json
@@ -75,7 +75,8 @@
   {
    "fieldname": "requirements",
    "fieldtype": "Text Editor",
-   "label": "Requirements"
+   "label": "Requirements",
+   "reqd": 1
   },
   {
    "allow_on_submit": 1,
@@ -142,7 +143,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-03-19 14:32:24.792056",
+ "modified": "2025-03-21 15:06:46.314975",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Transportation Request",


### PR DESCRIPTION

## Feature description

 1. make the field mandatory  field in  Transportation Request  doctype
 2.  Need Validate "Expected Check-in Time"and "Expected Check-out Time" in Employee Travel Request doctype
 3. Total Days has to be one if travel ends in the same day
 
## Solution description

1. make mandatory  field Requirements  in transportation request doctype
2. validated the   "Expected Check-in Time"and "Expected Check-out Time" in Employee Travel Request doctype
  if the expected checkout time is less than Expected Check-in Time in employee travel request doctype
3. Total Days has to be one if travel ends in the same day
 - if start_date and end_date are in same day make the total days  become one 
 - and if the start_date and end_date are removed the referesh the field total days (read only) in employee traavel request doctype
 

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/36e7a90c-153f-4ed9-8a86-d3b2688c1ec6)

[Screencast from 21-03-25 04:39:58 PM IST.webm](https://github.com/user-attachments/assets/49c303a0-8e1a-4340-8183-e9062c5afd80)

## Areas affected and ensured
 employee travel request doctype

## Is there any existing behavior change of other features due to this code change?
 No

## Was this feature tested on the browsers?
 
  - Mozilla Firefox
 
