### PR TITLE
feat:Added vehicle field in vehicle incident record doctye

### DIFF
--- a/beams/beams/doctype/vehicle_incident_record/vehicle_incident_record.json
+++ b/beams/beams/doctype/vehicle_incident_record/vehicle_incident_record.json
@@ -10,6 +10,7 @@
   "trip_sheet",
   "driver",
   "driver_name",
+  "vehicle",
   "column_break_hwrj",
   "offense_type",
   "trip_start_date",
@@ -109,12 +110,20 @@
   {
    "fieldname": "column_break_trzy",
    "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "trip_sheet.vehicle",
+   "fieldname": "vehicle",
+   "fieldtype": "Link",
+   "label": "Vehicle",
+   "options": "Vehicle",
+   "reqd": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-05-16 12:02:55.496053",
+ "modified": "2025-05-22 11:26:14.062368",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Vehicle Incident Record",


### PR DESCRIPTION
## Feature description
Need to: Add vehicle field in vehicle incident record doctype and when create vehicle incident record doctype  from trip sheet doctype then map  the vehicle name of that trip sheet

## Solution description
Added vehicle field in vehicle incident record doctype and when create vehicle incident record doctype  from trip sheet doctype then mapped  the vehicle name of that trip sheet

## Output screenshots (optional)
[Screencast from 22-05-25 11:30:17 AM IST.webm](https://github.com/user-attachments/assets/4e9c3de4-0cca-4d2e-974c-ae4fb762a75a)



## Areas affected and ensured
Vehicle incident record doctype

## Is there any existing behavior change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?
  - Mozilla Firefox
 
