### PR TITLE
TASK-2025-01096:Customised HD Ticket doctype

### DIFF
--- a/beams/beams/custom_scripts/hd_ticket/hd_ticket.js
+++ b/beams/beams/custom_scripts/hd_ticket/hd_ticket.js
@@ -50,7 +50,7 @@ frappe.ui.form.on('HD Ticket', {
 // Function to show/hide fields based on user's role
 function handle_agent_visibility(frm) {
     if (!frappe.user.has_role('Agent')) {
-        const visible_fields = ['subject', 'raised_by', 'description','ticket_type'];
+        const visible_fields = ['subject', 'raised_by','raised_for', 'description','ticket_type'];
         frm.fields.forEach(field => {
             const name = field.df.fieldname;
             if (name && !['Section Break', 'Column Break'].includes(field.df.fieldtype)) {

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -1,8 +1,7 @@
-import os
-import click
 import frappe
 from frappe import _
 from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+
 
 def after_install():
     #Creating BEAMS specific custom fields
@@ -1990,6 +1989,19 @@ def get_hd_ticket_custom_fields():
                 "insert_after": "spare_part_needed",
                 "options": "Spare Part Item",
                 "depends_on": "eval:doc.spare_part_needed == 1"
+            },
+            {
+                "fieldname": "raised_for",
+                "fieldtype": "Link",
+                "options": "User",
+                "label": "Raised For (Email)",
+                "insert_after": "raised_by"
+            },
+            {
+                "fieldname": "attach",
+                "fieldtype": "Attach",
+                "label": "Attachments",
+                "insert_after": "agent_group"
             }
         ]
     }


### PR DESCRIPTION
## Feature description
Add following fields to HD Ticket doctype

- Raised For(link,options:User)
- Attach(attach)


## Solution description
HD Ticket form should capture details of user for whom ticket is raised.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/c6f00f41-e090-41fa-8652-1a8d4cae9bd5)

## Areas affected and ensured
HD Ticket doctype.

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
