### PR TITLE
feat: TASK-2025-01018 send notification to admin upon creation of material request

### DIFF
--- a/beams/beams/custom_scripts/material_request/material_request.py
+++ b/beams/beams/custom_scripts/material_request/material_request.py
@@ -19,7 +19,7 @@ def notify_stock_managers(doc=None, method=None):
                 "user_type": "System User"
             },
             fields=["name", "email"]
-        ) if "Stock Manager" in frappe.get_roles(user.name)
+        ) if any(role in frappe.get_roles(user.name) for role in ["Stock Manager", "Admin"])
     ]
 
     if not recipients:


### PR DESCRIPTION
## Feature description
TASK-2025-01018 send notification to admin upon creation of material request


## Solution description
Added admin to the recipients in material request email notification

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/b56cb957-392d-4a47-b5a9-328654a4cda7)
![image](https://github.com/user-attachments/assets/f40605df-e548-477d-bd66-45e4f28dd1d2)
![image](https://github.com/user-attachments/assets/53783e88-cab7-4f10-8fe0-eb8a4f6eab44)


## Areas affected and ensured
List out the areas affected by your code changes.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
 
