### PR TITLE
fix: Hide LER button when Job Applicant status is Open

### DIFF
--- a/beams/beams/custom_scripts/job_applicant/job_applicant.js
+++ b/beams/beams/custom_scripts/job_applicant/job_applicant.js
@@ -82,38 +82,41 @@ function handle_custom_buttons(frm) {
                 });
             }
 
-            frappe.call({
-                method: 'beams.beams.custom_scripts.job_applicant.job_applicant.get_existing_local_enquiry_report',
-                args: {
-                    doc_name: frm.doc.name
-                },
-                callback: function (response) {
-                    if (response.message) {
-                        frappe.db.get_doc('Local Enquiry Report', response.message).then(report => {
-                            frm.add_custom_button(__('Local Enquiry Report'), function () {
-                                frappe.set_route('Form', 'Local Enquiry Report', report.name);
-                            }, __('View'));
-                        });
-                    } else {
-                        frm.add_custom_button(__('Local Enquiry Report'), function () {
-                            frappe.call({
-                                method: 'beams.beams.custom_scripts.job_applicant.job_applicant.create_and_return_report',
-                                args: {
-                                    job_applicant: frm.doc.name
-                                },
-                                callback: function (createResponse) {
-                                    if (createResponse.message) {
-                                        frm.add_custom_button(__('Local Enquiry Report'), function () {
-                                            frappe.set_route('Form', 'Local Enquiry Report', createResponse.message);
-                                        }, __('View'));
-                                        frm.refresh();
-                                    }
-                                }
-                            });
-                        }, __('Create'));
-                    }
-                }
-            });
+            // Add Local Enquiry Report (LER) buttons only if not "Open"
+            if (frm.doc.status !== 'Open') {
+				frappe.call({
+					method: 'beams.beams.custom_scripts.job_applicant.job_applicant.get_existing_local_enquiry_report',
+					args: {
+						doc_name: frm.doc.name
+					},
+					callback: function (response) {
+						if (response.message) {
+							frappe.db.get_doc('Local Enquiry Report', response.message).then(report => {
+								frm.add_custom_button(__('Local Enquiry Report'), function () {
+									frappe.set_route('Form', 'Local Enquiry Report', report.name);
+								}, __('View'));
+							});
+						} else {
+							frm.add_custom_button(__('Local Enquiry Report'), function () {
+								frappe.call({
+									method: 'beams.beams.custom_scripts.job_applicant.job_applicant.create_and_return_report',
+									args: {
+										job_applicant: frm.doc.name
+									},
+									callback: function (createResponse) {
+										if (createResponse.message) {
+											frm.add_custom_button(__('Local Enquiry Report'), function () {
+												frappe.set_route('Form', 'Local Enquiry Report', createResponse.message);
+											}, __('View'));
+											frm.refresh();
+										}
+									}
+								});
+							}, __('Create'));
+						}
+					}
+				});
+			}
 
             frm.add_custom_button(__('Send Magic Link'), function () {
                 frappe.confirm('Are you sure you want to send the magic link to the candidate?', function () {

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -2221,7 +2221,8 @@ def get_job_requisition_custom_fields():
 				"fieldtype": "Link",
 				"options": "Employee",
 				"insert_after": "request_for",
-				"depends_on": "eval:doc.request_for == 'Employee Replacement'"
+				"depends_on": "eval:doc.request_for == 'Employee Replacement'",
+				"mandatory_depends_on": "eval:doc.request_for == 'Employee Replacement'"
 			},
 			{
 				"fieldname": "relieving_date",


### PR DESCRIPTION
## Feature description
Need to: 

1. Hide LER button when Job Applicant status is Open
2. make  Employees Who Replaced  field is mandatory  when  Employee Replacement is selected in Request For field in job requisition doctype

## Solution description
1. Hide LER button when Job Applicant status is Open
2. made  Employees Who Replaced  field is mandatory  when  Employee Replacement is selected in Request For field in job requisition doctype through setup file

## Output screenshots (optional)


![image](https://github.com/user-attachments/assets/41bc7725-122f-4540-8733-d59ee0bbcc31)

![image](https://github.com/user-attachments/assets/dbd1bc5f-295c-475c-8070-0e75810ba289)

## Areas affected and ensured
Job Applicant doctype and Job Requisition doctype

## Is there any existing behavior change of other features due to this code change?
 No. 
## Was this feature tested on the browsers?
  - Chrome
