### PR TITLE
feat: TASK-2025-00826 Maintain Equipment transaction log , TASK-2025-00857

### DIFF
--- a/beams/beams/custom_scripts/project/project.js
+++ b/beams/beams/custom_scripts/project/project.js
@@ -6,7 +6,7 @@ frappe.ui.form.on('Project', {
             let grid = frm.fields_dict["allocated_item_details"].grid;
             grid.toggle_display("asset_movement", false);
             grid.toggle_display("return_date", false);
-            grid.toggle_display("returned", false);
+            grid.toggle_display("returned_count", false);
             grid.toggle_display("returned_reason", false);
             frm.refresh_field("allocated_item_details");
         }
@@ -364,6 +364,58 @@ frappe.ui.form.on('Project', {
               });
           },
           'Return Vehicle',
+          'Submit');
+      }
+  });
+
+  frappe.ui.form.on('Required Items Detail', {
+      return: function(frm, cdt, cdn) {
+          let child = locals[cdt][cdn];
+
+          frappe.prompt([
+              {
+                  label: 'Return Date',
+                  fieldname: 'return_date',
+                  fieldtype: 'Datetime',
+                  reqd: 1
+              },
+              {
+                  label: 'Returned Reason',
+                  fieldname: 'returned_reason',
+                  fieldtype: 'Small Text',
+                  reqd: 1
+              },
+              {
+                label: 'Returned Count',
+                fieldname: 'returned_count',
+                fieldtype: 'Int',
+                reqd: 1
+            }
+          ],
+          function(values) {
+              frappe.model.set_value(cdt, cdn, 'return_date', values.return_date);
+              frappe.model.set_value(cdt, cdn, 'returned_reason', values.returned_reason);
+              frappe.model.set_value(cdt, cdn, 'returned_count', values.returned_count);
+
+              let args = {
+                  project: frm.doc.name,
+                  required_item: child.required_item,
+                  return_date: values.return_date,
+                  returned_reason: values.returned_reason,
+                  returned_count: values.returned_count
+              };
+
+              frappe.call({
+                  method: "beams.beams.custom_scripts.project.project.update_return_details_in_equipment_log",
+                  args: args,
+                  callback: function(r) {
+                      if (!r.exc) {
+                          frappe.msgprint("Equipment Transaction Log updated successfully.");
+                      }
+                  }
+              });
+          },
+          'Return Equipment',
           'Submit');
       }
   });

--- a/beams/beams/doctype/equipment_transaction_log/equipment_transaction_log.json
+++ b/beams/beams/doctype/equipment_transaction_log/equipment_transaction_log.json
@@ -42,6 +42,7 @@
    "options": "Equipment Acquiral Request"
   },
   {
+   "fetch_from": "project.location",
    "fieldname": "location",
    "fieldtype": "Link",
    "label": "Location",
@@ -52,16 +53,19 @@
    "fieldtype": "Column Break"
   },
   {
+   "fetch_from": "project.expected_start_date",
    "fieldname": "expected_start_date",
    "fieldtype": "Datetime",
    "label": "Expected Start Date"
   },
   {
+   "fetch_from": "project.expected_end_date",
    "fieldname": "expected_end_date",
    "fieldtype": "Datetime",
    "label": "Expected End Date"
   },
   {
+   "fetch_from": "project.bureau",
    "fieldname": "bureau",
    "fieldtype": "Link",
    "label": "Bureau",
@@ -80,7 +84,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-04-30 12:30:35.674915",
+ "modified": "2025-05-02 16:37:17.492795",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Equipment Transaction Log",

--- a/beams/beams/doctype/required_items_detail/required_items_detail.json
+++ b/beams/beams/doctype/required_items_detail/required_items_detail.json
@@ -14,7 +14,7 @@
   "acquired_quantity",
   "asset_movement",
   "return_date",
-  "returned",
+  "returned_count",
   "returned_reason",
   "return"
  ],
@@ -67,12 +67,6 @@
    "read_only": 1
   },
   {
-   "default": "0",
-   "fieldname": "returned",
-   "fieldtype": "Check",
-   "label": "Returned"
-  },
-  {
    "fieldname": "returned_reason",
    "fieldtype": "Small Text",
    "label": "Returned Reason"
@@ -86,12 +80,18 @@
    "fieldname": "return_date",
    "fieldtype": "Datetime",
    "label": "Return Date"
+  },
+  {
+   "default": "0",
+   "fieldname": "returned_count",
+   "fieldtype": "Int",
+   "label": "Returned Count"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-04-30 12:51:19.145364",
+ "modified": "2025-05-02 16:34:43.864230",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Required Items Detail",

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -326,7 +326,9 @@ doc_events = {
             "beams.beams.custom_scripts.project.project.sync_manpower_logs",
             "beams.beams.custom_scripts.project.project.on_update_project",
             "beams.beams.custom_scripts.project.project.sync_vehicle_logs",
-            "beams.beams.custom_scripts.project.project.auto_return_vehicles_on_project_completion"
+            "beams.beams.custom_scripts.project.project.auto_return_vehicles_on_project_completion",
+            "beams.beams.custom_scripts.project.project.sync_equipment_logs",
+            "beams.beams.custom_scripts.project.project.auto_return_equipment_on_project_completion"
         ],
          "validate": "beams.beams.custom_scripts.project.project.validate_employee_assignment",
          "validate": "beams.beams.custom_scripts.project.project.validate_employee_assignment_in_same_project",


### PR DESCRIPTION
## Feature description

- [ ] TASK-2025-00826 : Maintain Equipment transaction log
- [ ] TASK-2025-00857 : Mark count of returned items in Equipment Transaction Log

## Solution description
TASK-2025-00826:
Update the Equipment Transaction Log doctype whenever there is any update in the Allocated items Detail field in the Project.
In project (Allocated Item Details field) added a popup when the Return button is clicked, allowing the user to enter the Returned Date and Return Reason and returned count.
Updated the corresponding values in the Equipment Transaction Log child table with the data from the popup.

TASK-2025-00857:
In Equipment Transaction Log display the count of returned equipment and mention that count in returned reason.
When the project is completed or cancelled, updated the 'Returned Count' and 'Returned Reason' fields accordingly.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/7ca8f215-ffd7-4aaf-9c3b-002220ce3566)
![image](https://github.com/user-attachments/assets/897358cd-a1ff-4a18-8cbd-bf193bfc46f3)
![image](https://github.com/user-attachments/assets/a4957ea7-3771-44e4-9329-6987f714e3c7)
![image](https://github.com/user-attachments/assets/918f1b67-a223-4e4b-9dd1-a9d9320c9b07)
![image](https://github.com/user-attachments/assets/f9f52424-f1c7-4fe5-a4d6-a3e0b098f823)
![image](https://github.com/user-attachments/assets/8f9b1da6-5882-423e-b321-af55b47c5ddb)


## Areas affected and ensured
List out the areas affected by your code changes.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
