### PR TITLE
TASK-2025-01218 : Add filter for shelf,row and bin in assets and asset movement

### DIFF
--- a/beams/beams/custom_scripts/asset/asset.js
+++ b/beams/beams/custom_scripts/asset/asset.js
@@ -1,0 +1,31 @@
+frappe.ui.form.on('Asset', {
+    refresh: function(frm) {
+        // Filter for shelf based on selected room
+        frm.set_query('shelf', function() {
+            return {
+                filters: {
+                    'room': frm.doc.room
+                }
+            };
+        });
+
+        // Filter for row based on selected shelf
+        frm.set_query('row', function() {
+            return {
+                filters: {
+                    'shelf': frm.doc.shelf
+                }
+            };
+        });
+
+        // Filter for bin based on selected row
+        frm.set_query('bin', function() {
+            return {
+                filters: {
+                    'row': frm.doc.row
+                }
+            };
+        });
+    },
+});
+

--- a/beams/beams/custom_scripts/asset_movement/asset_movement.js
+++ b/beams/beams/custom_scripts/asset_movement/asset_movement.js
@@ -9,6 +9,7 @@ frappe.ui.form.on('Asset Movement', {
         });
     },
     refresh: function(frm) {
+        frm.trigger('toggle_asset_movement_item_fields');
         // Filter for 'Shelf','Row' & 'Bin' field in assets child table
         frm.fields_dict.assets.grid.get_field('shelf').get_query = function(doc, cdt, cdn) {
             let row = locals[cdt][cdn];
@@ -34,6 +35,19 @@ frappe.ui.form.on('Asset Movement', {
                 }
             };
         };
-    }
+    },
+    purpose: function(frm) {
+        // Call toggle_fields when purpose changes
+        frm.trigger('toggle_asset_movement_item_fields');
+    },
 
+    toggle_asset_movement_item_fields: function(frm) {
+        // Hide Room, Shelf, Row, and Bin fields in Asset Movement Item when purpose is 'Issue'
+        const hide_fields = (frm.doc.purpose === 'Issue');
+
+        frm.fields_dict.assets.grid.update_docfield_property('room', 'hidden', hide_fields);
+        frm.fields_dict.assets.grid.update_docfield_property('shelf', 'hidden', hide_fields);
+        frm.fields_dict.assets.grid.update_docfield_property('row', 'hidden', hide_fields);
+        frm.fields_dict.assets.grid.update_docfield_property('bin', 'hidden', hide_fields);
+    }
 });

--- a/beams/beams/custom_scripts/asset_movement/asset_movement.js
+++ b/beams/beams/custom_scripts/asset_movement/asset_movement.js
@@ -7,5 +7,33 @@ frappe.ui.form.on('Asset Movement', {
         frm.set_query('reference_name', function() {
             return { filters: {} };
         });
+    },
+    refresh: function(frm) {
+        // Filter for 'Shelf','Row' & 'Bin' field in assets child table
+        frm.fields_dict.assets.grid.get_field('shelf').get_query = function(doc, cdt, cdn) {
+            let row = locals[cdt][cdn];
+            return {
+                filters: {
+                    'room': row.room
+                }
+            };
+        };
+        frm.fields_dict.assets.grid.get_field('row').get_query = function(doc, cdt, cdn) {
+            let row = locals[cdt][cdn];
+            return {
+                filters: {
+                    'shelf': row.shelf
+                }
+            };
+        };
+        frm.fields_dict.assets.grid.get_field('bin').get_query = function(doc, cdt, cdn) {
+            let row = locals[cdt][cdn];
+            return {
+                filters: {
+                    'row': row.row
+                }
+            };
+        };
     }
+
 });

--- a/beams/beams/doctype/container/container.json
+++ b/beams/beams/doctype/container/container.json
@@ -6,6 +6,9 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
+  "room",
+  "shelf",
+  "row",
   "bin"
  ],
  "fields": [
@@ -14,11 +17,29 @@
    "fieldtype": "Data",
    "label": "Bin",
    "unique": 1
+  },
+  {
+   "fieldname": "room",
+   "fieldtype": "Link",
+   "label": "Room",
+   "options": "Service Unit"
+  },
+  {
+   "fieldname": "shelf",
+   "fieldtype": "Link",
+   "label": "Shelf",
+   "options": "Shelf"
+  },
+  {
+   "fieldname": "row",
+   "fieldtype": "Link",
+   "label": "Row",
+   "options": "Row"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-05-19 14:49:51.465962",
+ "modified": "2025-06-05 10:22:31.030169",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Container",
@@ -38,6 +59,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/beams/beams/doctype/row/row.json
+++ b/beams/beams/doctype/row/row.json
@@ -6,6 +6,8 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
+  "room",
+  "shelf",
   "row"
  ],
  "fields": [
@@ -14,11 +16,23 @@
    "fieldtype": "Data",
    "label": "Row",
    "unique": 1
+  },
+  {
+   "fieldname": "shelf",
+   "fieldtype": "Link",
+   "label": "Shelf",
+   "options": "Shelf"
+  },
+  {
+   "fieldname": "room",
+   "fieldtype": "Link",
+   "label": "Room",
+   "options": "Service Unit"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-05-19 14:46:35.472765",
+ "modified": "2025-06-05 10:20:06.066569",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Row",
@@ -38,6 +52,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/beams/beams/doctype/shelf/shelf.json
+++ b/beams/beams/doctype/shelf/shelf.json
@@ -6,6 +6,7 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
+  "room",
   "shelf"
  ],
  "fields": [
@@ -14,11 +15,17 @@
    "fieldtype": "Data",
    "label": "Shelf",
    "unique": 1
+  },
+  {
+   "fieldname": "room",
+   "fieldtype": "Link",
+   "label": "Room",
+   "options": "Service Unit"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-05-19 14:45:16.563262",
+ "modified": "2025-06-05 11:54:52.916235",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Shelf",
@@ -38,6 +45,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -67,7 +67,8 @@ doctype_js = {
     "Full and Final Statement":"beams/custom_scripts/full_and_final_statement/full_and_final_statement.js",
     "HD Ticket":"beams/custom_scripts/hd_ticket/hd_ticket.js",
     "Vehicle":"beams/custom_scripts/vehicle/vehicle.js",
-    "Material Request":"beams/custom_scripts/material_request/material_request.js"
+    "Material Request":"beams/custom_scripts/material_request/material_request.js",
+    "Asset":"beams/custom_scripts/asset/asset.js"
 }
 doctype_list_js = {
     "Sales Invoice" : "beams/custom_scripts/sales_invoice/sales_invoice_list.js",


### PR DESCRIPTION
## Feature description

- [ ] TASK-2025-01218: Need filters for Room, Shelf, Row, and Bin in Asset and Asset Movement.
- [ ] TASK-2025-01219 : No need to enter Room, Shelf, or Row values in Asset Movement if the purpose is 'Issue'


## Solution description
TASK-2025-01218 :
Added fields in Shelf , Row , and Bin doctypes.
In the Asset doctype and in the child table of the Asset Movement doctype, filters are applied so that the Shelf field shows only shelves linked to the selected Room, the Row field shows only rows under the selected Shelf, and the Bin field shows only bins under the selected Row

TASK-2025-01219:
Dynamically hides or shows the Room, Shelf, Row, and Bin fields in the Asset Movement Item child table based on the selected purpose in the Asset Movement. If purpose = "Issue", those fields are hidden; otherwise, they remain visible.

## Output screenshots (optional)
TASK-2025-01218
[Screencast from 05-06-25 01:20:12 PM IST.webm](https://github.com/user-attachments/assets/444f7d01-a95c-4877-8219-0423376b27cf)

[Screencast from 05-06-25 01:23:17 PM IST.webm](https://github.com/user-attachments/assets/97c3661a-37cd-45a6-b58e-70853b9fde9a)

TASK-2025-01219
![image](https://github.com/user-attachments/assets/83329f69-b970-4739-9b4f-7fd8f1eb02e3)

[Screencast from 05-06-25 02:54:12 PM IST.webm](https://github.com/user-attachments/assets/2810f39f-04aa-4b23-8ff8-756dedc4d49f)

## Areas affected and ensured
List out the areas affected by your code changes.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
