### PR TITLE
feat:Trigger total_days_calculate on end_date change

### DIFF
--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.js
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.js
@@ -43,16 +43,16 @@ frappe.ui.form.on('Employee Travel Request', {
     posting_date:function (frm){
       frm.call("validate_posting_date");
     },
-    end_date:function (frm){
-      frm.call("validate_dates");
-       calculateTotalDays(frm);
-    },
     validate:function(frm){
       frm.call("validate_expected_time");
     },
     start_date:function(frm){
       calculateTotalDays(frm);
+    },
+    end_date:function (frm){
+      frm.call("total_days_calculate");
     }
+
 });
 
 function set_room_criteria_filter(frm) {

--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.py
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.py
@@ -20,9 +20,9 @@ class EmployeeTravelRequest(Document):
 
     def validate(self):
         self.validate_dates()
-        self.calculate_total_days()
         self.validate_expected_time()
         self.total_days_calculate()
+
 
     def before_save(self):
         self.validate_posting_date()
@@ -42,9 +42,7 @@ class EmployeeTravelRequest(Document):
                 if self.start_date < today():
                     frappe.throw("Start Date cannot be in the past.")
 
-    def calculate_total_days(self):
-        if self.start_date and self.end_date:
-            self.total_days = date_diff(self.end_date, self.start_date)
+
 
     def on_update_after_submit(self):
         """
@@ -83,6 +81,7 @@ class EmployeeTravelRequest(Document):
             if self.expected_check_out_time < self.expected_check_in_time:
                 frappe.throw("Expected Check-out Time cannot be earlier than Expected Check-in Time.")
 
+    @frappe.whitelist()
     def total_days_calculate(self):
         """Calculate the total number of travel days, ensuring at least one day."""
         if self.start_date and self.end_date:


### PR DESCRIPTION
## Feature description
- Trigger total_days_calculate on end_date change

## Solution description

 **Trigger total_days_calculate on end_date change**  

- Added `end_date` event to call `total_days_calculate`.  
- Ensures `total_days` updates dynamically when `end_date` is modified.  
- Improves user experience by recalculating travel days in real-time.

## Output screenshots (optional)
[Screencast from 25-03-25 02:20:47 PM IST.webm](https://github.com/user-attachments/assets/52da6aa1-e232-4fbf-bba5-f0aad9e8805a)

## Areas affected and ensured
 
 - Employee Travel Request


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - Yes
  - Opera Mini
  - Safari
