### PR TITLE
    TASK-2025-01036:hide fields for non-Agent users on HD Ticket load

### DIFF
--- a/beams/beams/custom_scripts/hd_ticket/hd_ticket.js
+++ b/beams/beams/custom_scripts/hd_ticket/hd_ticket.js
@@ -1,15 +1,25 @@
 frappe.ui.form.on('HD Ticket', {
-  /**
+    /**
      * Adds the 'Material Request' button under the 'Create' group
      * if 'spare_part_needed' is checked.
+     *Runs when the form loads to show or hide fields based on user role
      */
+
+    // Called when form is loaded
+    onload: function(frm) {
+        handle_agent_visibility(frm);
+    },
+
+    // Called every time the form is refreshed
     refresh: function(frm) {
+        handle_agent_visibility(frm);
         if (frm.doc.spare_part_needed) {
             frm.page.set_inner_btn_group_as_primary(__('Create'));
             add_material_request_button(frm);
         }
     },
 
+    // Called when the 'spare_part_needed' checkbox is changed
     spare_part_needed: function(frm) {
         frm.clear_custom_buttons();
         if (frm.doc.spare_part_needed) {
@@ -19,12 +29,26 @@ frappe.ui.form.on('HD Ticket', {
     }
 });
 
+// Function to show/hide fields based on user's role
+function handle_agent_visibility(frm) {
+    if (!frappe.user.has_role('Agent')) {
+        const visible_fields = ['subject', 'raised_by', 'description'];
+        frm.fields.forEach(field => {
+            const name = field.df.fieldname;
+            if (name && !['Section Break', 'Column Break'].includes(field.df.fieldtype)) {
+                frm.set_df_property(name, 'hidden', !visible_fields.includes(name));
+            }
+        });
+        frm.refresh_fields();
+    }
+}
+
 // Function to add a custom button to create Material Request
 function add_material_request_button(frm) {
     frm.add_custom_button(__('Material Request'), function() {
-      // Create a new Material Request document
+        // Create a new Material Request document
         let mr = frappe.model.get_new_doc('Material Request');
-           
+
         // Populate the Material Request with items from 'spare_part_item_table'
         (frm.doc.spare_part_item_table || []).forEach(row => {
             let child = frappe.model.add_child(mr, 'Material Request Item', 'items');


### PR DESCRIPTION
## Feature description
     --hide fields for non-Agent users on HD Ticket load

## Solution description
    --When the form loads (onload), the function checks if the user has the role Agent.
    --If the user is not an Agent, it hides all fields except:
    subject
    raised_by
    description

## Output screenshots (optional)
[Screencast from 17-05-25 11:25:49 PM IST.webm](https://github.com/user-attachments/assets/83ce1414-68ef-43c2-97f4-58e8dc96378a)


## Is there any existing behavior change of other features due to this code change?
      --No. 

## Was this feature tested on the browsers?
    --Mozilla Firefox
  
