### PR TITLE
TASK-2025-01147:Added connections in Trip Sheet doctype and Driver doctype

### DIFF
--- a/beams/beams/custom_scripts/driver_dashboard/driver_dashboard.py
+++ b/beams/beams/custom_scripts/driver_dashboard/driver_dashboard.py
@@ -1,0 +1,14 @@
+from frappe import _
+
+def get_data(data=None):
+    return {
+        "fieldname": "driver",
+        "non_standard_fieldnames": {
+            "Vehicle Incident Record": "driver"
+        },
+        "transactions": [
+            {
+                "items": ["Vehicle Incident Record"]
+            }
+        ]
+    }

--- a/beams/beams/doctype/trip_sheet/trip_sheet.json
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.json
@@ -211,8 +211,13 @@
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
- "links": [],
- "modified": "2025-05-22 11:06:53.708549",
+ "links": [
+  {
+   "link_doctype": "Vehicle Incident Record",
+   "link_fieldname": "trip_sheet"
+  }
+ ],
+ "modified": "2025-05-30 10:42:22.958496",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Trip Sheet",

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -437,6 +437,7 @@ override_doctype_dashboards = {
     'Project':'beams.beams.custom_scripts.project_dashboard.project_dashboard.get_data',
     'Department': 'beams.beams.custom_scripts.department.department_dashboard.get_data',
     'Vehicle': 'beams.beams.custom_scripts.vehicle_dashboard.vehicle_dashboard.get_data',
+    'Driver': 'beams.beams.custom_scripts.driver_dashboard.driver_dashboard.get_data',
 }
 
 # exempt linked doctypes from being automatically cancelled


### PR DESCRIPTION
## Feature description
- [ ] TASK-2025-01147:Add connection in Trip Sheet doctype .
- [ ] TASK-2025-01148: Add connection in Driver doctype

## Solution description
Added connection in Trip Sheet doctype and Driver doctype for Vehicle Incident Record doctype

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/0851ca0e-48d0-4741-8fd5-24101e026d94)

![image](https://github.com/user-attachments/assets/7d30ab9e-01c3-4f94-9290-dec4ef97cf11)

## Areas affected and ensured
Trip Sheet doctype
Driver doctype

## Is there any existing behavior change of other features due to this code change?
No. 

## Was this feature tested on the browsers?
  - Mozilla Firefox

