### PR TITLE
feat:Created Expense Claim connection from Employee Travel Request doctype to Expense Claim doctype

### DIFF
--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.js
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.js
@@ -13,7 +13,7 @@ frappe.ui.form.on('Employee Travel Request', {
             }, __("Create"));
         }
 
-        if (frm.doc.is_unplanned === 1 && frm.doc.docstatus === 1 ) {
+        if (frm.doc.is_unplanned === 1 ) {
             frm.add_custom_button(__('Expense Claim'), function () {
                 const dialog = new frappe.ui.Dialog({
                     title: 'Travel Claim Expenses',

--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.js
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.js
@@ -13,75 +13,74 @@ frappe.ui.form.on('Employee Travel Request', {
             }, __("Create"));
         }
 
-        if (frm.doc.is_unplanned === 1) {
-        	frm.add_custom_button(__('Expense Claim'), function () {
-        		const dialog = new frappe.ui.Dialog({
-        			title: 'Travel Claim Expenses',
-        			fields: [
-        				{
-        					fieldtype: 'Table',
-        					label: 'Expenses',
-        					fieldname: 'expenses',
-        					reqd: 1,
-        					fields: [
-        						{
-        							label: 'Expense Date',
-        							fieldtype: 'Date',
-        							fieldname: 'expense_date',
-        							in_list_view: 1,
-        							reqd: 1
-        						},
-        						{
-        							label: 'Expense Claim Type',
-        							fieldtype: 'Link',
-        							options: 'Expense Claim Type',
-        							fieldname: 'expense_type',
-        							in_list_view: 1,
-        							reqd: 1
-        						},
-        						{
-        							label: 'Description',
-        							fieldtype: 'Small Text',
-        							fieldname: 'description',
-        							in_list_view: 1
-        						},
-        						{
-        							label: 'Amount',
-        							fieldtype: 'Currency',
-        							fieldname: 'amount',
-        							in_list_view: 1,
-        							reqd: 1
-        						}
-        					]
-        				}
-        			],
-        			size: 'large',
-        			primary_action_label: 'Submit',
-        			primary_action(values) {
-        				const expenses = values.expenses || [];
-        				if (!expenses.length) {
-        					frappe.msgprint(__('Please enter at least one expense item.'));
-        					return;
-        				}
-        				frappe.call({
-        					method: 'beams.beams.doctype.employee_travel_request.employee_travel_request.create_expense_claim',
-        					args: {
-        						employee: frm.doc.requested_by,
-        						travel_request: frm.doc.name,
-        						expenses: expenses
-        					},
-        					callback: function (r) {
-        						if (!r.exc) {
-        							dialog.hide();
-        							frappe.set_route('Form', 'Expense Claim', r.message);
-        						}
-        					}
-        				});
-        			}
-        		});
-        		dialog.show();
-        	}, __('Create'));
-        }
+        if (frm.doc.is_unplanned === 1 && frm.doc.docstatus === 1 ) {
+            frm.add_custom_button(__('Expense Claim'), function () {
+                const dialog = new frappe.ui.Dialog({
+                    title: 'Travel Claim Expenses',
+                    fields: [
+                        {
+                            fieldtype: 'Table',
+                            label: 'Expenses',
+                            fieldname: 'expenses',
+                            reqd: 1,
+                            fields: [
+                                {
+                                    label: 'Expense Date',
+                                    fieldtype: 'Date',
+                                    fieldname: 'expense_date',
+                                    in_list_view: 1,
+                                    reqd: 1
+                                },
+                                {
+                                    label: 'Expense Claim Type',
+                                    fieldtype: 'Link',
+                                    options: 'Expense Claim Type',
+                                    fieldname: 'expense_type',
+                                    in_list_view: 1,
+                                    reqd: 1
+                                },
+                                {
+                                    label: 'Description',
+                                    fieldtype: 'Small Text',
+                                    fieldname: 'description',
+                                    in_list_view: 1
+                                },
+                                {
+                                    label: 'Amount',
+                                    fieldtype: 'Currency',
+                                    fieldname: 'amount',
+                                    in_list_view: 1,
+                                    reqd: 1
+                                }
+                            ]
+                        }
+                    ],
+                    size: 'large',
+                    primary_action_label: 'Submit',
+                    primary_action(values) {
+                        const expenses = values.expenses || [];
+                        if (!expenses.length) {
+                            frappe.msgprint(__('Please enter at least one expense item.'));
+                            return;
+                        }
+                        frappe.call({
+                            method: 'beams.beams.doctype.employee_travel_request.employee_travel_request.create_expense_claim',
+                            args: {
+                                employee: frm.doc.requested_by,
+                                travel_request: frm.doc.name,
+                                expenses: expenses
+                            },
+                            callback: function (r) {
+                                if (!r.exc) {
+                                    dialog.hide();
+                                    frappe.set_route('Form', 'Expense Claim', r.message);
+                                }
+                            }
+                        });
+                    }
+                });
+                dialog.show();
+            }, __('Create'));
 
 
         if (frm.doc.workflow_state === "Approved by HOD" && frm.doc.is_vehicle_required) {

--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.js
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.js
@@ -272,7 +272,7 @@ function set_vehicle_filters(frm, cdt, cdn) {
   const selected_vehicles = (frm.doc.travel_vehicle_allocation || [])
       .filter(row => row.name !== current_row.name && row.vehicle)
       .map(row => row.vehicle);
-  
+
   // Set query filter on the vehicle field to exclude selected vehicles
   frm.fields_dict.travel_vehicle_allocation.grid.get_field("vehicle").get_query = function(doc, cdt, cdn) {
       return {

--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.js
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.js
@@ -81,7 +81,7 @@ frappe.ui.form.on('Employee Travel Request', {
                 });
                 dialog.show();
             }, __('Create'));
-
+        }
 
         if (frm.doc.workflow_state === "Approved by HOD" && frm.doc.is_vehicle_required) {
             frm.set_df_property("travel_vehicle_allocation", "read_only", 0);

--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.js
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.js
@@ -13,75 +13,76 @@ frappe.ui.form.on('Employee Travel Request', {
             }, __("Create"));
         }
 
-        if (frm.doc.is_unplanned === 1 && frm.doc.docstatus === 1 && ['Approved', 'Approved by HOD'].includes(frm.doc.workflow_state)) {
-            frm.add_custom_button(__('Expense Claim'), function () {
-                const dialog = new frappe.ui.Dialog({
-                    title: 'Travel Claim Expenses',
-                    fields: [
-                        {
-                            fieldtype: 'Table',
-                            label: 'Expenses',
-                            fieldname: 'expenses',
-                            reqd: 1,
-                            fields: [
-                                {
-                                    label: 'Expense Date',
-                                    fieldtype: 'Date',
-                                    fieldname: 'expense_date',
-                                    in_list_view: 1,
-                                    reqd: 1
-                                },
-                                {
-                                    label: 'Expense Claim Type',
-                                    fieldtype: 'Link',
-                                    options: 'Expense Claim Type',
-                                    fieldname: 'expense_type',
-                                    in_list_view: 1,
-                                    reqd: 1
-                                },
-                                {
-                                    label: 'Description',
-                                    fieldtype: 'Small Text',
-                                    fieldname: 'description',
-                                    in_list_view: 1
-                                },
-                                {
-                                    label: 'Amount',
-                                    fieldtype: 'Currency',
-                                    fieldname: 'amount',
-                                    in_list_view: 1,
-                                    reqd: 1
-                                }
-                            ]
-                        }
-                    ],
-                    size: 'large',
-                    primary_action_label: 'Submit',
-                    primary_action(values) {
-                        const expenses = values.expenses || [];
-                        if (!expenses.length) {
-                            frappe.msgprint(__('Please enter at least one expense item.'));
-                            return;
-                        }
-                        frappe.call({
-                            method: 'beams.beams.doctype.employee_travel_request.employee_travel_request.create_expense_claim',
-                            args: {
-                                employee: frm.doc.requested_by,
-                                travel_request: frm.doc.name,
-                                expenses: expenses
-                            },
-                            callback: function (r) {
-                                if (!r.exc) {
-                                    dialog.hide();
-                                    frappe.set_route('Form', 'Expense Claim', r.message);
-                                }
-                            }
-                        });
-                    }
-                });
-                dialog.show();
-            }, __('Create'));
+        if (frm.doc.is_unplanned === 1) {
+        	frm.add_custom_button(__('Expense Claim'), function () {
+        		const dialog = new frappe.ui.Dialog({
+        			title: 'Travel Claim Expenses',
+        			fields: [
+        				{
+        					fieldtype: 'Table',
+        					label: 'Expenses',
+        					fieldname: 'expenses',
+        					reqd: 1,
+        					fields: [
+        						{
+        							label: 'Expense Date',
+        							fieldtype: 'Date',
+        							fieldname: 'expense_date',
+        							in_list_view: 1,
+        							reqd: 1
+        						},
+        						{
+        							label: 'Expense Claim Type',
+        							fieldtype: 'Link',
+        							options: 'Expense Claim Type',
+        							fieldname: 'expense_type',
+        							in_list_view: 1,
+        							reqd: 1
+        						},
+        						{
+        							label: 'Description',
+        							fieldtype: 'Small Text',
+        							fieldname: 'description',
+        							in_list_view: 1
+        						},
+        						{
+        							label: 'Amount',
+        							fieldtype: 'Currency',
+        							fieldname: 'amount',
+        							in_list_view: 1,
+        							reqd: 1
+        						}
+        					]
+        				}
+        			],
+        			size: 'large',
+        			primary_action_label: 'Submit',
+        			primary_action(values) {
+        				const expenses = values.expenses || [];
+        				if (!expenses.length) {
+        					frappe.msgprint(__('Please enter at least one expense item.'));
+        					return;
+        				}
+        				frappe.call({
+        					method: 'beams.beams.doctype.employee_travel_request.employee_travel_request.create_expense_claim',
+        					args: {
+        						employee: frm.doc.requested_by,
+        						travel_request: frm.doc.name,
+        						expenses: expenses
+        					},
+        					callback: function (r) {
+        						if (!r.exc) {
+        							dialog.hide();
+        							frappe.set_route('Form', 'Expense Claim', r.message);
+        						}
+        					}
+        				});
+        			}
+        		});
+        		dialog.show();
+        	}, __('Create'));
         }
+
 
         if (frm.doc.workflow_state === "Approved by HOD" && frm.doc.is_vehicle_required) {
             frm.set_df_property("travel_vehicle_allocation", "read_only", 0);

--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.json
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.json
@@ -97,7 +97,7 @@
   {
    "fieldname": "travel_type",
    "fieldtype": "Link",
-   "label": "Propose of Travel",
+   "label": "Purpose of Travel",
    "options": "Purpose of Travel",
    "reqd": 1
   },
@@ -256,8 +256,13 @@
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
- "links": [],
- "modified": "2025-05-08 10:25:58.519959",
+ "links": [
+  {
+   "link_doctype": "Expense Claim",
+   "link_fieldname": "travel_request"
+  }
+ ],
+ "modified": "2025-05-07 15:11:30.696679",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Employee Travel Request",

--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.py
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.py
@@ -177,6 +177,7 @@ def create_expense_claim(employee, travel_request, expenses):
     travel_doc = frappe.get_doc("Employee Travel Request", travel_request)
 
     expense_claim = frappe.new_doc("Expense Claim")
+    expense_claim.travel_request = travel_request
     expense_claim.employee = employee
     expense_claim.approval_status = "Draft"
     expense_claim.posting_date = today()

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -57,6 +57,7 @@ def after_install():
     create_custom_fields(get_asset_category_custom_fields(),ignore_validate=True)
     create_custom_fields(get_asset_movement_custom_fields(),ignore_validate=True)
     create_custom_fields(get_full_and_final_statement_custom_fields(),ignore_validate=True)
+    create_custom_fields(get_expense_claim_custom_fields(),ignore_validate=True)
 
 
     #Creating BEAMS specific Property Setters
@@ -125,6 +126,7 @@ def before_uninstall():
     delete_custom_fields(get_asset_category_custom_fields())
     delete_custom_fields(get_asset_movement_custom_fields())
     delete_custom_fields(get_full_and_final_statement_custom_fields())
+    delete_custom_fields(get_expense_claim_custom_fields())
 
 
 def delete_custom_fields(custom_fields: dict):
@@ -4486,6 +4488,22 @@ def get_full_and_final_statement_custom_fields():
                 "label": "Allocated Bundles",
                 "options": "Full and Final Bundle",
                 "insert_after": "assets_allocated"
+            }
+        ]
+    }
+def get_expense_claim_custom_fields():
+    '''
+        Custom fields that need to be added to the Expense Claim DocType
+    '''
+    return {
+        "Expense Claim": [
+            {
+                "fieldname": "travel_request",
+                "fieldtype": "Link",
+                "label": "Travel Request",
+                "options": "Employee Travel Request",
+                "insert_after": "approval_status",
+                "read_only": 1
             }
         ]
     }

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -4491,6 +4491,7 @@ def get_full_and_final_statement_custom_fields():
             }
         ]
     }
+    
 def get_expense_claim_custom_fields():
     '''
         Custom fields that need to be added to the Expense Claim DocType


### PR DESCRIPTION
## Feature description
Need to: 

- Create Expense Claim connection from Employee Travel Request doctype to Expense Claim doctype.
- Remove the workflow condition , because of  Expense Claim button is visible if trip is unplanned
         

## Solution description

- Created Expense Claim connection from Employee Travel Request doctype to Expense Claim doctype .
- Removed the workflow condition , because of  Expense Claim button is visible if trip is unplanned.


## Output screenshots (optional)
[Screencast from 07-05-25 04:38:47 PM IST.webm](https://github.com/user-attachments/assets/4c6788c8-cf87-4412-8ff0-f4eb7b6ae282)


## Areas affected and ensured
Employee Travel Request doctype and Expense Claim doctype

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Mozilla Firefox
