### PR TITLE
feat: Filter Asset field to show only submitted and eligible assets

### DIFF
--- a/beams/beams/doctype/asset_transfer_request/asset_transfer_request.js
+++ b/beams/beams/doctype/asset_transfer_request/asset_transfer_request.js
@@ -129,7 +129,9 @@ frappe.ui.form.on("Asset Transfer Request", {
         frappe.db.get_list("Asset Transfer Request", {
             fields: ["asset"], filters: { workflow_state: "Transferred" }
         }).then(res => frm.set_query("asset", () => ({
-            filters: [["Asset", "status", "!=", "Transferred"], ["Asset", "name", "not in", res.map(a => a.asset)]]
+            filters: [["Asset", "status", "!=", "Transferred"], ["Asset", "name", "not in", res.map(a => a.asset)],
+            ["Asset", "docstatus", "=", 1]]
+
         }))).catch(err => console.error("Error:", err));
     }
 });


### PR DESCRIPTION
## Feature description
 Filter Asset field to show only submitted and eligible assets

## Solution description

- Enhanced the asset field in the Asset Transfer Request DocType to show only submitted assets 

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/0782853b-067f-44c2-9dd5-20307e74851b)


## Areas affected and ensured
Asset Transfer Request

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - YES
  - Opera Mini
  - Safari
