### PR TITLE
feat: changes in allocated manpower details

### DIFF
--- a/beams/beams/doctype/external_resource_request/external_resource_request.py
+++ b/beams/beams/doctype/external_resource_request/external_resource_request.py
@@ -87,6 +87,7 @@ def update_hired_field(doc, method=None):
             for manpower in project.allocated_manpower_details:
                 if (
                     resource.designation == manpower.designation
+                    and resource.hired_personnel == manpower.hired_personnel
                     and get_datetime(resource.required_from) == get_datetime(manpower.assigned_from)
                     and get_datetime(resource.required_to) == get_datetime(manpower.assigned_to)
                 ):


### PR DESCRIPTION
## Feature description
In allocated manpower details put hired tick mark only to the exact hired person ,not for everyone with the same designation.

## Solution description
Added condition ensures that only the exact hired person is marked, not everyone with the same designation.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/0b7af56d-ba9f-4e3d-b6b9-e1e14e8da390)
![image](https://github.com/user-attachments/assets/42a36067-578c-4acb-8b4a-11a7b996a80b)


## Areas affected and ensured
List out the areas affected by your code changes.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
 
