### PR TITLE
feat: restrict backdated attendance request submissions

### DIFF
--- a/beams/beams/custom_scripts/attendance_request/attendance_request.py
+++ b/beams/beams/custom_scripts/attendance_request/attendance_request.py
@@ -59,9 +59,7 @@ class AttendanceRequestOverride(AttendanceRequest):
 		'''
 			Prevents the attendance request if the from date exceeds the limit configured in Beams HR Settings
 		'''
-		settings = frappe.get_single("Beams HR Settings")
-		limit_days = settings.attendance_request_submission_limit_days
-
+		limit_days = frappe.db.get_single_value("Beams HR Settings", "attendance_request_submission_limit_days")
 		if self.from_date and date_diff(today(), self.from_date) > limit_days:
 			frappe.throw(
 				_("You can only submit an Attendance Request within {0} days from the From Date.").format(limit_days)

--- a/beams/beams/doctype/beams_hr_settings/beams_hr_settings.json
+++ b/beams/beams/doctype/beams_hr_settings/beams_hr_settings.json
@@ -43,7 +43,9 @@
   "appraisal_creation_period",
   "appraisal_reminder_template",
   "column_break_dwmr",
-  "assessment_reminder_template"
+  "assessment_reminder_template",
+  "tab_6_tab",
+  "attendance_request_submission_limit_days"
  ],
  "fields": [
   {
@@ -264,13 +266,23 @@
    "fieldtype": "Link",
    "label": "Assessment Reminder Template ",
    "options": "Email Template"
+  },
+  {
+   "fieldname": "tab_6_tab",
+   "fieldtype": "Tab Break",
+   "label": "Attendance Settings"
+  },
+  {
+   "fieldname": "attendance_request_submission_limit_days",
+   "fieldtype": "Int",
+   "label": "Attendance Request Submission Limit (Days)"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-07-05 13:21:41.761656",
+ "modified": "2025-07-05 14:36:09.302029",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Beams HR Settings",


### PR DESCRIPTION
## Feature description
Restrict submission of Attendance Requests for backdated entries based on a configurable limit set in Beams HR Settings. Users will not be allowed to submit attendance requests if the from_date is older than the allowed number of days

## Analysis and design (optional)
No major design changes. This is a server-side validation implemented using the before_insert hook in the Attendance Request DocType (via override class).

## Solution description
- Added validation logic in the before_insert method of the Attendance Request override class.
- The logic checks whether the from_date exceeds the limit defined in Beams HR Settings (attendance_request_submission_limit_days).
- If the limit is exceeded, a frappe.throw is raised with an error message

## Output screenshots (optional)
[Screencast from 07-05-2025 03:28:45 PM.webm](https://github.com/user-attachments/assets/23c40b5b-c0a1-4d15-a40e-4a49414bdbe4)
![image](https://github.com/user-attachments/assets/00596d1c-0a6b-47b5-96c7-f9b48dc84fbf)

## Areas affected and ensured
Attendance Request creation 
Beams HR Settings-added field for specifying day limit

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
