### PR TITLE
feat: Added fiters on the employee onboarding template and job appllicant

### DIFF
--- a/beams/beams/custom_scripts/employee_onboarding/employee_onboarding.js
+++ b/beams/beams/custom_scripts/employee_onboarding/employee_onboarding.js
@@ -43,15 +43,22 @@ frappe.ui.form.on('Employee Onboarding', {
                     let excluded_applicants = r.message;
 
                     frm.set_query("job_applicant", function () {
-                        return {
-                            filters: {
-                                name: ["not in", excluded_applicants]
-                            }
+                        let filters = {
+                            name: ["not in", excluded_applicants]
                         };
+                        if (frm.doc.designation) {
+                            filters["designation"] = frm.doc.designation;
+                        }
+                        if (frm.doc.department) {
+                            filters["department"] = frm.doc.department;
+                        }
+
+                        return { filters };
                     });
                 }
             }
         });
+        apply_template_filter(frm);
     },
 
     employee: function(frm) {
@@ -88,5 +95,32 @@ frappe.ui.form.on('Employee Onboarding', {
                 }
             });
         }
-    }
+    },
+    department: function(frm) {
+        apply_template_filter(frm);
+    },
+
+    designation: function(frm) {
+        apply_template_filter(frm);
+    },
 });
+
+
+function apply_template_filter(frm) {
+    /**
+    * Applies a dynamic filter to the "employee_onboarding_template" field,
+    * showing only templates that match the current department and designation.
+    */
+    if (frm.doc.department && frm.doc.designation) {
+        frm.set_query("employee_onboarding_template", function () {
+            return {
+                filters: {
+                    department: frm.doc.department,
+                    designation: frm.doc.designation
+                }
+            };
+        });
+    }
+}
+
+


### PR DESCRIPTION


## Feature description
Need to add filters on the employee onboarding template and job applicant  in employee onboarding doctype 
need to add employee onboarding template which is The selected Employee Onboarding Template matches the designation and department in the form
need to add filters in job applicant that The selected Job Applicant also matches the designation and department 

## Solution description
1. Added filters in the employee onboarding template in employee onboarding doctype
Filters are applied such that if the form has a designation and department set, only templates with the same designation and department are shown
2. Added the filters in the job applicant in employee onboarding doctype 
Filters are applied such that if the form has a designation and department set, only job applicants with the same designation and department are shown and also excludes applicants already linked to active employees or existing onboarding
## Output screenshots (optional)
[Screencast from 09-07-25 04:28:10 PM IST.webm](https://github.com/user-attachments/assets/25856515-3acd-4581-8c53-6afe61639fa3)


## Areas affected and ensured
employee onboarding 

## Is there any existing behavior change of other features due to this code change?
 No
## Was this feature tested on the browsers?
  -
  - Mozilla Firefox
  
