### PR TITLE
TASK-2025-01184:Edited Asset Transfer Request doctype

### DIFF
--- a/beams/beams/doctype/asset_transfer_request/asset_transfer_request.js
+++ b/beams/beams/doctype/asset_transfer_request/asset_transfer_request.js
@@ -105,26 +105,6 @@ frappe.ui.form.on("Asset Transfer Request", {
           frm.refresh_field('assets');
       }
   },
-    asset_return_checklist_template: function(frm) {
-        if (frm.doc.asset_return_checklist_template) {
-            frappe.call({
-                method: "beams.beams.doctype.asset_transfer_request.asset_transfer_request.get_asset_return_checklist_template",
-                args: {
-                    template_name: frm.doc.asset_return_checklist_template
-                },
-                callback: function(response) {
-                    if (response.message) {
-                        frm.clear_table("aresponse.messageet_return_checklist");
-                        response.message.forEach(item => {
-                            let row = frm.add_child("asset_return_checklist");
-                            row.checklist_item = item.checklist_item;
-                        });
-                        frm.refresh_field("asset_return_checklist");
-                    }
-                }
-            });
-        }
-    },
     refresh(frm) {
         frappe.db.get_list("Asset Transfer Request", {
             fields: ["asset", "bundle"],
@@ -143,6 +123,12 @@ frappe.ui.form.on("Asset Transfer Request", {
                 ]
             }));
         }).catch(err => console.error("Error:", err));
+
+
+        frm.set_df_property("asset_return_checklist", "cannot_add_rows", true);
+        frm.fields_dict.asset_return_checklist.grid.update_docfield_property(
+            'checklist_item', 'read_only', 1
+        );
     }
 });
 

--- a/beams/beams/doctype/asset_transfer_request/asset_transfer_request.json
+++ b/beams/beams/doctype/asset_transfer_request/asset_transfer_request.json
@@ -22,7 +22,6 @@
   "stock_entry",
   "section_break_sesi",
   "items",
-  "asset_return_checklist_template",
   "asset_return_checklist",
   "amended_from"
  ],
@@ -67,16 +66,7 @@
   },
   {
    "allow_on_submit": 1,
-   "depends_on": "eval:doc.workflow_state == \"Transferred\"",
-   "fieldname": "asset_return_checklist_template",
-   "fieldtype": "Link",
-   "label": "Asset Return Checklist template",
-   "mandatory_depends_on": "eval:doc.workflow_state == \"Transferred\"",
-   "options": "Asset Return Checklist Template"
-  },
-  {
-   "allow_on_submit": 1,
-   "depends_on": "eval:doc.asset_return_checklist_template",
+   "depends_on": "eval:doc.workflow_state == 'Transferred and Received'\n",
    "fieldname": "asset_return_checklist",
    "fieldtype": "Table",
    "label": "Asset Return Checklist",
@@ -171,7 +161,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-03-03 13:58:26.799954",
+ "modified": "2025-06-10 10:15:13.555858",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Asset Transfer Request",

--- a/beams/beams/doctype/asset_transfer_request/asset_transfer_request.py
+++ b/beams/beams/doctype/asset_transfer_request/asset_transfer_request.py
@@ -41,7 +41,7 @@ class AssetTransferRequest(Document):
            Handles updates after submission by adding  assets,items,asset to the asset return checklist when the workflow state is 'Transferred'
         '''
 
-        if self.workflow_state == "Transferred" and self.asset_return_checklist_template:
+        if self.workflow_state == "Transferred and Received":
             existing_checklist_items = {row.checklist_item for row in self.get("asset_return_checklist")}
             assets_to_add = set()
 
@@ -362,18 +362,6 @@ def get_stock_items_from_bundle(bundle):
         fields=["item", "uom", "qty"]
     )
     return stock_items
-
-
-@frappe.whitelist()
-def get_asset_return_checklist_template(template_name):
-    if not frappe.db.exists("Asset Return Checklist Template", template_name):
-        frappe.msgprint(_("Asset Return Checklist Template '{}' not found").format(template_name))
-
-    return frappe.get_all(
-        "Asset Return Check",
-        filters={"parent": template_name},
-        fields=["checklist_item"]
-    )
 
 @frappe.whitelist()
 def get_bundle_assets(bundle):


### PR DESCRIPTION
## Feature description
Need to:
- Remove the Asset Return Checklist Template field in asset transfer request doctype.
- Show  Asset Return Checklist table with asset or asset in the bundle if it is bundle when workflow state is transfered and    received.
- Disable "Add Row" in  Asset Return Checklist Table.
- Make the checklist item field in  Asset Return Checklist  table is  read-only.

## Solution description
- Removed the Asset Return Checklist Template field in asset transfer request doctype.
- Showed  Asset Return Checklist table with asset or asset in the bundle if it is bundle when workflow state is transfered and    received.
- Disabled "Add Row" in  Asset Return Checklist Table.
- Made the checklist item field in  Asset Return Checklist  table is  read-only.


## Output screenshots (optional)
[Screencast from 10-06-25 11:37:18 AM IST.webm](https://github.com/user-attachments/assets/2326a663-6e80-4afb-a6a4-b179c7add247)
[Screencast from 10-06-25 11:39:11 AM IST.webm](https://github.com/user-attachments/assets/36da84f9-d805-4542-bc83-3134a0de4ca2)
[Screencast from 10-06-25 11:40:41 AM IST.webm](https://github.com/user-attachments/assets/6b2c00f8-c6a8-4d37-8181-40b1b2b249e5)

## Areas affected and ensured
Asset Transfer Request Doctype

## Is there any existing behavior change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?
  - Mozilla Firefox
 
