### PR TITLE
fix:Corrected odometer value reading in Trip Sheet when vehicle is selected

### DIFF
--- a/beams/beams/doctype/trip_sheet/trip_sheet.js
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.js
@@ -25,11 +25,7 @@ frappe.ui.form.on('Trip Sheet', {
                     vehicle: frm.doc.vehicle
                 },
                 callback: function (r) {
-                    if (r.message) {
-                        frm.set_value("initial_odometer_reading", r.message);
-                    } else {
-                        frm.set_value("initial_odometer_reading", 0);
-                    }
+                    frm.set_value("initial_odometer_reading", r.message || 0);
                 }
             });
         } else {

--- a/beams/beams/doctype/trip_sheet/trip_sheet.py
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.py
@@ -107,21 +107,18 @@ def get_last_odometer(vehicle):
     if not vehicle:
         return 0
 
-    last_trip_exists = frappe.db.exists(
+    final_odometer = frappe.db.get_value(
         "Trip Sheet",
         {"vehicle": vehicle, "docstatus": 1},
+        "final_odometer_reading",
+        order_by="creation desc"
     )
 
-    if last_trip_exists:
-        final_odometer = frappe.db.get_value(
-            "Trip Sheet",
-            {"vehicle": vehicle, "docstatus": 1},
-            "final_odometer_reading",
-            order_by="creation desc",
-        )
+    if final_odometer is not None:
         return final_odometer or 0
-    else:
-        return 0
+    vehicle_odometer = frappe.db.get_value("Vehicle", vehicle, "last_odometer") or 0
+    return vehicle_odometer
+
 
 @frappe.whitelist()
 def get_selected_requests(child_table, fieldname):

--- a/beams/beams/doctype/trip_sheet/trip_sheet.py
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.py
@@ -111,7 +111,7 @@ def get_last_odometer(vehicle):
         "Trip Sheet",
         {"vehicle": vehicle, "docstatus": 1},
         "final_odometer_reading",
-        order_by="creation desc"
+        order_by="starting_date_and_time desc"
     )
 
     if final_odometer is not None:


### PR DESCRIPTION
## Feature description
Need to: Correct the issue for odometer value reading in Trip Sheet when vehicle is selected

## Solution description
 Ensures  the odometer reading is correctly set when vehicle is selected before saving the Trip Sheet.

## Output screenshots (optional)
[Screencast from 13-05-25 11:49:46 AM IST.webm](https://github.com/user-attachments/assets/7bf35644-2955-44db-aa3b-691d85b31deb)


## Areas affected and ensured
Trip Sheet doctype

## Is there any existing behavior change of other features due to this code change?
No. 

## Was this feature tested on the browsers?
  - Mozilla Firefox

