### PR TITLE
feat:Auto-create Journal Entry for employee-payable vehicle incident

### DIFF
--- a/beams/beams/doctype/beams_admin_settings/beams_admin_settings.json
+++ b/beams/beams/doctype/beams_admin_settings/beams_admin_settings.json
@@ -19,7 +19,8 @@
   "notification_for_asset_reservation",
   "role_receiving_asset_reservation_notification",
   "notification_template_for_asset_reservation",
-  "notification_for_asset_reservation_before"
+  "notification_for_asset_reservation_before",
+  "default_employee_payable_account"
  ],
  "fields": [
   {
@@ -123,12 +124,18 @@
    "fieldtype": "Link",
    "label": "Default Asset Location ",
    "options": "Location"
+  },
+  {
+   "fieldname": "default_employee_payable_account",
+   "fieldtype": "Link",
+   "label": "Default Employee Payable Account",
+   "options": "Account"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-04-09 12:57:13.541525",
+ "modified": "2025-05-17 11:08:21.034982",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "BEAMS Admin Settings",

--- a/beams/beams/doctype/vehicle_incident_record/vehicle_incident_record.py
+++ b/beams/beams/doctype/vehicle_incident_record/vehicle_incident_record.py
@@ -74,10 +74,7 @@ class VehicleIncidentRecord(Document):
                 })
 
                 journal_entry.insert()
-                journal_entry.submit()
-
                 row.journal_entry = journal_entry.name
-
                 frappe.msgprint(f"Journal Entry {journal_entry.name} has been created successfully.", alert=True, indicator="green")
 
         self.save(ignore_permissions=True)


### PR DESCRIPTION
## Feature description
Auto-create Journal Entry for employee-payable vehicle incidents

## Solution description

- [ ] TASK-2025-01048

- Added 'default employee payable account' to BEAMS Admin Settings
- Implemented `create_journal_entry_for_payable_items` in Vehicle Incident Record
  - Creates Journal Entry when `is_employee_payable` is checked
  - Links created Journal Entry to child row
  - Displays success message on creation
- Triggered JE creation on `on_update` if workflow_state == 'Approved'

## Output screenshots (optional)

[Screencast from 17-05-25 02:47:46 PM IST.webm](https://github.com/user-attachments/assets/6a03b10a-1030-475b-80c2-d90cd4360fe1)


## Areas affected and ensured

- JE

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - Yes 
  - Opera Mini
  - Safari
