### PR TITLE
feat: TASK-2025-00790 :Add validation to map only items with acquired_qty > 0 in equipment acquiral request

### DIFF
--- a/beams/beams/doctype/equipment_request/equipment_request.py
+++ b/beams/beams/doctype/equipment_request/equipment_request.py
@@ -107,11 +107,11 @@ def map_equipment_acquiral_request(source_name, target_doc=None):
     )
 
     for item in equipment_request.required_equipments:
-        acquired_qty = item.required_quantity - item.issued_quantity
-        if acquired_qty > 0:
+        required_qty = item.required_quantity - item.issued_quantity
+        if required_qty > 0:
             target_item = target_doc.append("required_items", {
                 "item": item.required_item,
-                "quantity": acquired_qty
+                "quantity": required_qty
         })
 
     return target_doc

--- a/beams/beams/doctype/equipment_request/equipment_request.py
+++ b/beams/beams/doctype/equipment_request/equipment_request.py
@@ -108,9 +108,10 @@ def map_equipment_acquiral_request(source_name, target_doc=None):
 
     for item in equipment_request.required_equipments:
         acquired_qty = item.required_quantity - item.issued_quantity
-        target_item = target_doc.append("required_items", {
-            "item": item.required_item,
-            "quantity": acquired_qty
+        if acquired_qty > 0:
+            target_item = target_doc.append("required_items", {
+                "item": item.required_item,
+                "quantity": acquired_qty
         })
 
     return target_doc


### PR DESCRIPTION

## Feature description
Add validation to map only items with acquired_qty > 0 in equipment acquiral request

## Solution description
-  prevent items with no remaining quantity to be mapped.
- Solution: Added a conditional check (if acquired_qty > 0) before appending the item to the required_items child table in the Equipment Acquiral Request mapping function.

## Output screenshots (optional)
[Screencast from 29-04-25 12:57:13 PM IST.webm](https://github.com/user-attachments/assets/902465da-ac98-4f97-abaa-6fd2e74d3eb8)


## Areas affected and ensured

- Equipment Acquiral Request

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - YES
  - Opera Mini
  - Safari
