### PR TITLE
feat: TASK-2025-01061 allow only the admin to see the journal entry button

### DIFF
--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.js
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.js
@@ -11,7 +11,7 @@ frappe.ui.form.on('Employee Travel Request', {
         }
     },
     refresh: function (frm) {
-        if (!frm.is_new()) {
+        if (!frm.is_new() && frappe.user.has_role("Admin")) {
             frm.add_custom_button(__('Journal Entry'), function () {
                 let journal_entry = frappe.model.get_new_doc("Journal Entry");
                 journal_entry.voucher_type = "Journal Entry";


### PR DESCRIPTION
## Feature description
TASK-2025-01061 allow only the admin to see the journal entry button

## Solution description
Restricted the visibility of the Journal Entry button to the admin, it should not be visible to other users

## Output screenshots (optional)
Admin
![image](https://github.com/user-attachments/assets/d1c20684-afe5-4642-a90b-9d91733360ed)
HOD
![image](https://github.com/user-attachments/assets/2fa30775-2c9e-4e31-8dd5-77c94cde8ad7)


## Areas affected and ensured
List out the areas affected by your code changes.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
 
