### PR TITLE
TASK-2025-01200:Created Stock Entry when  workflow state is Returned in  Asset Transfer Request doctype

### DIFF
--- a/beams/beams/doctype/asset_transfer_request/asset_transfer_request.py
+++ b/beams/beams/doctype/asset_transfer_request/asset_transfer_request.py
@@ -282,7 +282,7 @@ class AssetTransferRequest(Document):
                 ),
                 alert=True, indicator='green'
             )
-            
+
     def create_return_stock_entries(self):
         '''
             Create Stock Entry when the workflow state is 'Returned'.
@@ -304,6 +304,9 @@ class AssetTransferRequest(Document):
         for item in self.items:
             if item.item and item.item not in consumed_or_missing_items:
                 items_to_return.append(item)
+
+        if not items_to_return:
+            return
 
         warehouse = frappe.db.get_value("Beams Admin Settings", None, "asset_transfer_warehouse")
         if not warehouse:


### PR DESCRIPTION
## Feature description
Need to:Create Stock Entry when  workflow state is Returned in  Asset Transfer Request doctype

## Solution description
Created Stock Entry when  workflow state is Returned in  Asset Transfer Request doctype

## Output screenshots (optional)

[Screencast from 04-06-25 03:25:30 PM IST.webm](https://github.com/user-attachments/assets/f573e49d-153a-47dc-befd-1ed2e555c8b2)

[Screencast from 04-06-25 03:35:48 PM IST.webm](https://github.com/user-attachments/assets/9c4564c4-84db-4517-985b-2f14dacdf1a0)

[Screencast from 04-06-25 03:38:49 PM IST.webm](https://github.com/user-attachments/assets/032b83f2-45da-4062-a9ea-e6a8d7b33e9b)


## Areas affected and ensured
Asset Transfer Request doctype

## Is there any existing behavior change of other features due to this code change?
No. 

## Was this feature tested on the browsers?
  - Mozilla Firefox

