### PR TITLE
feat: added option to show budget dimensions

### DIFF
--- a/beams/beams/report/detailed_budget_allocation_report/detailed_budget_allocation_report.js
+++ b/beams/beams/report/detailed_budget_allocation_report/detailed_budget_allocation_report.js
@@ -111,7 +111,13 @@ frappe.query_reports["Detailed Budget Allocation Report"] = {
             fieldtype: "Select",
             options: "ASC\nDESC",
             default: "DESC"
-        }
+        },
+        {
+            fieldname: "budget_amount_only",
+            label: "Budget Amount Only",
+            fieldtype: "Check",
+            default: 1
+        },
     ],
     tree: true,
     treeView: true,

--- a/beams/beams/report/detailed_budget_allocation_report/detailed_budget_allocation_report.json
+++ b/beams/beams/report/detailed_budget_allocation_report/detailed_budget_allocation_report.json
@@ -1,5 +1,6 @@
 {
- "add_total_row": 1,
+ "add_total_row": 0,
+ "add_translate_data": 0,
  "columns": [],
  "creation": "2025-03-05 20:54:32.054081",
  "disabled": 0,
@@ -9,7 +10,7 @@
  "idx": 0,
  "is_standard": "Yes",
  "letterhead": null,
- "modified": "2025-03-14 15:16:01.173074",
+ "modified": "2025-03-27 15:14:45.563936",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Detailed Budget Allocation Report",


### PR DESCRIPTION
## Feature description
Need to show budget dimensions in the Detailed Budget Allocation Report by user choice

## Solution description
Added a checkbox "Budget Amount Only" which, when unchecked, will show the details of Budget in extra columns

## Output screenshots
![image](https://github.com/user-attachments/assets/f17a54b7-9e8d-49cc-a14e-5c16c873af07)

## Areas affected and ensured
Report
- Detailed Budget Allocation Report

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome - Yes
  - Mozilla Firefox
  - Opera Mini
  - Safari
