### PR TITLE
TASK-2025-01097 add ability to scan qrcode for asset in asset auditing

### DIFF
--- a/beams/beams/doctype/asset_auditing/asset_auditing.js
+++ b/beams/beams/doctype/asset_auditing/asset_auditing.js
@@ -14,6 +14,7 @@ frappe.ui.form.on('Asset Auditing', {
     posting_date:function (frm){
       frm.call("validate_posting_date");
     },
+    // Fetch asset by scanned QR code and set 'asset' field
     scan_qr_code: function(frm) {
         if (frm.doc.scan_qr_code) {
             frappe.db.get_value('Asset', frm.doc.scan_qr_code, 'name')

--- a/beams/beams/doctype/asset_auditing/asset_auditing.js
+++ b/beams/beams/doctype/asset_auditing/asset_auditing.js
@@ -13,5 +13,19 @@ frappe.ui.form.on('Asset Auditing', {
     },
     posting_date:function (frm){
       frm.call("validate_posting_date");
+    },
+    scan_qr_code: function(frm) {
+        if (frm.doc.scan_qr_code) {
+            frappe.db.get_value('Asset', frm.doc.scan_qr_code, 'name')
+                .then(r => {
+                    if (r && r.message) {
+                        frm.set_value('asset', r.message.name);
+                    } else {
+                        frappe.msgprint(__('Asset not found for scanned QR code'));
+                        frm.set_value('asset', null);
+                    }
+                    frm.set_value('scan_qr_code', null);
+                });
+        }
     }
 });

--- a/beams/beams/doctype/asset_auditing/asset_auditing.json
+++ b/beams/beams/doctype/asset_auditing/asset_auditing.json
@@ -6,15 +6,17 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
+  "scan_qr_code",
   "asset",
   "employee",
   "column_break_bgwn",
   "posting_date",
   "location",
+  "employee_name",
   "section_break_rev9",
   "asset_photos",
-  "remarks",
   "has_damage",
+  "remarks",
   "amended_from"
  ],
  "fields": [
@@ -83,12 +85,24 @@
   {
    "fieldname": "column_break_bgwn",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "scan_qr_code",
+   "fieldtype": "Data",
+   "label": "Scan QR Code",
+   "options": "Barcode"
+  },
+  {
+   "fetch_from": "employee.employee_name",
+   "fieldname": "employee_name",
+   "fieldtype": "Data",
+   "label": "Employee Name"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-04-30 14:52:09.761054",
+ "modified": "2025-05-23 13:12:53.697528",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Asset Auditing",


### PR DESCRIPTION
## Feature description

- [ ] TASK-2025-01097 : add ability to scan qr code for asset in asset auditing
- [ ] TASK-2025-01094 : correct alignment in asset auditing

## Solution description

- Rearrange ' Has Damage ' field position.
- Added field named ' Employee name ', ' Scan QR Code '
- When a QR code is scanned, it fills the Asset field with the corresponding Asset ID


## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/f172316a-5f28-4d2f-b81e-c7bd28a1796a)


## Areas affected and ensured
List out the areas affected by your code changes.(Asset auditing)

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
