### PR TITLE
fix: TASK-2025-00908: fix issue in employee travel request

### DIFF
--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.js
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.js
@@ -216,12 +216,12 @@ function set_mode_of_travel_filter(frm) {
 function calculate_days(frm) {
     if (frm.doc.start_date && frm.doc.end_date) {
         frm.call("validate_dates")
-            .then(() => {
-                return frm.call("total_days_calculate");
-            })
-            .then(() => {
-                frm.refresh_field("total_days");
-            });
+        .then(() => {
+            return frm.call("total_days_calculate");
+        })
+        .then(() => {
+            frm.refresh_field("total_days");
+        });
     } else {
         frm.set_value("total_days", null);
     }

--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.js
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.js
@@ -129,28 +129,29 @@ frappe.ui.form.on('Employee Travel Request', {
         calculate_days(frm);
     },
 
-    end_date: function (frm) {
+	end_date: function (frm) {
         calculate_days(frm);
-				update_number_of_travellers_visibility(frm);
-    },
+        update_number_of_travellers_visibility(frm);
+	},
 
-    is_group: function (frm) {
-				update_number_of_travellers_visibility(frm);
+	is_group: function (frm) {
+        update_number_of_travellers_visibility(frm);
         if (!frm.doc.is_group) {
             frm.set_value("travellers", []);
             frm.set_value("number_of_travellers", 1);
         }
-    },
+	},
 
-    travellers: function (frm) {
+	travellers: function (frm) {
         if (frm.doc.is_group && frm.doc.travellers) {
-            frm.set_value("number_of_travellers", frm.doc.travellers.length+1);
+        frm.set_value("number_of_travellers", frm.doc.travellers.length + 1);
         }
-				update_number_of_travellers_visibility(frm); 
-    },
-		is_unplanned: function(frm) {
         update_number_of_travellers_visibility(frm);
-    }
+	},
+
+	is_unplanned: function (frm) {
+        update_number_of_travellers_visibility(frm);
+	}
 });
 
 function update_number_of_travellers_visibility(frm) {

--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.js
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.js
@@ -155,6 +155,8 @@ frappe.ui.form.on('Employee Travel Request', {
 
 });
 
+// Toggles visibility of 'number_of_travellers' field based on 'is_group' status and 'travellers' table length.
+
 function update_number_of_travellers_visibility(frm) {
     if (frm.doc.is_group && frm.doc.travellers && frm.doc.travellers.length > 0) {
         frm.set_df_property("number_of_travellers", "hidden", 0);

--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.js
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.js
@@ -131,23 +131,35 @@ frappe.ui.form.on('Employee Travel Request', {
 
     end_date: function (frm) {
         calculate_days(frm);
+				update_number_of_travellers_visibility(frm);
     },
 
     is_group: function (frm) {
+				update_number_of_travellers_visibility(frm);
         if (!frm.doc.is_group) {
             frm.set_value("travellers", []);
-            frm.set_value("number_of_travellers", 0);
+            frm.set_value("number_of_travellers", 1);
         }
     },
 
     travellers: function (frm) {
         if (frm.doc.is_group && frm.doc.travellers) {
             frm.set_value("number_of_travellers", frm.doc.travellers.length+1);
-        } else {
-            frm.set_value("number_of_travellers", 0);
         }
+				update_number_of_travellers_visibility(frm); 
+    },
+		is_unplanned: function(frm) {
+        update_number_of_travellers_visibility(frm);
     }
 });
+
+function update_number_of_travellers_visibility(frm) {
+    if (frm.doc.is_group && frm.doc.travellers && frm.doc.travellers.length > 0) {
+        frm.set_df_property("number_of_travellers", "hidden", 0);
+    } else {
+        frm.set_df_property("number_of_travellers", "hidden", 1);
+    }
+}
 
 function set_room_criteria_filter(frm) {
     if (frm.doc.batta_policy) {

--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.js
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.js
@@ -129,11 +129,11 @@ frappe.ui.form.on('Employee Travel Request', {
         calculate_days(frm);
     },
 
-	end_date: function (frm) {
+    end_date: function (frm) {
         calculate_days(frm);
         update_number_of_travellers_visibility(frm);
     },
-    
+
     is_group: function (frm) {
         update_number_of_travellers_visibility(frm);
         if (!frm.doc.is_group) {
@@ -141,18 +141,18 @@ frappe.ui.form.on('Employee Travel Request', {
             frm.set_value("number_of_travellers", 1);
         }
     },
-    
+
     travellers: function (frm) {
         if (frm.doc.is_group && frm.doc.travellers) {
             frm.set_value("number_of_travellers", frm.doc.travellers.length + 1);
         }
         update_number_of_travellers_visibility(frm);
     },
-    
+
     is_unplanned: function (frm) {
         update_number_of_travellers_visibility(frm);
     }
-    
+
 });
 
 function update_number_of_travellers_visibility(frm) {
@@ -214,12 +214,12 @@ function set_mode_of_travel_filter(frm) {
 function calculate_days(frm) {
     if (frm.doc.start_date && frm.doc.end_date) {
         frm.call("validate_dates")
-        .then(() => {
-            return frm.call("total_days_calculate");
-        })
-        .then(() => {
-            frm.refresh_field("total_days");
-        });
+            .then(() => {
+                return frm.call("total_days_calculate");
+            })
+            .then(() => {
+                frm.refresh_field("total_days");
+            });
     } else {
         frm.set_value("total_days", null);
     }

--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.js
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.js
@@ -132,26 +132,27 @@ frappe.ui.form.on('Employee Travel Request', {
 	end_date: function (frm) {
         calculate_days(frm);
         update_number_of_travellers_visibility(frm);
-	},
-
-	is_group: function (frm) {
+    },
+    
+    is_group: function (frm) {
         update_number_of_travellers_visibility(frm);
         if (!frm.doc.is_group) {
             frm.set_value("travellers", []);
             frm.set_value("number_of_travellers", 1);
         }
-	},
-
-	travellers: function (frm) {
+    },
+    
+    travellers: function (frm) {
         if (frm.doc.is_group && frm.doc.travellers) {
-        frm.set_value("number_of_travellers", frm.doc.travellers.length + 1);
+            frm.set_value("number_of_travellers", frm.doc.travellers.length + 1);
         }
         update_number_of_travellers_visibility(frm);
-	},
-
-	is_unplanned: function (frm) {
+    },
+    
+    is_unplanned: function (frm) {
         update_number_of_travellers_visibility(frm);
-	}
+    }
+    
 });
 
 function update_number_of_travellers_visibility(frm) {
@@ -161,6 +162,7 @@ function update_number_of_travellers_visibility(frm) {
         frm.set_df_property("number_of_travellers", "hidden", 1);
     }
 }
+
 
 function set_room_criteria_filter(frm) {
     if (frm.doc.batta_policy) {


### PR DESCRIPTION
## Feature description
TASK-2025-00908: fix issue in employee travel request
Fix the issue of showing number of travellers field with value 0 when 'is unplanned' ticked and 'end date' entered.


## Solution description

1. Resolved the issue of showing ' number of travellers ' field with value 0 when 'is unplanned' ticked and 'end date' entered. 
2. Set number of travellers default value as 1

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/632df1ec-2985-461b-b959-ded94f2d6d6c)


## Areas affected and ensured
List out the areas affected by your code changes.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  
