### PR TITLE
feat:auto-set employee for security role and add checked field to patrol log

### DIFF
--- a/beams/beams/doctype/patrol_log_detail/patrol_log_detail.json
+++ b/beams/beams/doctype/patrol_log_detail/patrol_log_detail.json
@@ -7,6 +7,7 @@
  "engine": "InnoDB",
  "field_order": [
   "service_unit",
+  "checked",
   "remarks"
  ],
  "fields": [
@@ -23,12 +24,19 @@
    "fieldtype": "Small Text",
    "in_list_view": 1,
    "label": "Remarks"
+  },
+  {
+   "default": "0",
+   "fieldname": "checked",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Checked"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-01-25 23:38:12.278668",
+ "modified": "2025-05-14 12:22:05.991502",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Patrol Log Detail",

--- a/beams/beams/doctype/security_patrol_log/security_patrol_log.js
+++ b/beams/beams/doctype/security_patrol_log/security_patrol_log.js
@@ -34,7 +34,7 @@ frappe.ui.form.on('Security Patrol Log', {
                 }
             });
         }
-        else{
+        else {
             frm.clear_table('patrol_log');
             frm.refresh_field('patrol_log');
         }

--- a/beams/beams/doctype/security_patrol_log/security_patrol_log.js
+++ b/beams/beams/doctype/security_patrol_log/security_patrol_log.js
@@ -2,6 +2,17 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Security Patrol Log', {
+    onload: function (frm) {
+        if (frappe.session.user !== 'Administrator' && frappe.user.has_role('Security')) {
+            // Get the Employee linked to the current user
+            frappe.db.get_value('Employee', { user_id: frappe.session.user }, 'name')
+                .then(r => {
+                    if (r.message && r.message.name) {
+                        frm.set_value('employee', r.message.name);
+                    }
+                });
+        }
+    },
     patrol_template: function (frm) {
         if (frm.doc.patrol_template) {
             frappe.call({
@@ -23,5 +34,10 @@ frappe.ui.form.on('Security Patrol Log', {
                 }
             });
         }
+        else{
+            frm.clear_table('patrol_log');
+            frm.refresh_field('patrol_log');
+        }
+
     }
 });

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -4319,7 +4319,7 @@ def get_beams_roles():
     '''
         Method to get BEAMS specific roles
     '''
-    return ['Production Manager', 'CEO', 'Company Secretary', 'HOD','Enquiry Officer','Enquiry Manager','Shift Publisher','Program Producer','Operations Head','Operations User','Admin','Driver','Budget User','Technical Store Head','Budget Verifier','Budget Verifier Finance','Budget Approver','Admin User','Bureau User','Coordinating Editor','News Coordinator']
+    return ['Production Manager', 'CEO', 'Company Secretary', 'HOD','Enquiry Officer','Enquiry Manager','Shift Publisher','Program Producer','Operations Head','Operations User','Admin','Driver','Budget User','Technical Store Head','Budget Verifier','Budget Verifier Finance','Budget Approver','Admin User','Bureau User','Coordinating Editor','News Coordinator','Security']
 
 def get_custom_translations():
     '''


### PR DESCRIPTION
## Feature description

- auto-set employee for security role and add checked field to patrol log
 

## Solution description

- [x] [TASK-2025-00996](https://erpefeone.frappe.cloud/app/task/TASK-2025-00996)
 
- **Auto-set Employee Field:**
      - When a user with the "Security" role logs in and opens the Security Patrol Log, the employee field is now automatically set based on the logged-in user's linked Employee record.
 
- **Clear patrol log on template removal:**
       -  If the patrol_template field is cleared, the patrol_log child table will now be cleared as well, ensuring no outdated entries remain.
 
- **New Field in Patrol Log Detail:**
       - A new "Checked" (Check field) has been added to the Patrol Log Detail child table, and it is shown in the list view .
- **Role Update:**
      - Added the "Security" role to the get_beams_roles() list to ensure role-based access.

## Output screenshots (optional)
[Screencast from 14-05-25 01:09:33 PM IST.webm](https://github.com/user-attachments/assets/c620e208-9121-42d9-ac6f-a5176e77c39a)


## Areas affected and ensured

- Security patrol log

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox -Yes
  - Opera Mini
  - Safari
