### PR TITLE
feat:Validate trip times and odometer fields

### DIFF
--- a/beams/beams/doctype/trip_sheet/trip_sheet.js
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.js
@@ -139,11 +139,37 @@ frappe.ui.form.on('Trip Sheet', {
 
 frappe.ui.form.on('Trip Details', {
     from_time: function (frm, cdt, cdn) {
+        let child = locals[cdt][cdn];
+
+        if (child.from_time) {
+            // Validate if from_time is within the range of starting_date_and_time and ending_date_and_time
+            if (child.from_time < frm.doc.starting_date_and_time || child.from_time > frm.doc.ending_date_and_time) {
+                frappe.msgprint(__('From Time must be between Starting Date and Time and Ending Date and Time.'));
+                frappe.model.set_value(cdt, cdn, 'from_time', null); // Reset the invalid value
+                return;
+            }
+        }else{
+            frappe.model.set_value(cdt, cdn, 'hrs', null);
+        }
+
         frm.call('calculate_hours').then(() => {
             frm.refresh_field('trip_details');
         });
     },
     to_time: function (frm, cdt, cdn) {
+        let child = locals[cdt][cdn];
+
+        if (child.to_time) {
+            // Validate if to_time is within the range of starting_date_and_time and ending_date_and_time
+            if (child.to_time < frm.doc.starting_date_and_time || child.to_time > frm.doc.ending_date_and_time) {
+                frappe.msgprint(__('To Time must be between Starting Date and Time and Ending Date and Time.'));
+                frappe.model.set_value(cdt, cdn, 'to_time', null); // Reset the invalid value
+                return;
+            }
+        }else{
+            frappe.model.set_value(cdt, cdn, 'hrs', null);
+        }
+
         frm.call('calculate_hours').then(() => {
             frm.refresh_field('trip_details');
         });

--- a/beams/beams/doctype/trip_sheet/trip_sheet.js
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.js
@@ -139,39 +139,15 @@ frappe.ui.form.on('Trip Sheet', {
 
 frappe.ui.form.on('Trip Details', {
     from_time: function (frm, cdt, cdn) {
-        let child = locals[cdt][cdn];
-
-        if (child.from_time) {
-            // Validate if from_time is within the range of starting_date_and_time and ending_date_and_time
-            if (child.from_time < frm.doc.starting_date_and_time || child.from_time > frm.doc.ending_date_and_time) {
-                frappe.msgprint(__('From Time must be between Starting Date and Time and Ending Date and Time.'));
-                frappe.model.set_value(cdt, cdn, 'from_time', null); // Reset the invalid value
-                return;
-            }
-        }else{
-            frappe.model.set_value(cdt, cdn, 'hrs', null);
-        }
-
         frm.call('calculate_hours').then(() => {
             frm.refresh_field('trip_details');
+            return frm.call('validate_trip_times');
         });
     },
     to_time: function (frm, cdt, cdn) {
-        let child = locals[cdt][cdn];
-
-        if (child.to_time) {
-            // Validate if to_time is within the range of starting_date_and_time and ending_date_and_time
-            if (child.to_time < frm.doc.starting_date_and_time || child.to_time > frm.doc.ending_date_and_time) {
-                frappe.msgprint(__('To Time must be between Starting Date and Time and Ending Date and Time.'));
-                frappe.model.set_value(cdt, cdn, 'to_time', null); // Reset the invalid value
-                return;
-            }
-        }else{
-            frappe.model.set_value(cdt, cdn, 'hrs', null);
-        }
-
         frm.call('calculate_hours').then(() => {
             frm.refresh_field('trip_details');
+            return frm.call('validate_trip_times');
         });
     }
 });

--- a/beams/beams/doctype/trip_sheet/trip_sheet.py
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.py
@@ -65,6 +65,8 @@ class TripSheet(Document):
         Validate odometer readings and calculate distance traveled and fuel consumption per km.
         Automatically updates the fields on the same document.
         '''
+        if self.final_odometer_reading is None or self.initial_odometer_reading is None:
+            return
         if self.initial_odometer_reading > self.final_odometer_reading:
             frappe.throw(_("Initial Odometer Reading must be less than  Final Odometer Reading"))
 

--- a/beams/beams/doctype/trip_sheet/trip_sheet.py
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.py
@@ -21,6 +21,7 @@ class TripSheet(Document):
         self.validate_start_datetime_and_end_datetime()
         self.calculate_and_validate_fuel_data()
         self.calculate_hours()
+        self.validate_trip_times()
 
 
     def before_save(self):
@@ -39,6 +40,20 @@ class TripSheet(Document):
                 else:
                     trip.hrs = 0
                     frappe.throw(f"To Time must be after From Time for trip from {trip.departure} to {trip.destination}")
+            else:
+                trip.hrs = None
+
+    @frappe.whitelist()
+    def validate_trip_times(self):
+        for row in self.trip_details:
+            if row.get("from_time"):
+                if not (self.starting_date_and_time <= row.from_time <= self.ending_date_and_time):
+                    frappe.throw(_("Row #{0}: From Time must be between Starting and Ending Date and Time.").format(row.idx))
+            if row.get("to_time"):
+                if not (self.starting_date_and_time <= row.to_time <= self.ending_date_and_time):
+                    frappe.throw(_("Row #{0}: To Time must be between Starting and Ending Date and Time.").format(row.idx))
+
+
 
 
     @frappe.whitelist()

--- a/beams/beams/doctype/trip_sheet/trip_sheet.py
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.py
@@ -48,13 +48,12 @@ class TripSheet(Document):
         for row in self.trip_details:
             if row.get("from_time"):
                 if not (self.starting_date_and_time <= row.from_time <= self.ending_date_and_time):
-                    frappe.throw(_("Row #{0}: From Time must be between Starting and Ending Date and Time.").format(row.idx))
+                    frappe.throw(_("Row #{0}: From Time must be between Starting and Ending Date and Time.").format(row.idx),
+                    title=_("Message"))
             if row.get("to_time"):
                 if not (self.starting_date_and_time <= row.to_time <= self.ending_date_and_time):
-                    frappe.throw(_("Row #{0}: To Time must be between Starting and Ending Date and Time.").format(row.idx))
-
-
-
+                    frappe.throw(_("Row #{0}: To Time must be between Starting and Ending Date and Time.").format(row.idx),
+                    title=_("Message"))
 
     @frappe.whitelist()
     def validate_start_datetime_and_end_datetime(self):

--- a/beams/beams/doctype/vehicle_incident_record/vehicle_incident_record.json
+++ b/beams/beams/doctype/vehicle_incident_record/vehicle_incident_record.json
@@ -82,8 +82,7 @@
    "fieldname": "driver_name",
    "fieldtype": "Data",
    "label": "Driver Name",
-   "read_only": 1,
-   "reqd": 1
+   "read_only": 1
   },
   {
    "fetch_from": "trip_sheet.starting_date_and_time",
@@ -112,11 +111,10 @@
    "fieldtype": "Column Break"
   }
  ],
- "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-05-06 15:36:17.994950",
+ "modified": "2025-05-09 13:23:18.991915",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Vehicle Incident Record",


### PR DESCRIPTION
## Feature description

- Validate trip times and odometer fields; update driver_name field in Vehicle Incident Record

## Solution description

- [ ] [TASK-2025-00946](https://jalebi.efeone.com/app/task/TASK-2025-00946)
- [ ] [TASK-2025-00920](https://jalebi.efeone.com/app/task/TASK-2025-00946)

**Trip Sheet JS (trip_sheet.js):**
- Added validation to ensure 'from_time' and 'to_time' in Trip Details are within the trip's starting and ending datetime range.
- Invalid entries are reset with a user message.
- Clears 'hrs' field if time fields are cleared.
- Triggers hour recalculation after changes.

**Trip Sheet Python (trip_sheet.py):**
- Skips odometer reading validation if 'initial_odometer_reading' or 'final_odometer_reading' is missing.

**Vehicle Incident Record (vehicle_incident_record.json):**
- Removed 'reqd: 1' from 'driver_name', making it optional but still read-only.
- Allows saving record without requiring driver name.



## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/fd8210ed-9c2a-42ce-a4a2-6b1f171e4b76)
![image](https://github.com/user-attachments/assets/b0434a88-08e1-4213-aa04-258a9cfaedae)



## Areas affected and ensured

- Trip Sheet
- Vehicle Incident Record

## Is there any existing behavior change of other features due to this code change?


## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - Yes
  - Opera Mini
  - Safari
