### PR TITLE
feat: TASK-2025-01078 for automatically created trip sheet bring safety insepection template

### DIFF
--- a/beams/beams/doctype/trip_sheet/trip_sheet.json
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.json
@@ -23,7 +23,6 @@
   "vehicle_template",
   "vehicle_safety_inspection_details",
   "safety_inspection_completed",
-  "remarks",
   "trip_details_section",
   "trip_details",
   "section_break_ygej",
@@ -33,7 +32,9 @@
   "column_break_anpp",
   "fuel_consumed",
   "mileage",
-  "amended_from"
+  "amended_from",
+  "section_break_kwfq",
+  "remarks"
  ],
  "fields": [
   {
@@ -202,12 +203,16 @@
    "fieldtype": "Check",
    "label": "Safety Inspection Completed",
    "read_only": 1
+  },
+  {
+   "fieldname": "section_break_kwfq",
+   "fieldtype": "Section Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-05-16 11:47:41.240388",
+ "modified": "2025-05-22 11:06:53.708549",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Trip Sheet",


### PR DESCRIPTION

## Feature description
TASK-2025-01078 for automatically created trip sheet bring safety inspection template


## Solution description
Rearranged position of field named 'remarks' in trip sheet
Added a feature to bring the safety inspection template of the vehicle into the automatically created trip sheet.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/a3795595-2e54-4b70-b363-bd842d972b4b)
![image](https://github.com/user-attachments/assets/7541e427-6464-4d26-aa9e-83033c256954)
![image](https://github.com/user-attachments/assets/6a111b3f-cd9f-42fb-a7da-06a64aae18cb)


## Areas affected and ensured
List out the areas affected by your code changes.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
