### PR TITLE
feat:Use Date instead of Datetime for trip and incident date validations

### DIFF
--- a/beams/beams/doctype/trip_sheet/trip_sheet.js
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.js
@@ -49,7 +49,7 @@ frappe.ui.form.on('Trip Sheet', {
                     },
                     callback: function (r) {
                         if (r.message) {
-                            frappe.set_route("form", "Vehicle Incident Record", r.message);
+                            frappe.new_doc("Vehicle Incident Record", r.message);
                         }
                     }
                 });

--- a/beams/beams/doctype/trip_sheet/trip_sheet.json
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.json
@@ -118,14 +118,14 @@
   },
   {
    "fieldname": "starting_date_and_time",
-   "fieldtype": "Datetime",
-   "label": "Starting Date and Time ",
+   "fieldtype": "Date",
+   "label": "Starting Date",
    "reqd": 1
   },
   {
    "fieldname": "ending_date_and_time",
-   "fieldtype": "Datetime",
-   "label": " Ending Date and Time",
+   "fieldtype": "Date",
+   "label": " Ending Date",
    "reqd": 1
   },
   {
@@ -207,7 +207,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-05-13 11:40:29.508434",
+ "modified": "2025-05-16 11:47:41.240388",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Trip Sheet",

--- a/beams/beams/doctype/trip_sheet/trip_sheet.py
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.py
@@ -99,7 +99,7 @@ class TripSheet(Document):
             frappe.throw(
                 msg=_("Starting Date and Time cannot be after Ending Date and Time."),
                 title=_("Validation Error")
-                )    
+                )
 
     @frappe.whitelist()
     def calculate_and_validate_fuel_data(self):

--- a/beams/beams/doctype/trip_sheet/trip_sheet.py
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.py
@@ -36,6 +36,9 @@ class TripSheet(Document):
 
     @frappe.whitelist()
     def calculate_hours(self):
+        '''
+        Calculate hours between from_time and to_time for each trip, validating their order.
+        '''
         for trip in self.trip_details:
             if trip.from_time and trip.to_time:
                 from_time = frappe.utils.get_datetime(trip.from_time)
@@ -52,6 +55,10 @@ class TripSheet(Document):
 
     @frappe.whitelist()
     def validate_trip_times(self):
+        '''
+        Validates that all `from_time` and `to_time` values in the trip_details table fall
+        within the range defined by `starting_date_and_time` and `ending_date_and_time`.
+        '''
         if not self.starting_date_and_time or not self.ending_date_and_time:
             return
 

--- a/beams/beams/doctype/trip_sheet/trip_sheet.py
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.py
@@ -5,6 +5,7 @@ from frappe.model.document import Document
 from frappe.utils import get_datetime
 from frappe.utils import today
 from frappe import _
+from frappe.utils import getdate
 
 class TripSheet(Document):
     def validate(self):
@@ -51,15 +52,28 @@ class TripSheet(Document):
 
     @frappe.whitelist()
     def validate_trip_times(self):
+        if not self.starting_date_and_time or not self.ending_date_and_time:
+            return
+
+        starting_date = frappe.utils.getdate(self.starting_date_and_time)
+        ending_date = frappe.utils.getdate(self.ending_date_and_time)
+
         for row in self.trip_details:
             if row.get("from_time"):
-                if not (self.starting_date_and_time <= row.from_time <= self.ending_date_and_time):
-                    frappe.throw(_("Row #{0}: From Time must be between Starting and Ending Date and Time.").format(row.idx),
-                    title=_("Message"))
+                from_date = frappe.utils.getdate(row.from_time)
+                if not (starting_date <= from_date <= ending_date):
+                    frappe.throw(
+                        _("Row #{0}: From Date must be between Starting Date and Ending Date.").format(row.idx),
+                        title=_("Message")
+                    )
             if row.get("to_time"):
-                if not (self.starting_date_and_time <= row.to_time <= self.ending_date_and_time):
-                    frappe.throw(_("Row #{0}: To Time must be between Starting and Ending Date and Time.").format(row.idx),
-                    title=_("Message"))
+                to_date = frappe.utils.getdate(row.to_time)
+                if not (starting_date <= to_date <= ending_date):
+                    frappe.throw(
+                        _("Row #{0}: To Date must be between Starting Date and Ending Date.").format(row.idx),
+                        title=_("Message")
+                    )
+
 
     @frappe.whitelist()
     def validate_start_datetime_and_end_datetime(self):
@@ -70,14 +84,15 @@ class TripSheet(Document):
         if not self.starting_date_and_time or not self.ending_date_and_time:
             return
 
-        starting_date_and_time = get_datetime(self.starting_date_and_time)
-        ending_date_and_time = get_datetime(self.ending_date_and_time)
+        starting_date_and_time = getdate(self.starting_date_and_time)
+        ending_date_and_time = getdate(self.ending_date_and_time)
+
 
         if starting_date_and_time > ending_date_and_time:
             frappe.throw(
                 msg=_("Starting Date and Time cannot be after Ending Date and Time."),
                 title=_("Validation Error")
-                )
+                )    
 
     @frappe.whitelist()
     def calculate_and_validate_fuel_data(self):
@@ -165,15 +180,12 @@ def create_vehicle_incident_record(trip_sheet):
 
     trip_sheet_doc = frappe.get_doc("Trip Sheet", trip_sheet)
 
-    vehicle_incident = frappe.get_doc({
+    vehicle_incident_data = {
         "doctype": "Vehicle Incident Record",
         "trip_sheet": trip_sheet
-    })
+    }
 
-    vehicle_incident.insert(ignore_mandatory=True)
-
-    return vehicle_incident.name
-
+    return vehicle_incident_data
 
 @frappe.whitelist()
 def get_filtered_travel_requests(doctype, txt, searchfield, start, page_len, filters):

--- a/beams/beams/doctype/vehicle_incident_record/vehicle_incident_record.json
+++ b/beams/beams/doctype/vehicle_incident_record/vehicle_incident_record.json
@@ -87,13 +87,13 @@
   {
    "fetch_from": "trip_sheet.starting_date_and_time",
    "fieldname": "trip_start_date",
-   "fieldtype": "Datetime",
+   "fieldtype": "Date",
    "label": "Trip Start Date"
   },
   {
    "fetch_from": "trip_sheet.ending_date_and_time",
    "fieldname": "trip_end_date",
-   "fieldtype": "Datetime",
+   "fieldtype": "Date",
    "label": "Trip End Date"
   },
   {
@@ -114,7 +114,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-05-09 13:23:18.991915",
+ "modified": "2025-05-16 12:02:55.496053",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Vehicle Incident Record",

--- a/beams/beams/doctype/vehicle_incident_record/vehicle_incident_record.py
+++ b/beams/beams/doctype/vehicle_incident_record/vehicle_incident_record.py
@@ -19,6 +19,9 @@ class VehicleIncidentRecord(Document):
 
     @frappe.whitelist()
     def validate_offense_date_and_time(self):
+        '''
+        Validates that the offense date is not in the future and falls within the trip start and end dates.
+        '''
         if self.offense_date_and_time:
             offense_date = frappe.utils.getdate(self.offense_date_and_time)
             current_date = frappe.utils.getdate()

--- a/beams/beams/doctype/vehicle_incident_record/vehicle_incident_record.py
+++ b/beams/beams/doctype/vehicle_incident_record/vehicle_incident_record.py
@@ -6,6 +6,8 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 from frappe.utils import today
+from frappe.utils import getdate
+
 
 
 class VehicleIncidentRecord(Document):
@@ -18,13 +20,13 @@ class VehicleIncidentRecord(Document):
     @frappe.whitelist()
     def validate_offense_date_and_time(self):
         if self.offense_date_and_time:
-            current_datetime = frappe.utils.now_datetime()
-            offense_datetime = frappe.utils.get_datetime(self.offense_date_and_time)
+            offense_date = frappe.utils.getdate(self.offense_date_and_time)
+            current_date = frappe.utils.getdate()
 
-            if offense_datetime > current_datetime:
-                frappe.throw(_("Offense Date and Time cannot be in the future."))
+            if offense_date > current_date:
+                frappe.throw(_("Offense Date cannot be in the future."))
 
-            offense_date = offense_datetime.date()
+            offense_date = frappe.utils.getdate(self.offense_date_and_time)  
 
             if self.trip_start_date and self.trip_end_date:
                 start_date = frappe.utils.getdate(self.trip_start_date)


### PR DESCRIPTION
## Feature description
Use Date instead of Datetime for trip and incident date validations

## Solution description

- [x] TASK-2025-01028

- Changed 'starting_date_and_time' and 'ending_date_and_time' to Date fields in Trip Sheet
- Changed 'trip_start_date' and 'trip_end_date' to Date fields in Vehicle Incident Record
- Updated related validations to compare only dates
- Replaced frappe.set_route with frappe.new_doc since saving is not required during mapping.
- Simplified vehicle incident creation logic to return initial values without inserting

## Output screenshots (optional)
[Screencast from 16-05-25 03:57:28 PM IST.webm](https://github.com/user-attachments/assets/ad79d429-1c6c-4c30-b2c6-e7428a3cd605)


## Areas affected and ensured

- Tripsheet
- Vehicle Incident Record

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - YES
  - Opera Mini
  - Safari
