### PR TITLE
feat:add button to create Vehicle Safety Inspection

### DIFF
--- a/beams/beams/custom_scripts/vehicle/vehicle.js
+++ b/beams/beams/custom_scripts/vehicle/vehicle.js
@@ -1,0 +1,11 @@
+frappe.ui.form.on('Vehicle', {
+    refresh: function(frm) {
+        if (!frm.is_new()) {
+            frm.add_custom_button(__('New Vehicle Safety Inspection'), function () {
+                frappe.new_doc('Vehicle Safety Inspection', {
+                    vehicle: frm.doc.name
+                });
+            }, __('Create'));
+        }
+    }
+});

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -65,7 +65,8 @@ doctype_js = {
     "Lead":"beams/custom_scripts/lead/lead.js",
     "Payment Entry":"beams/custom_scripts/payment_entry/payment_entry.js",
     "Full and Final Statement":"beams/custom_scripts/full_and_final_statement/full_and_final_statement.js",
-    "HD Ticket":"beams/custom_scripts/hd_ticket/hd_ticket.js"
+    "HD Ticket":"beams/custom_scripts/hd_ticket/hd_ticket.js",
+    "Vehicle":"beams/custom_scripts/vehicle/vehicle.js"
 }
 doctype_list_js = {
     "Sales Invoice" : "beams/custom_scripts/sales_invoice/sales_invoice_list.js",

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -65,8 +65,7 @@ doctype_js = {
     "Lead":"beams/custom_scripts/lead/lead.js",
     "Payment Entry":"beams/custom_scripts/payment_entry/payment_entry.js",
     "Full and Final Statement":"beams/custom_scripts/full_and_final_statement/full_and_final_statement.js",
-    "HD Ticket":"beams/custom_scripts/hd_ticket/hd_ticket.js",
-    "Vehicle":"beams/custom_scripts/vehicle/vehicle.js"
+    "HD Ticket":"beams/custom_scripts/hd_ticket/hd_ticket.js"
 }
 doctype_list_js = {
     "Sales Invoice" : "beams/custom_scripts/sales_invoice/sales_invoice_list.js",


### PR DESCRIPTION
## Feature description

- Add custom button in Vehicle form to create new Vehicle Safety Inspection

## Solution description

- Added a custom button to the Vehicle form that allows users to create a new Vehicle Safety Inspection document.

- The button appears only when viewing an existing Vehicle (not on new unsaved forms) and automatically links the new inspection to the current Vehicle.

## Output screenshots (optional)

![image](https://github.com/user-attachments/assets/3cc9b67e-26e3-45e7-bac3-8c4ddf2ab45f)
![image](https://github.com/user-attachments/assets/804365ef-c3cd-4825-aba6-32ad1553519e)

## Areas affected and ensured

- Vehicle Safety Inspection
- Vehicle 

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - Yes
  - Opera Mini
  - Safari
