### PR TITLE
TASK-2025-01006:Assign ticket to active Agents

### DIFF
--- a/beams/beams/custom_scripts/hd_ticket/hd_ticket.js
+++ b/beams/beams/custom_scripts/hd_ticket/hd_ticket.js
@@ -1,35 +1,39 @@
-frappe.ui.form.on('HD Ticket', {
-    /**
-     * Adds the 'Material Request' button under the 'Create' group
-     * if 'spare_part_needed' is checked.
-     *Runs when the form loads to show or hide fields based on user role
-     */
 
-    // Called when form is loaded
-    onload: function(frm) {
+frappe.ui.form.on('HD Ticket', {
+    onload(frm) {
+        if (frm.is_new() && !frm.doc.raised_by) {
+            frm.set_value('raised_by', frappe.session.user);
+        }
         handle_agent_visibility(frm);
     },
 
-    // Called every time the form is refreshed
-    refresh: function(frm) {
+    refresh(frm) {
         handle_agent_visibility(frm);
+        frm.clear_custom_buttons();
+
         if (frm.doc.spare_part_needed) {
             frm.page.set_inner_btn_group_as_primary(__('Create'));
             add_material_request_button(frm);
         }
     },
 
-    // Called when the 'spare_part_needed' checkbox is changed
-    spare_part_needed: function(frm) {
+    spare_part_needed(frm) {
         frm.clear_custom_buttons();
         if (frm.doc.spare_part_needed) {
             frm.page.set_inner_btn_group_as_primary(__('Create'));
             add_material_request_button(frm);
         }
+    },
+
+    ticket_type(frm) {
+        if (!frm.doc.ticket_type) return frm.set_value('agent_group', '');
+
+        frappe.db.get_value('HD Ticket Type', frm.doc.ticket_type, 'team_name')
+            .then(r => frm.set_value('agent_group', r.message?.team_name || ''))
+            .catch(() => frm.set_value('agent_group', ''));
     }
 });
 
-// Function to show/hide fields based on user's role
 function handle_agent_visibility(frm) {
     if (!frappe.user.has_role('Agent')) {
         const visible_fields = ['subject', 'raised_by', 'description'];
@@ -43,20 +47,15 @@ function handle_agent_visibility(frm) {
     }
 }
 
-// Function to add a custom button to create Material Request
 function add_material_request_button(frm) {
-    frm.add_custom_button(__('Material Request'), function() {
-        // Create a new Material Request document
-        let mr = frappe.model.get_new_doc('Material Request');
-
-        // Populate the Material Request with items from 'spare_part_item_table'
+    frm.add_custom_button(__('Material Request'), function () {
+        const mr = frappe.model.get_new_doc('Material Request');
         (frm.doc.spare_part_item_table || []).forEach(row => {
-            let child = frappe.model.add_child(mr, 'Material Request Item', 'items');
-            child.item_code = row.item;
-            child.qty = row.quantity;
-            child.schedule_date = row.required_by;
+            const item = frappe.model.add_child(mr, 'Material Request Item', 'items');
+            item.item_code = row.item;
+            item.qty = row.quantity;
+            item.schedule_date = row.required_by;
         });
-
         frappe.set_route('Form', 'Material Request', mr.name);
     }, __('Create'));
 }

--- a/beams/beams/custom_scripts/hd_ticket/hd_ticket.js
+++ b/beams/beams/custom_scripts/hd_ticket/hd_ticket.js
@@ -1,5 +1,16 @@
 
 frappe.ui.form.on('HD Ticket', {
+       /**
+    onload(frm) {
+     * Adds the 'Material Request' button under the 'Create' group
+        if (frm.is_new() && !frm.doc.raised_by) {
+     * if 'spare_part_needed' is checked.
+            frm.set_value('raised_by', frappe.session.user);
+     *Runs when the form loads to show or hide fields based on user role
+        }
+     */
+
+    // Called when form is loaded
     onload(frm) {
         if (frm.is_new() && !frm.doc.raised_by) {
             frm.set_value('raised_by', frappe.session.user);
@@ -8,6 +19,7 @@ frappe.ui.form.on('HD Ticket', {
     },
 
     refresh(frm) {
+        // Called every time the form is refreshed
         handle_agent_visibility(frm);
         frm.clear_custom_buttons();
 
@@ -17,6 +29,7 @@ frappe.ui.form.on('HD Ticket', {
         }
     },
 
+    // Called when the 'spare_part_needed' checkbox is changed
     spare_part_needed(frm) {
         frm.clear_custom_buttons();
         if (frm.doc.spare_part_needed) {
@@ -34,6 +47,7 @@ frappe.ui.form.on('HD Ticket', {
     }
 });
 
+// Function to show/hide fields based on user's role
 function handle_agent_visibility(frm) {
     if (!frappe.user.has_role('Agent')) {
         const visible_fields = ['subject', 'raised_by', 'description'];
@@ -49,6 +63,7 @@ function handle_agent_visibility(frm) {
 
 function add_material_request_button(frm) {
     frm.add_custom_button(__('Material Request'), function () {
+        // Create a new Material Request document
         const mr = frappe.model.get_new_doc('Material Request');
         (frm.doc.spare_part_item_table || []).forEach(row => {
             const item = frappe.model.add_child(mr, 'Material Request Item', 'items');

--- a/beams/beams/custom_scripts/hd_ticket/hd_ticket.js
+++ b/beams/beams/custom_scripts/hd_ticket/hd_ticket.js
@@ -50,7 +50,7 @@ frappe.ui.form.on('HD Ticket', {
 // Function to show/hide fields based on user's role
 function handle_agent_visibility(frm) {
     if (!frappe.user.has_role('Agent')) {
-        const visible_fields = ['subject', 'raised_by', 'description'];
+        const visible_fields = ['subject', 'raised_by', 'description','ticket_type'];
         frm.fields.forEach(field => {
             const name = field.df.fieldname;
             if (name && !['Section Break', 'Column Break'].includes(field.df.fieldtype)) {

--- a/beams/beams/custom_scripts/hd_ticket/hd_ticket.py
+++ b/beams/beams/custom_scripts/hd_ticket/hd_ticket.py
@@ -1,55 +1,144 @@
 import frappe
 from frappe.desk.form.assign_to import add as assign_to_user
-from frappe.desk.form.assign_to import clear as clear_all_assignments
 from helpdesk.helpdesk.doctype.hd_ticket.hd_ticket import HDTicket
 
 
 class HDTicketOverride(HDTicket):
 
     def on_update(self):
-        super(HDTicketOverride, self).on_update()
-        self.remove_assignment_if_not_in_team()
-
-    def after_insert(self):
-        super(HDTicketOverride, self).after_insert()
+        super().on_update()
+        if self.agent_group and self.status == "Open":
+            self.handle_assignment_by_team()
 
     def validate(self):
-        super(HDTicketOverride, self).validate()
+        super().validate()
 
-    def get_active_users_from_team(self, team_name):
-        active_users = []
-        team_doc = frappe.get_doc("HD Team", team_name)
-        for user_entry in team_doc.users:
-            agent = frappe.get_value("HD Agent", {"user": user_entry.user, "is_active": 1})
-            if agent:
-                active_users.append(user_entry.user)
-        return active_users
+    def handle_assignment_by_team(self):
+        """Auto-assign to an agent based on the team's assignment rule."""
+        try:
+            if not self.agent_group:
+                return
 
-    def remove_assignment_if_not_in_team(self):
-        if self.has_value_changed("agent_group") and self.agent_group and self.status == "Open":
-            current_assigned_agent_doc = self.get_assigned_agent()
+            team_exists = frappe.db.exists("HD Team", self.agent_group)
+            if not team_exists:
+                return
 
-            team_doc = frappe.get_doc("HD Team", self.agent_group)
-            assignment_rule = frappe.get_doc("Assignment Rule", team_doc.assignment_rule)
+            team = frappe.get_doc("HD Team", self.agent_group)
 
-            if (
-                current_assigned_agent_doc
-                and not current_assigned_agent_doc.in_group(self.agent_group)
-            ) and assignment_rule.users:
-                clear_all_assignments("HD Ticket", self.name)
-                frappe.publish_realtime(
-                    "helpdesk:update-ticket-assignee",
-                    {"ticket_id": self.name},
-                    after_commit=True,
-                )
+            if not team.assignment_rule:
+                return
+
+            rule_exists = frappe.db.exists("Assignment Rule", team.assignment_rule)
+            if not rule_exists:
+                return
+
+            rule = frappe.get_doc("Assignment Rule", team.assignment_rule)
 
             active_users = self.get_active_users_from_team(self.agent_group)
-            if active_users:
-                for user in active_users:
-                    assign_to_user({
-                        'doctype': self.doctype,
-                        'name': self.name,
-                        'assign_to': [user],
-                        'description': 'Auto-assigned to active HD Agent from team',
-                    })
-         
+            if not active_users:
+                return
+
+            selected_user = self.select_user_from_assignment_rule(rule, active_users)
+            if not selected_user:
+                return
+
+            existing_todo = frappe.db.exists("ToDo", {
+                "reference_type": self.doctype,
+                "reference_name": self.name,
+                "owner": selected_user,
+                "status": ["!=", "Cancelled"],
+            })
+
+            if not existing_todo:
+                assign_to_user({
+                    'doctype': self.doctype,
+                    'name': self.name,
+                    'assign_to': [selected_user],
+                    'description': 'Auto-assigned to active HD Agent from team',
+                })
+
+        except Exception:
+            frappe.log_error(frappe.get_traceback(), "handle_assignment_by_team")
+
+
+    def get_active_users_from_team(self, team_name):
+        try:
+            if not team_name or not frappe.db.exists("HD Team", team_name):
+                return []
+
+            team = frappe.get_doc("HD Team", team_name)
+            users = []
+            for row in team.users:
+                for user in row.user.split(","):
+                    user = user.strip()
+                    if frappe.db.exists("HD Agent", {"user": user, "is_active": 1}):
+                        users.append(user)
+            return users
+        except Exception:
+            frappe.log_error(frappe.get_traceback(), "get_active_users_from_team")
+            return []
+
+    def select_user_from_assignment_rule(self, rule_doc, active_users):
+        eligible_users = [
+            u.user for u in rule_doc.users
+            if u.user.lower().strip() in [a.lower().strip() for a in active_users]
+        ]
+        if not eligible_users:
+            return None
+
+        if rule_doc.assignment_based_on == "Round Robin":
+            return self.get_next_round_robin_user(rule_doc, eligible_users)
+        elif rule_doc.assignment_based_on == "Load":
+            return self.get_least_assigned_user(eligible_users)
+
+        return eligible_users[0]
+
+    def get_next_round_robin_user(self, rule_doc, eligible_users):
+        last_user = rule_doc.get("last_user") or ""
+        try:
+            idx = eligible_users.index(last_user)
+            next_user = eligible_users[(idx + 1) % len(eligible_users)]
+        except ValueError:
+            next_user = eligible_users[0]
+        rule_doc.last_user = next_user
+        rule_doc.save(ignore_permissions=True)
+        return next_user
+
+    def get_least_assigned_user(self, eligible_users):
+        if not eligible_users:
+            return None
+
+        counts = frappe.db.sql("""
+            SELECT owner, COUNT(*) AS count
+            FROM `tabToDo`
+            WHERE reference_type = 'HD Ticket'
+              AND owner IN %(users)s
+              AND status = 'Open'
+            GROUP BY owner
+        """, {"users": tuple(eligible_users)}, as_dict=True)
+
+        load_map = {user: 0 for user in eligible_users}
+        for row in counts:
+            load_map[row.owner] = row.count
+
+        return min(load_map, key=load_map.get)
+
+    def get_assigned_agent(self):
+        assignees = frappe.parse_json(getattr(self, '_assign', '[]') or '[]')
+        if assignees:
+            user = assignees[0]
+            if frappe.db.exists("HD Agent", {"user": user}):
+                return frappe.get_doc("HD Agent", {"user": user})
+
+        todos = frappe.get_all("ToDo", {
+            "reference_type": self.doctype,
+            "reference_name": self.name,
+            "status": "Open"
+        }, ["owner"], limit=1)
+
+        if todos:
+            user = todos[0].owner
+            if frappe.db.exists("HD Agent", {"user": user}):
+                return frappe.get_doc("HD Agent", {"user": user})
+
+        return None

--- a/beams/beams/custom_scripts/hd_ticket/hd_ticket.py
+++ b/beams/beams/custom_scripts/hd_ticket/hd_ticket.py
@@ -14,7 +14,7 @@ class HDTicketOverride(HDTicket):
         super().validate()
 
     def handle_assignment_by_team(self):
-        """Auto-assign to an agent based on the team's assignment rule."""
+        """Auto-assign the ticket to all active agents in the agent group team."""
         try:
             if not self.agent_group:
                 return
@@ -23,107 +23,52 @@ class HDTicketOverride(HDTicket):
             if not team_exists:
                 return
 
-            team = frappe.get_doc("HD Team", self.agent_group)
-
-            if not team.assignment_rule:
-                return
-
-            rule_exists = frappe.db.exists("Assignment Rule", team.assignment_rule)
-            if not rule_exists:
-                return
-
-            rule = frappe.get_doc("Assignment Rule", team.assignment_rule)
-
             active_users = self.get_active_users_from_team(self.agent_group)
             if not active_users:
                 return
 
-            selected_user = self.select_user_from_assignment_rule(rule, active_users)
-            if not selected_user:
-                return
-
-            existing_todo = frappe.db.exists("ToDo", {
-                "reference_type": self.doctype,
-                "reference_name": self.name,
-                "owner": selected_user,
-                "status": ["!=", "Cancelled"],
-            })
-
-            if not existing_todo:
-                assign_to_user({
-                    'doctype': self.doctype,
-                    'name': self.name,
-                    'assign_to': [selected_user],
-                    'description': 'Auto-assigned to active HD Agent from team',
+            for user in active_users:
+                existing_todo = frappe.db.exists("ToDo", {
+                    "reference_type": self.doctype,
+                    "reference_name": self.name,
+                    "owner": user,
+                    "status": ["!=", "Cancelled"],
                 })
+
+                if not existing_todo:
+                    assign_to_user({
+                        'doctype': self.doctype,
+                        'name': self.name,
+                        'assign_to': [user],
+                        'description': 'Auto-assigned to active HD Agent from team',
+                    })
 
         except Exception:
             frappe.log_error(frappe.get_traceback(), "handle_assignment_by_team")
 
-
     def get_active_users_from_team(self, team_name):
+        """Get list of active HD Agents from a given HD Team."""
         try:
             if not team_name or not frappe.db.exists("HD Team", team_name):
                 return []
 
             team = frappe.get_doc("HD Team", team_name)
             users = []
+
             for row in team.users:
                 for user in row.user.split(","):
                     user = user.strip()
                     if frappe.db.exists("HD Agent", {"user": user, "is_active": 1}):
                         users.append(user)
+
             return users
+
         except Exception:
             frappe.log_error(frappe.get_traceback(), "get_active_users_from_team")
             return []
 
-    def select_user_from_assignment_rule(self, rule_doc, active_users):
-        eligible_users = [
-            u.user for u in rule_doc.users
-            if u.user.lower().strip() in [a.lower().strip() for a in active_users]
-        ]
-        if not eligible_users:
-            return None
-
-        if rule_doc.assignment_based_on == "Round Robin":
-            return self.get_next_round_robin_user(rule_doc, eligible_users)
-        elif rule_doc.assignment_based_on == "Load":
-            return self.get_least_assigned_user(eligible_users)
-
-        return eligible_users[0]
-
-    def get_next_round_robin_user(self, rule_doc, eligible_users):
-        last_user = rule_doc.get("last_user") or ""
-        try:
-            idx = eligible_users.index(last_user)
-            next_user = eligible_users[(idx + 1) % len(eligible_users)]
-        except ValueError:
-            next_user = eligible_users[0]
-        rule_doc.last_user = next_user
-        rule_doc.save(ignore_permissions=True)
-        return next_user
-
-    def get_least_assigned_user(self, eligible_users):
-        if not eligible_users:
-            return None
-
-        counts = frappe.db.sql("""
-            SELECT owner, COUNT(*) AS count
-            FROM `tabToDo`
-            WHERE reference_type = 'HD Ticket'
-              AND owner IN %(users)s
-              AND status = 'Open'
-            GROUP BY owner
-        """, {"users": tuple(eligible_users)}, as_dict=True)
-
-        load_map = {user: 0 for user in eligible_users}
-        for row in counts:
-            load_map[row.owner] = row.count
-
-        return min(load_map, key=load_map.get)
-
     def get_assigned_agent(self):
+        """Get the first assigned HD Agent from the ToDo or _assign field."""
         assignees = frappe.parse_json(getattr(self, '_assign', '[]') or '[]')
         if assignees:
             user = assignees[0]

--- a/beams/beams/custom_scripts/hd_ticket/hd_ticket.py
+++ b/beams/beams/custom_scripts/hd_ticket/hd_ticket.py
@@ -1,0 +1,55 @@
+import frappe
+from frappe.desk.form.assign_to import add as assign_to_user
+from frappe.desk.form.assign_to import clear as clear_all_assignments
+from helpdesk.helpdesk.doctype.hd_ticket.hd_ticket import HDTicket
+
+
+class HDTicketOverride(HDTicket):
+
+    def on_update(self):
+        super(HDTicketOverride, self).on_update()
+        self.remove_assignment_if_not_in_team()
+
+    def after_insert(self):
+        super(HDTicketOverride, self).after_insert()
+
+    def validate(self):
+        super(HDTicketOverride, self).validate()
+
+    def get_active_users_from_team(self, team_name):
+        active_users = []
+        team_doc = frappe.get_doc("HD Team", team_name)
+        for user_entry in team_doc.users:
+            agent = frappe.get_value("HD Agent", {"user": user_entry.user, "is_active": 1})
+            if agent:
+                active_users.append(user_entry.user)
+        return active_users
+
+    def remove_assignment_if_not_in_team(self):
+        if self.has_value_changed("agent_group") and self.agent_group and self.status == "Open":
+            current_assigned_agent_doc = self.get_assigned_agent()
+
+            team_doc = frappe.get_doc("HD Team", self.agent_group)
+            assignment_rule = frappe.get_doc("Assignment Rule", team_doc.assignment_rule)
+
+            if (
+                current_assigned_agent_doc
+                and not current_assigned_agent_doc.in_group(self.agent_group)
+            ) and assignment_rule.users:
+                clear_all_assignments("HD Ticket", self.name)
+                frappe.publish_realtime(
+                    "helpdesk:update-ticket-assignee",
+                    {"ticket_id": self.name},
+                    after_commit=True,
+                )
+
+            active_users = self.get_active_users_from_team(self.agent_group)
+            if active_users:
+                for user in active_users:
+                    assign_to_user({
+                        'doctype': self.doctype,
+                        'name': self.name,
+                        'assign_to': [user],
+                        'description': 'Auto-assigned to active HD Agent from team',
+                    })
+         

--- a/beams/beams/custom_scripts/hd_ticket/hd_ticket.py
+++ b/beams/beams/custom_scripts/hd_ticket/hd_ticket.py
@@ -63,27 +63,9 @@ class HDTicketOverride(HDTicket):
 
             return users
 
+                                                                                                                     
         except Exception:
             frappe.log_error(frappe.get_traceback(), "get_active_users_from_team")
             return []
 
-    def get_assigned_agent(self):
-        """Get the first assigned HD Agent from the ToDo or _assign field."""
-        assignees = frappe.parse_json(getattr(self, '_assign', '[]') or '[]')
-        if assignees:
-            user = assignees[0]
-            if frappe.db.exists("HD Agent", {"user": user}):
-                return frappe.get_doc("HD Agent", {"user": user})
-
-        todos = frappe.get_all("ToDo", {
-            "reference_type": self.doctype,
-            "reference_name": self.name,
-            "status": "Open"
-        }, ["owner"], limit=1)
-
-        if todos:
-            user = todos[0].owner
-            if frappe.db.exists("HD Agent", {"user": user}):
-                return frappe.get_doc("HD Agent", {"user": user})
-
-        return None
+  

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -161,7 +161,8 @@ permission_query_conditions = {
 override_doctype_class = {
     "Attendance Request": "beams.beams.custom_scripts.attendance_request.attendance_request.AttendanceRequestOverride",
     "Shift Type": "beams.beams.custom_scripts.shift_type.shift_type.ShiftTypeOverride",
-    "Interview": "beams.beams.custom_scripts.interview.interview.InterviewOverride"
+    "Interview": "beams.beams.custom_scripts.interview.interview.InterviewOverride",
+    "HD Ticket": "beams.beams.custom_scripts.hd_ticket.hd_ticket.HDTicketOverride"  
 }
 
 # Document Events

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -162,7 +162,7 @@ override_doctype_class = {
     "Attendance Request": "beams.beams.custom_scripts.attendance_request.attendance_request.AttendanceRequestOverride",
     "Shift Type": "beams.beams.custom_scripts.shift_type.shift_type.ShiftTypeOverride",
     "Interview": "beams.beams.custom_scripts.interview.interview.InterviewOverride",
-    "HD Ticket": "beams.beams.custom_scripts.hd_ticket.hd_ticket.HDTicketOverride"  
+    "HD Ticket" :"beams.beams.custom_scripts.hd_ticket.hd_ticket.HDTicketOverride"
 }
 
 # Document Events

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -1,7 +1,8 @@
+import os
+import click
 import frappe
 from frappe import _
 from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
-
 
 def after_install():
     #Creating BEAMS specific custom fields

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -1,8 +1,7 @@
-import os
-import click
 import frappe
 from frappe import _
 from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+
 
 def after_install():
     #Creating BEAMS specific custom fields
@@ -59,6 +58,7 @@ def after_install():
     create_custom_fields(get_full_and_final_statement_custom_fields(),ignore_validate=True)
     create_custom_fields(get_expense_claim_custom_fields(),ignore_validate=True)
     create_custom_fields(get_hd_ticket_custom_fields(),ignore_validate=True)
+    create_custom_fields(get_hd_ticket_type_custom_fields(),ignore_validate=True)
 
 
     #Creating BEAMS specific Property Setters
@@ -129,6 +129,7 @@ def before_uninstall():
     delete_custom_fields(get_full_and_final_statement_custom_fields())
     delete_custom_fields(get_expense_claim_custom_fields())
     delete_custom_fields(get_hd_ticket_custom_fields())
+    delete_custom_fields(get_hd_ticket_type_custom_fields())
 
 
 def delete_custom_fields(custom_fields: dict):
@@ -170,6 +171,22 @@ def get_shift_assignment_custom_fields():
 
             }
 
+        ]
+    }
+    
+def get_hd_ticket_type_custom_fields():
+    '''
+    Custom fields that need to be added to the HD Ticket Type DocType
+    '''
+    return {
+        "HD Ticket Type": [
+            {
+                "fieldname": "team_name",
+                "fieldtype": "Link",
+                "label": "Team Name",
+                "options":"HD Team",
+                "insert_after": "is_system"
+            }
         ]
     }
 
@@ -3296,6 +3313,7 @@ def get_property_setters():
         BEAMS specific property setters that need to be added to the Customer ,Account and Supplier DocTypes
     '''
     return [
+    
         {
             "doctype_or_field": "DocField",
             "doc_type": "Customer",


### PR DESCRIPTION
## Feature description
Assign tickets to only Active Agents.

## Solution description
When a ticket is created assign ticket to only Agents who are Active.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/e06073f3-a12b-420f-892b-9f73bc8914b0)

## Areas affected and ensured
HD Ticket doctype

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox

