### PR TITLE
feat: TASK-2025-00819 create patrol log template

### DIFF
--- a/beams/beams/doctype/patrol_log_template/patrol_log_template.js
+++ b/beams/beams/doctype/patrol_log_template/patrol_log_template.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, efeone and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Patrol Log Template", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/beams/beams/doctype/patrol_log_template/patrol_log_template.json
+++ b/beams/beams/doctype/patrol_log_template/patrol_log_template.json
@@ -1,0 +1,55 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "format:{template_name}-{#####} ",
+ "creation": "2025-04-28 16:42:03.449869",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "section_break_hith",
+  "template_name",
+  "patrol_log"
+ ],
+ "fields": [
+  {
+   "fieldname": "section_break_hith",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "template_name",
+   "fieldtype": "Data",
+   "label": "Template Name"
+  },
+  {
+   "fieldname": "patrol_log",
+   "fieldtype": "Table",
+   "label": "Patrol Log",
+   "options": "Patrol Log Detail"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2025-04-30 10:33:31.719018",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "Patrol Log Template",
+ "naming_rule": "Expression",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/beams/beams/doctype/patrol_log_template/patrol_log_template.json
+++ b/beams/beams/doctype/patrol_log_template/patrol_log_template.json
@@ -1,7 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
- "autoname": "format:{template_name}-{#####} ",
+ "autoname": "field:template_name",
  "creation": "2025-04-28 16:42:03.449869",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -18,7 +18,8 @@
   {
    "fieldname": "template_name",
    "fieldtype": "Data",
-   "label": "Template Name"
+   "label": "Template Name",
+   "unique": 1
   },
   {
    "fieldname": "patrol_log",
@@ -29,11 +30,11 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-04-30 10:33:31.719018",
+ "modified": "2025-04-30 17:03:14.890825",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Patrol Log Template",
- "naming_rule": "Expression",
+ "naming_rule": "By fieldname",
  "owner": "Administrator",
  "permissions": [
   {

--- a/beams/beams/doctype/patrol_log_template/patrol_log_template.py
+++ b/beams/beams/doctype/patrol_log_template/patrol_log_template.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class PatrolLogTemplate(Document):
+	pass

--- a/beams/beams/doctype/patrol_log_template/test_patrol_log_template.py
+++ b/beams/beams/doctype/patrol_log_template/test_patrol_log_template.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, efeone and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestPatrolLogTemplate(FrappeTestCase):
+	pass

--- a/beams/beams/doctype/security_patrol_log/security_patrol_log.js
+++ b/beams/beams/doctype/security_patrol_log/security_patrol_log.js
@@ -1,8 +1,27 @@
 // Copyright (c) 2025, efeone and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Security Patrol Log", {
-// 	refresh(frm) {
-
-// 	},
-// });
+frappe.ui.form.on('Security Patrol Log', {
+    patrol_template: function (frm) {
+        if (frm.doc.patrol_template) {
+            frappe.call({
+                method: 'frappe.client.get',
+                args: {
+                    doctype: 'Patrol Log Template',
+                    name: frm.doc.patrol_template
+                },
+                callback: function (r) {
+                    if (r.message) {
+                        frm.clear_table('patrol_log');
+                        (r.message.patrol_log || []).forEach(function (d) {
+                            let row = frm.add_child('patrol_log');
+                            row.service_unit = d.service_unit;
+                            row.remarks = d.remarks;
+                        });
+                        frm.refresh_field('patrol_log');
+                    }
+                }
+            });
+        }
+    }
+});

--- a/beams/beams/doctype/security_patrol_log/security_patrol_log.json
+++ b/beams/beams/doctype/security_patrol_log/security_patrol_log.json
@@ -8,7 +8,10 @@
  "field_order": [
   "section_break_ielw",
   "employee",
+  "column_break_r4ox",
   "full_name",
+  "section_break_hfts",
+  "patrol_template",
   "patrol_log",
   "remarks",
   "amended_from"
@@ -53,12 +56,26 @@
    "fieldtype": "Data",
    "label": "Full Name",
    "read_only": 1
+  },
+  {
+   "fieldname": "patrol_template",
+   "fieldtype": "Link",
+   "label": "Patrol Log Template",
+   "options": "Patrol Log Template"
+  },
+  {
+   "fieldname": "column_break_r4ox",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_hfts",
+   "fieldtype": "Section Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-02-28 12:21:30.350671",
+ "modified": "2025-04-30 10:06:35.442305",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Security Patrol Log",


### PR DESCRIPTION
## Feature description
TASK-2025-00819 , create patrol log template with required fields 
(When a Patrol Template is selected in the Security Patrol Log form, fetches the corresponding Patrol Log Template record)


## Solution description
Created Patrol log template with  fields Template name and patrol log , 
Added field named patrol log template in security patrol log doctype .

( When a Patrol Template is selected in the Security Patrol Log form, fetches the corresponding Patrol Log Template record, copies its child table entries into the Security Patrol Log's patrol_log child table, and refreshes the field to display the updated entries.)

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/d30c5462-22c6-42c1-bda5-c5c7fa80313e)
![image](https://github.com/user-attachments/assets/6908beb6-18da-457a-af04-6ab3045fbd50)


## Areas affected and ensured
List out the areas affected by your code changes.(security patrol log)

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox

