### PR TITLE
feat:Add Requested By field to Equipment Request with default set to current user

### DIFF
--- a/beams/beams/doctype/equipment_request/equipment_request.json
+++ b/beams/beams/doctype/equipment_request/equipment_request.json
@@ -10,6 +10,7 @@
   "project",
   "bureau",
   "location",
+  "requested_by",
   "column_break_dsby",
   "posting_date",
   "required_from",
@@ -108,12 +109,19 @@
    "fieldtype": "Select",
    "label": "Priority",
    "options": "Low\nMedium\nHigh"
+  },
+  {
+   "default": "__user",
+   "fieldname": "requested_by",
+   "fieldtype": "Link",
+   "label": "Requested By",
+   "options": "User"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-04-07 14:56:40.418558",
+ "modified": "2025-04-10 23:12:54.804433",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Equipment Request",


### PR DESCRIPTION

## Feature description
- Add Requested By field to Equipment Request with default set to current user

## Solution description

- Introduced a new field requested_by in the Equipment Request DocType.

- The field is a Link to the User doctype.

- It uses the default value __user, so the field automatically captures the current logged-in user.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/31d01b9a-0db0-4354-a359-7fdfacf29d92)


## Areas affected and ensured

- Equipment Request


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - yes
  - Opera Mini
  - Safari
