### PR TITLE
feat: TASK-2025-01220: Validate asset locations in Asset Bundle

### DIFF
--- a/beams/beams/doctype/asset_bundle/asset_bundle.py
+++ b/beams/beams/doctype/asset_bundle/asset_bundle.py
@@ -44,6 +44,26 @@ class AssetBundle(Document):
 		_file.save()
 		self.db_set("bundle_qr_code", _file.file_url)
 
+	def validate(self):
+		self.validate_asset_locations()
+
+	def validate_asset_locations(self):
+		"""
+			Ensure all selected assets are from the same location.
+		"""
+		if not self.assets:
+			return
+
+		locations = set()
+
+		for asset in self.assets:
+			asset_doc = frappe.get_doc("Asset", asset.asset)
+			if asset_doc.location:
+				locations.add(asset_doc.location)
+
+		if len(locations) > 1:
+			frappe.throw("Selected assets belong to different locations. Please select assets from the same location.")
+
 	def get_si_file(self):
 		return self.name
 


### PR DESCRIPTION
## Feature description
Validate asset locations in Asset Bundle to allow only same-location assets

## Solution description
This ensures that a bundle cannot be created using assets from multiple locations.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/60509126-cc37-4f86-b3d8-959ce5982129)


## Areas affected and ensured
Asset Bundle

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox- Yes
  - Opera Mini
  - Safari
