### PR TITLE
feat:Added validation for offense dates

### DIFF
--- a/beams/beams/doctype/vehicle_incident_record/vehicle_incident_record.json
+++ b/beams/beams/doctype/vehicle_incident_record/vehicle_incident_record.json
@@ -13,6 +13,8 @@
   "driver_name",
   "column_break_hwrj",
   "posting_date",
+  "trip_start_date",
+  "trip_end_date",
   "offense_date_and_time",
   "amended_from"
  ],
@@ -79,12 +81,25 @@
    "label": "Driver Name",
    "read_only": 1,
    "reqd": 1
+  },
+  {
+   "fetch_from": "trip_sheet.starting_date_and_time",
+   "fieldname": "trip_start_date",
+   "fieldtype": "Datetime",
+   "label": "Trip Start Date"
+  },
+  {
+   "fetch_from": "trip_sheet.ending_date_and_time",
+   "fieldname": "trip_end_date",
+   "fieldtype": "Datetime",
+   "label": "Trip End Date"
   }
  ],
+ "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-01-31 15:12:22.481381",
+ "modified": "2025-05-05 11:01:32.435060",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Vehicle Incident Record",

--- a/beams/beams/doctype/vehicle_incident_record/vehicle_incident_record.py
+++ b/beams/beams/doctype/vehicle_incident_record/vehicle_incident_record.py
@@ -1,10 +1,12 @@
 # Copyright (c) 2025, efeone and contributors
 # For license information, please see license.txt
 
+
 import frappe
+from frappe import _
 from frappe.model.document import Document
 from frappe.utils import today
-from frappe import _
+
 
 class VehicleIncidentRecord(Document):
     @frappe.whitelist()
@@ -16,5 +18,17 @@ class VehicleIncidentRecord(Document):
     @frappe.whitelist()
     def validate_offense_date_and_time(self):
         if self.offense_date_and_time:
-            if self.offense_date_and_time > today():
-                frappe.throw(_("Offense Date cannot be set after today's date."))
+            current_datetime = frappe.utils.now_datetime()
+            offense_datetime = frappe.utils.get_datetime(self.offense_date_and_time)
+
+            if offense_datetime > current_datetime:
+                frappe.throw(_("Offense Date and Time cannot be in the future."))
+
+            offense_date = offense_datetime.date()
+
+            if self.trip_start_date and self.trip_end_date:
+                start_date = frappe.utils.getdate(self.trip_start_date)
+                end_date = frappe.utils.getdate(self.trip_end_date)
+
+                if not (start_date <= offense_date <= end_date):
+                    frappe.throw(_("Offense Date must be between Start Date and End Date of the trip."))


### PR DESCRIPTION
## Feature description
Added server-side validation logic in the Vehicle Incident Record DocType to ensure that:
-    Added fields Trip Start Date and Trip End Date 
-  Fetch values in these fields from Trip Sheet.
-     The Offense Date and Time is not set in the future.
-     The Offense Date falls between the Trip Start Date and Trip End Date.


## Solution description
-Fetched values fromfor start and End dates when a Trip Sheet is selected.
    Converted offense_date_and_time to a datetime object using frappe.utils.get_datetime() before performing comparisons.
    Validated that:
-         Offense Date and Time is not in the future.
-         Offense Date falls within the Trip Start Date and Trip End Date.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/26c778b0-4f77-48b8-b4bd-3f7ab2b6e3da)


## Areas affected and ensured
Vehicle Incident Record doctype.

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox

