### PR TITLE
feat:Created doctype Visit Request

### DIFF
--- a/beams/beams/doctype/inward_register/inward_register.json
+++ b/beams/beams/doctype/inward_register/inward_register.json
@@ -13,6 +13,7 @@
   "column_break_weuy",
   "posting_date",
   "posting_time",
+  "visit_date",
   "section_break_zgfs",
   "received_by",
   "purpose_of_visit",
@@ -107,8 +108,14 @@
    "fieldname": "courier_service",
    "fieldtype": "Data",
    "label": "Courier Service"
+  },
+  {
+   "fieldname": "visit_date",
+   "fieldtype": "Date",
+   "label": "Visit Date"
   }
  ],
+ "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],

--- a/beams/beams/doctype/inward_register/inward_register.py
+++ b/beams/beams/doctype/inward_register/inward_register.py
@@ -1,48 +1,58 @@
 # Copyright (c) 2025, efeone and contributors
 # For license information, please see license.txt
+
 import frappe
-from frappe.model.document import Document
-from frappe.utils import nowdate, nowtime
-from frappe.utils.user import get_users_with_role
-from frappe.desk.form.assign_to import add as add_assign
-from frappe.utils import today
 from frappe import _
+from frappe.desk.form.assign_to import add as add_assign
+from frappe.model.document import Document
+from frappe.utils import today
+from frappe.utils.user import get_users_with_role
 
 
 class InwardRegister(Document):
-	def before_save(self):
-		self.validate_posting_date()
+    def before_save(self):
+        self.validate_posting_date()
 
-	def on_submit(self, method=None):
-	    """
-	    Creates a ToDo task for the driver when the 'vehicle_key' checkbox is checked.
-	    The notification message will be "Vehicle key handed over in Inward."
-	    """
-	    if self.vehicle_key:
-	        driver_users = get_users_with_role("Driver")
-	        if driver_users:
-	            description = f"Vehicle key handed over in Inward for {self.visitor_name}."
-	            if not frappe.db.exists('ToDo', {
-	                'reference_name': self.name,
-	                'reference_type': 'Inward Register',
-	                'description': description
-	            }):
-	                add_assign({
-	                    "assign_to": driver_users,
-	                    "doctype": "Inward Register",
-	                    "name": self.name,
-	                    "description": description
-	                })
+    def on_submit(self, method=None):
+        """
+        Creates a ToDo task for the driver when the 'vehicle_key' checkbox is checked.
+        The notification message will be "Vehicle key handed over in Inward."
+        """
+        if self.vehicle_key:
+            driver_users = get_users_with_role("Driver")
+            if driver_users:
+                description = f"Vehicle key handed over in Inward for {self.visitor_name}."
+                if not frappe.db.exists('ToDo', {
+                    'reference_name': self.name,
+                    'reference_type': 'Inward Register',
+                    'description': description
+                }):
+                    add_assign({
+                        "assign_to": driver_users,
+                        "doctype": "Inward Register",
+                        "name": self.name,
+                        "description": description
+                    })
 
-	    if self.visitor_type == 'Courier':
-	        courier_log = frappe.new_doc('Courier Log')
-	        courier_log.courier_service = self.courier_service
-	        courier_log.recipient = self.received_by
-	        courier_log.description = self.purpose_of_visit
-	        courier_log.insert()
+    def validate(self):
+        if self.visitor_type == "Ex Employee":
+            if not self.visitor_name or not self.visit_date:
+                frappe.throw("Visitor Name and Visit Date are required for Ex Employees.")
 
-	@frappe.whitelist()
-	def validate_posting_date(self):
-		if self.posting_date:
-			if self.posting_date > today():
-				frappe.throw(_("Posting Date cannot be set after today's date."))
+            # Check if a Visit Request exists
+            visit_request = frappe.db.exists(
+                "Visit Request",
+                {
+                    "visitor_name": self.visitor_name,
+                    "visit_date": self.visit_date
+                }
+            )
+
+            if not visit_request:
+                frappe.throw(f"No Visit Request found for {self.visitor_name} on {self.visit_date}.")
+
+    @frappe.whitelist()
+    def validate_posting_date(self):
+        if self.posting_date:
+            if self.posting_date > today():
+                frappe.throw(_("Posting Date cannot be set after today's date."))

--- a/beams/beams/doctype/visit_request/test_visit_request.py
+++ b/beams/beams/doctype/visit_request/test_visit_request.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, efeone and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestVisitRequest(FrappeTestCase):
+	pass

--- a/beams/beams/doctype/visit_request/visit_request.js
+++ b/beams/beams/doctype/visit_request/visit_request.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, efeone and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Visit Request", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/beams/beams/doctype/visit_request/visit_request.json
+++ b/beams/beams/doctype/visit_request/visit_request.json
@@ -1,7 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
- "autoname": "format:{DD}-{MM}-{####}",
+ "autoname": "format:{VR}-{DD}-{MM}-{####}",
  "creation": "2025-04-25 14:59:32.825122",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -92,7 +92,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-04-25 16:13:02.934375",
+ "modified": "2025-04-28 13:25:57.194656",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Visit Request",

--- a/beams/beams/doctype/visit_request/visit_request.json
+++ b/beams/beams/doctype/visit_request/visit_request.json
@@ -1,0 +1,119 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "format:{DD}-{MM}-{####}",
+ "creation": "2025-04-25 14:59:32.825122",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "section_break_tgtp",
+  "visitor_type",
+  "visitor_name",
+  "purpose_of_visit",
+  "contact_number",
+  "person_to_meet",
+  "amended_from",
+  "column_break_gbkg",
+  "request_date",
+  "visit_date",
+  "approval_status",
+  "approver"
+ ],
+ "fields": [
+  {
+   "fieldname": "section_break_tgtp",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "Visit Request",
+   "print_hide": 1,
+   "read_only": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "visitor_type",
+   "fieldtype": "Link",
+   "label": "Visitor Type",
+   "options": "Visitor Type"
+  },
+  {
+   "fieldname": "purpose_of_visit",
+   "fieldtype": "Data",
+   "label": "Purpose of Visit"
+  },
+  {
+   "fieldname": "contact_number",
+   "fieldtype": "Data",
+   "label": "Contact Number"
+  },
+  {
+   "fieldname": "person_to_meet",
+   "fieldtype": "Link",
+   "label": "Person to Meet",
+   "options": "Employee"
+  },
+  {
+   "fieldname": "request_date",
+   "fieldtype": "Date",
+   "label": "Request Date"
+  },
+  {
+   "fieldname": "visit_date",
+   "fieldtype": "Date",
+   "label": "Visit Date"
+  },
+  {
+   "fieldname": "approval_status",
+   "fieldtype": "Select",
+   "label": "Approval Status",
+   "options": "\nPending\nApproved\nRejected"
+  },
+  {
+   "fieldname": "approver",
+   "fieldtype": "Link",
+   "label": "Approver",
+   "options": "Employee"
+  },
+  {
+   "fieldname": "column_break_gbkg",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "visitor_name",
+   "fieldtype": "Data",
+   "label": "Visitor Name"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "is_submittable": 1,
+ "links": [],
+ "modified": "2025-04-25 16:13:02.934375",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "Visit Request",
+ "naming_rule": "Expression",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/beams/beams/doctype/visit_request/visit_request.py
+++ b/beams/beams/doctype/visit_request/visit_request.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class VisitRequest(Document):
+	pass


### PR DESCRIPTION
## Feature description
    Created a new Visit Request form to manage approval  for  Ex Employees.
    Fields include:
        Visitor Type
        Contact Number
        Purpose of Visit
        Person to Meet
        Request Date
        Visit Date
        Approval Status (Pending, Approved, Rejected)
        Approver (Employee)

## Analysis and design

- [x] Created Visit Request doctype with above mentioned fields.
- [x] This PR enhances the Visitor Log validation to ensure that if the visitor type is "Ex Employee", then:

    Visitor Name and Visit Date are mandatory.
    The system will check the Inward Register to verify if an entry exists with the same visitor name and visit date.
    If no matching record is found in the Inward Register, an error will be thrown.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/ba90cc58-0fb7-4d2f-983d-95a023cd8b18)
![image](https://github.com/user-attachments/assets/269a97ec-b820-454e-8b07-194a88d4e00a)


## Areas affected and ensured
Visit Request doctype
Inward Register doctype

## Is there any existing behavior change of other features due to this code change?
No


## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox

