### PR TITLE
fix:correct field 'name_of_father' from Job Applicant

### DIFF
--- a/beams/beams/custom_scripts/employee/employee.js
+++ b/beams/beams/custom_scripts/employee/employee.js
@@ -13,7 +13,7 @@ frappe.ui.form.on('Employee', {
 				frm.set_value('date_of_birth', job_applicant.date_of_birth);
 				frm.set_value('gender', job_applicant.gender);
 				frm.set_value('cell_number', job_applicant.phone_number);
-				frm.set_value('name_of_father_or_spouse', job_applicant.father_name);
+				frm.set_value('name_of_father', job_applicant.father_name);
 				frm.set_value('designation', job_applicant.designation);
 				frm.set_value('department', job_applicant.department);
 				frm.set_value('current_address', job_applicant.current_address);


### PR DESCRIPTION
## Feature description

-  map correct field 'name_of_father' from Job Applicant instead of 'name_of_father_or_spouse'

## Solution description

- fix  The error 'Field name_of_father_or_spouse not found' is raised when selecting a Job Applicant in the Employee doctype
-  map correct field 'name_of_father' from Job Applicant instead of 'name_of_father_or_spouse'

## Output screenshots (optional)
[Screencast from 09-07-25 03:41:34 PM IST.webm](https://github.com/user-attachments/assets/1b84eb24-cc54-474c-824b-60b56d3e38c7)


## Areas affected and ensured
employee

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox -yes
  - Opera Mini
  - Safari
