### PR TITLE
Fix Batta Claim date editing problem

### DIFF
--- a/beams/beams/doctype/batta_claim/batta_claim.js
+++ b/beams/beams/doctype/batta_claim/batta_claim.js
@@ -206,7 +206,7 @@ frappe.ui.form.on('Work Detail', {
         setTimeout(() => {
             set_batta_for_food_allowance(frm, cdt, cdn);
             calculate_batta(frm, cdt, cdn);
-        }, 30);
+        }, 500);
     },
     to_date_and_time: function(frm, cdt, cdn) {
       let row = locals[cdt][cdn];
@@ -225,7 +225,7 @@ frappe.ui.form.on('Work Detail', {
         setTimeout(() => {
             set_batta_for_food_allowance(frm, cdt, cdn);
             calculate_batta(frm, cdt, cdn);
-        }, 30);
+        }, 500);
     }
   }
 });


### PR DESCRIPTION

## Feature description
In batta claim now the date can be edited . after editing the total betta is fetching
## Solution description
In batta claim when we created a claim it cannot be edited . if it is edited total batta will turn to zero. now it is fixed
## Output

![Screenshot from 2025-05-14 14-16-38](https://github.com/user-attachments/assets/63832cc4-840a-4174-877f-52f02b2c1267)
![Screenshot from 2025-05-14 14-17-00](https://github.com/user-attachments/assets/9bd40040-20f1-45a4-9165-da6a6b5a2bcf)

## Areas affected and ensured
-New feature

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Chrome