### PR TITLE
feat: add connections in training request

### DIFF
--- a/beams/beams/doctype/training_request/training_request.js
+++ b/beams/beams/doctype/training_request/training_request.js
@@ -7,6 +7,7 @@ frappe.ui.form.on('Training Request', {
                 // Create a new Training Event
                 frappe.model.with_doctype('Training Event', function() {
                     let training_event = frappe.model.get_new_doc('Training Event');
+                    training_event.training_request = frm.doc.name;
                     // Add the employee from Training Request to the child table in Training Event
                     if (frm.doc.employee) {
                         let child = frappe.model.add_child(training_event, 'employees');

--- a/beams/beams/doctype/training_request/training_request.json
+++ b/beams/beams/doctype/training_request/training_request.json
@@ -99,8 +99,13 @@
   }
  ],
  "index_web_pages_for_search": 1,
- "links": [],
- "modified": "2024-11-12 12:42:55.187000",
+ "links": [
+  {
+   "link_doctype": "Training Event",
+   "link_fieldname": "training_request"
+  }
+ ],
+ "modified": "2025-07-07 12:37:00.960500",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Training Request",
@@ -144,6 +149,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -61,6 +61,7 @@ def after_install():
 	create_custom_fields(get_hd_ticket_type_custom_fields(),ignore_validate=True)
 	create_custom_fields(get_expense_claim_type_custom_fields(),ignore_validate=True)
 	create_custom_fields(get_supplier_quotation_custom_fields(), ignore_validate=True)
+	create_custom_fields(get_training_event_custom_fields(), ignore_validate=True)
 
 
 	#Creating BEAMS specific Property Setters
@@ -134,6 +135,7 @@ def before_uninstall():
 	delete_custom_fields(get_hd_ticket_type_custom_fields())
 	delete_custom_fields(get_expense_claim_type_custom_fields())
 	delete_custom_fields(get_supplier_quotation_custom_fields())
+	delete_custom_fields(get_training_event_custom_fields())
 
 
 def delete_custom_fields(custom_fields: dict):
@@ -4525,6 +4527,24 @@ def get_training_event_employee_custom_fields():
 			  }
 		]
 	}
+
+def get_training_event_custom_fields():
+    '''
+    Custom fields to be added to the Training Event Doctype
+    '''
+    return {
+        "Training Event": [
+           {
+                "fieldname": "training_request",
+                "fieldtype": "Link",
+                "label": "Training Request",
+                "options": "Training Request",
+                "insert_after": "company",
+                "hidden": 1
+
+            }
+        ]
+    }
 
 def get_beams_roles():
 	'''


### PR DESCRIPTION
## Feature description
Add connections in training request
issue : line25: no button to view the  created training event from training request

## Solution description
When a new Training Event is created, the training_request field in the event is populated with the originating Training Request’s ID. Additionally, the Training Event is linked in the Connections section of the Training Request via this training_request field.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/0a3bd039-035f-4f21-a430-65c38e83406b)
![image](https://github.com/user-attachments/assets/a3b2637e-5d4b-4a53-8a1e-d7a3bed0631c)


## Areas affected and ensured
List out the areas affected by your code changes.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
