### PR TITLE
feat: TASK-2025-01064 mark requested person id in material request

### DIFF
--- a/beams/beams/custom_scripts/material_request/material_request.js
+++ b/beams/beams/custom_scripts/material_request/material_request.js
@@ -1,0 +1,14 @@
+
+frappe.ui.form.on('Material Request', {
+    onload(frm) {
+        if (!frm.doc.requested_by) {
+            frappe.db.get_value('Employee', { user_id: frappe.session.user }, 'name')
+                .then(r => {
+                    if (r.message) {
+                        frm.set_value('requested_by', r.message.name);
+                    }
+                });
+        }
+    }
+});
+

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -66,7 +66,8 @@ doctype_js = {
     "Payment Entry":"beams/custom_scripts/payment_entry/payment_entry.js",
     "Full and Final Statement":"beams/custom_scripts/full_and_final_statement/full_and_final_statement.js",
     "HD Ticket":"beams/custom_scripts/hd_ticket/hd_ticket.js",
-    "Vehicle":"beams/custom_scripts/vehicle/vehicle.js"
+    "Vehicle":"beams/custom_scripts/vehicle/vehicle.js",
+    "Material Request":"beams/custom_scripts/material_request/material_request.js"
 }
 doctype_list_js = {
     "Sales Invoice" : "beams/custom_scripts/sales_invoice/sales_invoice_list.js",

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -4099,6 +4099,13 @@ def get_material_request_custom_fields():
                 "no_copy":1,
                 "depends_on": "eval:doc.budget_exceeded == 1"
 
+            },
+            {
+                "fieldname": "requested_by",
+                "fieldtype": "Link",
+                "label": "Requested By",
+                "insert_after": "material_request_type",
+                "options": "Employee"
             }
         ]
     }


### PR DESCRIPTION
## Feature description
TASK-2025-01064 mark requested person id in material request


## Solution description

- Added a field named ' Requested By' in material request
- Automatically sets the "requested_by" field in the Material Request form to the current user's associated Employee record when the form loads

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/f1f2ecd9-5e9a-427e-8044-e4297aa25ac5)


## Areas affected and ensured
List out the areas affected by your code changes.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox

