### PR TITLE
feat:modify required_hired_vehicle_detail child table in vehicle_hire_request

### DIFF
--- a/beams/beams/doctype/required_hired_vehicle_detail/required_hired_vehicle_detail.json
+++ b/beams/beams/doctype/required_hired_vehicle_detail/required_hired_vehicle_detail.json
@@ -9,6 +9,9 @@
   "section_break_iy51",
   "vehicle_type",
   "no_of_vehicles",
+  "from",
+  "to",
+  "no_of_travellers",
   "amended_from"
  ],
  "fields": [
@@ -41,13 +44,33 @@
    "label": "No. of Vehicles",
    "non_negative": 1,
    "reqd": 1
+  },
+  {
+   "fieldname": "from",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "From",
+   "options": "Location"
+  },
+  {
+   "fieldname": "to",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "To",
+   "options": "Location"
+  },
+  {
+   "fieldname": "no_of_travellers",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "No. of Travellers"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-03-17 13:44:48.687888",
+ "modified": "2025-04-07 14:43:17.355413",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Required Hired Vehicle Detail",

--- a/beams/beams/doctype/transportation_request/transportation_request.json
+++ b/beams/beams/doctype/transportation_request/transportation_request.json
@@ -15,6 +15,7 @@
   "posting_date",
   "required_on",
   "noof_travallers",
+  "vehicle_hire_request",
   "section_break_yjlc",
   "requirements",
   "required_vehicle",
@@ -138,12 +139,19 @@
    "label": "To",
    "options": "Location",
    "reqd": 1
+  },
+  {
+   "fieldname": "vehicle_hire_request",
+   "fieldtype": "Link",
+   "label": " Vehicle Hire Request",
+   "options": "Vehicle Hire Request",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-04-03 12:01:17.267442",
+ "modified": "2025-04-07 15:09:44.880644",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Transportation Request",

--- a/beams/beams/doctype/vehicle_hire_request/vehicle_hire_request.py
+++ b/beams/beams/doctype/vehicle_hire_request/vehicle_hire_request.py
@@ -8,6 +8,13 @@ from frappe import _
 
 class VehicleHireRequest(Document):
     def on_submit(self):
+        if self.transportation_request:
+            frappe.db.set_value(
+            "Transportation Request",
+            self.transportation_request,
+            "vehicle_hire_request",
+            self.name
+            )
         self.update_hired_vehicles_on_submit()
 
     def on_cancel(self):


### PR DESCRIPTION

## Feature description
modify required_hired_vehicle_detail child table in vehicle_hire_request

## Solution description
1. Transportation Request Doctype (transportation_request.json):
Added a new field:

  - vehicle_hire_request (type: Link → Vehicle Hire Request)
   - Marked as read-only
   - Used to display and store the link to the submitted Vehicle Hire Request associated with the Transportation Request.

2. Vehicle Hire Request Python Controller (vehicle_hire_request.py):
   
    - If a transportation_request is linked,
    -  updates the vehicle_hire_request field in the corresponding Transportation Request with the name of the submitted        Vehicle Hire Request.

3. Required Hired Vehicle Detail Doctype (required_hired_vehicle_detail.json):
Added 3 new fields to better capture vehicle routing and traveler data:

    - from (Link → Location)
    - to (Link → Location) 
    - no_of_travellers (Data)


## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/ea6042a9-653d-463c-a4c0-f2a3d17d33c1)
![image](https://github.com/user-attachments/assets/ac52fe5b-43ae-4261-bdd0-5c6ee5dbddc5)


## Areas affected and ensured

- Vehicle Hire Request
- Transportation Request

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - yes
  - Opera Mini
  - Safari
