### PR TITLE
feat: modify the process of equipment request

### DIFF
--- a/beams/beams/custom_scripts/asset_movement/asset_movement.py
+++ b/beams/beams/custom_scripts/asset_movement/asset_movement.py
@@ -1,29 +1,64 @@
 import frappe
+from frappe.utils import flt
 
 def update_issued_quantity(doc, method):
     """
-    Update Issued Quantity in Equipment Request's Required Items Detail child table and Project
+    Update or insert Issued Quantity in Project's Allocated Item Details table
+    based on Equipment Request, using reference from Asset Movement.
     """
-    if frappe.db.exists("Required Items Detail", doc.reference_name):
-        issued_qty = frappe.db.get_value("Required Items Detail", doc.reference_name, "issued_quantity") or 0
-        frappe.db.set_value("Required Items Detail", doc.reference_name, "issued_quantity", issued_qty + 1)
 
-        equipment_request = frappe.db.get_value("Required Items Detail", doc.reference_name, "parent")
-        if equipment_request:
-            project_name = frappe.db.get_value("Equipment Request", equipment_request, "project")
+    # Validate the reference
+    if not frappe.db.exists("Required Items Detail", doc.reference_name):
+        return
 
-            if project_name and frappe.db.exists("Project", project_name):
-                project_doc = frappe.get_doc("Project", project_name)
-                updated = False
-                required_item_value = frappe.db.get_value("Required Items Detail", doc.reference_name, "required_item")
+    # Get existing issued quantity and increment by quantity moved (default = 1)
+    movement_qty = flt(getattr(doc, "quantity", 1))
+    existing_issued = flt(frappe.db.get_value("Required Items Detail", doc.reference_name, "issued_quantity")) or 0
+    frappe.db.set_value("Required Items Detail", doc.reference_name, "issued_quantity", existing_issued + movement_qty)
 
-                for item in project_doc.required_items:
-                    if item.required_item == required_item_value:
-                        item.issued_quantity += 1
-                        updated = True
+    # Get parent Equipment Request from the child table
+    equipment_request = frappe.db.get_value("Required Items Detail", doc.reference_name, "parent")
+    if not equipment_request:
+        return
 
-                if updated:
-                    project_doc.save()
+    # Get associated project
+    project_name = frappe.db.get_value("Equipment Request", equipment_request, "project")
+    if not project_name:
+        return
+
+    # Get the required item from the Required Items Detail
+    required_item_value = frappe.db.get_value("Required Items Detail", doc.reference_name, "required_item")
+    if not required_item_value:
+        return
+
+    # Get required_quantity from the Equipment Request's child table
+    eq_doc = frappe.get_doc("Equipment Request", equipment_request)
+    required_quantity = 0
+    for item in eq_doc.required_equipments:
+        if item.required_item == required_item_value:
+            required_quantity = flt(item.required_quantity or 0)
+            break
+
+    # Update the Project's allocated_item_details table
+    if frappe.db.exists("Project", project_name):
+        project_doc = frappe.get_doc("Project", project_name)
+        found = False
+
+        for row in project_doc.allocated_item_details:
+            if row.required_item == required_item_value:
+                row.issued_quantity = flt(row.issued_quantity or 0) + movement_qty
+                found = True
+                break
+
+        if not found:
+            project_doc.append("allocated_item_details", {
+                "required_item": required_item_value,
+                "required_quantity": required_quantity,
+                "issued_quantity": movement_qty,
+            })
+
+        project_doc.save(ignore_permissions=True)
+        
 
 def before_save(doc, method):
     if doc.assets:

--- a/beams/beams/custom_scripts/asset_movement/asset_movement.py
+++ b/beams/beams/custom_scripts/asset_movement/asset_movement.py
@@ -7,31 +7,25 @@ def update_issued_quantity(doc, method):
     based on Equipment Request, using reference from Asset Movement.
     """
 
-    # Validate the reference
     if not frappe.db.exists("Required Items Detail", doc.reference_name):
         return
 
-    # Get existing issued quantity and increment by quantity moved (default = 1)
     movement_qty = flt(getattr(doc, "quantity", 1))
     existing_issued = flt(frappe.db.get_value("Required Items Detail", doc.reference_name, "issued_quantity")) or 0
     frappe.db.set_value("Required Items Detail", doc.reference_name, "issued_quantity", existing_issued + movement_qty)
 
-    # Get parent Equipment Request from the child table
     equipment_request = frappe.db.get_value("Required Items Detail", doc.reference_name, "parent")
     if not equipment_request:
         return
 
-    # Get associated project
     project_name = frappe.db.get_value("Equipment Request", equipment_request, "project")
     if not project_name:
         return
 
-    # Get the required item from the Required Items Detail
     required_item_value = frappe.db.get_value("Required Items Detail", doc.reference_name, "required_item")
     if not required_item_value:
         return
 
-    # Get required_quantity from the Equipment Request's child table
     eq_doc = frappe.get_doc("Equipment Request", equipment_request)
     required_quantity = 0
     for item in eq_doc.required_equipments:
@@ -58,7 +52,7 @@ def update_issued_quantity(doc, method):
             })
 
         project_doc.save(ignore_permissions=True)
-        
+
 
 def before_save(doc, method):
     if doc.assets:

--- a/beams/beams/custom_scripts/project/project.js
+++ b/beams/beams/custom_scripts/project/project.js
@@ -8,23 +8,6 @@ frappe.ui.form.on('Project', {
             frm.refresh_field("allocated_item_details");
         }
 
-        // Add "Adhoc Budget" button
-        frm.add_custom_button(__('Adhoc Budget'), function () {
-            frappe.model.open_mapped_doc({
-                method: "beams.beams.custom_scripts.project.project.create_adhoc_budget",
-                frm: frm,
-            });
-        }, __("Create"));
-
-
-        // Add "Adhoc Budget" button
-        frm.add_custom_button(__('Adhoc Budget'), function () {
-            frappe.model.open_mapped_doc({
-                method: "beams.beams.custom_scripts.project.project.create_adhoc_budget",
-                frm: frm,
-            });
-        }, __("Create"));
-
       //function adds a button to the 'Project' form to create an Adhoc Budget.
         frm.add_custom_button(__('Adhoc Budget'), function () {
             frappe.model.open_mapped_doc({

--- a/beams/beams/custom_scripts/project/project.js
+++ b/beams/beams/custom_scripts/project/project.js
@@ -1,6 +1,30 @@
 frappe.ui.form.on('Project', {
     refresh(frm) {
-      hide_asset_movement_field(frm);
+
+        // Hide Asset Movement in Allocated Item Details
+        if (frm.fields_dict["allocated_item_details"] && frm.fields_dict["allocated_item_details"].grid) {
+            let grid = frm.fields_dict["allocated_item_details"].grid;
+            grid.toggle_display("asset_movement", false);
+            frm.refresh_field("allocated_item_details");
+        }
+
+        // Add "Adhoc Budget" button
+        frm.add_custom_button(__('Adhoc Budget'), function () {
+            frappe.model.open_mapped_doc({
+                method: "beams.beams.custom_scripts.project.project.create_adhoc_budget",
+                frm: frm,
+            });
+        }, __("Create"));
+
+
+        // Add "Adhoc Budget" button
+        frm.add_custom_button(__('Adhoc Budget'), function () {
+            frappe.model.open_mapped_doc({
+                method: "beams.beams.custom_scripts.project.project.create_adhoc_budget",
+                frm: frm,
+            });
+        }, __("Create"));
+
       //function adds a button to the 'Project' form to create an Adhoc Budget.
         frm.add_custom_button(__('Adhoc Budget'), function () {
             frappe.model.open_mapped_doc({
@@ -31,15 +55,17 @@ frappe.ui.form.on('Project', {
             fields: [
               {
                 label: 'Required From',
-                fieldtype: 'Datetime',
+                fieldtype: 'Date',
                 fieldname: 'required_from',
                 in_list_view: 1,
+                default: frm.doc.expected_start_date || frappe.datetime.now_datetime(),
                 reqd: 1
               },
               {
                 label: 'Required To',
-                fieldtype: 'Datetime',
+                fieldtype: 'Date',
                 fieldname: 'required_to',
+                default: frm.doc.expected_end_date || frappe.datetime.now_datetime(),
                 in_list_view: 1,
                 reqd: 1
               },
@@ -106,19 +132,6 @@ frappe.ui.form.on('Project', {
                         primary_action_label: 'Submit',
                         primary_action(values) {
                             const equipment_data = values?.equipments || [];
-
-                            // Validate required dates
-                            const required_from = values.required_from;
-                            const required_to = values.required_to;
-                            if(!required_from || !required_to) {
-                              frappe.msgprint(__('Both "Required From" and "Required To" are mandatory.'));
-                                return;
-                            }
-                            if(required_from >= required_to) {
-                              frappe.msgprint(__('"Required From" date should be earlier than "Required To" date.'));
-                                return;
-                            }
-
                             if(!equipment_data.length) {
                               frappe.msgprint(__('Please add at least one equipment row.'));
                                 return;
@@ -216,18 +229,6 @@ frappe.ui.form.on('Project', {
    }
     });
 
-    function hide_asset_movement_field(frm) {
-        /**
-         * Dynamically hides the "asset_movement" field in the "Required Items"
-         * child table within the relevant doctype.
-         */
-        ["required_items"].forEach(table_name => {
-            if (frm.fields_dict[table_name]) {
-                frm.fields_dict[table_name].grid.update_docfield_property("asset_movement", "hidden", 1);
-                frm.fields_dict[table_name].grid.refresh();
-            }
-        });
-    }
 
     // Apply filter dynamically when Designation field changes in child table
   frappe.ui.form.on('Allocated Manpower Detail', {

--- a/beams/beams/custom_scripts/purchase_order/purchase_order.py
+++ b/beams/beams/custom_scripts/purchase_order/purchase_order.py
@@ -146,7 +146,7 @@ def update_equipment_quantities(doc, method):
                             if project:
                                 project_doc = frappe.get_doc("Project", project)
 
-                                for p_item in project_doc.required_items:
+                                for p_item in project_doc.allocated_item_details:
                                     if p_item.required_item == ea_item:
                                         p_item.acquired_quantity += item.qty
 

--- a/beams/beams/doctype/equipment_request/equipment_request.json
+++ b/beams/beams/doctype/equipment_request/equipment_request.json
@@ -49,16 +49,18 @@
   },
   {
    "fieldname": "required_from",
-   "fieldtype": "Datetime",
+   "fieldtype": "Date",
    "in_list_view": 1,
    "label": "Required From",
+   "read_only": 1,
    "reqd": 1
   },
   {
    "fieldname": "required_to",
-   "fieldtype": "Datetime",
+   "fieldtype": "Date",
    "in_list_view": 1,
    "label": "Required To",
+   "read_only": 1,
    "reqd": 1
   },
   {
@@ -111,7 +113,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-03-19 12:09:30.504937",
+ "modified": "2025-04-04 10:19:23.460031",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Equipment Request",

--- a/beams/beams/doctype/required_items_table/required_items_table.json
+++ b/beams/beams/doctype/required_items_table/required_items_table.json
@@ -1,0 +1,52 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "format:RI-{YY}-{####}",
+ "creation": "2025-04-04 10:52:12.468298",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "required_item",
+  "available_quantity",
+  "required_quantity"
+ ],
+ "fields": [
+  {
+   "fieldname": "required_item",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Required Item",
+   "options": "Item",
+   "reqd": 1
+  },
+  {
+   "fieldname": "available_quantity",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Available Quantity",
+   "read_only": 1
+  },
+  {
+   "fieldname": "required_quantity",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Required Quantity",
+   "non_negative": 1,
+   "reqd": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2025-04-04 11:13:01.156332",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "Required Items Table",
+ "naming_rule": "Expression",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/beams/beams/doctype/required_items_table/required_items_table.py
+++ b/beams/beams/doctype/required_items_table/required_items_table.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class RequiredItemsTable(Document):
+	pass

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -306,6 +306,22 @@ def get_project_custom_fields():
                 "insert_after":"allocated_resources_details_section"
             },
             {
+                "fieldname": "allocated_item_details",
+                "fieldtype": "Table",
+                "label": "Allocated Item Details",
+                "options":"Required Items Detail",
+                "Allow on Submit" : 1,
+                "insert_after":"allocated_resources_details_section"
+
+            },
+            {
+                "fieldname": "allocated_item_details",
+                "fieldtype": "Table",
+                "label": "Allocated Item Details",
+                "options":"Required Items Detail",
+                "insert_after":"allocated_resources_details_section"
+            },
+            {
                 "fieldname": "approved_budget",
                 "fieldtype": "Currency",
                 "label": "Approved Budget",
@@ -355,7 +371,7 @@ def get_project_custom_fields():
                 "fieldname": "required_items",
                 "fieldtype": "Table",
                 "label": "Required Items",
-                "options": "Required Items Detail",
+                "options": "Required Items Table",
                 "insert_after": "requirements_details"
             },
             {


### PR DESCRIPTION
## Feature description
Modify the existing process of equipment request
Project: Remove existing table in the Required Items field, add a new table with required fields.
Equipment Request: Map Expected Start Date and Expected End Date from project to equipment request.
Project: Previous table in the required items field moved into  Allocated Resource Details field and update the values of the table (issued quantity , acquired quantity)

## Solution description

In project added new table named Required Items Table.
beams/setup.py : In project added new table named 'Required Items Table' and moved position of 'Required Items Detail table'
equipment_request.json: In equipment request change 'required from' , 'required to' field type from datetime into date.
project.js: Mapped Expected Start Date and Expected End Date from project to equipment request.
asset_movement.py: Updated the 'Allocated Item Details' field of the Project based on updates in the Equipment Request when ever an asset movement submitted.(Issued quantity)
purchase_order.py: Updated 'Allocated Item Details' field of the Project (Acquired Quantity) when purchase order created.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/9dc0c5c9-3ee7-4092-ac83-d15eb41b1b3d)
![image](https://github.com/user-attachments/assets/b27d8efc-ad22-4aa9-8e62-0bc5d1797715)
![image](https://github.com/user-attachments/assets/0f07e396-619c-443c-a665-1f1f03ed7a48)
![image](https://github.com/user-attachments/assets/b4131aea-2005-4944-b93d-6ecb9e01eea4)



## Areas affected and ensured
List out the areas affected by your code changes. (Project, Equipment Request )

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
