### PR TITLE
fix:validate offense date within trip date range on save

### DIFF
--- a/beams/beams/doctype/vehicle_incident_record/vehicle_incident_record.py
+++ b/beams/beams/doctype/vehicle_incident_record/vehicle_incident_record.py
@@ -6,14 +6,15 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 from frappe.utils import today
-from frappe.utils import getdate
-
 
 
 class VehicleIncidentRecord(Document):
     def on_update(self):
         if self.workflow_state == "Approved":
             self.create_journal_entry_for_payable_items()
+
+    def validate(self):
+        self.validate_offense_date_and_time()
 
     @frappe.whitelist()
     def validate_posting_date(self):


### PR DESCRIPTION
## Feature description
validation needed to be enforced to ensure the offense date is in between trip start and end date

## Solution description
-> validation added 
-> called under validation hook

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/a9ca4e87-9ceb-48a3-ac68-14282b6f2410)

## Was this feature tested on the browsers?
  - Chrome

