### PR TITLE
feat: TASK-2025-00764 mapping from inward register to courier log

### DIFF
--- a/beams/beams/doctype/inward_register/inward_register.py
+++ b/beams/beams/doctype/inward_register/inward_register.py
@@ -13,7 +13,6 @@ class InwardRegister(Document):
 	def before_save(self):
 		self.validate_posting_date()
 
-
 	def on_submit(self, method=None):
 	    """
 	    Creates a ToDo task for the driver when the 'vehicle_key' checkbox is checked.
@@ -34,6 +33,14 @@ class InwardRegister(Document):
 	                    "name": self.name,
 	                    "description": description
 	                })
+
+	    if self.visitor_type == 'Courier':
+	        courier_log = frappe.new_doc('Courier Log')
+	        courier_log.courier_service = self.courier_service
+	        courier_log.recipient = self.received_by
+	        courier_log.description = self.purpose_of_visit
+	        courier_log.insert()
+
 	@frappe.whitelist()
 	def validate_posting_date(self):
 		if self.posting_date:

--- a/beams/beams/doctype/visitor_log/visitor_log.json
+++ b/beams/beams/doctype/visitor_log/visitor_log.json
@@ -51,12 +51,12 @@
   {
    "fieldname": "in_time",
    "fieldtype": "Datetime",
-   "label": "In_Time "
+   "label": "In Time "
   },
   {
    "fieldname": "out_time",
    "fieldtype": "Datetime",
-   "label": "Out_Time "
+   "label": "Out Time "
   },
   {
    "fieldname": "visitor_type",
@@ -88,7 +88,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-04-23 15:35:31.089387",
+ "modified": "2025-04-24 12:32:09.117912",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Visitor Log",


### PR DESCRIPTION
## Feature description
When submitting an Inward Register, Map fields ( Courier Service to Courier Service, Received By to Recipient, Purpose of Visit to Description)

Correct field name (in time & out time) in visitor log.

## Solution description
When submitting an Inward Register, 
created a Courier Log and maped the following fields from the Inward Register to the Courier Log: Courier Service to Courier Service, Received By to Recipient, and Purpose of Visit to Description.

In visitor log doctype corrected  field name of in time and out time (in_time to in time and out_time to out time)

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/26dfd7a1-a9f9-433f-9653-c4240f4ab35f)
![image](https://github.com/user-attachments/assets/858f8618-9f0d-4bb7-af3e-b3a54149b1e4)
![image](https://github.com/user-attachments/assets/b85d8f57-fc16-4f92-8743-681d6403c40f)


## Areas affected and ensured
List out the areas affected by your code changes.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  
