### PR TITLE
fix:Added validation for assigning same employee to same project and disallowed creation after employee assignment

### DIFF
--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -324,7 +324,8 @@ doc_events = {
             "beams.beams.custom_scripts.project.project.update_program_request_status_on_project_completion",
             "beams.beams.custom_scripts.project.project.validate_project"
         ],
-         "validate": "beams.beams.custom_scripts.project.project.validate_employee_assignment"    
+         "validate": "beams.beams.custom_scripts.project.project.validate_employee_assignment",
+         "validate": "beams.beams.custom_scripts.project.project.validate_employee_assignment_in_same_project"
     },
     "Item": {
         "before_insert": [


### PR DESCRIPTION
## Feature description
Need to: 
- Add validation for assigning same employee to same project
- Disallow creation of Technical Request after employee assignment

## Solution description
- Added validation for assigning same employee to same project
- Disallowed creation of Technical Request after employee assignment

## Output screenshots (optional)
[Screencast from 22-04-25 11:03:04 AM IST.webm](https://github.com/user-attachments/assets/45904ae3-78de-48ce-940b-878f4b199de0)

[Screencast from 22-04-25 11:00:52 AM IST.webm](https://github.com/user-attachments/assets/62564697-de97-4c08-b2a4-1d27104d34d5)


## Areas affected and ensured
Project Doctype

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Mozilla Firefox
 
