### PR TITLE
feat: TASK-2025-01128: add total claimed and sanctioned amount to expense summary

### DIFF
--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.py
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.py
@@ -360,6 +360,8 @@ def get_expense_claim_html(doc):
     )
 
     full_claims = []
+    total_amount = 0
+    total_sanctioned_amount = 0
     for claim in expense_claims:
         ec_doc = frappe.get_doc("Expense Claim", claim.name)
         expenses = sorted(
@@ -367,6 +369,10 @@ def get_expense_claim_html(doc):
             key=lambda x: x.expense_date,
             reverse=True
         )
+        for row in expenses:
+            total_amount += row.amount or 0
+            total_sanctioned_amount += row.sanctioned_amount or 0
+
         full_claims.append({
             "name": ec_doc.name,
             "employee": ec_doc.employee,
@@ -388,7 +394,11 @@ def get_expense_claim_html(doc):
 
     html = frappe.render_template(
         "beams/doctype/employee_travel_request/expense_claim.html",
-        {"expense_claims": full_claims}
+        {
+            "expense_claims": full_claims,
+            "total_amount": total_amount,
+            "total_sanctioned_amount": total_sanctioned_amount
+        }
     )
 
     return {"html": html}

--- a/beams/beams/doctype/employee_travel_request/expense_claim.html
+++ b/beams/beams/doctype/employee_travel_request/expense_claim.html
@@ -23,6 +23,10 @@
             margin-bottom: 20px;
             width: 100%;
         }
+        .total-row {
+            font-weight: bold;
+            background-color: #f9f9f9;
+        }
         a {
             text-decoration: none;
         }
@@ -52,11 +56,8 @@
             <tbody>
                 {% for claim in expense_claims %}
                     {% for expense in claim.expenses %}
-                        {% set has_expenses = True %}
                         <tr>
-                            <td>
-                            <a href="{{ claim.url }}">{{ claim.name }}</a>
-                            </td>
+                            <td><a href="{{ claim.url }}">{{ claim.name }}</a></td>
                             <td>{{ claim.employee }}</td>
                             <td>{{ expense.expense_date }}</td>
                             <td>{{ expense.expense_type }}</td>
@@ -67,9 +68,16 @@
                         </tr>
                     {% endfor %}
                 {% endfor %}
+                <tr class="total-row">
+                    <td colspan="5">Total</td>
+                    <td>{{ total_amount }}</td>
+                    <td></td>
+                    <td>{{ total_sanctioned_amount }}</td>
+                </tr>
             </tbody>
         </table>
     {% else %}
+        <p>No expense claims found for this travel request.</p>
     {% endif %}
 </body>
 </html>


### PR DESCRIPTION
## Feature description
Show total claimed and sanctioned amount in expense claim summary

## Solution description
- Added logic in Python to calculate total claimed amount and total sanctioned amount
- Updated HTML template to display both totals in the final row
- Added fallback message if no expense claims are found
- removed unused variable {% set has_expenses = True %}

## Output screenshots (optional)

![image](https://github.com/user-attachments/assets/3df9ee3c-6630-4738-aebd-11a981f8ec6b)

## Areas affected and ensured

Employee Travel Request


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - yes
  - Opera Mini
  - Safari
