### PR TITLE
 TASK-2025-00907:Send appraisal review notification to assessment officer

### DIFF
--- a/beams/beams/custom_scripts/appraisal/appraisal.js
+++ b/beams/beams/custom_scripts/appraisal/appraisal.js
@@ -41,15 +41,23 @@ frappe.ui.form.on('Appraisal', {
                     return;
                 }
 
-                frappe.call({
-                    method: "beams.beams.custom_scripts.appraisal.appraisal.assign_tasks_sequentially",
-                    args: { doc: frm.doc.name, employee_id: frm.doc.employee },
-                    callback: function (response) {
-                        if (!response.exc) {
-                            frappe.msgprint(__('Notification sent and tasks assigned.'));
-                        }
+                frappe.confirm(
+                    'Do you want to send the notification and assign tasks now?',
+                    () => {
+                        frappe.call({
+                            method: "beams.beams.custom_scripts.appraisal.appraisal.assign_tasks_sequentially",
+                            args: {
+                                doc: frm.doc.name,
+                                employee_id: frm.doc.employee
+                            },
+                            callback: (response) => {
+                                if (!response.exc) {
+                                    frappe.msgprint('Notification sent and tasks assigned.');
+                                }
+                            }
+                        });
                     }
-                });
+                );
             }).addClass("btn-primary");
         }
 

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -1821,6 +1821,13 @@ def get_employee_custom_fields():
                 "fieldtype": "Data",
                 "label": "Relation",
                 "insert_after":"relation"
+            },
+            {
+                "fieldname": "assessment_officer",
+                "fieldtype": "Link",
+                "options": "Employee",
+                "label": "Assessment Officer",
+                "insert_after": "reports_to"
             }
 
         ],
@@ -3081,19 +3088,6 @@ def get_appraisal_template_custom_fields():
                 "fieldtype": "Data",
                 "label": "Label for Company KRA",
                 "insert_after": "company_rating_criteria"
-            },
-            {
-                "fieldname": "designation_section",
-                "fieldtype": "Section Break",
-                "label": "",
-                "insert_after": "label_for_company_kra"
-            },
-            {
-                "fieldname": "assessment_officers",
-                "fieldtype": "Table",
-                "options": "Assessment Officer",
-                "label": "Assessment Officers",
-                "insert_after": "designation_section"
             }
         ]
     }


### PR DESCRIPTION
## Feature description
  --add confirmation dialog before sending notification and assigning tasks

## Solution description
  -- removed legacy task assignment logic and replaced it with email notification for assessment officer review
  --Add confirmation dialog before sending notification and assigning tasks in Appraisal
  --Removed assessment officers table
  --add assessment officer filed  employee Doctype


## Output screenshots (optional)
[Screencast from 08-05-25 01:20:42 PM IST.webm](https://github.com/user-attachments/assets/d2da66ea-f9ec-4e49-a6c2-d11ff20a9c88)

## Areas affected and ensured
    --Appraisal Doctype

## Is there any existing behavior change of other features due to this code change?
    --No

## Was this feature tested on the browsers?
   --Mozilla Firefox
 