### PR TITLE
fix: Customize petty cash request doctype & dialog

### DIFF
--- a/beams/beams/custom_scripts/voucher_entry/voucher_entry.js
+++ b/beams/beams/custom_scripts/voucher_entry/voucher_entry.js
@@ -55,10 +55,23 @@ function show_petty_cash_dialog(frm) {
                 label: __("Requested Amount"),
                 fieldtype: "Currency",
                 reqd: 1
-            }
+            },
+            {
+                fieldname: "reason",
+                label: __("Reason"),
+                fieldtype: "Small Text",
+                reqd: 1
+            },
         ],
         primary_action_label: __("Submit"),
         primary_action(values) {
+            if (values.requested_amount <= 0) {
+                frappe.throw({
+                    title: __("Invalid Amount"),
+                    message: __("Requested Amount should be greater than 0. Please enter a valid amount."),
+                    indicator: "red"
+                });
+            }
             submit_petty_cash_request(frm, values, d);
         }
     });
@@ -74,7 +87,8 @@ function submit_petty_cash_request(frm, values, dialog) {
             bureau: values.bureau,
             mode_of_payment: values.mode_of_payment,
             account: values.account,
-            requested_amount: values.requested_amount
+            requested_amount: values.requested_amount,
+            reason: values.reason
         },
         callback: function (response) {
             if (response.message.status === "success") {

--- a/beams/beams/custom_scripts/voucher_entry/voucher_entry.py
+++ b/beams/beams/custom_scripts/voucher_entry/voucher_entry.py
@@ -1,7 +1,7 @@
 import frappe
 
 @frappe.whitelist()
-def create_petty_cash_request(voucher_entry_name, bureau, mode_of_payment, account, requested_amount):
+def create_petty_cash_request(voucher_entry_name, bureau, mode_of_payment, account, requested_amount, reason):
     """Create a Petty Cash Request linked to a Voucher Entry"""
 
     # Get Employee ID based on logged-in user
@@ -15,6 +15,7 @@ def create_petty_cash_request(voucher_entry_name, bureau, mode_of_payment, accou
         "account": account,
         "requested_amount": requested_amount,
         "reference_voucher": voucher_entry_name,
+        "reason": reason,
         "employee": employee
     })
 

--- a/beams/beams/doctype/petty_cash_request/petty_cash_request.js
+++ b/beams/beams/doctype/petty_cash_request/petty_cash_request.js
@@ -36,6 +36,15 @@ frappe.ui.form.on("Petty Cash Request", {
                 }
             }
         });
+    },
+    validate: function (frm) {
+        if (frm.doc.requested_amount <= 0) {
+            frappe.throw({
+                title: __("Invalid Amount"),
+                message: __("Requested Amount should be greater than 0. Please enter a valid amount."),
+                indicator: "red"
+            });
+        }
     }
 });
 

--- a/beams/beams/doctype/petty_cash_request/petty_cash_request.json
+++ b/beams/beams/doctype/petty_cash_request/petty_cash_request.json
@@ -14,7 +14,8 @@
   "column_break_pflc",
   "petty_cash_account",
   "account",
-  "requested_amount"
+  "requested_amount",
+  "reason"
  ],
  "fields": [
   {
@@ -71,12 +72,17 @@
    "fieldtype": "Link",
    "label": "Petty Cash Account",
    "options": "Mode of Payment"
+  },
+  {
+   "fieldname": "reason",
+   "fieldtype": "Small Text",
+   "label": "Reason"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-03-21 15:48:04.534573",
+ "modified": "2025-03-24 16:15:48.424785",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Petty Cash Request",


### PR DESCRIPTION
## Feature description
Add a field named "Reason" in the Petty Cash Request dialog in Voucher Entry and in the Petty Cash Request DocType. Ensure that its value is fetched from the dialog into the Petty Cash Request DocType.
Additionally, apply validation for the Requested Amount in this dialog, and implement the same validation in the Petty Cash Request DocType.

## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description
Added the requested fields and Applied validation
## Output screenshots (optional)
Added field Reason in Petty Cash Request dialog
![image](https://github.com/user-attachments/assets/34194a75-92f1-412d-ae2d-6b1d07bb63a9)

Validation for Requested Amount field in Petty Cash Request dialog
![image](https://github.com/user-attachments/assets/3be60cde-cb09-490a-93b8-67c7bc3eb6e3)

Created Petty Cash Request document up on the submission of dialog and ensured that all values are fetched from the dialog into the Petty Cash Request DocType.
![image](https://github.com/user-attachments/assets/f534b5ba-81e6-4105-8021-9d5f5d8bd709)

Validation for Requested Amount field in Petty Cash Request doctype
![image](https://github.com/user-attachments/assets/15822490-b36e-41d9-b6c4-9d13cfbdea55)

## Areas affected and ensured
Petty Cash Request doctype 
## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
 
