### PR TITLE
TASK-2025-01155 : prevent transferring a bundle already transferred in asset transfer request

### DIFF
--- a/beams/beams/doctype/asset_transfer_request/asset_transfer_request.js
+++ b/beams/beams/doctype/asset_transfer_request/asset_transfer_request.js
@@ -133,6 +133,16 @@ frappe.ui.form.on("Asset Transfer Request", {
             ["Asset", "docstatus", "=", 1]]
 
         }))).catch(err => console.error("Error:", err));
+        frappe.db.get_list("Asset Transfer Request", {
+            fields: ["bundle"],
+            filters: { workflow_state: "Transferred" }
+        }).then(res => {
+            frm.set_query("bundle", () => ({
+                filters: [
+                    ["Asset Bundle", "name", "not in", res.map(a => a.bundle)]
+                ]
+            }));
+        }).catch(err => console.error("Error:", err));
     }
 });
 


### PR DESCRIPTION

## Feature description
Do not allow transferring a bundle that has already been transferred , unless it has been returned


## Solution description
Fetches transferred bundles from Asset Transfer Request and filters them out from the bundle selection (Asset Transfer Request)

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/1586fc68-b10c-49b4-bef6-39ee8055063b)
![image](https://github.com/user-attachments/assets/b1f5d7d8-fa7c-4c07-b48a-15160382cad8)


Post the output screenshots, if a UI is affected or added due to this feature.

## Areas affected and ensured
List out the areas affected by your code changes.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
