### PR TITLE
feat: Add API to fetch employee shift for a specific date

### DIFF
--- a/beams/api/api.py
+++ b/beams/api/api.py
@@ -1,6 +1,7 @@
 import frappe
 from frappe import _
 from frappe.utils import getdate
+from hrms.api.roster import get_shifts
 
 @frappe.whitelist(allow_guest=True)
 def response(message, data, success, status_code):
@@ -451,3 +452,22 @@ def get_employees(employee_id=None, department=None):
         frappe.log_error(frappe.get_traceback())
         clean_exception_message = strip_html_tags(str(exception))
         return response(clean_exception_message, {}, False, 401)
+
+@frappe.whitelist()
+def get_employee_shift(employee: str, date: str):
+    '''
+	    Fetch the shift details of an employee for a specific date.
+
+	    :param employee: Employee ID (e.g., "EMP-0001")
+	    :param date: Date in YYYY-MM-DD format
+	    :return: Shift details if found, else an empty dictionary
+    '''
+
+    # Define filters
+    employee_filters = {"name": employee}
+    shift_filters = {}
+
+    shifts = get_shifts(date, date, employee_filters, shift_filters)
+
+    # Return the shift details if found
+    return shifts.get(employee, [])


### PR DESCRIPTION
## Feature description
Added an API to fetch the shift details of an employee for a specific date.

## Analysis and design (optional)
- Uses get_shifts from HRMS to fetch shift details.
- Filters shift assignments based on the provided employee ID and date.

## Solution description
- Implemented get_employee_shift(employee, date) API.
- Accepts employee (ID) and date (YYYY-MM-DD).
- Calls get_shifts with the given parameters.
- Returns the shift details if found, else an empty list.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/7982e7bb-7e35-434e-9d42-05fcfff5e3df)
## Areas affected and ensured
- API implementation in beams/api/api.py
- Integration with get_shifts from hrms/api/roster.py

## Is there any existing behavior change of other features due to this code change?
No.

