### PR TITLE
feat: TASK-2025-01157: allow updating location in Asset by setting allow_on_submit

### DIFF
--- a/beams/setup.py
+++ b/beams/setup.py
@@ -4152,6 +4152,13 @@ def get_property_setters():
             "doc_type": "Job Requisition",
             "property": "field_order",
             "value": '["workflow_state", "naming_series", "request_for", "employee_left", "relieving_date", "suggested_designation", "designation", "department", "location", "employment_type", "column_break_qkna", "no_of_positions", "expected_compensation", "reason_for_requesting", "column_break_4", "company", "status", "section_break_7", "requested_by", "requested_by_name", "column_break_10", "requested_by_dept", "requested_by_designation", "interview", "interview_rounds", "work_details", "no_of_days_off", "min_experience", "work_details_column_break", "is_work_shift_needed", "travel_required", "driving_license_needed", "license_type", "education", "min_education_qual", "reset_column", "language_proficiency", "skill_proficiency", "publish_on_job_section", "publish_on_job_opening", "timelines_tab", "posting_date", "completed_on", "column_break_15", "expected_by", "time_to_fill", "job_description_tab", "job_description_template", "job_title", "description", "suggestions", "connections_tab"]'
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Asset",
+            "field_name": "location",
+            "property": "allow_on_submit",
+            "value": 1
         }
     ]
 


### PR DESCRIPTION
## Feature description
 enable location field update on submitted Asset via property setter

## Solution description

- Added a property setter in setup.py to set `allow on submit '  for the ' location`  field in the Asset DocType. 
- This resolves UpdateAfterSubmitError, which is encountered during asset movement processing when the location changes.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/58ada022-4d3f-409d-8447-903af7fa4fb7)
![image](https://github.com/user-attachments/assets/7cf66c32-84f9-4bd4-be30-a5452526678f)


## Areas affected and ensured

- Asset transfer request
- Asset Movment

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - Yes
  - Opera Mini
  - Safari
