### PR TITLE
Remove Bureau field from Employee with help of patches.

### DIFF
--- a/beams/patches.txt
+++ b/beams/patches.txt
@@ -1,4 +1,6 @@
 [pre_model_sync]
+
+beams.patches.delete_employee_fields  #25-02-2024
 beams.patches.rename_hod_role #30-10-2024
 beams.patches.delete_custom_fields  #26-11-2024-1
 beams.patches.no_of_children_patch  #06-03-2025

--- a/beams/patches/delete_employee_fields.py
+++ b/beams/patches/delete_employee_fields.py
@@ -1,0 +1,14 @@
+import frappe
+
+fields_to_remove = [
+    {
+        'dt':'Employee',
+        'fieldname':'bureau'
+    }
+]
+
+def execute():
+    for field in fields_to_remove:
+        if frappe.db.exists('Custom Field', field):
+            frappe.db.delete('Custom Field', field)
+    frappe.db.commit()


### PR DESCRIPTION
## Feature description
This patch removes the "bureau" field from the Employee doctype by deleting the associated custom field entry in the database.

## Analysis and design (optional)
The field "bureau" was identified as obsolete and is no longer required in the Employee doctype.
The patch ensures database cleanup to prevent unnecessary data clutter.

## Solution description
The following script will execute during migration:

-     It iterates over a list of fields to be removed.
-     It checks if the field exists in the Custom Field table.
-     If it exists, it deletes the field and commits the changes to the database.


## Areas affected and ensured
Employee doctype

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
