### PR TITLE
feat:TASK-2025-00530: Date validation for Required Manpower Detail

### DIFF
--- a/beams/beams/custom_scripts/project/project.js
+++ b/beams/beams/custom_scripts/project/project.js
@@ -206,7 +206,14 @@ frappe.ui.form.on('Project', {
                 }
             };
         };
-      }
+      },
+    required_from : function(frm) {
+       frm.doc.required_manpower_details.forEach(row => {
+           if (row.required_from < row.required_to) {
+               frappe.throw(__('Required To must be greater than Required From date in row {0}', [row.idx]));
+           }
+       });
+   }
     });
 
     function hide_asset_movement_field(frm) {
@@ -240,3 +247,15 @@ frappe.ui.form.on('Project', {
           frm.refresh_field("allocated_manpower_details");
       }
   });
+  frappe.ui.form.on('Required Manpower Details', {
+      required_to: function(frm, cdt, cdn) {
+          validate_dates(cdt, cdn);
+      }
+  });
+
+  function validate_dates(cdt, cdn) {
+      let row = locals[cdt][cdn];
+      if (row.required_from && row.required_to && row.required_from > row.required_to) {
+          frappe.msgprint(`Row ${row.idx || ''}: "Required From" must be before "Required To"`);
+      }
+  }

--- a/beams/beams/custom_scripts/project/project.py
+++ b/beams/beams/custom_scripts/project/project.py
@@ -5,6 +5,35 @@ from frappe import _
 from frappe.utils import nowdate
 from erpnext.accounts.utils import get_fiscal_year
 
+def validate_project(doc, method):
+    for row in doc.get("required_manpower_details"):
+        if row.required_from and row.required_to:
+            if row.required_from > row.required_to:
+                frappe.throw(f"Row {row.idx}: 'Required From' date must be before 'Required To' date.")
+
+
+def validate_project_dates(doc, method):
+    """Validate Required From and Required To against Expected Start Date and Expected End Date"""
+    if not doc.expected_start_date or not doc.expected_end_date:
+        return
+    for row in doc.required_manpower_details:
+        if row.required_from and row.required_from < doc.expected_start_date:
+            frappe.throw(_("Row {0}: Required From ({1}) cannot be before Expected Start Date ({2})").format(
+                row.idx, row.required_from, doc.expected_start_date
+            ))
+        if row.required_to and row.required_to < doc.expected_start_date:
+            frappe.throw(_("Row {0}: Required To ({1}) cannot be before Expected Start Date ({2})").format(
+                row.idx, row.required_to, doc.expected_start_date
+            ))
+        if row.required_from and row.required_from > doc.expected_end_date:
+            frappe.throw(_("Row {0}: Required From ({1}) cannot be after Expected End Date ({2})").format(
+                row.idx, row.required_from, doc.expected_end_date
+            ))
+        if row.required_to and row.required_to > doc.expected_end_date:
+            frappe.throw(_("Row {0}: Required To ({1}) cannot be after Expected End Date ({2})").format(
+                row.idx, row.required_to, doc.expected_end_date
+            ))
+
 @frappe.whitelist()
 def create_adhoc_budget(source_name, target_doc=None):
     '''

--- a/beams/beams/custom_scripts/project/project.py
+++ b/beams/beams/custom_scripts/project/project.py
@@ -11,9 +11,8 @@ def validate_project(doc, method):
             if row.required_from > row.required_to:
                 frappe.throw(f"Row {row.idx}: 'Required From' date must be before 'Required To' date.")
 
-
 def validate_project_dates(doc, method):
-    """Validate Required From and Required To against Expected Start Date and Expected End Date"""
+    """Validate 'Required From' and 'Required To' dates in the Required Manpower Details child table against the project's Expected Start Date and Expected End Date."""
     if not doc.expected_start_date or not doc.expected_end_date:
         return
     for row in doc.required_manpower_details:

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -319,8 +319,16 @@ doc_events = {
         ]
     },
     "Project": {
-         "on_update": "beams.beams.custom_scripts.project.project.update_program_request_status_on_project_completion",
-         "validate":"beams.beams.custom_scripts.project.project.validate_employee_assignment"
+         "on_update":  [
+            "beams.beams.custom_scripts.project.project.update_program_request_status_on_project_completion",
+            "beams.beams.custom_scripts.project.project.validate_project"
+        ],
+
+         "validate": [
+            "beams.beams.custom_scripts.project.project.validate_employee_assignment",
+            "beams.beams.custom_scripts.project.project.validate_project_dates"
+        ]
+
     },
     "Item": {
         "before_insert": [

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -323,12 +323,10 @@ doc_events = {
             "beams.beams.custom_scripts.project.project.update_program_request_status_on_project_completion",
             "beams.beams.custom_scripts.project.project.validate_project"
         ],
-
          "validate": [
             "beams.beams.custom_scripts.project.project.validate_employee_assignment",
             "beams.beams.custom_scripts.project.project.validate_project_dates"
         ]
-
     },
     "Item": {
         "before_insert": [


### PR DESCRIPTION
## Feature description
 - Validate Required To must be greater than Required from fields
 - Required From and Required To dates in the Required Manpower Details child table stay within the range of the Expected 
    Start Date and Expected End Date of the project.

## Solution description
 -  Validated Required To must be greater than Required from fields
 - Validated Required From and Required To dates in the Required Manpower Details child table stay within the range of the
    Expected  Start Date and Expected End Date

## Output screenshots (optional)

![image](https://github.com/user-attachments/assets/48a3b968-78d0-459b-8aba-8bd6e1af6e64)
![image](https://github.com/user-attachments/assets/a91ee24c-c2b4-4c58-9763-879f8ec1d57e)



## Was this feature tested on the browsers?
 - Mozilla Firefox


