### PR TITLE
feat:TASK-2025-00904: Bypass filters for Admin in Employee Travel Request

### DIFF
--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.js
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.js
@@ -91,7 +91,11 @@ frappe.ui.form.on('Employee Travel Request', {
 	},
 
 	requested_by: function (frm) {
-		apply_travellers_filter(frm);
+    // Skip applying filter if user has "Admin" role
+    if (!frappe.user.has_role("Admin")) {
+      apply_travellers_filter(frm);
+    }
+
 		frappe.call({
 			method: "beams.beams.doctype.employee_travel_request.employee_travel_request.get_batta_policy",
 			args: { requested_by: frm.doc.requested_by },
@@ -168,6 +172,13 @@ function set_room_criteria_filter(frm) {
 }
 
 function set_mode_of_travel_filter(frm) {
+  // Skip filter if user has "Admin" role
+  if (frappe.user.has_role("Admin")) {
+    frm.set_query("mode_of_travel", function () {
+      return {};
+    });
+    return;
+  }
 	frappe.call({
 		method: "beams.beams.doctype.employee_travel_request.employee_travel_request.filter_mode_of_travel",
 		args: {


### PR DESCRIPTION
## Feature description
 Skip traveller and mode of travel filters for Admin role in Employee Travel Request

## Solution description

- This update enhances the user experience for admin by conditionally disabling filters in the Employee Travel Request form based on user role:
 -     apply_travellers_filter(frm) is now skipped when the logged-in user has the "Admin" role. 
 -     set_mode_of_travel_filter(frm) is also bypassed for Admins, allowing them to view all mode_of_travel options without restriction.
 
- This ensures that policy-based filters do not constrain Admin users, while regular users continue to receive filtered options based on the selected batta_policy.
 

## Output screenshots (optional)

[Screencast from 07-05-25 02:29:31 PM IST.webm](https://github.com/user-attachments/assets/3f380a0e-b76f-438b-84a9-cece4af1dcc8)


## Areas affected and ensured

- Employee Travel Request


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - YES
  - Opera Mini
  - Safari
