### PR TITLE
feat: TASK-2025-01205: regenerate asset bundle QR code on every save

### DIFF
--- a/beams/beams/doctype/asset_bundle/asset_bundle.py
+++ b/beams/beams/doctype/asset_bundle/asset_bundle.py
@@ -13,9 +13,9 @@ class AssetBundle(Document):
 	def before_save(self):
 		if not(self.assets or self.bundles or self.stock_items):
 			frappe.throw("At least one of Stock Items, Assets, or Bundles must be filled in.")
+		self.generate_asset_bundle_qr()
 
 	def after_insert(self):
-		self.generate_asset_bundle_qr()
 		self.generate_asset_bundle_qr_file()
 
 
@@ -48,10 +48,6 @@ class AssetBundle(Document):
 		return self.name
 
 	def generate_asset_bundle_qr(self):
-		qr_code = self.get("qr_code")
-		if qr_code and frappe.db.exists({"doctype": "File", "file_url": qr_code}):
-			return
-
 		doc_url = self.get_si_json()
 		qr_image = io.BytesIO()
 		url = create(doc_url, error="L")


### PR DESCRIPTION
## Feature description
regenerate asset bundle QR code on every save

## Solution description
Moved QR code generation from after insert to before save to ensure updated assets, bundles, or stock items are 
reflected in the QR. Prevents stale QR data when modifying existing Asset Bundles.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/0736da0b-dca8-4e3a-8898-f79feb2577ad)


## Areas affected and ensured
Asset Bundle

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - Yes
  - Opera Mini
  - Safari
