### PR TITLE
TASK-2025-01136:Added Attach field in Vehicle Documents Table in Vehicle Documents Log doctype

### DIFF
--- a/beams/beams/doctype/vehicle_documents/vehicle_documents.json
+++ b/beams/beams/doctype/vehicle_documents/vehicle_documents.json
@@ -8,6 +8,7 @@
  "engine": "InnoDB",
  "field_order": [
   "document",
+  "attach",
   "reference_no",
   "expiry_date",
   "remarks"
@@ -42,12 +43,18 @@
    "fieldtype": "Small Text",
    "in_list_view": 1,
    "label": "Remarks"
+  },
+  {
+   "fieldname": "attach",
+   "fieldtype": "Attach",
+   "in_list_view": 1,
+   "label": "Attach"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-05-19 09:23:20.497204",
+ "modified": "2025-05-29 10:21:37.173600",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Vehicle Documents",


### PR DESCRIPTION
## Feature description
Need to: Add Attach field in Vehicle Documents Table in Vehicle Documents Log doctype

## Solution description
Added Attach field in Vehicle Documents Table in Vehicle Documents Log doctype

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/f69a7fb9-4905-453b-84b2-98ace9c22a03)


## Areas affected and ensured
Vehicle Documents Log doctype

## Is there any existing behavior change of other features due to this code change?
No. 

## Was this feature tested on the browsers?
  - Mozilla Firefox

