### PR TITLE
feat: prevent duplicate driver and vehicle selection in Vehicle Allocation child table.

### DIFF
--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.js
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.js
@@ -258,7 +258,7 @@ function set_vehicle_filters(frm, cdt, cdn) {
       .filter(row => row.name !== current_row.name && row.vehicle)
       .map(row => row.vehicle);
   
-      // Set query filter on the vehicle field to exclude selected vehicles
+  // Set query filter on the vehicle field to exclude selected vehicles
   frm.fields_dict.travel_vehicle_allocation.grid.get_field("vehicle").get_query = function(doc, cdt, cdn) {
       return {
           filters: [

--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.js
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.js
@@ -231,12 +231,16 @@ frappe.ui.form.on('Vehicle Allocation', {
   }
 });
 
+
+// Sets filter for the `driver` field to exclude already selected drivers in other rows
 function set_driver_filters(frm, cdt, cdn) {
   const current_row = locals[cdt][cdn];
+  // Collect all drivers already selected in other rows
   const selected_drivers = (frm.doc.travel_vehicle_allocation || [])
       .filter(row => row.name !== current_row.name && row.driver)
       .map(row => row.driver);
 
+  // Set query filter on the driver field to exclude selected drivers
   frm.fields_dict.travel_vehicle_allocation.grid.get_field("driver").get_query = function(doc, cdt, cdn) {
       return {
           filters: [
@@ -246,12 +250,15 @@ function set_driver_filters(frm, cdt, cdn) {
   };
 }
 
+// Sets filter for the `vehicle` field to exclude already selected vehicles in other rows
 function set_vehicle_filters(frm, cdt, cdn) {
   const current_row = locals[cdt][cdn];
+  // Collect all vehicles already selected in other rows
   const selected_vehicles = (frm.doc.travel_vehicle_allocation || [])
       .filter(row => row.name !== current_row.name && row.vehicle)
       .map(row => row.vehicle);
-
+  
+      // Set query filter on the vehicle field to exclude selected vehicles
   frm.fields_dict.travel_vehicle_allocation.grid.get_field("vehicle").get_query = function(doc, cdt, cdn) {
       return {
           filters: [

--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.js
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.js
@@ -217,3 +217,46 @@ function apply_travellers_filter(frm) {
         };
     });
 }
+
+frappe.ui.form.on('Vehicle Allocation', {
+  driver: function(frm, cdt, cdn) {
+      set_driver_filters(frm, cdt, cdn);
+  },
+  vehicle: function(frm, cdt, cdn) {
+      set_vehicle_filters(frm, cdt, cdn);
+  },
+  travel_vehicle_allocation_add: function(frm, cdt, cdn) {
+      set_driver_filters(frm, cdt, cdn);
+      set_vehicle_filters(frm, cdt, cdn);
+  }
+});
+
+function set_driver_filters(frm, cdt, cdn) {
+  const current_row = locals[cdt][cdn];
+  const selected_drivers = (frm.doc.travel_vehicle_allocation || [])
+      .filter(row => row.name !== current_row.name && row.driver)
+      .map(row => row.driver);
+
+  frm.fields_dict.travel_vehicle_allocation.grid.get_field("driver").get_query = function(doc, cdt, cdn) {
+      return {
+          filters: [
+              ["name", "not in", selected_drivers]
+          ]
+      };
+  };
+}
+
+function set_vehicle_filters(frm, cdt, cdn) {
+  const current_row = locals[cdt][cdn];
+  const selected_vehicles = (frm.doc.travel_vehicle_allocation || [])
+      .filter(row => row.name !== current_row.name && row.vehicle)
+      .map(row => row.vehicle);
+
+  frm.fields_dict.travel_vehicle_allocation.grid.get_field("vehicle").get_query = function(doc, cdt, cdn) {
+      return {
+          filters: [
+              ["name", "not in", selected_vehicles]
+          ]
+      };
+  };
+}


### PR DESCRIPTION
## Feature description
Prevent duplicate driver and vehicle selection in Vehicle Allocation child table.

## Solution description
- Dynamic filtering of `driver` and `vehicle` fields to exclude already selected values in other rows.
- Filters applied in real-time when:
  - A new row is added
  - A value is selected/changed in an existing row
- Logic only activates when:
  - `is_vehicle_required` is checked
  - `workflow_state` is "Approved by HOD"

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/0846df17-7ed5-4384-bdfc-c37832ea6a81)


## Areas affected and ensured
Employee Travel Request.

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
