### PR TITLE
Fix:Default asset location fetched only if not given in Project.

### DIFF
--- a/beams/beams/custom_scripts/project/project.js
+++ b/beams/beams/custom_scripts/project/project.js
@@ -239,23 +239,28 @@ frappe.ui.form.on('Project', {
       }
   }
 
+ 
   frappe.ui.form.on('Required Items Table', {
     required_item: function(frm, cdt, cdn) {
-      
-      let row = locals[cdt][cdn]
+      let row = locals[cdt][cdn];
       if (row.required_item) {
-        
         frappe.call({
           method: "beams.beams.custom_scripts.project.project.get_available_quantities",
           args: {
-            items: JSON.stringify([row.required_item])
+            items: JSON.stringify([row.required_item]),
+            source_name: frm.doc.name  
           },
-          callback: function (r) {
+          callback: function(r) {
             if (r.message) {
-              frappe.model.set_value(cdt, cdn, 'available_quantity', r.message[row.required_item] || 0);
+              if (r.message._error) {
+                frappe.model.set_value(cdt, cdn, 'available_quantity', 0);
+              } else {
+                frappe.model.set_value(cdt, cdn, 'available_quantity', r.message[row.required_item] || 0);
+              }
             }
           }
         });
       }
     }
   });
+  

--- a/beams/beams/custom_scripts/project/project.py
+++ b/beams/beams/custom_scripts/project/project.py
@@ -285,6 +285,7 @@ def create_equipment_request(source_name, equipment_data, required_from, require
 
     return request_doc.name
 
+
 @frappe.whitelist()
 def get_available_quantities(items, source_name=None):
     """Returns available quantities for specified items based on location from Project or Beams Admin Settings."""
@@ -296,6 +297,7 @@ def get_available_quantities(items, source_name=None):
         frappe.throw("Items should be a list.")
 
     location = None
+
     if source_name:
         location = frappe.db.get_value("Project", source_name, "asset_location")
 
@@ -303,12 +305,18 @@ def get_available_quantities(items, source_name=None):
         location = frappe.db.get_single_value("Beams Admin Settings", "default_asset_location")
 
     if not location:
-        frappe.throw("Asset location not configured in Project or Beams Admin Settings.")
+        frappe.msgprint("Asset location not configured in Project or Beams Admin Settings.")
+        return {"_error": "Asset location not configured in Project or Beams Admin Settings."}
+
 
     result = {}
     for item in items:
         if item:
-            quantity = frappe.db.count("Asset", {"item_code": item, "location": location})
+            quantity = frappe.db.count("Asset", {
+                "item_code": item,
+                "location": location,
+                "docstatus": 1 
+            })
             result[item] = quantity or 0
 
     return result


### PR DESCRIPTION
## Feature description
When location not given in Project  fetch from Beams Admin Settings.


## Solution description
The code now checks if Asset Location field in Project has value,if it has fetch assets that matches with the location else fetch location from Beams Admin Settings(Default Asset Location).

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/cdfa48aa-3925-48ae-9b90-387df8e267d6)


## Areas affected and ensured
Project doctype
Equipment Request doctype.

## Is there any existing behavior change of other features due to this code change?  
       No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  