### PR TITLE
feat: TASK-2025-01156: ensure QR code is generated for all assets created from Purchase Receipt

### DIFF
--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -358,8 +358,10 @@ doc_events = {
         "before_save": "beams.beams.custom_scripts.asset_movement.asset_movement.before_save",
     },
     "Asset":{
-        "after_insert":"beams.beams.custom_scripts.asset.asset.generate_asset_qr",
-        "on_submit":"beams.beams.custom_scripts.asset.asset.generate_asset_details_qr",
+        "on_submit": [
+            "beams.beams.custom_scripts.asset.asset.generate_asset_qr",
+            "beams.beams.custom_scripts.asset.asset.generate_asset_details_qr"
+        ],
         "on_update_after_submit":"beams.beams.custom_scripts.asset.asset.create_asset_location_log"
     },
     "Budget":{


### PR DESCRIPTION

## Feature description

- ensure QR code is generated for all assets created from Purchase Receipt

## Solution description

- Fixed QR code generation issue for multiple assets from Purchase Receipt by moving generate_asset_qr from after_insert to on_submit. This ensures QR codes are consistently generated for all assets upon submission, regardless of quantity.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/ca005b6e-4be7-447d-96d4-0698330c0bab)
![image](https://github.com/user-attachments/assets/4933042a-561a-4271-9d30-badd367d6978)


## Areas affected and ensured
Asset

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - Yes
  - Opera Mini
  - Safari
