### PR TITLE
feat:change field type in equipment request and make fields read only…

### DIFF
--- a/beams/beams/custom_scripts/project/project.js
+++ b/beams/beams/custom_scripts/project/project.js
@@ -38,7 +38,7 @@ frappe.ui.form.on('Project', {
             fields: [
               {
                 label: 'Required From',
-                fieldtype: 'Date',
+                fieldtype: 'Datetime',
                 fieldname: 'required_from',
                 in_list_view: 1,
                 default: frm.doc.expected_start_date || frappe.datetime.now_datetime(),
@@ -46,7 +46,7 @@ frappe.ui.form.on('Project', {
               },
               {
                 label: 'Required To',
-                fieldtype: 'Date',
+                fieldtype: 'Datetime',
                 fieldname: 'required_to',
                 default: frm.doc.expected_end_date || frappe.datetime.now_datetime(),
                 in_list_view: 1,

--- a/beams/beams/doctype/equipment_request/equipment_request.json
+++ b/beams/beams/doctype/equipment_request/equipment_request.json
@@ -49,7 +49,7 @@
   },
   {
    "fieldname": "required_from",
-   "fieldtype": "Date",
+   "fieldtype": "Datetime",
    "in_list_view": 1,
    "label": "Required From",
    "read_only": 1,
@@ -57,7 +57,7 @@
   },
   {
    "fieldname": "required_to",
-   "fieldtype": "Date",
+   "fieldtype": "Datetime",
    "in_list_view": 1,
    "label": "Required To",
    "read_only": 1,
@@ -113,7 +113,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-04-04 10:19:23.460031",
+ "modified": "2025-04-07 14:56:40.418558",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Equipment Request",

--- a/beams/beams/doctype/required_items_detail/required_items_detail.json
+++ b/beams/beams/doctype/required_items_detail/required_items_detail.json
@@ -21,6 +21,7 @@
    "in_list_view": 1,
    "label": "Required Item",
    "options": "Item",
+   "read_only_depends_on": "eval:doc.parenttype === \"Project\"",
    "reqd": 1
   },
   {
@@ -44,6 +45,7 @@
    "in_list_view": 1,
    "label": "Required Quantity",
    "non_negative": 1,
+   "read_only_depends_on": "eval:doc.parenttype === \"Project\"",
    "reqd": 1
   },
   {
@@ -64,7 +66,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-03-17 12:48:04.260155",
+ "modified": "2025-04-07 16:15:29.316451",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Required Items Detail",


### PR DESCRIPTION
## Feature description
change field type in ' equipment request' doctype and make fields read only  in required items detail

## Solution description
Equipment Request doctype: Changed 'Required From' and 'Required To' field type into Datetime.
Required Items Detail Child table: Changed 'Required Item' and 'Required Quantity' field read only in Project doctype

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/8db372a5-60f7-489d-9080-ba13c5ffefd3)
![image](https://github.com/user-attachments/assets/dc01132f-669b-4bc9-aa92-4438e6643cf9)

## Areas affected and ensured
List out the areas affected by your code changes.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox

