### PR TITLE
feat: Update Revenue Budget and Revenue Template

### DIFF
--- a/beams/beams/doctype/revenue_account/revenue_account.json
+++ b/beams/beams/doctype/revenue_account/revenue_account.json
@@ -8,8 +8,11 @@
  "field_order": [
   "revenue_centre",
   "account",
+  "revenue_group",
   "column_break_quzd",
+  "revenue_region",
   "revenue_amount",
+  "description",
   "monthly_amount_distribution_section",
   "april",
   "may",
@@ -24,7 +27,23 @@
   "december",
   "january",
   "february",
-  "march"
+  "march",
+  "monthly_amount_distributioninr_section",
+  "april_inr",
+  "may_inr",
+  "june_inr",
+  "july_inr",
+  "column_break_ulxk",
+  "august_inr",
+  "september_inr",
+  "october_inr",
+  "november_inr",
+  "column_break_poio",
+  "december_inr",
+  "january_inr",
+  "february_inr",
+  "march_inr",
+  "revenue_amount_inr"
  ],
  "fields": [
   {
@@ -41,6 +60,7 @@
    "fieldtype": "Currency",
    "in_list_view": 1,
    "label": "Revenue Amount",
+   "options": "company_currency",
    "precision": "2",
    "reqd": 1
   },
@@ -123,17 +143,158 @@
    "label": "December"
   },
   {
+   "fetch_from": "revenue_centre.account",
    "fieldname": "account",
    "fieldtype": "Link",
    "label": "Account",
    "options": "Account",
+   "read_only": 1,
    "reqd": 1
+  },
+  {
+   "fieldname": "revenue_group",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Revenue Group",
+   "options": "Revenue Group",
+   "reqd": 1
+  },
+  {
+   "fieldname": "revenue_region",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Finance Region",
+   "options": "National\nGCC",
+   "reqd": 1
+  },
+  {
+   "fieldname": "description",
+   "fieldtype": "Small Text",
+   "label": "Description"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "monthly_amount_distributioninr_section",
+   "fieldtype": "Section Break",
+   "label": "Monthly Amount Distribution (INR)"
+  },
+  {
+   "fieldname": "may_inr",
+   "fieldtype": "Currency",
+   "label": "May (INR)",
+   "options": "default_currency",
+   "precision": "2",
+   "read_only": 1
+  },
+  {
+   "fieldname": "june_inr",
+   "fieldtype": "Currency",
+   "label": "June (INR)",
+   "options": "default_currency",
+   "precision": "2",
+   "read_only": 1
+  },
+  {
+   "fieldname": "july_inr",
+   "fieldtype": "Currency",
+   "label": "July (INR)",
+   "options": "default_currency",
+   "precision": "2",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_ulxk",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "august_inr",
+   "fieldtype": "Currency",
+   "label": "August (INR)",
+   "options": "default_currency",
+   "precision": "2",
+   "read_only": 1
+  },
+  {
+   "fieldname": "september_inr",
+   "fieldtype": "Currency",
+   "label": "September (INR)",
+   "options": "default_currency",
+   "precision": "2",
+   "read_only": 1
+  },
+  {
+   "fieldname": "october_inr",
+   "fieldtype": "Currency",
+   "label": "October (INR)",
+   "options": "default_currency",
+   "precision": "2",
+   "read_only": 1
+  },
+  {
+   "fieldname": "november_inr",
+   "fieldtype": "Currency",
+   "label": "November (INR)",
+   "options": "default_currency",
+   "precision": "2",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_poio",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "december_inr",
+   "fieldtype": "Currency",
+   "label": "December (INR)",
+   "options": "default_currency",
+   "precision": "2",
+   "read_only": 1
+  },
+  {
+   "fieldname": "january_inr",
+   "fieldtype": "Currency",
+   "label": "January (INR)",
+   "options": "default_currency",
+   "precision": "2",
+   "read_only": 1
+  },
+  {
+   "fieldname": "february_inr",
+   "fieldtype": "Currency",
+   "label": "February (INR)",
+   "options": "default_currency",
+   "precision": "2",
+   "read_only": 1
+  },
+  {
+   "fieldname": "march_inr",
+   "fieldtype": "Currency",
+   "label": "March (INR)",
+   "options": "default_currency",
+   "precision": "2",
+   "read_only": 1
+  },
+  {
+   "fieldname": "revenue_amount_inr",
+   "fieldtype": "Currency",
+   "label": "Revenue Amount (INR)",
+   "options": "default_currency",
+   "precision": "2",
+   "read_only": 1
+  },
+  {
+   "fieldname": "april_inr",
+   "fieldtype": "Currency",
+   "label": "April (INR)",
+   "options": "default_currency",
+   "precision": "2",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-03-18 11:44:42.181253",
+ "modified": "2025-04-07 17:24:47.191935",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Revenue Account",

--- a/beams/beams/doctype/revenue_budget/revenue_budget.js
+++ b/beams/beams/doctype/revenue_budget/revenue_budget.js
@@ -6,6 +6,41 @@ frappe.ui.form.on("Revenue Budget", {
     },
     company: function (frm) {
         set_filters(frm);
+        fetch_template(frm);
+    },
+    revenue_category: function (frm) {
+       set_filters(frm);
+       fetch_template(frm);
+    },
+    revenue_template: function(frm) {
+        if (frm.doc.revenue_template) {
+            frappe.call({
+                method: 'frappe.client.get',
+                args: {
+                    doctype: 'Revenue Template',
+                    name: frm.doc.revenue_template
+                },
+                callback: function (response) {
+                    if (response.message) {
+                        let revenue_template = response.message;
+
+                        frm.clear_table('revenue_accounts');
+
+                        // Loop through the revenue_template_item child table
+                        let template_items = revenue_template.revenue_template_item || [];
+                        template_items.forEach(function (item) {
+                            let row = frm.add_child('revenue_accounts');
+                            row.revenue_group = item.revenue_group;
+                            row.account = item.account;
+                            row.revenue_region = item.revenue_region;
+                            row.revenue_centre = item.revenue_centre;
+                        });
+
+                        frm.refresh_field('revenue_accounts');
+                    }
+                }
+            });
+        }
     }
 });
 function set_filters(frm) {
@@ -13,6 +48,14 @@ function set_filters(frm) {
         return {
             filters: {
                 company: frm.doc.company
+            }
+        };
+    });
+    frm.set_query('revenue_template', function () {
+        return {
+            filters: {
+                company: frm.doc.company,
+                revenue_category: frm.doc.revenue_category
             }
         };
     });
@@ -84,4 +127,23 @@ function calculate_revenue_amount(frm, cdt, cdn) {
 
     frappe.model.set_value(cdt, cdn, 'revenue_amount', total);
     frm.refresh_field('revenue_account');
+}
+
+function fetch_template(frm) {
+    if (frm.doc.revenue_category && frm.doc.company) {
+        frappe.call({
+            method: 'beams.beams.doctype.revenue_budget.revenue_budget.get_revenue_template',
+            args: {
+                revenue_category: frm.doc.revenue_category,
+                company: frm.doc.company
+            },
+            callback: function(r) {
+                if (r.message) {
+                    frm.set_value('revenue_template', r.message);
+                } else {
+                    frm.set_value('revenue_template', '');
+                }
+            }
+        });
+    }
 }

--- a/beams/beams/doctype/revenue_budget/revenue_budget.js
+++ b/beams/beams/doctype/revenue_budget/revenue_budget.js
@@ -12,6 +12,7 @@ frappe.ui.form.on("Revenue Budget", {
        set_filters(frm);
        fetch_template(frm);
     },
+    /* Fetch Revenue Template Items in to Revenue Accounts when a Revenue Template is Selected */
     revenue_template: function(frm) {
         if (frm.doc.revenue_template) {
             frappe.call({
@@ -128,7 +129,7 @@ function calculate_revenue_amount(frm, cdt, cdn) {
     frappe.model.set_value(cdt, cdn, 'revenue_amount', total);
     frm.refresh_field('revenue_account');
 }
-
+/* Fetch Revenue Template in Revenue Budget based on Revenue category and Selected company */
 function fetch_template(frm) {
     if (frm.doc.revenue_category && frm.doc.company) {
         frappe.call({

--- a/beams/beams/doctype/revenue_budget/revenue_budget.json
+++ b/beams/beams/doctype/revenue_budget/revenue_budget.json
@@ -1,18 +1,20 @@
 {
  "actions": [],
  "allow_rename": 1,
- "autoname": "format:{revenue_group}-{revenue_region}/{fiscal_year}/{###}",
+ "autoname": "format:{revenue_category} {fiscal_year}-{abbreviation}",
  "creation": "2025-01-29 09:40:07.549966",
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
   "section_break_epzm",
   "company",
-  "revenue_group",
+  "abbreviation",
   "revenue_category",
+  "default_currency",
+  "company_currency",
   "column_break_wemo",
   "fiscal_year",
-  "revenue_region",
+  "revenue_template",
   "naming_series",
   "total_amount",
   "section_break",
@@ -75,12 +77,38 @@
    "read_only": 1
   },
   {
-   "fieldname": "revenue_group",
+   "fieldname": "amended_from",
    "fieldtype": "Link",
-   "in_list_view": 1,
-   "label": "Revenue Group",
-   "options": "Revenue Group",
-   "reqd": 1
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "Revenue Budget",
+   "print_hide": 1,
+   "read_only": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "revenue_template",
+   "fieldtype": "Link",
+   "label": "Revenue Template",
+   "options": "Revenue Template"
+  },
+  {
+   "default": "INR",
+   "fieldname": "default_currency",
+   "fieldtype": "Link",
+   "hidden": 1,
+   "label": "Default Currency",
+   "options": "Currency",
+   "read_only": 1
+  },
+  {
+   "fetch_from": "company.default_currency",
+   "fieldname": "company_currency",
+   "fieldtype": "Link",
+   "hidden": 1,
+   "label": "Company Currency",
+   "options": "Currency",
+   "read_only": 1
   },
   {
    "fieldname": "revenue_category",
@@ -90,27 +118,19 @@
    "reqd": 1
   },
   {
-   "fieldname": "revenue_region",
-   "fieldtype": "Select",
-   "label": "Revenue Region",
-   "options": "National\nGCC",
-   "reqd": 1
-  },
-  {
-   "fieldname": "amended_from",
-   "fieldtype": "Link",
-   "label": "Amended From",
-   "no_copy": 1,
-   "options": "Revenue Budget",
-   "print_hide": 1,
-   "read_only": 1,
-   "search_index": 1
+   "fetch_from": "company.abbr",
+   "fieldname": "abbreviation",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Abbreviation",
+   "read_only": 1
   }
  ],
+ "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-03-18 12:09:29.003630",
+ "modified": "2025-04-07 15:00:03.238147",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Revenue Budget",

--- a/beams/beams/doctype/revenue_budget/revenue_budget.py
+++ b/beams/beams/doctype/revenue_budget/revenue_budget.py
@@ -44,6 +44,7 @@ class RevenueBudget(Document):
 
 @frappe.whitelist()
 def get_revenue_template(revenue_category, company):
+    """Get Revenue Template based on Revenue category and selected Company"""
     template = frappe.db.get_value(
         "Revenue Template",
         {"revenue_category": revenue_category, "company": company},

--- a/beams/beams/doctype/revenue_budget/revenue_budget.py
+++ b/beams/beams/doctype/revenue_budget/revenue_budget.py
@@ -5,10 +5,48 @@ import frappe
 from frappe.model.document import Document
 
 class RevenueBudget(Document):
-
     def before_save(self):
         self.calculate_total_amount()
+
+    def validate(self):
+        self.convert_currency()
 
     def calculate_total_amount(self):
         total = sum([row.revenue_amount for row in self.get("revenue_accounts") if row.revenue_amount])
         self.total_amount = total
+
+    def convert_currency(self):
+        """Convert Revenue amounts for non-INR companies"""
+        company_currency = frappe.db.get_value("Company", self.company, "default_currency")
+        exchange_rate = 1
+
+        if company_currency != "INR":
+            exchange_rate = frappe.db.get_value("Company", self.company, "exchange_rate_to_inr")
+            if not exchange_rate:
+                frappe.throw(
+                    f"Please set Exchange Rate from <b>{company_currency}</b> to <b>INR</b> for <b>{self.company}</b>",
+                    title="Message",
+                )
+
+        months = [
+            "january", "february", "march", "april", "may", "june",
+            "july", "august", "september", "october", "november", "december"
+        ]
+
+        def apply_conversion(row):
+            """Apply exchange rate conversion to a revenue row"""
+            row.revenue_amount_inr = row.revenue_amount * exchange_rate
+            for month in months:
+                setattr(row, f"{month}_inr", (getattr(row, month, 0) or 0) * exchange_rate)
+
+        for row in self.revenue_accounts:
+            apply_conversion(row)
+
+@frappe.whitelist()
+def get_revenue_template(revenue_category, company):
+    template = frappe.db.get_value(
+        "Revenue Template",
+        {"revenue_category": revenue_category, "company": company},
+        "name"
+    )
+    return template

--- a/beams/beams/doctype/revenue_centre/revenue_centre.js
+++ b/beams/beams/doctype/revenue_centre/revenue_centre.js
@@ -1,8 +1,14 @@
 // Copyright (c) 2025, efeone and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Revenue Centre", {
-// 	refresh(frm) {
-
-// 	},
-// });
+frappe.ui.form.on("Revenue Centre", {
+    onload: function(frm) {
+        frm.set_query("account", function() {
+            return {
+                filters: {
+                    account_type: "Income Account"
+                }
+            };
+        });
+    }
+});

--- a/beams/beams/doctype/revenue_centre/revenue_centre.json
+++ b/beams/beams/doctype/revenue_centre/revenue_centre.json
@@ -6,19 +6,30 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
-  "revenue_centre"
+  "revenue_centre",
+  "account"
  ],
  "fields": [
   {
    "fieldname": "revenue_centre",
    "fieldtype": "Data",
+   "in_list_view": 1,
    "label": "Revenue Centre",
+   "reqd": 1,
    "unique": 1
+  },
+  {
+   "fieldname": "account",
+   "fieldtype": "Link",
+   "label": "Account",
+   "options": "Account",
+   "reqd": 1
   }
  ],
+ "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-03-18 11:35:03.479904",
+ "modified": "2025-04-07 10:10:07.817821",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Revenue Centre",

--- a/beams/beams/doctype/revenue_template/revenue_template.json
+++ b/beams/beams/doctype/revenue_template/revenue_template.json
@@ -1,24 +1,19 @@
 {
  "actions": [],
  "allow_rename": 1,
- "autoname": "field:template_title",
+ "autoname": "format:{revenue_category} - {abbreviation}",
  "creation": "2025-02-17 14:10:03.498118",
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
-  "template_title",
   "company",
+  "abbreviation",
+  "column_break_ofsa",
+  "revenue_category",
   "section_break_ybn1",
   "revenue_template_item"
  ],
  "fields": [
-  {
-   "fieldname": "template_title",
-   "fieldtype": "Data",
-   "label": "Template Title",
-   "reqd": 1,
-   "unique": 1
-  },
   {
    "fieldname": "company",
    "fieldtype": "Link",
@@ -36,15 +31,35 @@
    "fieldtype": "Table",
    "label": "Revenue Template Item",
    "options": "Revenue Template Item"
+  },
+  {
+   "fieldname": "revenue_category",
+   "fieldtype": "Link",
+   "label": "Revenue Category",
+   "options": "Revenue Category",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "company.abbr",
+   "fieldname": "abbreviation",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Abbreviation",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_ofsa",
+   "fieldtype": "Column Break"
   }
  ],
+ "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-02-21 13:33:27.864251",
+ "modified": "2025-04-07 14:45:56.321830",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Revenue Template",
- "naming_rule": "By fieldname",
+ "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [
   {

--- a/beams/beams/doctype/revenue_template_item/revenue_template_item.json
+++ b/beams/beams/doctype/revenue_template_item/revenue_template_item.json
@@ -7,9 +7,9 @@
  "engine": "InnoDB",
  "field_order": [
   "revenue_centre",
-  "revenue_group",
+  "account",
   "column_break_vrbs",
-  "revenue_category",
+  "revenue_group",
   "revenue_region"
  ],
  "fields": [
@@ -18,39 +18,44 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Revenue Group",
-   "options": "Revenue Group"
-  },
-  {
-   "fieldname": "revenue_category",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "label": "Revenue Category",
-   "options": "Revenue Category"
+   "options": "Revenue Group",
+   "reqd": 1
   },
   {
    "fieldname": "revenue_centre",
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Revenue Centre",
-   "options": "Account",
+   "options": "Revenue Centre",
    "reqd": 1
   },
   {
    "fieldname": "revenue_region",
-   "fieldtype": "Link",
+   "fieldtype": "Select",
    "in_list_view": 1,
-   "label": "Revenue Region",
-   "options": "Region"
+   "label": "Finance Region",
+   "options": "National\nGCC",
+   "reqd": 1
   },
   {
    "fieldname": "column_break_vrbs",
    "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "revenue_centre.account",
+   "fieldname": "account",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Account",
+   "options": "Account",
+   "reqd": 1
   }
  ],
+ "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-02-21 13:33:45.317169",
+ "modified": "2025-04-07 16:38:54.754188",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Revenue Template Item",


### PR DESCRIPTION
## Feature description
- Customize Revenue Budget,Revenue Template and Revenue Centre doctype.
- Customize Revenue Account and Revenue Template Item child table.
- Apply filter revenue category and company in Revenue template of Revenue Budget.
- Fetch Revenue template in Revenue Budget based on Revenue category and company.
- Apply filter account type = Income Account in account of Revenue Centre doctype.
- Convert revenue amaounts for non INR companies.

## Solution description
- Customized Revenue Budget,Revenue Template and Revenue Centre doctype.
- Customized Revenue Account and Revenue Template Item child table.
- Applied filter revenue category and company in Revenue template of Revenue Budget.
- Fetches Revenue template in Revenue Budget based on Revenue category and company.
- Applied filter account type = Income Account in account of Revenue Centre doctype.
- Converted revenue amaounts for non INR companies.
- Fetches revenue centre,account,revenue region from revenue template in Revenue Budget.

## Output screenshots (optional)
[Screencast from 08-04-25 11:04:04 AM IST.webm](https://github.com/user-attachments/assets/188723af-afd4-4860-a983-cd1591daee7c)
![image](https://github.com/user-attachments/assets/6a287c53-904d-4fc9-8dc5-21931b3dfa2f)
![image](https://github.com/user-attachments/assets/88c712ee-a2f6-4bfa-a896-f6bdb4a52a57)

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox