### PR TITLE
feat: TASK-2025-01065 add connections in employee travel request

### DIFF
--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.js
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.js
@@ -16,7 +16,9 @@ frappe.ui.form.on('Employee Travel Request', {
                 let journal_entry = frappe.model.get_new_doc("Journal Entry");
                 journal_entry.voucher_type = "Journal Entry";
                 journal_entry.posting_date = frm.doc.posting_date;
+                journal_entry.employee_travel_request = frm.doc.name;
                 journal_entry.user_remark = "Journal Entry for Travel Request " + frm.doc.name;
+                frappe.model.set_value("Journal Entry", journal_entry.name, "employee_travel_request", frm.doc.name);
                 frappe.set_route("form", "Journal Entry", journal_entry.name);
             }, __("Create"));
         }

--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.json
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.json
@@ -245,7 +245,7 @@
    "default": "0",
    "fieldname": "is_vehicle_required",
    "fieldtype": "Check",
-   "label": "Is Vehicle Required"
+   "label": "Vehicle Required"
   },
   {
    "allow_on_submit": 1,
@@ -268,9 +268,17 @@
   {
    "link_doctype": "Expense Claim",
    "link_fieldname": "travel_request"
+  },
+  {
+   "link_doctype": "Journal Entry",
+   "link_fieldname": "employee_travel_request"
+  },
+  {
+   "link_doctype": "Trip Sheet",
+   "link_fieldname": "employee_travel_request"
   }
  ],
- "modified": "2025-05-16 15:14:49.480986",
+ "modified": "2025-05-20 17:15:56.197036",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Employee Travel Request",

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -4251,6 +4251,14 @@ def get_journal_entry_custom_fields():
                 "read_only": 1,
                 "options": "Substitute Booking",
                 "insert_after": "batta_claim_reference"
+            },
+            {
+                "fieldname": "employee_travel_request",
+                "fieldtype": "Link",
+                "label": "Employee Travel Request",
+                "options": "Employee Travel Request",
+                "insert_after":"naming_series",
+                "read_only":1
             }
 
         ]


### PR DESCRIPTION
## Feature description
TASK-2025-01065 Add connections in Employee Travel Request for journal entry, trip sheet.

## Solution description

- Added a field named 'employee_travel_request ' in journal entry and mapped value to this field
- Changed is_vehicle_required label to vehicle_required in Employee Travel Request
- Added connections in Employee Travel Request for journal entry, trip sheet

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/bcfe7d7e-3307-4e72-b807-701dd2e53874)
![image](https://github.com/user-attachments/assets/3d4e06a0-b21b-464a-ba6d-f6a108f7c9ea)
![image](https://github.com/user-attachments/assets/69a8c2f9-8071-4910-8280-241931378eb3)


## Areas affected and ensured
List out the areas affected by your code changes.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
