### PR TITLE
fix: TASK-2025-01055 mark attendance request properly

### DIFF
--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.py
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.py
@@ -81,6 +81,21 @@ class EmployeeTravelRequest(Document):
         employees = list(set(filter(None, employees)))
 
         for emp in employees:
+            if emp == self.requested_by:
+                attendance = frappe.get_doc({
+                    "doctype": "Attendance Request",
+                    "employee": emp,
+                    "from_date": self.start_date,
+                    "to_date": self.end_date,
+                    "request_type": "On Duty",
+                    "company": frappe.db.get_value("Employee", emp, "company"),
+                    "description": f"From Travel Request {self.name}",
+                    "reason": "On Duty"
+                })
+                attendance.insert(ignore_permissions=True)
+                frappe.msgprint(f"Attendance Request created for {emp}", alert=True, indicator='green')
+                continue
+
             overlapping = frappe.db.exists(
                 "Attendance Request",
                 {


### PR DESCRIPTION
## Feature description
TASK-2025-01055 mark attendance request properly when an employee travel request approved.


## Solution description
Issue: If the same group of employees (including requested_by) already exists in a previously Approved Employee Travel Request with mark_attendance, then they apply for another employee travel request with mark_attendance that time all employees get Attendance Requests except the requested_by employee.
Resolved above issue.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/78a99ab4-d7b8-4426-8241-ee5acbaea178)
![image](https://github.com/user-attachments/assets/2bd1934f-65da-42fb-b26f-145688ac6f34)
![image](https://github.com/user-attachments/assets/2dbaf226-05c5-43ad-8689-80ce9866ab86)


## Areas affected and ensured
List out the areas affected by your code changes.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox

