### PR TITLE
feat: TASK-2025-00918: Exclude requested_by from travellers and allow all employees selection

### DIFF
--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.js
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.js
@@ -91,6 +91,7 @@ frappe.ui.form.on('Employee Travel Request', {
     },
 
     requested_by: function (frm) {
+        apply_travellers_filter(frm);
         frappe.call({
             method: "beams.beams.doctype.employee_travel_request.employee_travel_request.get_batta_policy",
             args: { requested_by: frm.doc.requested_by },
@@ -107,10 +108,6 @@ frappe.ui.form.on('Employee Travel Request', {
                 }
             }
         });
-        // Skip applying filter if user has "Admin" role
-        if (!frappe.user.has_role("Admin")) {
-            apply_travellers_filter(frm);
-        }
     },
 
     accommodation_required: function (frm) {

--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.json
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.json
@@ -79,6 +79,7 @@
    "depends_on": "eval:doc.is_group;",
    "fieldname": "travellers",
    "fieldtype": "Table MultiSelect",
+   "ignore_user_permissions": 1,
    "label": "Travellers",
    "options": "Traveller"
   },
@@ -256,7 +257,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-05-05 15:14:01.727506",
+ "modified": "2025-05-08 10:25:58.519959",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Employee Travel Request",

--- a/beams/beams/doctype/traveller/traveller.json
+++ b/beams/beams/doctype/traveller/traveller.json
@@ -12,6 +12,7 @@
   {
    "fieldname": "employee",
    "fieldtype": "Link",
+   "ignore_user_permissions": 1,
    "in_list_view": 1,
    "label": "Employee",
    "options": "Employee",
@@ -21,7 +22,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-01-21 15:01:41.141357",
+ "modified": "2025-05-08 11:48:05.048084",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Traveller",

--- a/beams/beams/doctype/trip_sheet/trip_sheet.js
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.js
@@ -59,8 +59,8 @@ frappe.ui.form.on('Trip Sheet', {
              });
          }, __("Create"));
      }
-     
-     frm.set_query('travel_requests', function() {
+
+    frm.set_query('travel_requests', function() {
         return {
             query: 'beams.beams.doctype.trip_sheet.trip_sheet.get_filtered_travel_requests',
             filters: {

--- a/beams/beams/doctype/trip_sheet/trip_sheet.js
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.js
@@ -59,6 +59,16 @@ frappe.ui.form.on('Trip Sheet', {
              });
          }, __("Create"));
      }
+     
+     frm.set_query('travel_requests', function() {
+        return {
+            query: 'beams.beams.doctype.trip_sheet.trip_sheet.get_filtered_travel_requests',
+            filters: {
+                driver: frm.doc.driver
+            }
+        };
+    });
+
  },
 
    onload: function(frm) {
@@ -116,17 +126,6 @@ frappe.ui.form.on('Trip Sheet', {
         }
     },
     driver: function(frm) {
-        frm.set_query('travel_requests', function() {
-            return {
-                query: 'beams.beams.doctype.trip_sheet.trip_sheet.get_filtered_travel_requests',
-                filters: {
-                    driver: frm.doc.driver
-                }
-            };
-        });
-    },
-
-    refresh: function(frm) {
         frm.set_query('travel_requests', function() {
             return {
                 query: 'beams.beams.doctype.trip_sheet.trip_sheet.get_filtered_travel_requests',

--- a/beams/beams/doctype/trip_sheet/trip_sheet.js
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.js
@@ -2,29 +2,29 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Trip Sheet', {
-    posting_date:function (frm){
+    posting_date: function (frm) {
         frm.call("validate_posting_date");
-      },
-    starting_date_and_time: function(frm) {
+    },
+    starting_date_and_time: function (frm) {
         frm.call({
             method: "validate_start_datetime_and_end_datetime",
             doc: frm.doc,
         });
     },
-    ending_date_and_time: function(frm) {
+    ending_date_and_time: function (frm) {
         frm.call({
             method: "validate_start_datetime_and_end_datetime",
             doc: frm.doc,
         });
     },
-    vehicle: function(frm) {
+    vehicle: function (frm) {
         if (frm.doc.vehicle) {
             frappe.call({
                 method: 'beams.beams.doctype.trip_sheet.trip_sheet.get_last_odometer',
                 args: {
                     vehicle: frm.doc.vehicle
                 },
-                callback: function(r) {
+                callback: function (r) {
                     if (r.message) {
                         frm.set_value("initial_odometer_reading", r.message);
                     } else {
@@ -36,42 +36,42 @@ frappe.ui.form.on('Trip Sheet', {
             frm.set_value("initial_odometer_reading", null);
         }
     },
-    final_odometer_reading: function(frm) {
+    final_odometer_reading: function (frm) {
         frm.call("calculate_and_validate_fuel_data");
     },
-    fuel_consumed: function(frm) {
+    fuel_consumed: function (frm) {
         frm.call("calculate_and_validate_fuel_data");
     },
 
-    refresh: function(frm) {
-     if (!frm.is_new()) {
-         frm.add_custom_button(__('Vehicle Incident Record'), function() {
-             frappe.call({
-                 method: "beams.beams.doctype.trip_sheet.trip_sheet.create_vehicle_incident_record",
-                 args: {
-                     trip_sheet: frm.doc.name
-                 },
-                 callback: function(r) {
-                     if (r.message) {
-                         frappe.set_route("form", "Vehicle Incident Record", r.message);
-                     }
-                 }
-             });
-         }, __("Create"));
-     }
+    refresh: function (frm) {
+        if (!frm.is_new()) {
+            frm.add_custom_button(__('Vehicle Incident Record'), function () {
+                frappe.call({
+                    method: "beams.beams.doctype.trip_sheet.trip_sheet.create_vehicle_incident_record",
+                    args: {
+                        trip_sheet: frm.doc.name
+                    },
+                    callback: function (r) {
+                        if (r.message) {
+                            frappe.set_route("form", "Vehicle Incident Record", r.message);
+                        }
+                    }
+                });
+            }, __("Create"));
+        }
 
-    frm.set_query('travel_requests', function() {
-        return {
-            query: 'beams.beams.doctype.trip_sheet.trip_sheet.get_filtered_travel_requests',
-            filters: {
-                driver: frm.doc.driver
-            }
-        };
-    });
+        frm.set_query('travel_requests', function () {
+            return {
+                query: 'beams.beams.doctype.trip_sheet.trip_sheet.get_filtered_travel_requests',
+                filters: {
+                    driver: frm.doc.driver
+                }
+            };
+        });
 
- },
+    },
 
-   onload: function(frm) {
+    onload: function (frm) {
         if (frappe.session.user !== 'Administrator' && frappe.user.has_role('Driver')) {
             // Get Employee linked to current user
             frappe.db.get_value('Employee', { user_id: frappe.session.user }, 'name')
@@ -90,14 +90,14 @@ frappe.ui.form.on('Trip Sheet', {
                     }
                 });
         }
-        frm.set_query('transportation_requests', function() {
+        frm.set_query('transportation_requests', function () {
             return {
                 filters: {
                     name: ['not in', get_selected_requests('Transportation Request Details', 'transportation_request')]
                 }
             };
         });
-        frm.set_query('travel_requests', function() {
+        frm.set_query('travel_requests', function () {
             return {
                 filters: {
                     name: ['not in', get_selected_requests('Employee Travel Request Details', 'employee_travel_request')]
@@ -115,7 +115,7 @@ frappe.ui.form.on('Trip Sheet', {
                     fieldname: fieldname
                 },
                 async: false,
-                callback: function(response) {
+                callback: function (response) {
                     if (response && response.message) {
                         selected_requests = response.message;
                     }
@@ -125,8 +125,8 @@ frappe.ui.form.on('Trip Sheet', {
             return selected_requests;
         }
     },
-    driver: function(frm) {
-        frm.set_query('travel_requests', function() {
+    driver: function (frm) {
+        frm.set_query('travel_requests', function () {
             return {
                 query: 'beams.beams.doctype.trip_sheet.trip_sheet.get_filtered_travel_requests',
                 filters: {


### PR DESCRIPTION
## Feature description
To allow selection of other employees (besides the one set in requested_by)

## Solution description

- Automatically filter out the employee set as requested_by from being selected again in the travellers field (which uses the Table MultiSelect fieldtype).

- Allow all other employees to be selectable.

**1. Refactored filter logic:**

-     Moved the call to apply_travellers_filter(frm) outside the admin role check and directly into the requested_by handler, ensuring the filter is always applied regardless of user role.


- Allow users to see all employees (beyond their user permission restrictions) when selecting from the travellers field.
 
 - Moved the 'travel_requests' set_query function under the refresh event to avoid redundancy.
- Ensured driver-specific filtering for travel requests is correctly handled.


## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/e5331a04-85fd-4d3a-b23d-56643b19eca0)
![image](https://github.com/user-attachments/assets/15ad843b-2a50-430f-ba23-103fd0aa123a)


## Areas affected and ensured
Employee Travel Request

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - YES
  - Opera Mini
  - Safari
