### PR TITLE
feat: clear default language when adding new row in Language Proficiency child table

### DIFF
--- a/beams/beams/custom_scripts/job_requisition/job_requisition.js
+++ b/beams/beams/custom_scripts/job_requisition/job_requisition.js
@@ -92,3 +92,13 @@ function set_filters(frm) {
 		};
 	});
 }
+
+frappe.ui.form.on('Language Proficiency', {
+	language_proficiency_add(frm, cdt, cdn) {
+		row = locals[cdt][cdn];
+		if (row.language) {
+			row.language = "";
+		}
+		frm.refresh_fields();
+	}
+})


### PR DESCRIPTION
## Feature description
Prevent setting a default value ("English") in the language field of the Language Proficiency child table when a new row is added via the ERPNext frontend.
## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description
Added a client-side script in frappe.ui.form.on('Language Proficiency') that listens to the language_proficiency_add event.
When a new row is added to the child table, the script sets the language field of the new row to an empty string ("") and refreshes the field to ensure the UI reflects the cleared state.
## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/ba072130-3136-422a-82cd-8493bfb2f23a)

## Areas affected and ensured
Job Applicant or any parent Doctype using the Language Proficiency child table
Frontend form behavior when adding new rows to the language_proficiency table
## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
