### PR TITLE
feat: Make Total Amount field read only in Voucher Entry

### DIFF
--- a/beams/setup.py
+++ b/beams/setup.py
@@ -4066,7 +4066,15 @@ def get_property_setters():
             "property": "in_standard_filter",
             "property_type": "Check",
             "value":1
-        }
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Voucher Entry",
+            "field_name": "total_amount",
+            "property": "read_only",
+            "property_type": "Check",
+            "value": 1
+        },
     ]
 
 def get_material_request_custom_fields():


### PR DESCRIPTION
## Feature description
Make Total Amount field read only in Voucher Entry
## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description
Made Total Amount field read only in Voucher Entry
## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/15aa6d6e-da68-4cd1-8f3a-dd8b566d69a8)
## Areas affected and ensured
Voucher Entry
## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
