### PR TITLE
feat: TASK-2025-00897: Rename child table Owered By to Ownered By in Fuel Card Log

### DIFF
--- a/beams/beams/doctype/fuel_card_log/fuel_card_log.js
+++ b/beams/beams/doctype/fuel_card_log/fuel_card_log.js
@@ -24,7 +24,7 @@ frappe.ui.form.on("Fuel Card Log", {
     if (!frm.is_new()) {
 
       // Button: Set Current Ownership
-      frm.add_custom_button('Set Current Ownership', () => {
+      frm.add_custom_button('Ownership Transaction', () => {
         frappe.prompt([
           {
             label: 'New Owner',
@@ -41,7 +41,7 @@ frappe.ui.form.on("Fuel Card Log", {
             reqd: 1
           }
         ], (values) => {
-          let last_row = frm.doc.owered_by && frm.doc.owered_by.slice(-1)[0];
+          let last_row = frm.doc.ownered_by && frm.doc.ownered_by.slice(-1)[0];
 
           if (last_row && last_row.ownership === values.new_owner) {
             frappe.msgprint(`The last owner is already "${values.new_owner}". No new row added.`);
@@ -49,18 +49,18 @@ frappe.ui.form.on("Fuel Card Log", {
             return;
           }
 
-          let child = frm.add_child('owered_by', {
+          let child = frm.add_child('ownered_by', {
             ownership: values.new_owner,
             date: values.date
           });
-          frm.refresh_field('owered_by');
+          frm.refresh_field('ownered_by');
           frm.set_value('current_holder', values.new_owner);
           frm.save();
-        }, 'Set Current Ownership', 'Save');
-      });
+        }, 'Add', 'Save');
+      }, 'Add');
 
       // Button: Set Recharge History
-      frm.add_custom_button('Set Recharge History', () => {
+      frm.add_custom_button('Recharge', () => {
         frappe.prompt([
           {
             label: 'Recharge Amount',
@@ -89,8 +89,8 @@ frappe.ui.form.on("Fuel Card Log", {
           });
           frm.refresh_field('recharge_history');
           frm.save();
-        }, 'Set Recharge History', 'Save');
-      });
+        }, 'Add', 'Save');
+      }, 'Add');
     }
   }
 });

--- a/beams/beams/doctype/fuel_card_log/fuel_card_log.json
+++ b/beams/beams/doctype/fuel_card_log/fuel_card_log.json
@@ -10,7 +10,7 @@
   "column_break_yjyq",
   "current_holder",
   "section_break_6qhb",
-  "owered_by",
+  "ownered_by",
   "recharge_history"
  ],
  "fields": [
@@ -19,13 +19,6 @@
    "fieldtype": "Link",
    "label": " Fuel Card",
    "options": "Fuel Card"
-  },
-  {
-   "fieldname": "owered_by",
-   "fieldtype": "Table",
-   "label": "Owered By",
-   "options": "Owered By",
-   "read_only": 1
   },
   {
    "fieldname": "recharge_history",
@@ -48,11 +41,18 @@
   {
    "fieldname": "section_break_6qhb",
    "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "ownered_by",
+   "fieldtype": "Table",
+   "label": "Ownership History",
+   "options": "Ownered By",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-05-05 15:02:56.840722",
+ "modified": "2025-05-06 12:57:16.601870",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Fuel Card Log",

--- a/beams/beams/doctype/ownered_by/ownered_by.json
+++ b/beams/beams/doctype/ownered_by/ownered_by.json
@@ -30,7 +30,7 @@
  "modified": "2025-05-05 10:18:47.025674",
  "modified_by": "Administrator",
  "module": "BEAMS",
- "name": "Owered By",
+ "name": "Ownered By",
  "owner": "Administrator",
  "permissions": [],
  "sort_field": "modified",

--- a/beams/beams/doctype/ownered_by/ownered_by.py
+++ b/beams/beams/doctype/ownered_by/ownered_by.py
@@ -5,5 +5,5 @@
 from frappe.model.document import Document
 
 
-class OweredBy(Document):
+class OwneredBy(Document):
 	pass


### PR DESCRIPTION
## Feature description

- Rename child table Owered By to Ownered By in Fuel Card Log


## Solution description
 - Renamed fieldname from `owered_by` to `ownered_by` in the Fuel Card Log DocType JSON.
 - Updated JS file (fuel_card_log.js) to reference the correct field name `ownered_by`.
 - Changed button labels:
    • "Set Current Ownership" → "Ownership Transaction"
     • "Set Recharge History" → "Recharge"
 - Grouped both actions under the "Add" dropdown (matching standard UI dropdown style).
 - Removed obsolete DocType files for `Owered By`:
     • __init__.py
     • owered_by.json
     • owered_by.py

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/1b16ebb8-db94-4904-aa20-04808ee5f761)


## Areas affected and ensured

- Fuel Card Log

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox- YES
  - Opera Mini
  - Safari
