### PR TITLE
feat:Map items with count > 0 in Asset Movement and log each item in a separate Asset Reservation

### DIFF
--- a/beams/beams/custom_scripts/asset_movement/asset_movement.py
+++ b/beams/beams/custom_scripts/asset_movement/asset_movement.py
@@ -21,7 +21,7 @@ def update_issued_quantity(doc, method):
     )
 
     if not required_items:
-        frappe.throw(f"No Required Items found for Equipment Request {reference_name}.")
+        return
 
     asset_count = {}
     for asset in doc.assets:
@@ -37,7 +37,7 @@ def update_issued_quantity(doc, method):
 
     project_name = frappe.db.get_value("Equipment Request", reference_name, "project")
     if not project_name:
-        frappe.throw(f"Project not linked in Equipment Request {reference_name}.")
+        return
 
     project_doc = frappe.get_doc("Project", project_name)
 

--- a/beams/beams/custom_scripts/asset_movement/asset_movement.py
+++ b/beams/beams/custom_scripts/asset_movement/asset_movement.py
@@ -12,7 +12,7 @@ def update_issued_quantity(doc, method):
 
     reference_name = doc.reference_name
     if not reference_name:
-        frappe.throw("Reference name missing in Asset Movement.")
+        return
 
     required_items = frappe.get_all(
         "Required Items Detail",


### PR DESCRIPTION
## Feature description
Map items with count > 0 in Asset Movement and log each item in a separate Asset Reservation

## Solution description

- [ ] TASK-2025-00856
- [ ] TASK-2025-00854

**- Asset Movement Mapping Enhancement**

      - Updated the map_asset_movement function to skip items where the count is missing or <= 0.
      
      - Ensures only valid asset quantities are considered for asset selection and movement.
      
      - Replaced frappe.throw with return to avoid errors when reference_name is missing in Asset Movement, ensuring smoother processing.

**- Asset Reservation Log Logic Refactor**

    - Instead of aggregating all required items into a single Asset Reservation Log, each required item creates an individual log entry.
     
    -  added a check to ensure the item exists before creating a log to prevent unexpected errors.
     
**- Improved Error Handling in update_issued_quantity Hook**

    - Instead of throwing errors when required_items or project_name is missing in the related Equipment Request, the         function now safely returns early, avoiding disruption in workflow.

## Output screenshots (optional)
[Screencast from 02-05-25 01:20:33 PM IST.webm](https://github.com/user-attachments/assets/a1eabb55-2736-4e0b-8246-362f45fd5905)


## Areas affected and ensured

- Asset Reservation Log
- equipment request
- equipment aquiral request

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - Yes
  - Opera Mini
  - Safari
