### PR TITLE
TASK-2025-01185 : filter item_code in makeup consumption entry

### DIFF
--- a/beams/beams/doctype/beams_admin_settings/beams_admin_settings.json
+++ b/beams/beams/doctype/beams_admin_settings/beams_admin_settings.json
@@ -135,14 +135,14 @@
   {
    "fieldname": "item_group",
    "fieldtype": "Link",
-   "label": "Item Group",
+   "label": "Makeup Item Group",
    "options": "Item Group"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-06-04 10:09:37.922822",
+ "modified": "2025-06-04 11:43:38.073135",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "BEAMS Admin Settings",

--- a/beams/beams/doctype/beams_admin_settings/beams_admin_settings.json
+++ b/beams/beams/doctype/beams_admin_settings/beams_admin_settings.json
@@ -20,7 +20,8 @@
   "role_receiving_asset_reservation_notification",
   "notification_template_for_asset_reservation",
   "notification_for_asset_reservation_before",
-  "default_employee_payable_account"
+  "default_employee_payable_account",
+  "item_group"
  ],
  "fields": [
   {
@@ -130,12 +131,18 @@
    "fieldtype": "Link",
    "label": "Default Employee Payable Account",
    "options": "Account"
+  },
+  {
+   "fieldname": "item_group",
+   "fieldtype": "Link",
+   "label": "Item Group",
+   "options": "Item Group"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-05-17 11:08:21.034982",
+ "modified": "2025-06-04 10:09:37.922822",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "BEAMS Admin Settings",
@@ -152,6 +159,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/beams/beams/doctype/makeup_consumption_entry/makeup_consumption_entry.js
+++ b/beams/beams/doctype/makeup_consumption_entry/makeup_consumption_entry.js
@@ -1,8 +1,30 @@
 // Copyright (c) 2025, efeone and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Makeup Consumption Entry", {
-// 	refresh(frm) {
 
-// 	},
-// });
+frappe.ui.form.on("Makeup Consumption Entry", {
+    // Filter on the item_code field to list only items from the selected item group with is_makeup_item checked
+    onload: function (frm) {
+      frappe.call({
+        method: "frappe.client.get_value",
+        args: {
+          doctype: "BEAMS Admin Settings",
+          fieldname: "item_group"
+        },
+        callback: function (r) {
+          if (r.message) {
+            var item_group = r.message.item_group;
+
+            frm.fields_dict.items.grid.get_field("item_code").get_query = function () {
+              return {
+                filters: {
+                  item_group: item_group,
+                  is_makeup_item: 1
+                }
+              };
+            };
+          }
+        }
+      });
+    }
+  });

--- a/beams/beams/doctype/required_items_detail/required_items_detail.json
+++ b/beams/beams/doctype/required_items_detail/required_items_detail.json
@@ -12,7 +12,6 @@
   "required_quantity",
   "issued_quantity",
   "acquired_quantity",
-  "asset_movement",
   "return_date",
   "returned_count",
   "returned_reason",
@@ -54,12 +53,6 @@
   },
   {
    "allow_on_submit": 1,
-   "fieldname": "asset_movement",
-   "fieldtype": "Button",
-   "label": "Asset Movement"
-  },
-  {
-   "allow_on_submit": 1,
    "fieldname": "acquired_quantity",
    "fieldtype": "Int",
    "in_list_view": 1,
@@ -91,7 +84,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-05-02 16:34:43.864230",
+ "modified": "2025-06-03 16:07:01.558706",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Required Items Detail",

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -1632,6 +1632,12 @@ def get_item_custom_fields():
                "options":"\nJanuary\nFebruary\nMarch\nApril\nMay\nJune\nJuly\nAugust\nSeptember\nOctober\nNovember\nDecember",
                "depends_on": "eval:doc.item_audit_notification == 1",
                "insert_after": "item_audit_notification"
+           },
+           {
+               "fieldname": "is_makeup_item",
+               "fieldtype": "Check",
+               "label": "Is Makeup Item",
+               "insert_after": "is_exempt"
            }
         ]
     }


### PR DESCRIPTION
## Feature description
Apply filter item_code in makeup consumption entry
Remove the Asset Movement button from the Required Items Detail child table

## Solution description

- Added field named '  Is Makeup Item' in Item
- Added field named ' Item Group' in BEAMS admin settings
- Makeup Consumption Entry : Applied Filter on the item_code field to list only items from the selected item group with is_makeup_item checked

- Removed the Asset Movement button from the Required Items Detail child table because it is not used for asset movement; we are using another button for that

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/c93f028a-ae85-4afa-8aab-e3e8cc8311f2)
![image](https://github.com/user-attachments/assets/e25dbe70-2de9-46ac-a958-e3bb3315ca03)
![image](https://github.com/user-attachments/assets/2386c2cf-de7e-4715-b701-99f86d439c41)



## Areas affected and ensured
List out the areas affected by your code changes.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
