### PR TITLE
feat: TASK-2025-01039 create a vehicle documents log doctype and update child table

### DIFF
--- a/beams/beams/doctype/vehicle_documents/vehicle_documents.json
+++ b/beams/beams/doctype/vehicle_documents/vehicle_documents.json
@@ -19,8 +19,7 @@
    "in_list_view": 1,
    "label": "Document",
    "options": "Vehicle Document",
-   "reqd": 1,
-   "unique": 1
+   "reqd": 1
   },
   {
    "default": "Today",
@@ -48,7 +47,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-03-17 15:17:06.506556",
+ "modified": "2025-05-19 09:23:20.497204",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Vehicle Documents",

--- a/beams/beams/doctype/vehicle_documents_log/test_vehicle_documents_log.py
+++ b/beams/beams/doctype/vehicle_documents_log/test_vehicle_documents_log.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, efeone and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestVehicleDocumentsLog(FrappeTestCase):
+	pass

--- a/beams/beams/doctype/vehicle_documents_log/vehicle_documents_log.js
+++ b/beams/beams/doctype/vehicle_documents_log/vehicle_documents_log.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, efeone and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Vehicle Documents Log", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/beams/beams/doctype/vehicle_documents_log/vehicle_documents_log.json
+++ b/beams/beams/doctype/vehicle_documents_log/vehicle_documents_log.json
@@ -1,0 +1,88 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "format:VDL-{YYYY}-{#####}",
+ "creation": "2025-05-17 10:59:25.811855",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "section_break_vgbn",
+  "vehicle",
+  "license_plate",
+  "column_break_jiz6",
+  "make",
+  "model",
+  "vehicle_document_details_section",
+  "vehicle_documents"
+ ],
+ "fields": [
+  {
+   "fieldname": "section_break_vgbn",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fetch_from": "vehicle.license_plate",
+   "fieldname": "license_plate",
+   "fieldtype": "Data",
+   "label": "License Plate"
+  },
+  {
+   "fieldname": "vehicle",
+   "fieldtype": "Link",
+   "label": "Vehicle",
+   "options": "Vehicle"
+  },
+  {
+   "fetch_from": "vehicle.make",
+   "fieldname": "make",
+   "fieldtype": "Data",
+   "label": "Make"
+  },
+  {
+   "fetch_from": "vehicle.model",
+   "fieldname": "model",
+   "fieldtype": "Data",
+   "label": "Model"
+  },
+  {
+   "fieldname": "column_break_jiz6",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "vehicle_document_details_section",
+   "fieldtype": "Section Break",
+   "label": "Vehicle Document Details"
+  },
+  {
+   "fieldname": "vehicle_documents",
+   "fieldtype": "Table",
+   "label": "Vehicle Documents",
+   "options": "Vehicle Documents"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2025-05-19 10:18:17.596085",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "Vehicle Documents Log",
+ "naming_rule": "Expression",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/beams/beams/doctype/vehicle_documents_log/vehicle_documents_log.py
+++ b/beams/beams/doctype/vehicle_documents_log/vehicle_documents_log.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class VehicleDocumentsLog(Document):
+	pass

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -368,7 +368,10 @@ doc_events = {
     },
     "Expense Claim": {
         "after_insert": "beams.beams.custom_scripts.expense_claim.expense_claim.notify_expense_approver_on_creation"
-    }
+    },
+    "Vehicle" :{
+        "on_update":"beams.beams.custom_scripts.vehicle.vehicle.create_vehicle_documents_log"    
+    }    
 }
 
 # Scheduled Tasks


### PR DESCRIPTION
## Feature description
TASK-2025-01039 create a vehicle documents log doctype and update child table 


## Solution description

- Removed the 'unique' property from the 'documents' field in the Vehicle Documents child table, as it is no longer necessary.
- Created a doctype named Vehicle Documents Log
- Logs newly added vehicle document records into a single log per vehicle, avoiding duplicates and preserving a history of document entries.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/944701fa-79da-4036-9020-d8320635b247)
![image](https://github.com/user-attachments/assets/67a43dc2-fdb6-4385-88b9-660fed371cff)
![image](https://github.com/user-attachments/assets/f2c25ff9-40aa-4588-94de-a6fac1446a7b)


## Areas affected and ensured
List out the areas affected by your code changes.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  
