### PR TITLE
feat: TASK-2025-00750 new doctype named courier log

### DIFF
--- a/beams/beams/doctype/courier_log/courier_log.js
+++ b/beams/beams/doctype/courier_log/courier_log.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, efeone and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Courier Log", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/beams/beams/doctype/courier_log/courier_log.json
+++ b/beams/beams/doctype/courier_log/courier_log.json
@@ -1,0 +1,102 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "format:CL-{YY}-{####}",
+ "creation": "2025-04-24 11:06:10.851229",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "section_break_fuje",
+  "courier_type",
+  "tracking_number",
+  "sender",
+  "recipient",
+  "column_break_qyhg",
+  "courier_service",
+  "date",
+  "status",
+  "section_break_cwuh",
+  "description"
+ ],
+ "fields": [
+  {
+   "fieldname": "section_break_fuje",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "courier_type",
+   "fieldtype": "Select",
+   "label": "Courier Type",
+   "options": "\nIncoming\nOutgoing"
+  },
+  {
+   "fieldname": "tracking_number",
+   "fieldtype": "Data",
+   "label": "Tracking Number"
+  },
+  {
+   "fieldname": "sender",
+   "fieldtype": "Data",
+   "label": "Sender"
+  },
+  {
+   "fieldname": "recipient",
+   "fieldtype": "Data",
+   "label": "Recipient"
+  },
+  {
+   "fieldname": "courier_service",
+   "fieldtype": "Data",
+   "label": "Courier Service"
+  },
+  {
+   "fieldname": "date",
+   "fieldtype": "Datetime",
+   "label": "Date"
+  },
+  {
+   "fieldname": "description",
+   "fieldtype": "Small Text",
+   "label": "Description"
+  },
+  {
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "label": "Status",
+   "options": "\nReceived\nDispatched\nDelivered"
+  },
+  {
+   "fieldname": "column_break_qyhg",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_cwuh",
+   "fieldtype": "Section Break"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2025-04-24 11:22:54.412911",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "Courier Log",
+ "naming_rule": "Expression",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/beams/beams/doctype/courier_log/courier_log.py
+++ b/beams/beams/doctype/courier_log/courier_log.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class CourierLog(Document):
+	pass

--- a/beams/beams/doctype/courier_log/test_courier_log.py
+++ b/beams/beams/doctype/courier_log/test_courier_log.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, efeone and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestCourierLog(FrappeTestCase):
+	pass

--- a/beams/beams/doctype/inward_register/inward_register.json
+++ b/beams/beams/doctype/inward_register/inward_register.json
@@ -9,6 +9,7 @@
   "section_break_65yf",
   "visitor_type",
   "visitor_name",
+  "courier_service",
   "column_break_weuy",
   "posting_date",
   "posting_time",
@@ -71,8 +72,7 @@
    "fieldname": "received_by",
    "fieldtype": "Link",
    "label": "Received By",
-   "options": "Employee",
-   "reqd": 1
+   "options": "Employee"
   },
   {
    "depends_on": "eval:doc.vehicle_key;",
@@ -101,12 +101,18 @@
    "in_list_view": 1,
    "label": "Visitor Name ",
    "reqd": 1
+  },
+  {
+   "depends_on": "eval:doc.visitor_type == 'Courier'",
+   "fieldname": "courier_service",
+   "fieldtype": "Data",
+   "label": "Courier Service"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-01-27 11:15:43.490320",
+ "modified": "2025-04-25 14:30:34.845221",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Inward Register",


### PR DESCRIPTION
## Feature description
TASK-2025-00750
1.Create new doctype courier log
2. Edit inward register doctype

## Solution description
Created new doctype named courier log with fields (courier_type, tracking_number, sender, recipient, courier_service, date, description, status)

Added a new field named 'courier service' in inward register doctype ( 'courier service' field shows only when visitor type is 'courier'

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/4384663f-f3fb-43b6-86ca-2077cb9f4c41)
![image](https://github.com/user-attachments/assets/6d45db9f-cb8b-456d-9f36-817572213f0f)


## Areas affected and ensured
List out the areas affected by your code changes.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox

