### PR TITLE
feat: TASK-2025-00896: auto-set driver from logged-in user & calculate trip hours

### DIFF
--- a/beams/beams/doctype/trip_details/trip_details.json
+++ b/beams/beams/doctype/trip_details/trip_details.json
@@ -8,7 +8,10 @@
  "field_order": [
   "departure",
   "destination",
-  "time",
+  "from_time",
+  "to_time",
+  "hrs",
+  "distance_traveled",
   "remark"
  ],
  "fields": [
@@ -25,22 +28,40 @@
    "label": "Destination"
   },
   {
-   "fieldname": "time",
-   "fieldtype": "Time",
-   "in_list_view": 1,
-   "label": "Time Duration"
-  },
-  {
    "fieldname": "remark",
    "fieldtype": "Small Text",
    "in_list_view": 1,
    "label": "Remark"
+  },
+  {
+   "fieldname": "from_time",
+   "fieldtype": "Datetime",
+   "in_list_view": 1,
+   "label": "From Time"
+  },
+  {
+   "fieldname": "to_time",
+   "fieldtype": "Datetime",
+   "in_list_view": 1,
+   "label": "To Time"
+  },
+  {
+   "fieldname": "hrs",
+   "fieldtype": "Float",
+   "in_list_view": 1,
+   "label": " Hrs "
+  },
+  {
+   "fieldname": "distance_traveled",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Distance traveled"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-05-05 14:10:25.947875",
+ "modified": "2025-05-06 09:53:53.084978",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Trip Details",

--- a/beams/beams/doctype/trip_sheet/trip_sheet.js
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.js
@@ -61,6 +61,39 @@ frappe.ui.form.on('Trip Sheet', {
      }
  },
    onload: function(frm) {
+     if (frappe.session.user !== 'Administrator') {
+         frappe.call({
+             method: 'frappe.client.get_list',
+             args: {
+                 doctype: 'Employee',
+                 filters: {
+                     user_id: frappe.session.user
+                 },
+                 fields: ['name']
+             },
+             callback: function(emp_res) {
+                 if (emp_res.message.length > 0) {
+                     const employee_id = emp_res.message[0].name;
+
+                     frappe.call({
+                         method: 'frappe.client.get_list',
+                         args: {
+                             doctype: 'Driver',
+                             filters: {
+                                 employee: employee_id
+                             },
+                             fields: ['name']
+                         },
+                         callback: function(driver_res) {
+                             if (driver_res.message.length > 0) {
+                                 frm.set_value('driver', driver_res.message[0].name);
+                             }
+                         }
+                     });
+                 }
+             }
+         });
+     }
         frm.set_query('transportation_requests', function() {
             return {
                 filters: {
@@ -95,5 +128,18 @@ frappe.ui.form.on('Trip Sheet', {
 
             return selected_requests;
         }
+    }
+});
+
+frappe.ui.form.on('Trip Details', {
+    from_time: function (frm, cdt, cdn) {
+        frm.call('calculate_hours').then(() => {
+            frm.refresh_field('trip_details');
+        });
+    },
+    to_time: function (frm, cdt, cdn) {
+        frm.call('calculate_hours').then(() => {
+            frm.refresh_field('trip_details');
+        });
     }
 });

--- a/beams/beams/doctype/trip_sheet/trip_sheet.js
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.js
@@ -61,26 +61,24 @@ frappe.ui.form.on('Trip Sheet', {
      }
  },
    onload: function(frm) {
-     if (frappe.session.user !== 'Administrator' && frappe.user.has_role('Driver')) {
-         // Get Employee linked to current user
-         frappe.db.get_value('Employee', { user_id: frappe.session.user }, 'name')
-             .then(r => {
-                 if (r.message && r.message.name) {
-                     const employee_id = r.message.name;
-
-                     // Get Driver linked to the employee
-                     frappe.db.get_list('Driver', {
-                         filters: { employee: employee_id },
-                         fields: ['name'],
-                         limit: 1
-                     }).then(driver_list => {
-                         if (driver_list.length > 0) {
-                             frm.set_value('driver', driver_list[0].name);
-                         }
-                     });
-                 }
-             });
-     }
+        if (frappe.session.user !== 'Administrator' && frappe.user.has_role('Driver')) {
+            // Get Employee linked to current user
+            frappe.db.get_value('Employee', { user_id: frappe.session.user }, 'name')
+                .then(r => {
+                    if (r.message && r.message.name) {
+                        const employee_id = r.message.name;
+                        frappe.db.get_list('Driver', {
+                            filters: { employee: employee_id },
+                            fields: ['name'],
+                            limit: 1
+                        }).then(driver_list => {
+                            if (driver_list.length > 0) {
+                                frm.set_value('driver', driver_list[0].name);
+                            }
+                        });
+                    }
+                });
+        }
         frm.set_query('transportation_requests', function() {
             return {
                 filters: {


### PR DESCRIPTION
## Feature description

- auto-set driver from logged-in user & calculate trip hours

## Solution description

- ' **Driver Auto-Assignmen**t:
   - ' On Trip Sheet load, the driver field is auto-populated by tracing:
   - ' current user → corresponding Employee → matching Driver.
 
- ' **Trip Hours Calculation**:
     - ' Added from_time, to_time, hrs, and distance_traveled fields in Trip Details.
     - ' Total hours (hrs) are calculated based on the time difference.
 
- ' **Validation**:
    - ' Ensures to_time is after from_time. If not, throws a validation error.
 
- ' **Client-Side Updates**:
     - ' Triggers calculate_hours when from_time or to_time changes
     - ' in the Trip Details child table.


## Output screenshots (optional)
[Screencast from 06-05-25 12:31:46 PM IST.webm](https://github.com/user-attachments/assets/feecddd6-6b95-4f89-aeec-ed436b41fb1c)



## Areas affected and ensured

- Tripsheet

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - YES
  - Opera Mini
  - Safari
