### PR TITLE
fix:fixed the odometer issue in trip sheet doctype

### DIFF
--- a/beams/beams/doctype/trip_sheet/trip_sheet.js
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.js
@@ -17,21 +17,6 @@ frappe.ui.form.on('Trip Sheet', {
             doc: frm.doc,
         });
     },
-    vehicle: function (frm) {
-        if (frm.doc.vehicle) {
-            frappe.call({
-                method: 'beams.beams.doctype.trip_sheet.trip_sheet.get_last_odometer',
-                args: {
-                    vehicle: frm.doc.vehicle
-                },
-                callback: function (r) {
-                    frm.set_value("initial_odometer_reading", r.message || 0);
-                }
-            });
-        } else {
-            frm.set_value("initial_odometer_reading", null);
-        }
-    },
     final_odometer_reading: function (frm) {
         frm.call("calculate_and_validate_fuel_data");
     },
@@ -131,9 +116,18 @@ frappe.ui.form.on('Trip Sheet', {
             };
         });
     },
-    // Trigger when the vehicle field changes
-    vehicle(frm) {
+    vehicle: function(frm) {
         if (frm.doc.vehicle) {
+            frappe.call({
+                method: 'beams.beams.doctype.trip_sheet.trip_sheet.get_last_odometer',
+                args: {
+                    vehicle: frm.doc.vehicle
+                },
+                callback: function(r) {
+                    frm.set_value("initial_odometer_reading", r.message || 0);
+                }
+            });
+
             frappe.db.get_list('Vehicle Safety Inspection', {
                 filters: {
                     vehicle: frm.doc.vehicle
@@ -149,7 +143,9 @@ frappe.ui.form.on('Trip Sheet', {
                     frm.refresh_field('vehicle_safety_inspection_details');
                 }
             });
+
         } else {
+            frm.set_value("initial_odometer_reading", null);
             frm.set_value('vehicle_template', null);
             frm.clear_table('vehicle_safety_inspection_details');
             frm.refresh_field('vehicle_safety_inspection_details');


### PR DESCRIPTION
## Feature description
Need to:Fix the odometer issue in trip sheet doctype ie, two vehicle functions defined inside the js file so fetching of initial odometer is not working 

## Solution description
Fixed the odometer issue in trip sheet doctype ie,  Replaced existing vehicle field function in Trip Sheet to ensure correct fetching of initial odometer

## Output screenshots (optional)
[Screencast from 21-05-25 12:29:47 PM IST.webm](https://github.com/user-attachments/assets/c7877550-d596-4d1f-93e2-2620408fd364)


## Areas affected and ensured
Trip sheet doctype

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox

