### PR TITLE
feat: TASK-2025-00883: Modified the flow of Trip Sheet

### DIFF
--- a/beams/beams/doctype/trip_details/trip_details.json
+++ b/beams/beams/doctype/trip_details/trip_details.json
@@ -1,0 +1,52 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-05-05 13:12:28.065169",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "departure",
+  "destination",
+  "time",
+  "remark"
+ ],
+ "fields": [
+  {
+   "fieldname": "departure",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Departure"
+  },
+  {
+   "fieldname": "destination",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Destination"
+  },
+  {
+   "fieldname": "time",
+   "fieldtype": "Time",
+   "in_list_view": 1,
+   "label": "Time Duration"
+  },
+  {
+   "fieldname": "remark",
+   "fieldtype": "Small Text",
+   "in_list_view": 1,
+   "label": "Remark"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2025-05-05 14:10:25.947875",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "Trip Details",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/beams/beams/doctype/trip_details/trip_details.py
+++ b/beams/beams/doctype/trip_details/trip_details.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class TripDetails(Document):
+	pass

--- a/beams/beams/doctype/trip_sheet/trip_sheet.json
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.json
@@ -164,7 +164,7 @@
   {
    "fieldname": "mileage",
    "fieldtype": "Float",
-   "label": "Mileage(Kmpl)",
+   "label": "Mileage(kmpl)",
    "read_only": 1
   },
   {
@@ -189,7 +189,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-05-05 16:21:55.643770",
+ "modified": "2025-05-05 16:31:07.920511",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Trip Sheet",

--- a/beams/beams/doctype/trip_sheet/trip_sheet.json
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.json
@@ -21,8 +21,8 @@
   "safety_inspection",
   "remarks",
   "trip_details_section",
-  "departure_location",
-  "destination_location",
+  "trip_details",
+  "section_break_ygej",
   "initial_odometer_reading",
   "final_odometer_reading",
   "distance_traveledkm",
@@ -94,7 +94,7 @@
    "default": "0",
    "fieldname": "clean_vehicle",
    "fieldtype": "Check",
-   "label": "Clean Vehicle"
+   "label": "Is Cleaned"
   },
   {
    "default": "0",
@@ -133,20 +133,6 @@
    "reqd": 1
   },
   {
-   "fieldname": "departure_location",
-   "fieldtype": "Link",
-   "label": "Departure Location ",
-   "options": "Location",
-   "reqd": 1
-  },
-  {
-   "fieldname": "destination_location",
-   "fieldtype": "Link",
-   "label": "Destination Location ",
-   "options": "Location",
-   "reqd": 1
-  },
-  {
    "fetch_from": "vehicle.last_odometer",
    "fetch_if_empty": 1,
    "fieldname": "initial_odometer_reading",
@@ -169,7 +155,7 @@
   {
    "fieldname": "fuel_consumed",
    "fieldtype": "Float",
-   "label": "Fuel Consumed"
+   "label": "Fuel Consumed(Ltr)"
   },
   {
    "fieldname": "column_break_anpp",
@@ -178,7 +164,7 @@
   {
    "fieldname": "mileage",
    "fieldtype": "Float",
-   "label": "Mileage",
+   "label": "Mileage(Km/Ltr)",
    "read_only": 1
   },
   {
@@ -188,12 +174,22 @@
    "in_list_view": 1,
    "label": "Posting Date",
    "reqd": 1
+  },
+  {
+   "fieldname": "trip_details",
+   "fieldtype": "Table",
+   "label": "Trip Details",
+   "options": "Trip Details"
+  },
+  {
+   "fieldname": "section_break_ygej",
+   "fieldtype": "Section Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-01-31 13:52:37.720123",
+ "modified": "2025-05-05 14:29:37.226321",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Trip Sheet",

--- a/beams/beams/doctype/trip_sheet/trip_sheet.json
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.json
@@ -164,7 +164,7 @@
   {
    "fieldname": "mileage",
    "fieldtype": "Float",
-   "label": "Mileage(Km/Ltr)",
+   "label": "Mileage(Kmpl)",
    "read_only": 1
   },
   {
@@ -189,7 +189,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-05-05 14:29:37.226321",
+ "modified": "2025-05-05 16:21:55.643770",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Trip Sheet",


### PR DESCRIPTION
## Feature description
Modified the flow of Trip Sheet

## Solution description
**Created a new child DocType named Trip Details with fields:**

-         departure (Data), destination (Data),  time (Time Duration), remark (Small Text)
-         Linked this child table to the Trip Sheet DocType using a Table field (trip_details), enabling detailed tracking of multiple legs or events within a trip.


**Renamed/Updated Fields for Clarity:**

-     Changed label of clean_vehicle checkbox from "Clean Vehicle" to "Is Cleaned" for consistency with naming conventions.
-     Updated fuel_consumed field label to "Fuel Consumed (Ltr)" for unit clarity.
-     Updated mileage field label to "Mileage (Km/Ltr)" to make the measurement unit explicit.


**Removed Redundant Fields:**

-     Removed departure_location and destination_location Link fields (previously pointing to Location), as this information is now handled in the new Trip Details child table.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/5607b416-5a85-4fda-9cab-e2a2da01d9cd)


## Areas affected and ensured

- Tripsheet

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - yes
  - Opera Mini
  - Safari
