### PR TITLE
feat: TASK-2025-00971 modify vehicle safety inspection in trip sheet

### DIFF
--- a/beams/beams/doctype/trip_sheet/trip_sheet.js
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.js
@@ -135,7 +135,32 @@ frappe.ui.form.on('Trip Sheet', {
             };
         });
     },
-    // Updates the vehicle safety inspection details based on the selected vehicle template
+    // Trigger when the vehicle field changes
+    vehicle(frm) {
+        if (frm.doc.vehicle) {
+            frappe.db.get_list('Vehicle Safety Inspection', {
+                filters: {
+                    vehicle: frm.doc.vehicle
+                },
+                fields: ['name'],
+                limit: 1
+            }).then(result => {
+                if (result && result.length > 0) {
+                    frm.set_value('vehicle_template', result[0].name);
+                } else {
+                    frm.set_value('vehicle_template', null);
+                    frm.clear_table('vehicle_safety_inspection_details');
+                    frm.refresh_field('vehicle_safety_inspection_details');
+                }
+            });
+        } else {
+            frm.set_value('vehicle_template', null);
+            frm.clear_table('vehicle_safety_inspection_details');
+            frm.refresh_field('vehicle_safety_inspection_details');
+        }
+    },
+
+    // Updates the vehicle safety inspection details based on the vehicle template
     vehicle_template(frm) {
         let template = frm.doc.vehicle_template;
 
@@ -151,12 +176,19 @@ frappe.ui.form.on('Trip Sheet', {
                 doc.vehicle_safety_inspection.forEach(d => {
                     frm.add_child('vehicle_safety_inspection_details', {
                         item: d.item,
-                        status: d.status,
+                        fit_for_use: d.fit_for_use,
                         remarks: d.remarks
                     });
                 });
                 frm.refresh_field('vehicle_safety_inspection_details');
+                let all_fit_for_use = frm.doc.vehicle_safety_inspection_details.every(row => row.fit_for_use === 1);
+                frm.set_value('safety_inspection_completed', all_fit_for_use ? 1 : 0);
             });
+    },
+    // Trigger when vehicle_safety_inspection_details table is modified
+    vehicle_safety_inspection_details: function(frm) {
+        let all_fit_for_use = frm.doc.vehicle_safety_inspection_details.every(row => row.fit_for_use === 1);
+        frm.set_value('safety_inspection_completed', all_fit_for_use ? 1 : 0);
     }
 });
 

--- a/beams/beams/doctype/trip_sheet/trip_sheet.json
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.json
@@ -20,9 +20,9 @@
   "transportation_requests",
   "pre_trip_checklist_section",
   "clean_vehicle",
-  "safety_inspection",
   "vehicle_template",
   "vehicle_safety_inspection_details",
+  "safety_inspection_completed",
   "remarks",
   "trip_details_section",
   "trip_details",
@@ -97,12 +97,6 @@
    "fieldname": "clean_vehicle",
    "fieldtype": "Check",
    "label": "Is Cleaned"
-  },
-  {
-   "default": "0",
-   "fieldname": "safety_inspection",
-   "fieldtype": "Check",
-   "label": "Safety Inspection"
   },
   {
    "fieldname": "remarks",
@@ -188,24 +182,32 @@
    "fieldtype": "Section Break"
   },
   {
-   "depends_on": "eval:doc.safety_inspection == 1",
+   "depends_on": "eval:doc.vehicle\n",
    "fieldname": "vehicle_template",
    "fieldtype": "Link",
-   "label": "Vehicle Template",
-   "options": "Vehicle Safety Inspection"
+   "label": "Vehicle Safety Template",
+   "options": "Vehicle Safety Inspection",
+   "read_only": 1
   },
   {
-   "depends_on": "eval:doc.safety_inspection == 1",
+   "depends_on": "eval:doc.vehicle",
    "fieldname": "vehicle_safety_inspection_details",
    "fieldtype": "Table",
    "label": "Vehicle Safety Inspection Details",
    "options": "Vehicle Inspection Details"
+  },
+  {
+   "default": "0",
+   "fieldname": "safety_inspection_completed",
+   "fieldtype": "Check",
+   "label": "Safety Inspection Completed",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-05-12 10:55:32.663863",
+ "modified": "2025-05-13 11:40:29.508434",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Trip Sheet",

--- a/beams/beams/doctype/trip_sheet/trip_sheet.py
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.py
@@ -26,6 +26,12 @@ class TripSheet(Document):
 
     def before_save(self):
         self.validate_posting_date()
+        # Set safety_inspection_completed based on fit_for_use are checked
+        if self.vehicle_safety_inspection_details:
+            all_fit_for_use = all(row.fit_for_use == 1 for row in self.vehicle_safety_inspection_details)
+            self.safety_inspection_completed = 1 if all_fit_for_use else 0
+        else:
+            self.safety_inspection_completed = 0
 
     @frappe.whitelist()
     def calculate_hours(self):

--- a/beams/beams/doctype/vehicle_inspection_details/vehicle_inspection_details.json
+++ b/beams/beams/doctype/vehicle_inspection_details/vehicle_inspection_details.json
@@ -9,8 +9,8 @@
  "field_order": [
   "section_break_bv3z",
   "item",
-  "result",
-  "notes"
+  "fit_for_use",
+  "remarks"
  ],
  "fields": [
   {
@@ -24,23 +24,24 @@
    "label": "Item"
   },
   {
-   "fieldname": "result",
-   "fieldtype": "Select",
+   "default": "0",
+   "fieldname": "fit_for_use",
+   "fieldtype": "Check",
    "in_list_view": 1,
-   "label": "Result",
-   "options": "\nFit for Use\nNeeds Repair"
+   "label": "Fit for Use",
+   "options": "\n"
   },
   {
-   "fieldname": "notes",
+   "fieldname": "remarks",
    "fieldtype": "Small Text",
    "in_list_view": 1,
-   "label": "Notes"
+   "label": "Remarks"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-05-12 15:54:22.213485",
+ "modified": "2025-05-13 10:00:27.550581",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Vehicle Inspection Details",


### PR DESCRIPTION
## Feature description
TASK-2025-00971 modify vehicle safety inspection template in trip sheet


## Solution description

1. Changed field name and type in vehicle_inspection_details child table.
2. Changed field name, position and display depends on condition in Trip Sheet
3. Automatically check the safety_inspection_completed field in the Trip Sheet when all fit_for_use rows in the Vehicle Inspection Details child table are checked

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/3f7367dd-a73e-409a-954f-3153e3a9e008)
![image](https://github.com/user-attachments/assets/43f72d45-f2e2-4b14-b57b-9366d8646989)

[Screencast from 13-05-25 02:20:47 PM IST.webm](https://github.com/user-attachments/assets/4eff1c8a-497f-40a7-a4c5-5399073c1c77)

## Areas affected and ensured
List out the areas affected by your code changes.(Trip Sheet)

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
 
