### PR TITLE
feat: TASK-2025-00881 : filter employee travel request by driver in trip sheet

### DIFF
--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.js
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.js
@@ -90,17 +90,6 @@ frappe.ui.form.on('Employee Travel Request', {
 		}
 	},
 
-	onload: function (frm) {
-		apply_travellers_filter(frm);
-		frm.fields_dict.travel_vehicle_allocation.grid.get_field("driver").get_query = function () {
-			return {
-				filters: {
-					designation: "Driver"
-				}
-			};
-		};
-	},
-
 	requested_by: function (frm) {
 		apply_travellers_filter(frm);
 		frappe.call({
@@ -150,7 +139,7 @@ frappe.ui.form.on('Employee Travel Request', {
 
 	travellers: function (frm) {
 		if (frm.doc.is_group && frm.doc.travellers) {
-			frm.set_value("number_of_travellers", frm.doc.travellers.length);
+			frm.set_value("number_of_travellers", frm.doc.travellers.length+1);
 		} else {
 			frm.set_value("number_of_travellers", 0);
 		}

--- a/beams/beams/doctype/trip_sheet/trip_sheet.js
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.js
@@ -60,6 +60,7 @@ frappe.ui.form.on('Trip Sheet', {
          }, __("Create"));
      }
  },
+
    onload: function(frm) {
         if (frappe.session.user !== 'Administrator' && frappe.user.has_role('Driver')) {
             // Get Employee linked to current user
@@ -113,6 +114,27 @@ frappe.ui.form.on('Trip Sheet', {
 
             return selected_requests;
         }
+    },
+    driver: function(frm) {
+        frm.set_query('travel_requests', function() {
+            return {
+                query: 'beams.beams.doctype.trip_sheet.trip_sheet.get_filtered_travel_requests',
+                filters: {
+                    driver: frm.doc.driver
+                }
+            };
+        });
+    },
+
+    refresh: function(frm) {
+        frm.set_query('travel_requests', function() {
+            return {
+                query: 'beams.beams.doctype.trip_sheet.trip_sheet.get_filtered_travel_requests',
+                filters: {
+                    driver: frm.doc.driver
+                }
+            };
+        });
     }
 });
 

--- a/beams/beams/doctype/vehicle_allocation/vehicle_allocation.json
+++ b/beams/beams/doctype/vehicle_allocation/vehicle_allocation.json
@@ -28,13 +28,13 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Driver",
-   "options": "Employee"
+   "options": "Driver"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-05-05 14:55:13.700755",
+ "modified": "2025-05-07 11:11:45.907083",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Vehicle Allocation",


### PR DESCRIPTION
## Feature description

- [ ] TASK-2025-00881 : filter employee travel request by driver in trip sheet
- [ ] TASK-2025-00895 : correct the number of employee's count in employee travel request


## Solution description

1. Vehicle Allocation doctype: changed options of driver field in to 'driver'
2. Employee travel request: removed filter of driver by designation
3. Employee travel request: corrected  number of employee's count in ' number of travellers field'
4. Trip sheet: Applied a filter in the Travel Requests field to list only those Employee Travel Requests where the driver in the Vehicle Allocation child table matches the driver in the current Trip Sheet

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/ed640ec6-bbfa-46c4-9733-3a341eac6a0b)
![image](https://github.com/user-attachments/assets/94780f7c-c618-4605-bf15-eb466cb24587)
![image](https://github.com/user-attachments/assets/2ff4db2f-81cb-4ad9-9c18-b5f6769d7894)
![image](https://github.com/user-attachments/assets/ff2c3b6c-3c59-49f4-8d9c-368ace74a5f3)


## Areas affected and ensured
List out the areas affected by your code changes.(Employee travel request, trip sheet)

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  
