### PR TITLE
feat: fetch shift from employee default shift in Employee Checkin Permission

### DIFF
--- a/beams/beams/doctype/employee_checkin_permission/employee_checkin_permission.json
+++ b/beams/beams/doctype/employee_checkin_permission/employee_checkin_permission.json
@@ -44,6 +44,7 @@
    "reqd": 1
   },
   {
+   "fetch_from": "employee.default_shift",
    "fieldname": "shift",
    "fieldtype": "Link",
    "label": "Shift",
@@ -117,7 +118,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-03-01 12:27:22.637469",
+ "modified": "2025-07-07 10:13:22.263951",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Employee Checkin Permission",
@@ -137,6 +138,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []


### PR DESCRIPTION
## Feature description
Automatically fetch the "Shift" value in the Employee Checkin Permission DocType from the selected employee’s default shift.
## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description
Updated the shift field in Employee Checkin Permission DocType.

Added fetch_from: employee.default_shift to auto-populate the field when an employee is selected.
## Output screenshots (optional)
[Screencast from 07-07-2025 10:21:19 AM.webm](https://github.com/user-attachments/assets/1bc568d3-0e2c-45d4-989f-5d1e767823d0)
## Areas affected and ensured
Employee Checkin Permission DocType metadata.
Field auto-population logic for "Shift".

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
