### PR TITLE
feat: sync vehicle return details with transaction log and auto-update on project completion

### DIFF
--- a/beams/beams/custom_scripts/project/project.js
+++ b/beams/beams/custom_scripts/project/project.js
@@ -321,3 +321,46 @@ frappe.ui.form.on('Project', {
       }
     }
   });
+
+  frappe.ui.form.on('Allocated Vehicle Details', {
+      return: function(frm, cdt, cdn) {
+          let row = locals[cdt][cdn];
+          frappe.prompt([
+              {
+                  label: 'Return Date',
+                  fieldname: 'return_date',
+                  fieldtype: 'Datetime',
+                  reqd: 1
+              },
+              {
+                  label: 'Return Reason',
+                  fieldname: 'return_reason',
+                  fieldtype: 'Small Text',
+                  reqd: 1
+              }
+          ],
+          function(values) {
+              row.return_date = values.return_date;
+              row.return_reason = values.return_reason;
+              row.returned = 1;
+              frm.refresh_field('allocated_vehicle_details');
+              frappe.call({
+                  method: "beams.beams.custom_scripts.project.project.update_vehicle_return_details_in_log",
+                  args: {
+                      project: frm.doc.name,
+                      vehicle: row.vehicle,
+                      return_date: values.return_date,
+                      return_reason: values.return_reason
+                  },
+                  callback: function(r) {
+                      if (!r.exc) {
+                          frappe.msgprint("Vehicle Transaction Log updated.");
+                          frm.save();
+                      }
+                  }
+              });
+          },
+          'Return Vehicle',
+          'Submit');
+      }
+  });

--- a/beams/beams/doctype/vehicle_log_detail/vehicle_log_detail.json
+++ b/beams/beams/doctype/vehicle_log_detail/vehicle_log_detail.json
@@ -13,6 +13,7 @@
   "to",
   "no_of_travellers",
   "status",
+  "returned",
   "return_date",
   "return_reason"
  ],
@@ -65,12 +66,20 @@
    "fieldtype": "Small Text",
    "in_list_view": 1,
    "label": "Return Reason"
+  },
+  {
+   "allow_on_submit": 1,
+   "default": "0",
+   "fieldname": "returned",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "returned"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-04-19 11:51:05.520000",
+ "modified": "2025-04-23 16:29:53.868218",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Vehicle Log Detail",

--- a/beams/beams/doctype/vehicle_transaction_log/vehicle_transaction_log.json
+++ b/beams/beams/doctype/vehicle_transaction_log/vehicle_transaction_log.json
@@ -9,6 +9,10 @@
   "project",
   "transportation_request",
   "vehicle_hire_request",
+  "section_break_iztv",
+  "location",
+  "bureau",
+  "section_break_xcxm",
   "vehicle_log_details"
  ],
  "fields": [
@@ -35,11 +39,33 @@
    "fieldtype": "Table",
    "label": "Vehicle Log Details",
    "options": "Vehicle Log Detail"
+  },
+  {
+   "fieldname": "section_break_iztv",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "project.location",
+   "fieldname": "location",
+   "fieldtype": "Link",
+   "label": "Location",
+   "options": "Location"
+  },
+  {
+   "fetch_from": "project.bureau",
+   "fieldname": "bureau",
+   "fieldtype": "Link",
+   "label": "Bureau",
+   "options": "Bureau"
+  },
+  {
+   "fieldname": "section_break_xcxm",
+   "fieldtype": "Section Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-04-19 11:48:42.219763",
+ "modified": "2025-04-22 11:10:05.592968",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Vehicle Transaction Log",

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -324,7 +324,9 @@ doc_events = {
             "beams.beams.custom_scripts.project.project.update_program_request_status_on_project_completion",
             "beams.beams.custom_scripts.project.project.validate_project",
             "beams.beams.custom_scripts.project.project.sync_manpower_logs",
-            "beams.beams.custom_scripts.project.project.on_update_project"
+            "beams.beams.custom_scripts.project.project.on_update_project",
+            "beams.beams.custom_scripts.project.project.sync_vehicle_logs",
+            "beams.beams.custom_scripts.project.project.auto_return_vehicles_on_project_completion"
         ],
          "validate": "beams.beams.custom_scripts.project.project.validate_employee_assignment",
          "validate": "beams.beams.custom_scripts.project.project.validate_employee_assignment_in_same_project"


### PR DESCRIPTION

## Feature description
 sync vehicle return details with transaction log and auto-update on project completion

## Solution description

- **Vehicle Log Detail**
 
- Added a returned checkbox to indicate vehicle return.
 
- Made it visible in the list view.
 
- Project Form Enhancements (project.js)
 
- Added a Return button per vehicle in Allocated Vehicle Details.
 
- On click, prompts for Return Date and Reason, updates the row, and calls backend to sync return info.
 
**- Server-side Logic (project.py)**
 
- update_vehicle_return_details_in_log: Updates return info in Vehicle Transaction Log.
 
- sync_vehicle_logs: Syncs Project vehicles with the Transaction Log while preserving return data.
 
- auto_return_vehicles_on_project_completion: Automatically marks vehicles as returned when a project is completed or cancelled.
 
**- Vehicle Transaction Log**
 
- Added location and bureau fields (fetched from Project).
 
- UI layout improvements.
 
**- Hook Configuration (hooks.py)**
 
- Added hooks to run syncing and auto-return functions on Project update and status change.

## Output screenshots (optional)
[Screencast from 23-04-25 05:14:34 PM IST.webm](https://github.com/user-attachments/assets/567105bf-f35e-48dd-bda9-46e3fc6c6994)

![image](https://github.com/user-attachments/assets/0aaf851d-e34e-4597-bea0-653b43d212ea)


[Screencast from 23-04-25 05:16:34 PM IST.webm](https://github.com/user-attachments/assets/12bf231c-35b8-4d58-b508-e9eb809af70b)

![image](https://github.com/user-attachments/assets/7fc1402a-aa17-4748-95e1-a018af2b2512)

![image](https://github.com/user-attachments/assets/975a5865-cb2d-4024-8346-cb596f71b7b9)

## Areas affected and ensured
- project
- Vehicle Transaction Log

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox-yes
  - Opera Mini
  - Safari
