### PR TITLE
feat:Add support for scanning assets and asset bundles into multi-select fields

### DIFF
--- a/beams/beams/doctype/outward_pass/outward_pass.js
+++ b/beams/beams/doctype/outward_pass/outward_pass.js
@@ -28,6 +28,80 @@ frappe.ui.form.on("Outward Pass", {
             });
         }
     },
+    scan_bundle: function (frm) {
+        if (!frm.doc.scan_bundle) {
+            frappe.msgprint(__('Please ensure a bundle is scanned.'));
+            return;
+        }
+
+        let scanned_value = frm.doc.scan_bundle.trim();
+
+        frappe.call({
+            method: "frappe.client.get",
+            args: {
+                doctype: "Asset Bundle",
+                name: scanned_value,
+                fields: ["name", "assets"]
+            },
+            callback: function (r) {
+                if (r.message) {
+                    let asset_bundle = r.message;
+                    let existing_bundle = (frm.doc.bundles || []).find(
+                        row => row.asset_bundle === asset_bundle.name
+                    );
+
+                    if (!existing_bundle) {
+                        let new_row = frm.add_child("bundles");
+                        new_row.asset_bundle = asset_bundle.name;
+                        frm.refresh_field("bundles");
+
+                        if (asset_bundle.assets && asset_bundle.assets.length > 0) {
+                            let existing_assets = frm.doc.assets || [];
+                            let new_assets = asset_bundle.assets.map(asset => ({ asset: asset.asset }));
+                            let merged_assets = [...existing_assets];
+                            new_assets.forEach(new_asset => {
+                                if (!merged_assets.some(existing => existing.asset === new_asset.asset)) {
+                                    merged_assets.push(new_asset);
+                                }
+                            });
+
+                            frm.set_value("assets", merged_assets);
+                            frm.refresh_field("assets");
+                        } else {
+                            frappe.msgprint(__('No assets found in this bundle!'));
+                        }
+                    } else {
+                        frappe.msgprint(__('Bundle is already added!'));
+                    }
+
+                    frm.set_value("scan_bundle", "");
+                } else {
+                    frappe.msgprint(__('No bundle found with this QR code!'));
+                }
+            },
+            error: function (err) {
+                frappe.msgprint(__('Error occurred while fetching bundle: ') + err.message);
+            }
+        });
+    },
+    scan_asset: function (frm) {
+        if (!frm.doc.scan_asset) {
+            frappe.msgprint(__('Please scan an asset.'));
+            return;
+        }
+        let scanned_asset = frm.doc.scan_asset.trim();
+        let existing_assets = frm.doc.assets || [];
+        let already_exists = existing_assets.some(row => row.asset === scanned_asset);
+
+        if (already_exists) {
+            frappe.msgprint(__('This asset is already added.'));
+        } else {
+            let new_row = frm.add_child("assets");
+            new_row.asset = scanned_asset;
+            frm.refresh_field("assets");
+        }
+        frm.set_value("scan_asset", "");
+    }
 });
 
 function mergeArrays(arr1, arr2, key) {
@@ -37,3 +111,4 @@ function mergeArrays(arr1, arr2, key) {
     );
     return unique;
 }
+

--- a/beams/beams/doctype/outward_pass/outward_pass.json
+++ b/beams/beams/doctype/outward_pass/outward_pass.json
@@ -8,9 +8,11 @@
  "field_order": [
   "employee_in_charge",
   "assets",
+  "scan_asset",
   "column_break_cgmc",
   "posting_date_and_time",
   "bundles",
+  "scan_bundle",
   "section_break_ekgu",
   "stock_items",
   "amended_from"
@@ -68,11 +70,23 @@
    "fieldtype": "Table",
    "label": "Stock Items",
    "options": "Asset Bundle Stock Item"
+  },
+  {
+   "fieldname": "scan_asset",
+   "fieldtype": "Data",
+   "label": "Scan Asset",
+   "options": "Barcode"
+  },
+  {
+   "fieldname": "scan_bundle",
+   "fieldtype": "Data",
+   "label": "Scan Bundle",
+   "options": "Barcode"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-05-14 11:05:53.631672",
+ "modified": "2025-05-14 15:20:31.619027",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Outward Pass",


### PR DESCRIPTION
## Feature description

- Add support for scanning assets and asset bundles into multi-select fields Assets and Bundles


## Solution description

- **Scanning individual assets via the scan_asset field:**
      -     Automatically adds the scanned asset to the assets Table MultiSelect.
      -     Prevents duplicate entries. 
      -     Clears the input field after each successful scan.

- **Scanning asset bundles via the scan_bundle field:** 
      -     Fetches the Asset Bundle document using its name (assumed to be from the QR code).
      -     Adds the bundle to the bundles Table MultiSelect if not already present.
      -     Extracts assets from the bundle and adds them to the assets Table MultiSelect.
      -     Ensures no duplicate assets are added.
      -     Clears the bundle scan field after processing.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/5b712c2f-527e-499a-bd3a-b6fb8c97e6e8)


## Areas affected and ensured

- Outward Pass


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - YES
  - Opera Mini
  - Safari
