### PR TITLE
fix:TASK-2025-00817: handle datetime object type for start_date and end_date in travel days calculation

### DIFF
--- a/beams/beams/doctype/asset_auditing/asset_auditing.json
+++ b/beams/beams/doctype/asset_auditing/asset_auditing.json
@@ -41,6 +41,7 @@
    "reqd": 1
   },
   {
+   "description": "A minimum of 3 photos must be uploaded",
    "fieldname": "asset_photos",
    "fieldtype": "Table",
    "label": "Asset Photos",
@@ -87,7 +88,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-02-18 16:10:52.558484",
+ "modified": "2025-04-30 14:52:09.761054",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Asset Auditing",

--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.py
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.py
@@ -86,9 +86,11 @@ class EmployeeTravelRequest(Document):
     def total_days_calculate(self):
         """Calculate the total number of travel days, ensuring at least one day."""
         if self.start_date and self.end_date:
-            start_date = datetime.strptime(self.start_date, "%Y-%m-%d %H:%M:%S").date()
-            end_date = datetime.strptime(self.end_date, "%Y-%m-%d %H:%M:%S").date()
-            self.total_days = 1 if start_date == end_date else (end_date - start_date).days + 1
+            start_date = self.start_date if isinstance(self.start_date, datetime) else datetime.strptime(self.start_date, "%Y-%m-%d %H:%M:%S")
+            end_date = self.end_date if isinstance(self.end_date, datetime) else datetime.strptime(self.end_date, "%Y-%m-%d %H:%M:%S")
+
+            self.total_days = 1 if start_date.date() == end_date.date() else (end_date.date() - start_date.date()).days + 1
+
 
 @frappe.whitelist()
 def get_batta_policy(requested_by):


### PR DESCRIPTION
## Feature description

- handle datetime object type for start_date and end_date in travel days calculation
- add description to Asset Photos table in Asset Auditing Doctype

## Solution description

 - Previously, the `total_days_calculate` method assumed `start_date` and `end_date` were strings and used `datetime.strptime`, which caused a `TypeError` when these fields were already `datetime` objects.

 - This fix ensures type checking before parsing—if the fields are already `datetime`, they are used as-is; otherwise, they are parsed from strings. This prevents runtime errors during validation or submission of the Employee Travel Request document.
- Added a field description to the "Asset Photos" table in the Asset Auditing Doctype to inform users that a minimum of 3 photos must be uploaded. This enhances clarity and helps enforce data entry expectations, especially during audits or validations.

## Output screenshots (optional)
[Screencast from 30-04-25 10:16:26 AM IST.webm](https://github.com/user-attachments/assets/c8b93b82-aa73-4f74-ac19-47b2b735eb21)

![image](https://github.com/user-attachments/assets/aa556bef-05bb-45fa-9562-03d55fa80af1)

## Areas affected and ensured

- Employee Travel Request
- Asset Auditing

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox -YES
  - Opera Mini
  - Safari
