### PR TITLE
fix: Add conditional mandatory rule for Job Description Template field in Job Requisition

### DIFF
--- a/beams/setup.py
+++ b/beams/setup.py
@@ -2206,7 +2206,8 @@ def get_job_requisition_custom_fields():
 				"label": "Job Description Template",
 				"options": "Job Description Template",
 				"insert_after": "job_description_tab",
-				"permlevel": 1
+				"permlevel": 1,
+				"mandatory_depends_on": "eval: frappe.user_roles.includes('HR Manager') && doc.workflow_state == 'Pending HR Approval'"
 			},
 			{
 				"fieldname": "request_for",
@@ -4236,16 +4237,9 @@ def get_property_setters():
 		{
 			"doctype_or_field": "DocField",
 			"doc_type": "Job Requisition",
-			"field_name": "job_description_template",
-			"property": "mandatory_depends_on",
-			"value": "eval: frappe.user_roles.includes('HR Manager') && doc.workflow_state == 'Pending HR Approval'",
-		},
-		{
-			"doctype_or_field": "DocField",
-			"doc_type": "Job Requisition",
 			"field_name": "designation",
 			"property": "mandatory_depends_on",
-			"value": "eval: !(doc.workflow_state == 'Draft' && doc.request_for == 'New Vacancy')"
+			"value": "eval: !(doc.workflow_state == 'Draft' || doc.request_for == 'New Vacancy')"
 		},
 		{
 			"doctype_or_field": "DocField",


### PR DESCRIPTION
## Feature description
 Add conditional mandatory rule for Job Description Template field in Job Requisition

## Solution description

- Made the job_description_template field in the Job Requisition DocType conditionally mandatory only when:
-     The user has the 'HR Manager' role, and
-     The workflow_state is 'Pending HR Approval' 

- modified the mandatory_depends_on condition for the designation field to ensure it’s not mandatory only when:
-     The workflow_state is 'Draft', or
-     The request_for field is 'New Vacancy'

## Output screenshots (optional)

![image](https://github.com/user-attachments/assets/d1728c36-402b-4c87-9dad-62b153b69143)

## Areas affected and ensured

Job Requisition
## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - yes
  - Opera Mini
  - Safari
