### PR TITLE
feat:Created Attachments Table in Employee Travel Request doctype

### DIFF
--- a/beams/beams/doctype/attachment_detail/attachment_detail.json
+++ b/beams/beams/doctype/attachment_detail/attachment_detail.json
@@ -7,7 +7,7 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "ticket_name",
+  "document_name",
   "attach",
   "remarks"
  ],
@@ -26,19 +26,19 @@
    "label": "Remarks"
   },
   {
-   "fieldname": "ticket_name",
+   "fieldname": "document_name",
    "fieldtype": "Data",
    "in_list_view": 1,
-   "label": "Ticket Name"
+   "label": "Document Name"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-05-16 13:00:29.848967",
+ "modified": "2025-05-16 15:11:46.005876",
  "modified_by": "Administrator",
  "module": "BEAMS",
- "name": "Ticket Detail",
+ "name": "Attachment Detail",
  "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [],

--- a/beams/beams/doctype/attachment_detail/attachment_detail.py
+++ b/beams/beams/doctype/attachment_detail/attachment_detail.py
@@ -5,5 +5,5 @@
 from frappe.model.document import Document
 
 
-class TicketDetail(Document):
+class AttachmentDetail(Document):
 	pass

--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.js
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.js
@@ -10,7 +10,7 @@ frappe.ui.form.on('Employee Travel Request', {
                 });
         }
     },
-    
+
     refresh: function (frm) {
         if (!frm.is_new()) {
             frm.add_custom_button(__('Journal Entry'), function () {
@@ -96,6 +96,14 @@ frappe.ui.form.on('Employee Travel Request', {
             frm.set_df_property("travel_vehicle_allocation", "read_only", 0);
         } else {
             frm.set_df_property("travel_vehicle_allocation", "read_only", 1);
+        }
+
+        if (frm.doc.is_unplanned === 1) {
+            frm.set_df_property("ticket_details", "read_only", 0);
+        } else if (frm.doc.workflow_state === "Approved by HOD") {
+            frm.set_df_property("ticket_details", "read_only", 0);
+        } else {
+            frm.set_df_property("ticket_details", "read_only", 1);
         }
     },
 

--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.json
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.json
@@ -36,6 +36,7 @@
   "attendance_request",
   "reference_documents",
   "travel_vehicle_allocation",
+  "ticket_details",
   "reason_for_rejection",
   "section_break_fdom",
   "dynamic_link"
@@ -252,6 +253,13 @@
    "fieldtype": "Table",
    "label": "Travel Vehicle Allocation",
    "options": "Vehicle Allocation"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "ticket_details",
+   "fieldtype": "Table",
+   "label": "Ticket Details",
+   "options": "Ticket Detail"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -262,7 +270,7 @@
    "link_fieldname": "travel_request"
   }
  ],
- "modified": "2025-05-07 15:11:30.696679",
+ "modified": "2025-05-16 12:11:56.814195",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Employee Travel Request",

--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.json
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.json
@@ -36,7 +36,7 @@
   "attendance_request",
   "reference_documents",
   "travel_vehicle_allocation",
-  "ticket_details",
+  "attachments",
   "reason_for_rejection",
   "section_break_fdom",
   "dynamic_link"
@@ -256,10 +256,10 @@
   },
   {
    "allow_on_submit": 1,
-   "fieldname": "ticket_details",
+   "fieldname": "attachments",
    "fieldtype": "Table",
-   "label": "Ticket Details",
-   "options": "Ticket Detail"
+   "label": "Attachments",
+   "options": "Attachment Detail"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -270,7 +270,7 @@
    "link_fieldname": "travel_request"
   }
  ],
- "modified": "2025-05-16 12:11:56.814195",
+ "modified": "2025-05-16 15:14:49.480986",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Employee Travel Request",

--- a/beams/beams/doctype/ticket_detail/ticket_detail.json
+++ b/beams/beams/doctype/ticket_detail/ticket_detail.json
@@ -7,7 +7,7 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "document_name",
+  "ticket_name",
   "attach",
   "remarks"
  ],
@@ -19,23 +19,23 @@
    "label": "Attach"
   },
   {
-   "fieldname": "document_name",
-   "fieldtype": "Data",
-   "in_list_view": 1,
-   "label": "Ticket Name"
-  },
-  {
    "allow_on_submit": 1,
    "fieldname": "remarks",
    "fieldtype": "Small Text",
    "in_list_view": 1,
    "label": "Remarks"
+  },
+  {
+   "fieldname": "ticket_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Ticket Name"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-05-16 12:49:35.253114",
+ "modified": "2025-05-16 13:00:29.848967",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Ticket Detail",

--- a/beams/beams/doctype/ticket_detail/ticket_detail.json
+++ b/beams/beams/doctype/ticket_detail/ticket_detail.json
@@ -1,0 +1,48 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "format:TD-{YY}-{####}",
+ "creation": "2025-05-15 21:09:39.411470",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "document_name",
+  "attach",
+  "remarks"
+ ],
+ "fields": [
+  {
+   "fieldname": "attach",
+   "fieldtype": "Attach",
+   "in_list_view": 1,
+   "label": "Attach"
+  },
+  {
+   "fieldname": "document_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Ticket Name"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "remarks",
+   "fieldtype": "Small Text",
+   "in_list_view": 1,
+   "label": "Remarks"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2025-05-16 12:49:35.253114",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "Ticket Detail",
+ "naming_rule": "Expression",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/beams/beams/doctype/ticket_detail/ticket_detail.py
+++ b/beams/beams/doctype/ticket_detail/ticket_detail.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class TicketDetail(Document):
+	pass


### PR DESCRIPTION
## Feature description
Need to: Create Attachments Table in Employee Travel Request doctype when the employee travel request is unplanned and workflow state is "Approved by HOD"

## Solution description
Created Attachments Table in Employee Travel Request doctype  to manage Ticket and Accommodation Arrangements with the fields Attach , Document name and Remarks.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/d3cf4b2e-cafd-4766-adb9-39b80e6d0521)
![image](https://github.com/user-attachments/assets/07305bf3-cdce-462b-81b1-56c097cf5895)

## Areas affected and ensured
Employee Travel Request doctype

## Is there any existing behavior change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?
  - Mozilla Firefox

