### PR TITLE
feat: TASK-2025-00541:  Modified Technical request

### DIFF
--- a/beams/beams/doctype/program_request/program_request.json
+++ b/beams/beams/doctype/program_request/program_request.json
@@ -45,7 +45,7 @@
   {
    "default": "Today",
    "fieldname": "posting_date",
-   "fieldtype": "Datetime",
+   "fieldtype": "Date",
    "label": "Posting Date",
    "read_only": 1,
    "reqd": 1
@@ -71,7 +71,7 @@
   },
   {
    "fieldname": "end_date",
-   "fieldtype": "Date",
+   "fieldtype": "Datetime",
    "in_list_view": 1,
    "label": " End Date ",
    "reqd": 1
@@ -152,7 +152,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-04-05 15:17:29.882254",
+ "modified": "2025-04-05 15:48:07.334627",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Program Request",

--- a/beams/beams/doctype/program_request/program_request.json
+++ b/beams/beams/doctype/program_request/program_request.json
@@ -45,7 +45,7 @@
   {
    "default": "Today",
    "fieldname": "posting_date",
-   "fieldtype": "Date",
+   "fieldtype": "Datetime",
    "label": "Posting Date",
    "read_only": 1,
    "reqd": 1
@@ -64,7 +64,7 @@
   },
   {
    "fieldname": "start_date",
-   "fieldtype": "Date",
+   "fieldtype": "Datetime",
    "in_list_view": 1,
    "label": "Start Date ",
    "reqd": 1
@@ -152,7 +152,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-03-19 12:18:37.206677",
+ "modified": "2025-04-05 15:17:29.882254",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Program Request",

--- a/beams/beams/doctype/required_manpower_details/required_manpower_details.json
+++ b/beams/beams/doctype/required_manpower_details/required_manpower_details.json
@@ -51,13 +51,13 @@
    "fieldname": "no_of_employees",
    "fieldtype": "Int",
    "in_list_view": 1,
-   "label": "No of Employees"
+   "label": "No. of Employees"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-04-03 11:00:39.898242",
+ "modified": "2025-04-05 14:40:19.146465",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Required Manpower Details",

--- a/beams/beams/doctype/technical_request/technical_request.js
+++ b/beams/beams/doctype/technical_request/technical_request.js
@@ -6,9 +6,9 @@ frappe.ui.form.on('Technical Request', {
         set_employee_field_read_only(frm);
         set_employee_query(frm);
 
-        const readOnlyFields = ['project','bureau', 'location','posting_date', 'required_from', 'required_to'];
+        const read_only_fields = ['project','bureau', 'location','posting_date', 'required_from', 'required_to'];
         const should_be_read_only = !frm.is_new() && frm.doc.workflow_state === 'Draft';
-        readOnlyFields.forEach(field => {
+        read_only_fields.forEach(field => {
             frm.set_df_property(field, 'read_only', should_be_read_only);
         });
 

--- a/beams/beams/doctype/technical_request/technical_request.js
+++ b/beams/beams/doctype/technical_request/technical_request.js
@@ -6,6 +6,12 @@ frappe.ui.form.on('Technical Request', {
         set_employee_field_read_only(frm);
         set_employee_query(frm);
 
+        const readOnlyFields = ['project','bureau', 'location','posting_date', 'required_from', 'required_to'];
+        const should_be_read_only = !frm.is_new() && frm.doc.workflow_state === 'Draft';
+        readOnlyFields.forEach(field => {
+            frm.set_df_property(field, 'read_only', should_be_read_only);
+        });
+
         if (!frm.is_new() && frm.doc.workflow_state === "Approved") {
             frm.add_custom_button("External Resource Request", function() {
                 frappe.call({
@@ -22,7 +28,6 @@ frappe.ui.form.on('Technical Request', {
               }, __("Create"));
         }
       },
-
       workflow_state: function(frm) {
         set_employee_field_read_only(frm);
     },

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -3548,6 +3548,20 @@ def get_property_setters():
         },
         {
             "doctype_or_field": "DocField",
+            "doc_type": "Project",
+            "field_name": "expected_start_date",
+            "property": "fieldtype",
+            "value":"Datetime"
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Project",
+            "field_name": "expected_end_date",
+            "property": "fieldtype",
+            "value":"Datetime"
+        },
+        {
+            "doctype_or_field": "DocField",
             "doc_type": "Job Requisition",
             "field_name": "designation",
             "property": "fetch_from",


### PR DESCRIPTION
## Feature description
 - When coming from a project to a technical request, make the custom fields  change to read-only
 - Modify the No of Employees field name in the Required Manpower Details
 - Modify fieldtype of dates in Project(Expected start date,Expected end date),Program Request(start date, end date)

## Solution description
 - Changed some fields to only when coming from the project to the technical request 
 - Modified the No of Employees field name in the Required Manpower Details
 - Modified fieldtype of dates in Project,Program Request


## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/b3b110f6-3360-4794-b607-0c972319bf28)

## Is there any existing behavior change of other features due to this code change?
 No

## Was this feature tested on the browsers?
  - Mozilla Firefox
 
