### PR TITLE
feat:Automated Allocation for Manpower Details TASK-2025-00506

### DIFF
--- a/beams/beams/doctype/required_manpower_details/required_manpower_details.json
+++ b/beams/beams/doctype/required_manpower_details/required_manpower_details.json
@@ -48,14 +48,16 @@
    "fieldname": "allocated",
    "fieldtype": "Check",
    "in_list_view": 1,
-   "label": "Allocated"
+   "label": "Allocated",
+   "read_only": 1
   },
   {
    "default": "0",
    "fieldname": "hired",
    "fieldtype": "Check",
    "in_list_view": 1,
-   "label": "Hired"
+   "label": "Hired",
+   "read_only": 1
   },
   {
    "fieldname": "column_break_cott",
@@ -65,7 +67,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-03-19 14:33:36.895152",
+ "modified": "2025-04-01 09:34:02.224709",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Required Manpower Details",


### PR DESCRIPTION
## Feature description
When a Technical Request is approved, the " Required Manpower Details" table in project should be updated with the "Allocated" field ticked.
When an External Resource Request is approved, the "Required Manpower Details" table in project should be updated with the "Hired" field ticked.
Make the "Allocated" and "Hired" fields read-only.

## Solution description
1.technical_request.py : The update_allocated_field function updates the "Allocated" field in the Project doctype when a Technical Request is approved. It checks for matching designation, required_from, and required_to between the Technical Request’s required_employees and the Project’s required_manpower_details table. If a match is found, it marks the corresponding row as allocated and saves the project. 

2. external_resource_request.py: The update_hired_field function updates the "Hired" field in the Project doctype when an External Resource Request is submitted. It checks for matching designation, required_from, and required_to between required_resources in the request and required_manpower_details in the project. If a match is found, the corresponding row is marked as hired and the project is saved. 

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/0d6f038f-beba-40fe-b7ab-a5868e126205)
![image](https://github.com/user-attachments/assets/84c9a589-de2e-4abc-b171-e8454370e6e4)
![image](https://github.com/user-attachments/assets/c2131884-1dbc-4c0a-a406-9e9591e7b25b)

## Areas affected and ensured
List out the areas affected by your code changes.( Project doctype)

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
 
