### PR TITLE
TASK-2025-00518: feat: Modified Required Manpower Detail  and Allocated Manpower Detail In Project

### DIFF
--- a/beams/beams/custom_scripts/project/project.js
+++ b/beams/beams/custom_scripts/project/project.js
@@ -14,7 +14,7 @@ frappe.ui.form.on('Project', {
          frappe.call({
              method: "beams.beams.custom_scripts.project.project.create_technical_request",
              args: {
-                 project_id: frm.doc.name  
+                 project_id: frm.doc.name
              },
              callback: function (r) {
                  if (r.message) {
@@ -198,7 +198,7 @@ frappe.ui.form.on('Project', {
             });
         }, __("Create"));
         // Ensure filtering is applied when form loads
-        frm.fields_dict.allocated_resources_details.grid.get_field("employee").get_query = function(doc, cdt, cdn) {
+        frm.fields_dict.allocated_manpower_details.grid.get_field("employee").get_query = function(doc, cdt, cdn) {
             let row = locals[cdt][cdn];
             return {
                 filters: {
@@ -223,12 +223,12 @@ frappe.ui.form.on('Project', {
     }
 
     // Apply filter dynamically when Designation field changes in child table
-  frappe.ui.form.on('Allocated Resource Detail', {
+  frappe.ui.form.on('Allocated Manpower Detail', {
       designation: function(frm, cdt, cdn) {
           let row = locals[cdt][cdn];
           frappe.model.set_value(cdt, cdn, 'employee', '');
           if (row.designation) {
-              frm.fields_dict.allocated_resources_details.grid.get_field("employee").get_query = function(doc, cdt, cdn) {
+              frm.fields_dict.allocated_manpower_details.grid.get_field("employee").get_query = function(doc, cdt, cdn) {
                   let child_row = locals[cdt][cdn];
                   return {
                       filters: {
@@ -237,6 +237,6 @@ frappe.ui.form.on('Project', {
                   };
               };
           }
-          frm.refresh_field("allocated_resources_details");
+          frm.refresh_field("allocated_manpower_details");
       }
   });

--- a/beams/beams/doctype/allocated_manpower_detail/allocated_manpower_detail.json
+++ b/beams/beams/doctype/allocated_manpower_detail/allocated_manpower_detail.json
@@ -12,7 +12,9 @@
   "assigned_to",
   "employee",
   "hired_personnel",
-  "hired_personnel_contact_info"
+  "hired_personnel_contact_info",
+  "allocated",
+  "hired"
  ],
  "fields": [
   {
@@ -66,15 +68,31 @@
    "in_list_view": 1,
    "label": "Assigned To",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "allocated",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Allocated",
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "hired",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Hired",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-03-21 09:12:39.666225",
+ "modified": "2025-04-03 10:19:02.966839",
  "modified_by": "Administrator",
  "module": "BEAMS",
- "name": "Allocated Resource Detail",
+ "name": "Allocated Manpower Detail",
  "owner": "Administrator",
  "permissions": [],
  "sort_field": "modified",

--- a/beams/beams/doctype/allocated_manpower_detail/allocated_manpower_detail.py
+++ b/beams/beams/doctype/allocated_manpower_detail/allocated_manpower_detail.py
@@ -5,5 +5,5 @@
 from frappe.model.document import Document
 
 
-class AllocatedResourceDetail(Document):
+class AllocatedManpowerDetail(Document):
 	pass

--- a/beams/beams/doctype/external_resource_request/external_resource_request.py
+++ b/beams/beams/doctype/external_resource_request/external_resource_request.py
@@ -21,7 +21,7 @@ class ExternalResourceRequest(Document):
         update_hired_field(self)
 
     def update_external_resources_project_allocated_resources(self):
-        """Update the allocated_resources_details table in Project when a External Resource Request is Submitted."""
+        """Update the allocated_manpower_details table in Project when a External Resource Request is Submitted."""
         if not frappe.db.exists('Project', self.project):
             frappe.throw(_("Invalid Project ID: {0}").format(self.project))
 
@@ -40,7 +40,7 @@ class ExternalResourceRequest(Document):
         ]
 
         if allocated_resources:
-            project.extend("allocated_resources_details", allocated_resources)
+            project.extend("allocated_manpower_details", allocated_resources)
             project.save(ignore_permissions=True)
 
 
@@ -80,18 +80,17 @@ def update_hired_field(doc, method=None):
         project = frappe.get_doc("Project", doc.project)
 
         # Ensure required tables exist
-        if not hasattr(doc, "required_resources") or not hasattr(project, "required_manpower_details"):
+        if not hasattr(doc, "required_resources") or not hasattr(project, "allocated_manpower_details"):
             frappe.throw("Required tables are missing in the External Resource Request or Project doctype.")
 
         for resource in doc.required_resources:
-            for manpower in project.required_manpower_details:
+            for manpower in project.allocated_manpower_details:
                 if (
                     resource.designation == manpower.designation
-                    and get_datetime(resource.required_from) == get_datetime(manpower.required_from)
-                    and get_datetime(resource.required_to) == get_datetime(manpower.required_to)
+                    and get_datetime(resource.required_from) == get_datetime(manpower.assigned_from)
+                    and get_datetime(resource.required_to) == get_datetime(manpower.assigned_to)
                 ):
                     manpower.hired = 1
-                    break
 
         project.save(ignore_permissions=True)
         frappe.msgprint(f"Hired manpower updated for Project {doc.project}")

--- a/beams/beams/doctype/required_manpower_details/required_manpower_details.json
+++ b/beams/beams/doctype/required_manpower_details/required_manpower_details.json
@@ -9,10 +9,9 @@
   "department",
   "designation",
   "column_break_cott",
+  "no_of_employees",
   "required_from",
-  "required_to",
-  "allocated",
-  "hired"
+  "required_to"
  ],
  "fields": [
   {
@@ -44,30 +43,21 @@
    "label": "Required To"
   },
   {
-   "default": "0",
-   "fieldname": "allocated",
-   "fieldtype": "Check",
-   "in_list_view": 1,
-   "label": "Allocated",
-   "read_only": 1
-  },
-  {
-   "default": "0",
-   "fieldname": "hired",
-   "fieldtype": "Check",
-   "in_list_view": 1,
-   "label": "Hired",
-   "read_only": 1
-  },
-  {
    "fieldname": "column_break_cott",
    "fieldtype": "Column Break"
+  },
+  {
+   "default": "1",
+   "fieldname": "no_of_employees",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "No of Employees"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-04-01 09:34:02.224709",
+ "modified": "2025-04-03 11:00:39.898242",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Required Manpower Details",

--- a/beams/beams/doctype/technical_request/technical_request.js
+++ b/beams/beams/doctype/technical_request/technical_request.js
@@ -3,16 +3,7 @@
 
 frappe.ui.form.on('Technical Request', {
     refresh: function(frm) {
-        // Initially hide the "Reason for Rejection" field
-        frm.set_df_property("employee", "read_only", false);
-        frm.set_df_property("employee", "hidden", false);
-
-        if (frm.doc.workflow_state === "Pending Approval" || frm.doc.workflow_state === "Draft") {
-            frm.set_df_property("employee", "read_only", false);
-        } else {
-            frm.set_df_property("employee", "read_only", true);
-        }
-
+        set_employee_field_read_only(frm);
         set_employee_query(frm);
 
         if (!frm.is_new() && frm.doc.workflow_state === "Approved") {
@@ -31,6 +22,11 @@ frappe.ui.form.on('Technical Request', {
               }, __("Create"));
         }
       },
+
+      workflow_state: function(frm) {
+        set_employee_field_read_only(frm);
+    },
+
     posting_date:function (frm){
         frm.call("validate_posting_date");
       },
@@ -70,4 +66,14 @@ function set_employee_query(frm) {
             }
         };
     };
+}
+
+
+function set_employee_field_read_only(frm) {
+    if (frm.doc.workflow_state === "Draft") {
+        frm.fields_dict["required_employees"].grid.update_docfield_property("employee", "read_only", 1);
+    } else {
+        frm.fields_dict["required_employees"].grid.update_docfield_property("employee", "read_only", 0);
+    }
+    frm.refresh_field("required_employees");
 }

--- a/beams/beams/doctype/technical_request/technical_request.json
+++ b/beams/beams/doctype/technical_request/technical_request.json
@@ -111,7 +111,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-03-19 12:16:08.476821",
+ "modified": "2025-04-03 13:05:47.576627",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Technical Request",

--- a/beams/beams/doctype/technical_request/technical_request.py
+++ b/beams/beams/doctype/technical_request/technical_request.py
@@ -30,7 +30,7 @@ class TechnicalRequest(Document):
         self.validate_required_from_and_required_to()
 
     def update_project_allocated_resources(self):
-        """Update the allocated_resources_details table in Project when a Technical Request is Approved."""
+        """Update the allocated_manpower_details table in Project when a Technical Request is Approved."""
         if not frappe.db.exists('Project', self.project):
             frappe.throw(_("Invalid Project ID: {0}").format(self.project))
 
@@ -50,7 +50,7 @@ class TechnicalRequest(Document):
         ]
 
         if allocated_resources:
-            project.extend("allocated_resources_details", allocated_resources)
+            project.extend("allocated_manpower_details", allocated_resources)
             project.save(ignore_permissions=True)
 
     @frappe.whitelist()
@@ -111,16 +111,16 @@ def update_allocated_field(doc):
         project = frappe.get_doc("Project", doc.project)
 
         # Ensure required tables exist in both doctypes
-        if not hasattr(doc, "required_employees") or not hasattr(project, "required_manpower_details"):
+        if not hasattr(doc, "required_employees") or not hasattr(project, "allocated_manpower_details"):
             frappe.throw("Required tables are missing in the Technical Request or Project doctype.")
 
         for emp in doc.required_employees:
             if emp.employee:
-                for mp in project.required_manpower_details:
+                for mp in project.allocated_manpower_details:
                     if (
                         emp.designation == mp.designation
-                        and emp.required_from == mp.required_from
-                        and emp.required_to == mp.required_to
+                        and emp.required_from == mp.assigned_from
+                        and emp.required_to == mp.assigned_to
                     ):
                         mp.allocated = 1
 

--- a/beams/beams/doctype/technical_request_details/technical_request_details.json
+++ b/beams/beams/doctype/technical_request_details/technical_request_details.json
@@ -51,7 +51,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-03-18 10:58:38.264971",
+ "modified": "2025-04-03 16:36:22.668835",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Technical Request Details",

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -299,10 +299,10 @@ def get_project_custom_fields():
                 "insert_after": "program_request"
             },
             {
-                "fieldname": "allocated_resources_details",
+                "fieldname": "allocated_manpower_details",
                 "fieldtype": "Table",
-                "label": "Allocated Resource Detail",
-                "options":"Allocated Resource Detail",
+                "label": "Allocated Manpower Detail",
+                "options":"Allocated Manpower Detail",
                 "insert_after":"allocated_resources_details_section"
             },
             {
@@ -377,7 +377,7 @@ def get_project_custom_fields():
                 "fieldtype": "Table",
                 "label": "Allocated Vehicle Details",
                 "options": "Allocated Vehicle Details",
-                "insert_after": "allocated_resources_details"
+                "insert_after": "allocated_manpower_details"
             }
 
 


### PR DESCRIPTION
## Feature description
 - Rename the table Allocated Resource Detail to Allocated Manpower Detail through customization
 - Remove Allocated and Hired Checkbox Field from Required Manpower Detail, and added to Allocated Manpower Detail Table
 - Add a field named No of Employees in Required manpower detail
 - Append rows in Technical Request Doctype  based on No of Employee in Required Manpower Detail from Project
 - Make employee field read-only – Based on workflow state Draft
 - Marked Hired and Allocated  in Allocated Manpower Detail after approving Technical Request and External Resource Request  

## Solution description
- Renamed the table Allocated Resource Detail to Allocated Manpower Detail through customization
 - Removed Allocated and Hired Checkbox Field from Required Manpower Detail, and added to Allocated Manpower Detail Table
 - Added a field named No of Employees in Required manpower detail
 - Appended rows in Technical Request Doctype  based on No of Employee in Required Manpower Detail from Project
 - Make employee field read-only – Based on workflow state Draft
 - Marked Hired and Allocated  in Allocated Manpower Detail after approving Technical Request and External Resource Request  

## Output screenshots (optional)

![image](https://github.com/user-attachments/assets/24b79690-a232-45a9-9a5c-d66c11eb35ac)
![image](https://github.com/user-attachments/assets/a14a8b0d-49f1-43ea-b33a-427cecc01a54)
![image](https://github.com/user-attachments/assets/447ee424-01a3-40af-a7ac-490609623563)
![image](https://github.com/user-attachments/assets/4d4e7ad3-a3bd-4575-9929-12484c19dcee)


## Was this feature tested on the browsers?
  - Mozilla Firefox


