### PR TITLE
fix: Update Requested amount in Petty cash request

### DIFF
--- a/beams/beams/custom_scripts/voucher_entry/voucher_entry.js
+++ b/beams/beams/custom_scripts/voucher_entry/voucher_entry.js
@@ -54,7 +54,9 @@ function show_petty_cash_dialog(frm) {
                 fieldname: "requested_amount",
                 label: __("Requested Amount"),
                 fieldtype: "Currency",
-                reqd: 1
+                reqd: 1,
+                read_only: 1,
+                default: frm.doc.total_amount - frm.doc.balance
             },
             {
                 fieldname: "reason",


### PR DESCRIPTION
## Feature description
- Update Requested amount in Petty cash Request.

## Solution description
- Set Requested amount as read only in petty cash request.
- Update Requested amount in Petty cash Request.

## Output screenshots (optional)
[Screencast from 28-03-25 12:28:00 PM IST.webm](https://github.com/user-attachments/assets/75358c22-03a2-4edb-bcf8-519f5e3c3ab1)

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox