### PR TITLE
feat:Add fields to fetch default shift of both employees in shift swap request

### DIFF
--- a/beams/beams/doctype/shift_swap_request/shift_swap_request.json
+++ b/beams/beams/doctype/shift_swap_request/shift_swap_request.json
@@ -133,20 +133,22 @@
    "fieldname": "shift",
    "fieldtype": "Link",
    "label": "Shift ",
-   "options": "Shift Type"
+   "options": "Shift Type",
+   "read_only": 1
   },
   {
    "fetch_from": "swap_with_employee.default_shift",
    "fieldname": "swapped_employee_shift",
    "fieldtype": "Link",
    "label": "Shift",
-   "options": "Shift Type"
+   "options": "Shift Type",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-04-07 11:48:56.131322",
+ "modified": "2025-04-08 13:09:12.711151",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Shift Swap Request",

--- a/beams/beams/doctype/shift_swap_request/shift_swap_request.json
+++ b/beams/beams/doctype/shift_swap_request/shift_swap_request.json
@@ -10,6 +10,7 @@
   "employee",
   "employee_name",
   "department",
+  "shift",
   "column_break_ayiq",
   "posting_date",
   "shift_start_date",
@@ -17,6 +18,7 @@
   "section_break_byjn",
   "swap_with_employee",
   "swap_with_employee_name",
+  "swapped_employee_shift",
   "column_break_ycao",
   "hod_employee",
   "hod_user",
@@ -125,12 +127,26 @@
    "print_hide": 1,
    "read_only": 1,
    "search_index": 1
+  },
+  {
+   "fetch_from": "employee.default_shift",
+   "fieldname": "shift",
+   "fieldtype": "Link",
+   "label": "Shift ",
+   "options": "Shift Type"
+  },
+  {
+   "fetch_from": "swap_with_employee.default_shift",
+   "fieldname": "swapped_employee_shift",
+   "fieldtype": "Link",
+   "label": "Shift",
+   "options": "Shift Type"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-03-05 16:29:17.794563",
+ "modified": "2025-04-07 11:48:56.131322",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Shift Swap Request",


### PR DESCRIPTION
## Feature description
       - Add fields to fetch shift details in Shift Swap Request

## Solution description
      - Added "shift" field to fetch the default shift of the requesting employee.
      - Added "swapped_employee_shift" field to fetch the default shift of the swap target.
      - Helps in displaying both employees' shifts clearly on the form.
    
## Output screenshots (optional)


[Screencast from 08-04-25 01:18:15 PM IST.webm](https://github.com/user-attachments/assets/9dace04a-503f-4f62-bce7-90cac3f50d5b)


## Areas affected and ensured
     - Shift Swap Request Doctype

## Is there any existing behavior change of other features due to this code change?
      - No

## Was this feature tested on the browsers?
     - Mozilla Firefox
