### PR TITLE
fix:showed LER button when Job Applicant status is Interview Completed

### DIFF
--- a/beams/beams/custom_scripts/job_applicant/job_applicant.js
+++ b/beams/beams/custom_scripts/job_applicant/job_applicant.js
@@ -82,8 +82,8 @@ function handle_custom_buttons(frm) {
                 });
             }
 
-            // Add Local Enquiry Report (LER) buttons only if not "Open"
-            if (frm.doc.status !== 'Open') {
+            // Show a "Local Enquiry Report (LER)" button in the Job Applicant form only when the status is "Interview Completed"
+            if (frm.doc.status == 'Interview Completed') {
 				frappe.call({
 					method: 'beams.beams.custom_scripts.job_applicant.job_applicant.get_existing_local_enquiry_report',
 					args: {


### PR DESCRIPTION
## Feature description
Neded to: Show LER button when Job Applicant status is Interview Completed

## Solution description
Showed  "Local Enquiry Report (LER)" button in the Job Applicant form only when the status is "Interview Completed" 

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/6367fb1d-e422-481d-b4e4-91d88e52ff4e)


## Areas affected and ensured
Job Applicant

## Is there any existing behavior change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?
  - Chrome
