### PR TITLE
fix:Allocated compensatory leave for double shift assignment

### DIFF
--- a/beams/beams/custom_scripts/employee_checkin/employee_checkin.py
+++ b/beams/beams/custom_scripts/employee_checkin/employee_checkin.py
@@ -35,7 +35,7 @@ def handle_employee_checkin_out(doc, method):
 
     if not shift_assignment:
         return
-    
+
     # Fetch Leave Allocation
     leave_allocation = frappe.get_all(
         "Leave Allocation",

--- a/beams/beams/custom_scripts/employee_checkin/employee_checkin.py
+++ b/beams/beams/custom_scripts/employee_checkin/employee_checkin.py
@@ -2,6 +2,8 @@ import frappe
 from frappe.utils import add_days, today
 from datetime import datetime
 from frappe.utils import nowdate, get_datetime
+from frappe import _ 
+from frappe.utils import get_url_to_form 
 
 
 def handle_employee_checkin_out(doc, method):
@@ -22,19 +24,18 @@ def handle_employee_checkin_out(doc, method):
     doc_time = datetime.strptime(doc.time, "%Y-%m-%d %H:%M:%S") if isinstance(doc.time, str) else doc.time
     start_date = doc_time.date()
     end_date = add_days(start_date, 30)
-    today_date = today()
-
-    # Verify Shift Assignment with roster_type 'OT'
+    
+    # Use check-out date to verify shift assignment
     shift_assignment = frappe.db.sql("""
         SELECT name FROM `tabShift Assignment`
         WHERE employee = %s
           AND roster_type = 'Double Shift'
           AND %s BETWEEN start_date AND end_date
-    """, (doc.employee, today_date), as_dict=True)
+    """, (doc.employee, start_date), as_dict=True)
 
     if not shift_assignment:
         return
-
+    
     # Fetch Leave Allocation
     leave_allocation = frappe.get_all(
         "Leave Allocation",
@@ -63,6 +64,16 @@ def handle_employee_checkin_out(doc, method):
         })
         leave_allocation_doc.insert(ignore_permissions=True)
         leave_allocation_doc.submit()
+        
+    allocation_name = allocation.name if leave_allocation else leave_allocation_doc.name
+
+    frappe.msgprint(
+        _('Double Shift found for <b>{employee}</b>.<br>'
+          'Compensatory Leave has been <b>allocated</b>: <a href="{url}">{name}</a>').format(
+            employee=doc.employee,
+            url=get_url_to_form("Leave Allocation", allocation_name),
+            name=allocation_name
+        ),alert=True,indicator='green')
 
 def set_hd_agent_active_status(doc, method=None):
 


### PR DESCRIPTION
## Feature description
Need to: Allocate compensatory leave for double shift assignment 

## Solution description
Allocated compensatory leave for double shift assignment

## Output screenshots (optional)

[Screencast from 09-07-25 05:27:51 PM IST.webm](https://github.com/user-attachments/assets/0028d0c3-355d-453b-b816-b80f2419df7c)

![Screenshot from 2025-07-09 17-14-59](https://github.com/user-attachments/assets/c516b0e7-73d2-4d79-a61f-d7ffb59ce1c8)


## Is there any existing behavior change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?
  - Chrome
