### PR TITLE
feat: TASK-2025-01003 show button to create event when guest appointment approved

### DIFF
--- a/beams/beams/doctype/guest_appointment/guest_appointment.js
+++ b/beams/beams/doctype/guest_appointment/guest_appointment.js
@@ -2,34 +2,34 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Guest Appointment', {
-    refresh: function(frm) {
-        // Add a button to the 'Create' group to create a new Event
-        frm.add_custom_button(__('Event'), function() {
-            // Create a new Event DocType (empty Event)
-            frappe.new_doc('Event', {
-                guest_appointment: frm.doc.name  // Optionally link the Event to this Guest Appointment
-            });
-        }, 'Create');  // Add the button under the 'Create' group
-
-        if (frm.doc.workflow_state === "Approved") {
-          frm.add_custom_button(__('Inward Register'), function() {
-            frappe.call({
-              method: 'beams.beams.doctype.guest_appointment.guest_appointment.create_inward_register',
-                args: {
-                guest_appointment: frm.doc.name
-            },
-            callback: function(r) {
-                if (r.message) {
-                    frappe.db.get_doc('Inward Register', r.message).then(doc => {
-                        frappe.new_doc('Inward Register', doc);
-                    });
-                }
-            }
+  refresh: function (frm) {
+    // Add a button to the 'Create' group to create a new Event
+    if (frm.doc.workflow_state === "Approved") {
+      frm.add_custom_button(__('Event'), function () {
+        // Create a new Event DocType (empty Event)
+        frappe.new_doc('Event', {
+          guest_appointment: frm.doc.name  // Optionally link the Event to this Guest Appointment
         });
-        }, __("Create"));
-        }
-      },
-      posting_date:function (frm){
-        frm.call("validate_posting_date");
-      }      
+      }, 'Create');  // Add the button under the 'Create' group
+
+      frm.add_custom_button(__('Inward Register'), function () {
+        frappe.call({
+          method: 'beams.beams.doctype.guest_appointment.guest_appointment.create_inward_register',
+          args: {
+            guest_appointment: frm.doc.name
+          },
+          callback: function (r) {
+            if (r.message) {
+              frappe.db.get_doc('Inward Register', r.message).then(doc => {
+                frappe.new_doc('Inward Register', doc);
+              });
+            }
+          }
+        });
+      }, __("Create"));
+    }
+  },
+  posting_date: function (frm) {
+    frm.call("validate_posting_date");
+  }
 });

--- a/beams/beams/doctype/guest_appointment/guest_appointment.py
+++ b/beams/beams/doctype/guest_appointment/guest_appointment.py
@@ -91,6 +91,8 @@ def create_inward_register(guest_appointment):
     inward_register.visitor_name = appointment.guest_name
     inward_register.received_by = appointment.received_by
     inward_register.purpose_of_visit = appointment.purpose_of_visit
+    inward_register.visit_date = appointment.appointment_date
+    inward_register.visitor_type = "Guest"
     inward_register.insert(ignore_mandatory=True)
 
     return inward_register.name


### PR DESCRIPTION
## Feature description
TASK-2025-01003 : When guest appointment is approved then show button to create Event


## Solution description

- Rearranged ' Event ' button in the Guest Appointment appears only when the guest appointment is approved.
- Mapped from guest appointment to Inward register : Appointment Date to Visit Date, and Visitor Type as Guest

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/c6e15390-17a3-4b00-b0c3-c24e2a4e2817)
![image](https://github.com/user-attachments/assets/7c13d953-ba6a-40d8-9ecc-bcba56f1b68c)
![image](https://github.com/user-attachments/assets/196f159c-5182-4f5a-8c43-f3a8b37a4cda)


## Areas affected and ensured
List out the areas affected by your code changes.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  
