### PR TITLE
feat:Auto-create Trip Sheets on ETR approval 

### DIFF
--- a/beams/beams/doctype/trip_sheet/trip_sheet.py
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.py
@@ -8,13 +8,6 @@ from frappe import _
 
 class TripSheet(Document):
     def validate(self):
-        # Ensure the final_odometer_reading is not None and is an integer
-        if self.final_odometer_reading is None:
-            frappe.throw("Please enter an integer value for Final Odometer Reading.")
-
-        if not isinstance(self.final_odometer_reading, int):
-            frappe.throw("Please enter an integer value for Final Odometer Reading.")
-
         if not self.travel_requests and not self.transportation_requests:
             frappe.throw("Please provide at least one of Travel Requests or Transportation Requests.")
 
@@ -32,6 +25,16 @@ class TripSheet(Document):
             self.safety_inspection_completed = 1 if all_fit_for_use else 0
         else:
             self.safety_inspection_completed = 0
+
+    def on_submit(self):
+        self.validate_final_odometer_reading()
+
+    def validate_final_odometer_reading(self):
+        if self.final_odometer_reading is None:
+            frappe.throw("Please enter an integer value for Final Odometer Reading.")
+
+        if not isinstance(self.final_odometer_reading, int):
+            frappe.throw("Please enter an integer value for Final Odometer Reading.")
 
     @frappe.whitelist()
     def calculate_hours(self):

--- a/beams/beams/doctype/vehicle_incident_record/vehicle_incident_record.py
+++ b/beams/beams/doctype/vehicle_incident_record/vehicle_incident_record.py
@@ -38,43 +38,43 @@ class VehicleIncidentRecord(Document):
                     frappe.throw(_("Offense Date must be between Start Date and End Date of the trip."))
                     
     def create_journal_entry_for_payable_items(self):
-        '''
-        Automatically creates and submits a Journal Entry for each payable vehicle incident
-        where the 'is_employee_payable' field is checked
-        '''
-        settings = frappe.get_single("BEAMS Admin Settings")
-        account = settings.default_employee_payable_account
+            '''
+            Automatically creates and submits a Journal Entry for each payable vehicle incident
+            where the 'is_employee_payable' field is checked
+            '''
+            settings = frappe.get_single("BEAMS Admin Settings")
+            account = settings.default_employee_payable_account
 
-        if not account:
-            frappe.throw("Default Employee Payable Account is not set in BEAMS Admin Settings.")
+            if not account:
+                frappe.throw("Default Employee Payable Account is not set in BEAMS Admin Settings.")
 
-        employee_id = frappe.db.get_value("Driver", self.driver, "employee")
-        if not employee_id:
-            frappe.throw(f"Employee not linked to Driver {self.driver}")
+            employee_id = frappe.db.get_value("Driver", self.driver, "employee")
+            if not employee_id:
+                frappe.throw(f"Employee not linked to Driver {self.driver}")
 
-        for row in self.vehicle_incident_details:
-            if row.is_employee_payable and not row.get("journal_entry"):  
-                journal_entry = frappe.new_doc("Journal Entry")
-                journal_entry.voucher_type = "Journal Entry"
-                journal_entry.posting_date = self.posting_date or nowdate()
-                journal_entry.company = frappe.defaults.get_user_default("Company")
-                journal_entry.remark = f"Payable offense recorded in Vehicle Incident Record {self.name}"
+            for row in self.vehicle_incident_details:
+                if row.is_employee_payable and not row.get("journal_entry"):  
+                    journal_entry = frappe.new_doc("Journal Entry")
+                    journal_entry.voucher_type = "Journal Entry"
+                    journal_entry.posting_date = self.posting_date or nowdate()
+                    journal_entry.company = frappe.defaults.get_user_default("Company")
+                    journal_entry.remark = f"Payable offense recorded in Vehicle Incident Record {self.name}"
 
-                journal_entry.append("accounts", {
-                    "account": account,
-                    "party_type": "Employee",
-                    "party": employee_id,
-                    "debit_in_account_currency": row.amount
-                })
-                journal_entry.append("accounts", {
-                    "account": account,
-                    "party_type": "Employee",
-                    "party": employee_id,
-                    "credit_in_account_currency": row.amount
-                })
+                    journal_entry.append("accounts", {
+                        "account": account,
+                        "party_type": "Employee",
+                        "party": employee_id,
+                        "debit_in_account_currency": row.amount
+                    })
+                    journal_entry.append("accounts", {
+                        "account": account,
+                        "party_type": "Employee",
+                        "party": employee_id,
+                        "credit_in_account_currency": row.amount
+                    })
 
-                journal_entry.insert()
-                row.journal_entry = journal_entry.name
-                frappe.msgprint(f"Journal Entry {journal_entry.name} has been created successfully.", alert=True, indicator="green")
+                    journal_entry.insert()
+                    row.journal_entry = journal_entry.name
+                    frappe.msgprint(f"Journal Entry {journal_entry.name} has been created successfully.", alert=True, indicator="green")
 
-        self.save(ignore_permissions=True)
+            self.save(ignore_permissions=True)


### PR DESCRIPTION
## Feature description
feat: Auto-create Trip Sheets on ETR approval and validate odometer on Trip Sheet submit
## Solution description

- [ ] TASK-2025-01035

- Moved final odometer validation logic from `validate` to `on_submit` in Trip Sheet to enforce check only on submission.

Checked  if any Trip Sheet exists already linked to this Employee Travel Request.

    If such a Trip Sheet exists, then:

    For each vehicle in the Employee Travel Request:

        If that specific vehicle doesn’t already have a Trip Sheet linked to this Employee Travel Request → Create a new Trip Sheet for it.

    If no Trip Sheet at all exists for this Employee Travel Request:

    Then, create a Trip Sheet for every vehicle in the request.

## Output screenshots (optional)
[Screencast from 19-05-25 01:37:29 PM IST.webm](https://github.com/user-attachments/assets/fea3c8e1-9f4e-49d8-beaa-4a54301e76aa)



## Areas affected and ensured

- tripsheet

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox -yes
  - Opera Mini
  - Safari
