### PR TITLE
fix:Fixed the editable  issue in travel vehicle  allocation table in employee travel request doctype

### DIFF
--- a/beams/beams/doctype/vehicle_allocation/vehicle_allocation.json
+++ b/beams/beams/doctype/vehicle_allocation/vehicle_allocation.json
@@ -17,6 +17,7 @@
    "fieldtype": "Section Break"
   },
   {
+   "allow_on_submit": 1,
    "fieldname": "vehicle",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -24,6 +25,7 @@
    "options": "Vehicle"
   },
   {
+   "allow_on_submit": 1,
    "fieldname": "driver",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -34,7 +36,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-05-07 11:11:45.907083",
+ "modified": "2025-05-29 12:59:06.279112",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Vehicle Allocation",


### PR DESCRIPTION
## Feature description
Need to: Fix the editable in issue  travel vehicle  allocation table in employee travel request doctype

## Solution description
Fixed the editable in issue  travel vehicle  allocation table in employee travel request doctype

## Output screenshots (optional)

[Screencast from 29-05-25 02:19:38 PM IST.webm](https://github.com/user-attachments/assets/4266baf6-34c2-4544-9734-6aebb51addd0)


## Areas affected and ensured
Employee Travel Request doctype


## Is there any existing behavior change of other features due to this code change?
No. 

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
