### PR TITLE
feat:Created workspace for security

### DIFF
--- a/beams/beams/doctype/outward_pass/outward_pass.json
+++ b/beams/beams/doctype/outward_pass/outward_pass.json
@@ -22,8 +22,7 @@
    "in_list_view": 1,
    "label": "Employee in Charge",
    "options": "Employee",
-   "reqd": 1,
-   "unique": 1
+   "reqd": 1
   },
   {
    "default": "Now",
@@ -73,7 +72,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-02-25 11:34:33.159474",
+ "modified": "2025-05-14 11:05:53.631672",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Outward Pass",

--- a/beams/beams/workspace/security/security.json
+++ b/beams/beams/workspace/security/security.json
@@ -1,0 +1,78 @@
+{
+ "charts": [],
+ "content": "[{\"id\":\"E4vYr1JOkg\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h2\\\">Security</span>\",\"col\":12}},{\"id\":\"3XNPUYGSzT\",\"type\":\"paragraph\",\"data\":{\"text\":\"<span class=\\\"h4\\\">Shortcuts</span>\",\"col\":12}},{\"id\":\"eeuvHsPTDU\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Inward Register\",\"col\":3}},{\"id\":\"JknCrrfN_a\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Outward Register\",\"col\":3}},{\"id\":\"0e5CvyGqUJ\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Outward Pass\",\"col\":3}},{\"id\":\"rj8vL3QMCa\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Security Patrol Log\",\"col\":3}},{\"id\":\"XWkXhBzA9s\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"esXgPlBIrO\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\"><b>Quick List</b></span>\",\"col\":12}},{\"id\":\"mOrfY8IP7w\",\"type\":\"quick_list\",\"data\":{\"quick_list_name\":\"Security Patrol Log\",\"col\":4}},{\"id\":\"aEmYA8j66M\",\"type\":\"quick_list\",\"data\":{\"quick_list_name\":\"Outward Register\",\"col\":4}},{\"id\":\"lGGYGuuufV\",\"type\":\"quick_list\",\"data\":{\"quick_list_name\":\"Inward Register\",\"col\":4}}]",
+ "creation": "2025-05-14 10:51:11.362892",
+ "custom_blocks": [],
+ "docstatus": 0,
+ "doctype": "Workspace",
+ "for_user": "",
+ "hide_custom": 0,
+ "icon": "quality",
+ "idx": 0,
+ "indicator_color": "blue",
+ "is_hidden": 0,
+ "label": "Security",
+ "links": [],
+ "modified": "2025-05-14 11:40:51.364088",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "Security",
+ "number_cards": [],
+ "owner": "Administrator",
+ "parent_page": "BEAMS",
+ "public": 1,
+ "quick_lists": [
+  {
+   "document_type": "Security Patrol Log",
+   "label": "Security Patrol Log",
+   "quick_list_filter": "[]"
+  },
+  {
+   "document_type": "Inward Register",
+   "label": "Inward Register",
+   "quick_list_filter": "[]"
+  },
+  {
+   "document_type": "Outward Register",
+   "label": "Outward Register",
+   "quick_list_filter": "[]"
+  }
+ ],
+ "roles": [],
+ "sequence_id": 42.0,
+ "shortcuts": [
+  {
+   "color": "Green",
+   "doc_view": "List",
+   "label": "Inward Register",
+   "link_to": "Inward Register",
+   "stats_filter": "[]",
+   "type": "DocType"
+  },
+  {
+   "color": "Orange",
+   "doc_view": "List",
+   "label": "Outward Register",
+   "link_to": "Outward Register",
+   "stats_filter": "[]",
+   "type": "DocType"
+  },
+  {
+   "color": "Pink",
+   "doc_view": "List",
+   "label": "Outward Pass",
+   "link_to": "Outward Pass",
+   "stats_filter": "[]",
+   "type": "DocType"
+  },
+  {
+   "color": "Yellow",
+   "doc_view": "List",
+   "label": "Security Patrol Log",
+   "link_to": "Security Patrol Log",
+   "stats_filter": "[]",
+   "type": "DocType"
+  }
+ ],
+ "title": "Security"
+}


### PR DESCRIPTION
## Feature description

- Created workspace for security

## Solution description

- [x] TASK-2025-00993

- Created workspace for security
- Field: Employee in Charge
 
-     Removed the "unique": 1 constraint.
 
-     Field is still required ("reqd": 1) and of type Link to the Employee DocType.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/a16af8e1-1697-4939-847b-ed8cea5c005f)

## Areas affected and ensured

- workspace
- Outer pass

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox -Yes
  - Opera Mini
  - Safari
