### PR TITLE
feat:  TASK-2025-00591 :Refactor map_asset_movement to support dynamic asset assignment and cleanup

### DIFF
--- a/beams/beams/doctype/equipment_request/equipment_request.js
+++ b/beams/beams/doctype/equipment_request/equipment_request.js
@@ -3,17 +3,77 @@
 
 frappe.ui.form.on('Equipment Request', {
     refresh: function (frm) {
-        set_item_query(frm)
-        if (frm.doc.workflow_state === "Approved"){
-          frm.add_custom_button(__('Equipment Acquiral Request'), function () {
-              frappe.model.open_mapped_doc({
-                  method: "beams.beams.doctype.equipment_request.equipment_request.map_equipment_acquiral_request",
-                  frm: frm,
-              });
-          }, __("Create"));
+        if (frm.doc.workflow_state === "Approved") {
+            frm.add_custom_button(__('Equipment Acquiral Request'), function () {
+                frappe.model.open_mapped_doc({
+                    method: "beams.beams.doctype.equipment_request.equipment_request.map_equipment_acquiral_request",
+                    frm: frm,
+                });
+            }, __("Create"));
+
+            frm.add_custom_button(__('Asset Movement'), function () {
+                const default_items = (frm.doc.required_equipments || []).map(row => ({
+                    item: row.required_item,
+                    count: row.required_quantity
+                }));
+
+                const fields = [
+                    {
+                        label: 'Assigned To',
+                        fieldname: 'assigned_to',
+                        fieldtype: 'Link',
+                        options: 'User',
+                        reqd: 1,
+                        default: frm.doc.requested_by || frappe.session.user 
+                    },
+                    {
+                        fieldname: 'asset_movement_details',
+                        label: 'Asset Movement Details',
+                        fieldtype: 'Table',
+                        cannot_add_rows: false,
+                        reqd: 1,
+                        fields: [
+                            {
+                                label: 'Item',
+                                fieldname: 'item',
+                                fieldtype: 'Link',
+                                options: 'Item',
+                                in_list_view: 1,
+                                reqd: 1
+                            },
+                            {
+                                label: 'Count',
+                                fieldname: 'count',
+                                fieldtype: 'Int',
+                                in_list_view: 1,
+                                reqd: 1
+                            }
+                        ],
+                        data: default_items
+                    }
+                ];
+
+                frappe.prompt(fields, function (values) {
+                    frappe.call({
+                        method: "beams.beams.doctype.equipment_request.equipment_request.map_asset_movement",
+                        args: {
+                            source_name: frm.doc.name,
+                            assigned_to: values.assigned_to,
+                            items: values.asset_movement_details,
+                            purpose: "Transfer"
+                        },
+                        callback: function (r) {
+                            if (r.message) {
+                                r.message.purpose = "Issue";
+                                frappe.model.sync(r.message);
+                                frappe.set_route('Form', r.message.doctype, r.message.name);
+                            }
+                        }
+                    });
+                }, __('Asset Movement'), __('Submit'));
+            }, __("Create"));
         }
     },
-
     bureau: function (frm) {
         set_item_query(frm)
     },
@@ -57,51 +117,7 @@ frappe.ui.form.on('Required Items Detail', {
                 }
             }
         });
-    },
-
-    asset_movement: function (frm, cdt, cdn) {
-       let row = locals[cdt][cdn];
-       frappe.db.get_value('Item', row.required_item, 'item_code', function(r) {
-           if (r && r.item_code) {
-               // Open the prompt dialog with employee and asset fields
-               frappe.prompt([
-                   {
-                       label: 'Employee',
-                       fieldname: 'employee',
-                       fieldtype: 'Link',
-                       options: 'Employee',
-                       reqd: 1
-                   },
-                   {
-                       label: 'Asset',
-                       fieldname: 'asset',
-                       fieldtype: 'Link',
-                       options: 'Asset',
-                       reqd: 1,
-                       get_query: function () {
-                           return {
-                               filters: { item_code: r.item_code }  // Filter assets by item_code
-                           };
-                       }
-                   }
-               ],
-               function (values) {
-                      frappe.model.open_mapped_doc({
-                          method: "beams.beams.doctype.equipment_request.equipment_request.map_asset_movement",
-                          frm: frm,
-                          args: {
-                              to_employee: values.employee,
-                              asset: values.asset,
-                              ref_type: row["doctype"],
-                              ref_name: row["name"]
-                          }
-                      });
-                  }, __('Asset Movement'), __('Create'));
-              } else {
-                  frappe.msgprint(__('Invalid required item selected.'));
-              }
-          });
-      }
+    }
   });
 
 function validate_dates(frm) {

--- a/beams/beams/doctype/equipment_request/equipment_request.py
+++ b/beams/beams/doctype/equipment_request/equipment_request.py
@@ -7,6 +7,7 @@ from frappe.utils import today,getdate,now_datetime
 from frappe.model.mapper import get_mapped_doc
 from frappe import _
 from datetime import datetime
+import json
 
 class EquipmentRequest(Document):
     def on_update_after_submit(self):
@@ -114,29 +115,46 @@ def map_equipment_acquiral_request(source_name, target_doc=None):
 
     return target_doc
 
-
 @frappe.whitelist()
-def map_asset_movement(source_name, target_doc=None):
-    to_employee = frappe.flags.get("args", {}).get("to_employee", '')
-    asset = frappe.flags.get("args", {}).get("asset", '')
-    ref_type = frappe.flags.get("args", {}).get("ref_type", '')
-    ref_name = frappe.flags.get("args", {}).get("ref_name", '')
-    print(ref_type, ref_name)
-    asset_movement = get_mapped_doc("Equipment Request", source_name, {
+def map_asset_movement(source_name, assigned_to=None, items=None, target_doc=None):
+    """
+    Maps an Equipment Request to an Asset Movement with selected assets and assigns them to an employee.
+    Only available assets with status 'Submitted' are considered for the movement.
+    """
+    if isinstance(items, str):
+        items = json.loads(items)
+
+    def postprocess(source, target):
+        employee_id = frappe.db.get_value("Employee", {"user_id": assigned_to})
+        if not employee_id:
+            frappe.throw(f"No Employee linked to User '{assigned_to}'")
+        target.to_employee = employee_id
+        if items:
+            for row in items:
+                item_code = row.get("item")
+                count = row.get("count")
+
+                assets = frappe.get_all("Asset",
+                    filters={
+                        "item_code": item_code,
+                        "docstatus": 1,
+                        "status": "Submitted"
+                    },
+                    fields=["name", "location"],
+                    limit=count
+                )
+
+                for asset in assets:
+                    target.append("assets", {
+                        "asset": asset.name,
+                        "source_location": asset.location,
+                        "to_employee": employee_id,
+                        "target_location": None
+                    })
+
+
+    return get_mapped_doc("Equipment Request", source_name, {
         "Equipment Request": {
             "doctype": "Asset Movement",
-            "field_map": {
-
-            }
         }
-    }, target_doc)
-    asset_movement.purpose = 'Issue'
-    asset_movement.append('assets', {
-            'asset': asset,
-            'to_employee': to_employee
-        })
-    asset_movement.reference_doctype = ref_type
-    asset_movement.reference_name = ref_name
-    asset_movement.flags.ignore_mandatory = True
-    asset_movement.save(ignore_permissions=True)
-    return asset_movement
+    }, target_doc, postprocess)


### PR DESCRIPTION


## Feature description

- Refactor map_asset_movement to support dynamic asset assignment and cleanup

## Solution description

- Replaced the old map_asset_movement implementation with a cleaner, more flexible version.

- assigned_to (User ID)

- items (list of item and count pairs)

- Dynamically maps available assets (with status = "Submitted") and assigns them to the linked employee.

- Ensures to_employee is correctly set based on the assigned_to user.

- Removes previously hardcoded arguments (to_employee, asset, ref_type, ref_name) and manual appending logic.

- Adds a two-line docstring for clarity.

- Prepares the function for flexible reuse across different contexts (not tied to UI flow anymore).

## Output screenshots (optional)

[Screencast from 11-04-25 05:25:47 PM IST.webm](https://github.com/user-attachments/assets/c75ed128-fa7f-45ff-93a8-38fd5a0b180c)

## Areas affected and ensured

- asset movment

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox  - yes
  - Opera Mini
  - Safari
