### PR TITLE
feat: TASK-2025-00994 enable creating courier log from inward register

### DIFF
--- a/beams/beams/doctype/inward_register/inward_register.js
+++ b/beams/beams/doctype/inward_register/inward_register.js
@@ -5,21 +5,35 @@ frappe.ui.form.on('Inward Register', {
         if (frm.doc.docstatus === 1) {
             frm.add_custom_button(__('Outward Register'), function () {
                 frappe.new_doc("Outward Register", {
-                  inward_register: frm.doc.name,
+                    inward_register: frm.doc.name,
                 });
             }, __("Create"));
 
-            frm.add_custom_button(__(' Visitor Pass'), function () {
-                frappe.new_doc("Visitor Pass", {
-                    inward_register: frm.doc.name,
-                    issued_date: frappe.datetime.now_date(),
-                    issued_time: frappe.datetime.now_time(),
-                    issued_to: frm.doc.visitor_name
-                });
-            }, __("Create"));
+            if (!frappe.user.has_role('Security') || frappe.user.has_role('Administrator')) {
+                frm.add_custom_button(__(' Visitor Pass'), function () {
+                    frappe.new_doc("Visitor Pass", {
+                        inward_register: frm.doc.name,
+                        issued_date: frappe.datetime.now_date(),
+                        issued_time: frappe.datetime.now_time(),
+                        issued_to: frm.doc.visitor_name
+                    });
+                }, __("Create"));
+                if (frm.doc.visitor_type === 'Courier') {
+                    frm.add_custom_button(__('Courier Log'), function () {
+                        frappe.new_doc("Courier Log", {
+                            inward_register: frm.doc.name,
+                            sender: frm.doc.visitor_name,
+                            recipient: frm.doc.received_by,
+                            courier_service: frm.doc.courier_service,
+                            date: frm.doc.visit_date,
+                            description: frm.doc.purpose_of_visit
+                        });
+                    }, __("Create"));
+                }
+            }
         }
     },
-    posting_date:function (frm){
+    posting_date: function (frm) {
         frm.call("validate_posting_date");
-      }
+    }
 });

--- a/beams/beams/doctype/inward_register/inward_register.json
+++ b/beams/beams/doctype/inward_register/inward_register.json
@@ -73,7 +73,8 @@
    "fieldname": "received_by",
    "fieldtype": "Link",
    "label": "Received By",
-   "options": "Employee"
+   "options": "Employee",
+   "reqd": 1
   },
   {
    "depends_on": "eval:doc.vehicle_key;",
@@ -115,11 +116,10 @@
    "label": "Visit Date"
   }
  ],
- "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-04-25 14:30:34.845221",
+ "modified": "2025-05-14 12:08:44.095780",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Inward Register",
@@ -140,6 +140,7 @@
    "write": 1
   }
  ],
+ "search_fields": "visitor_type,visitor_name,posting_date",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []


### PR DESCRIPTION
## Feature description

- [ ] TASK-2025-00994 :Enable creating courier log from inward register
- [ ] TASK-2025-00997 : Hide visitor pass and courier log in inward register for security
- [ ] TASK-2025-01004 : Map details from Inward Register to courier log


## Solution description
TASK-2025-00994

1. Added mandatory to 'Received by' field in inward register 
2. Added search fields (Visitor type, visitor name and visit date) in inward register
3. Added a button to create 'courier log' in inward register

TASK-2025-00997

1. Hided visitor pass and courier log button in inward register for security

TASK-2025-01004

1. Mapped details from Inward Register to Courier log

- Visitor Name to sender, 
- Received By to Recipient, 
- Courier Service to Courier Service, 
- Visit Date to Date, 
- Purpose of Visit to Description


## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/aee17508-7bff-4c0e-b30e-c9578b9f4547)
![image](https://github.com/user-attachments/assets/7ca4050e-c5c8-40ae-a50d-1ec42cf631e7)
![image](https://github.com/user-attachments/assets/9dac79f4-8b2c-4bcf-8626-891a44c80ccd)
![image](https://github.com/user-attachments/assets/7f3c2f17-d81a-4e4b-a50b-e83c75667c78)
![image](https://github.com/user-attachments/assets/6e73bad8-c601-4fdb-86f3-c4fe0ebf6004)


## Areas affected and ensured
List out the areas affected by your code changes.(Inward Register, Courier Log)

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  
