### PR TITLE
feat:Add validation for attachments in travel request and update custom fields

### DIFF
--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.py
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.py
@@ -53,6 +53,10 @@ class EmployeeTravelRequest(Document):
         if self.reason_for_rejection:
             frappe.throw(title="Approval Error", msg="You cannot approve this request if 'Reason for Rejection' is filled.")
 
+        if not self.is_unplanned:
+            if not self.attachments:
+                frappe.throw(title="Approval Error", msg="Attachments is required before final approval.")
+
         if self.is_vehicle_required:
             if not self.travel_vehicle_allocation:
                 frappe.throw(title="Approval Error", msg="Vehicle allocation is required before final approval.")

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -593,7 +593,7 @@ def get_customer_custom_fields():
                 "fieldtype": "Link",
                 "label": "Region",
                 "options": "Region",
-                "mandatory_depends_on": "eval:doc.is_agent",
+                "reqd": 1,
                 "insert_after": "msme_status"
             },
             {
@@ -2978,10 +2978,16 @@ def get_company_custom_fields():
                 "insert_after": "company_policy_tab"
             },
             {
+                "fieldname": "exception_budget_column",
+                "fieldtype": "Column Break",
+                "label": "",
+                "insert_after": "exception_budget_approver_role"
+            },
+            {
                 "fieldname": "exchange_rate_to_inr",
                 "fieldtype": "Float",
-                "label": "Exchange Rate to INR",
-                "insert_after": "exchange_gain_loss_account",
+                "label": "Budget Exchange Rate to INR",
+                "insert_after": "exception_budget_column",
                 "description": "1 Unit of Company Currency = [?] INR"
             }
         ]
@@ -4299,6 +4305,7 @@ def get_journal_entry_custom_fields():
                 "label": "Cost Center",
                 "read_only": 1,
                 "options": "Cost Center",
+                "in_list_view": 1,
                 "insert_after": "naming_series"
             },
             {


### PR DESCRIPTION
## Feature description
Add validation for attachments in travel request and update custom fields setup

## Solution description
**Employee Travel Request Validation**

-     Added a validation check to ensure that attachments are mandatory before final approval if the travel is not unplanned.
-     Ensures that a request cannot be approved without required documentation.

- Updated Region field in Customer custom fields to make it mandatory 
- Updated label of exchange_rate_to_inr to "Budget Exchange Rate to INR" and repositioned it after the new column break in company.
- Enabled Cost Center field to be shown in list view by setting  in Journal Entry

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/2d9b108b-4464-4b53-881b-e287aaf0b7cf)
![image](https://github.com/user-attachments/assets/0593c7f3-682a-41e0-912b-cc21d86cc811)
![image](https://github.com/user-attachments/assets/9973daca-0410-411f-8e13-6031489d676d)
![image](https://github.com/user-attachments/assets/f2767ff3-8e80-4c46-b8a7-c5f05c211cf7)

## Areas affected and ensured
- Employee Travel Request
- Journal Entry
-  company
-  Customer

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - 
  - Opera Mini
  - Safari
