### PR TITLE
fix: Bypass Permission Restrictions for Employee Retrieval

### DIFF
--- a/beams/api/api.py
+++ b/beams/api/api.py
@@ -442,7 +442,7 @@ def get_employees(employee_id=None, department=None):
             filters['department'] = emp_department
         elif department:
             filters['department'] = department
-        employees = frappe.db.get_list('Employee', fields=fields, filters=filters)
+        employees = frappe.get_all('Employee', fields=fields, filters=filters)
         if employees:
             return response('Employees retrieved successfully', employees, True, 200)
         else:


### PR DESCRIPTION
## Feature description
This update ensures that logged-in users can view all employees in their department, bypassing role-based permission restrictions.
## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description
Replaced frappe.db.get_list() with frappe.get_all() to bypass permission restrictions.
## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/6b612f5e-1338-4984-bc5b-9d46c388fad4)
![image](https://github.com/user-attachments/assets/4ae685bf-f882-4af2-b7da-3dfc1a90880d)

## Areas affected and ensured
Employee retrieval logic in get_employees() function.
Backend API behavior for fetching employees within a department.

## Is there any existing behavior change of other features due to this code change?
No.
