### PR TITLE
feat: add session user in training feedback

### DIFF
--- a/beams/beams/custom_scripts/training_feedback/training_feedback.js
+++ b/beams/beams/custom_scripts/training_feedback/training_feedback.js
@@ -1,6 +1,6 @@
 frappe.ui.form.on("Training Feedback", {
     onload(frm) {
-        if (!frm.doc.employee) {
+        if (frm.is_new() && !frm.doc.employee) {
             frappe.db.get_value('Employee', { user_id: frappe.session.user }, 'name')
                 .then(r => {
                     if (r.message) frm.set_value('employee', r.message.name);

--- a/beams/beams/custom_scripts/training_feedback/training_feedback.js
+++ b/beams/beams/custom_scripts/training_feedback/training_feedback.js
@@ -1,4 +1,13 @@
 frappe.ui.form.on("Training Feedback", {
+    onload(frm) {
+        if (!frm.doc.employee) {
+            frappe.db.get_value('Employee', { user_id: frappe.session.user }, 'name')
+                .then(r => {
+                    if (r.message) frm.set_value('employee', r.message.name);
+                });
+        }
+    },
+
     training_event: function(frm) {
         if (!frm.doc.training_event) {
             frm.set_query("employee", () => ({}));


### PR DESCRIPTION
## Feature description
Add session user in training feedback
issue 43 : When a user opens the Training Feedback Doctype, 
the Employee field should automatically be filled based on the logged-in user. 
Currently, we are selecting it manually


## Solution description
Auto set employee based on logged-in user

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/795eb4e0-23e3-4a1c-8280-5e0add610a35)



## Areas affected and ensured
List out the areas affected by your code changes.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
