### PR TITLE
Added child table in Employee Exit Clearance form

### DIFF
--- a/beams/beams/custom_scripts/employee_separation/employee_separation.py
+++ b/beams/beams/custom_scripts/employee_separation/employee_separation.py
@@ -5,15 +5,15 @@ from frappe.desk.form.assign_to import add as add_assign
 def create_exit_clearance(doc, method):
     '''
     Create Employee Exit Clearance records and assign tasks for department heads.
-
     '''
+
     for row in doc.employee_clearance:
         department = row.department
         status = row.status
 
         if status == "Completed":
             continue
-
+        
         # Check if an Employee Exit Clearance already exists for this department
         existing_clearance = frappe.db.exists(
             "Employee Exit Clearance",
@@ -21,62 +21,41 @@ def create_exit_clearance(doc, method):
         )
 
         if existing_clearance:
-            # Update the child table to reference the existing clearance
             frappe.db.set_value(
-                "Employee Clearance",
-                row.name,
-                "employee_exit_clearance",
+                "Employee Clearance", 
+                row.name, 
+                "employee_exit_clearance", 
                 existing_clearance
-            )
-            frappe.msgprint(f"Employee Exit Clearance already exists for department: {department}")
+                )
+            frappe.msgprint(f"Employee Exit Clearance already exists for <b>Employee</b>: {doc.employee} in <b>Department</b>: {department}.", title="Already Exists", indicator="blue")
             continue
 
-        # Fetch Department Head from the Department doctype
         department_head = frappe.db.get_value("Department", department, "head_of_department")
         department_head_user = frappe.db.get_value("Employee", department_head, "user_id") if department_head else None
-
+        
         # Create the Employee Exit Clearance document
         exit_clearance = frappe.get_doc({
             "doctype": "Employee Exit Clearance",
             "employee": doc.employee,
             "department": department,
             "status": "Pending",
-            "assigned_to": department_head_user or " "
+            "assigned_to": department_head_user or ""
         })
         exit_clearance.insert(ignore_permissions=True)
 
-        # Set the value of `employee_separation_begins_on` in the created document
         boarding_begins_on = frappe.db.get_value("Employee Separation", doc.name, "boarding_begins_on")
         if boarding_begins_on:
-            frappe.db.set_value(
-                "Employee Exit Clearance",
-                exit_clearance.name,
-                "employee_separation_begins_on",
-                boarding_begins_on
-                )
-        # Set the ID of the created Employee Exit Clearance in the child table field
-        frappe.db.set_value(
-            "Employee Clearance",
-            row.name,
-            "employee_exit_clearance",
-            exit_clearance.name
-        )
+            frappe.db.set_value("Employee Exit Clearance", exit_clearance.name, "employee_separation_begins_on", boarding_begins_on)
 
-        # Update the status in the Employee Clearance child table
-        frappe.db.set_value(
-            "Employee Clearance",
-            row.name,
-            "status",
-            "Pending"
-        )
+        frappe.db.set_value("Employee Clearance", row.name, "employee_exit_clearance", exit_clearance.name)
+        frappe.db.set_value("Employee Clearance", row.name, "status", "Pending")
 
-        # Assign the task to the department head using add_assign
-        admin_message = (f"Please review and complete the exit clearance process for Employee {doc.employee} "
-        f"assigned to the Department: {department}.")
+        admin_message = f"Please review and complete the exit clearance process for Employee {doc.employee} in Department: {department}."
 
-        add_assign({
-            "assign_to": [department_head_user],
-            "doctype": "Employee Exit Clearance",
-            "name": exit_clearance.name,
-            "description": admin_message
-        })
+        if department_head_user:
+            add_assign({
+                "assign_to": [department_head_user],
+                "doctype": "Employee Exit Clearance",
+                "name": exit_clearance.name,
+                "description": admin_message
+            })

--- a/beams/beams/custom_scripts/employee_separation/employee_separation.py
+++ b/beams/beams/custom_scripts/employee_separation/employee_separation.py
@@ -33,10 +33,7 @@ def create_exit_clearance(doc, method):
 
         # Fetch Department Head from the Department doctype
         department_head = frappe.db.get_value("Department", department, "head_of_department")
-        department_head_user = frappe.db.get_value("Employee", department_head, "user_id")
-        if not department_head_user:
-            frappe.msgprint(f"No Head of Department user found for department: {department}")
-            continue
+        department_head_user = frappe.db.get_value("Employee", department_head, "user_id") if department_head else None
 
         # Create the Employee Exit Clearance document
         exit_clearance = frappe.get_doc({
@@ -44,7 +41,7 @@ def create_exit_clearance(doc, method):
             "employee": doc.employee,
             "department": department,
             "status": "Pending",
-            "assigned_to": department_head_user
+            "assigned_to": department_head_user or " "
         })
         exit_clearance.insert(ignore_permissions=True)
 

--- a/beams/beams/doctype/employee_exit_clearance/employee_exit_clearance.json
+++ b/beams/beams/doctype/employee_exit_clearance/employee_exit_clearance.json
@@ -17,8 +17,7 @@
   "employee_separation_begins_on",
   "notice_period",
   "section_break_xyib",
-  "pending_dues",
-  "amount",
+  "dues",
   "amended_from"
  ],
  "fields": [
@@ -66,18 +65,6 @@
    "label": "Relieving Date"
   },
   {
-   "default": "0",
-   "fieldname": "pending_dues",
-   "fieldtype": "Check",
-   "label": "Pending Dues"
-  },
-  {
-   "depends_on": "eval:doc.pending_dues;",
-   "fieldname": "amount",
-   "fieldtype": "Currency",
-   "label": "Amount"
-  },
-  {
    "fieldname": "column_break_hpbb",
    "fieldtype": "Column Break"
   },
@@ -106,12 +93,19 @@
    "print_hide": 1,
    "read_only": 1,
    "search_index": 1
+  },
+  {
+   "fieldname": "dues",
+   "fieldtype": "Table",
+   "label": "Dues",
+   "options": "Dues",
+   "reqd": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-12-19 10:12:44.011757",
+ "modified": "2025-07-09 15:30:01.269857",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Employee Exit Clearance",
@@ -152,6 +146,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/beams/beams/doctype/employee_exit_clearance/employee_exit_clearance.json
+++ b/beams/beams/doctype/employee_exit_clearance/employee_exit_clearance.json
@@ -98,14 +98,13 @@
    "fieldname": "dues",
    "fieldtype": "Table",
    "label": "Dues",
-   "options": "Dues",
-   "reqd": 1
+   "options": "Dues"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-07-09 15:30:01.269857",
+ "modified": "2025-07-09 15:48:59.820914",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Employee Exit Clearance",

--- a/beams/beams/doctype/employee_exit_clearance/employee_exit_clearance.py
+++ b/beams/beams/doctype/employee_exit_clearance/employee_exit_clearance.py
@@ -8,6 +8,21 @@ class EmployeeExitClearance(Document):
     def on_submit(self):
         self.update_status()
 
+    def before_submit(self):
+        self.ensure_all_dues_cleared()
+
+    def ensure_all_dues_cleared(self):
+        '''
+        Prevent submission if any row in Dues table is not "Cleared".
+        '''
+        for row in self.dues:
+            if row.status != "Cleared":
+                frappe.throw(
+                    f"Dues not cleared: <br>"
+                    f"<b>Description:</b> {row.description or 'N/A'}<br>"
+                    f"<b>Amount:</b> {row.amount or 0}<br>"
+                    f"All dues must be <b>cleared</b> before submitting.")
+
     def update_status(self):
         '''
         Updates the 'status' field in the Employee Clearance child table of Employee Separation to 'Completed'.

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -297,7 +297,7 @@ doc_events = {
         "validate":"beams.beams.custom_scripts.job_offer.job_offer.validate_ctc"
     },
     "Employee Separation": {
-        "on_submit": "beams.beams.custom_scripts.employee_separation.employee_separation.create_exit_clearance"
+        "on_update": "beams.beams.custom_scripts.employee_separation.employee_separation.create_exit_clearance"
         },
     "Task":{
         "on_update":"beams.beams.custom_scripts.task.task.on_task_update"


### PR DESCRIPTION
## Feature description
Clearly and concisely describe the feature.
Fix issue where EEC not being created for those departments whose HOD is not defined.
Create EEC on saving Employee separation document.
New 'Dues' Child Table in Employee Exit Clearance

## Analysis and design (optional)
- When an Employee Separation document is saved, the system now automatically generates corresponding Employee Exit Clearance documents for each department listed in the Employee Clearance child table.
- Exit clearance is created even if the department does not have a Head of Department (HOD), ensuring no department is skipped.

A new table Dues has been added to the Employee Exit Clearance form.

This records:
- Description (reason/item for the due),
- Amount (if any),
- Status (e.g., "Pending", "Cleared").
Submit Restriction Based on Dues Clearance

The Employee Exit Clearance document can only be submitted if all rows in the Dues table have their Status marked as "Cleared".
A detailed error message is shown if any due is pending or rejected, including the description, amount, remarks, and current status.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/6e50b39f-d7ca-4208-961b-2cc9a58b240f)
![image](https://github.com/user-attachments/assets/f8dd2921-7cf0-447f-ba8a-87587530e59c)
![image](https://github.com/user-attachments/assets/40559565-60f5-4c0d-a050-0d05344d40c1)
![image](https://github.com/user-attachments/assets/f391da2c-1bf3-4f3e-808e-f974575f273a)

## Areas affected and ensured
Employee Separation 
Employee Exit Clearance

## Is there any existing behavior change of other features due to this code change?
No
## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
