### PR TITLE
feat: TASK-2025-00711 prevent data clearing in project when creating additional transportation request

### DIFF
--- a/beams/beams/doctype/visitor_log/test_visitor_log.py
+++ b/beams/beams/doctype/visitor_log/test_visitor_log.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, efeone and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestVisitorLog(FrappeTestCase):
+	pass

--- a/beams/beams/doctype/visitor_log/visitor_log.js
+++ b/beams/beams/doctype/visitor_log/visitor_log.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, efeone and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Visitor Log", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/beams/beams/doctype/visitor_log/visitor_log.json
+++ b/beams/beams/doctype/visitor_log/visitor_log.json
@@ -1,0 +1,114 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "format:VL-{YY}-{####}",
+ "creation": "2025-04-23 14:59:00.182504",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "section_break_mzzx",
+  "visitor_name",
+  "contact_number",
+  "purpose_of_visit",
+  "purpose",
+  "person_visited",
+  "column_break_mnww",
+  "in_time",
+  "out_time",
+  "visitor_type",
+  "pass_issued",
+  "identification"
+ ],
+ "fields": [
+  {
+   "fieldname": "section_break_mzzx",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "visitor_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Visitor Name",
+   "reqd": 1
+  },
+  {
+   "fieldname": "contact_number",
+   "fieldtype": "Data",
+   "label": "Contact Number"
+  },
+  {
+   "fieldname": "purpose_of_visit",
+   "fieldtype": "Select",
+   "label": "Purpose of Visit ",
+   "options": "\nMeeting\nInterview\nDelivery\nOther"
+  },
+  {
+   "fieldname": "person_visited",
+   "fieldtype": "Link",
+   "label": "Person Visited ",
+   "options": "Employee"
+  },
+  {
+   "fieldname": "in_time",
+   "fieldtype": "Datetime",
+   "label": "In_Time "
+  },
+  {
+   "fieldname": "out_time",
+   "fieldtype": "Datetime",
+   "label": "Out_Time "
+  },
+  {
+   "fieldname": "visitor_type",
+   "fieldtype": "Select",
+   "label": "Visitor Type ",
+   "options": "\nRegular\nContractor\nSupplier\nEx-Employee\nNews Guest\nPersonal"
+  },
+  {
+   "default": "0",
+   "fieldname": "pass_issued",
+   "fieldtype": "Check",
+   "label": "Pass Issued "
+  },
+  {
+   "fieldname": "identification",
+   "fieldtype": "Data",
+   "label": "Identification "
+  },
+  {
+   "fieldname": "column_break_mnww",
+   "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "eval:doc.purpose_of_visit=='Other'",
+   "fieldname": "purpose",
+   "fieldtype": "Small Text",
+   "label": "Purpose"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2025-04-23 15:35:31.089387",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "Visitor Log",
+ "naming_rule": "Expression",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/beams/beams/doctype/visitor_log/visitor_log.py
+++ b/beams/beams/doctype/visitor_log/visitor_log.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class VisitorLog(Document):
+	pass


### PR DESCRIPTION
## Feature description
TASK-2025-00711:
Prevent data clearing in project when creating additional transportation request

TASK-2025-00713:
Create new dotype Vistor Log

## Solution description
Now able to create multiple transportation request.
Prevented data clearance from allocated vehicle details when new allocation is made

Updated code , updates vehicle allocation in a project document by retrieving existing vehicle details, updating or adding new vehicles from transportation request

TASK-2025-00713: Created new dotype Vistor Log with fields (visitor_name, contact_number, purpose_of_visit, purpose, person_visited, in_time, out_time, visitor_type, pass_issued , identification)

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/2127617e-e947-41a0-b75b-0ef44b2cf2ca)
![image](https://github.com/user-attachments/assets/32bca5b6-b286-4002-b00e-60726507894c)
![image](https://github.com/user-attachments/assets/c5eddc0b-000a-4a71-9221-fe867bf0cbb4)
![image](https://github.com/user-attachments/assets/1497270d-ac5a-4602-9515-fe76991f64b8)
![image](https://github.com/user-attachments/assets/04bb2a89-2535-4f75-98fd-445c9fd796ae)

TASK-2025-00713:
![image](https://github.com/user-attachments/assets/06979117-7e06-4eb9-a3ff-bd380e02745a)


## Areas affected and ensured
List out the areas affected by your code changes.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
 
