### PR TITLE
fix: appraisal score and rating vanishing

### DIFF
--- a/beams/beams/custom_scripts/appraisal/appraisal.js
+++ b/beams/beams/custom_scripts/appraisal/appraisal.js
@@ -515,3 +515,20 @@ function set_table_properties(frm, table_name) {
     frm.set_df_property(table_name, 'cannot_delete_rows', true);
     frm.set_df_property(table_name, 'cannot_delete_all_rows', true);
 }
+
+frappe.ui.form.on('Employee Feedback Rating', {
+    marks: function (frm, cdt, cdn) {
+        const row = locals[cdt][cdn];
+        if (row.marks > 5) {
+            frappe.msgprint(__('Marks cannot be greater than 5.'));
+            frappe.model.set_value(cdt, cdn, 'marks', 0);
+        } else if (row.marks < 0) {
+            frappe.msgprint(__('Marks cannot be less than 0.'));
+            frappe.model.set_value(cdt, cdn, 'marks', 0);
+        }
+        else {
+            row.rating = row.marks/5
+        }
+        frm.refresh_fields();
+    }
+});

--- a/beams/beams/custom_scripts/appraisal/appraisal.py
+++ b/beams/beams/custom_scripts/appraisal/appraisal.py
@@ -1,10 +1,10 @@
-import frappe
-import json
-from frappe import _
-from six import string_types
-from frappe.utils import get_link_to_form
 import datetime
-from frappe.desk.form.assign_to import add as add_assign
+import json
+
+import frappe
+from frappe import _
+from frappe.utils import get_link_to_form
+from six import string_types
 
 
 def validate_kra_marks(doc, method):
@@ -15,6 +15,8 @@ def validate_kra_marks(doc, method):
 			for row in doc.get(field):
 				if row.marks and float(row.marks) > 5:
 					frappe.throw(_("Marks cannot be greater than 5."))
+				if row.marks and float(row.marks) < 0:
+					frappe.throw(_("Marks cannot be less than 0."))
 
 @frappe.whitelist()
 def create_employee_feedback(data, employee , appraisal_name , feedback_exists=False, method='save'):
@@ -220,7 +222,7 @@ def add_to_category_details(parent_docname, category, remarks):
 
 		parent_doc.save(ignore_permissions=True)
 		return "Success"
-	except Exception as e:
+	except Exception:
 		frappe.log_error(frappe.get_traceback(), "Add to Category Details Error")
 		return "Failed"
 

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -316,8 +316,6 @@ doc_events = {
             "beams.beams.custom_scripts.appraisal.appraisal.set_category_based_on_marks",
             "beams.beams.custom_scripts.appraisal.appraisal.validate_kra_marks",
         ],
-        "before_save": [
-			"beams.beams.custom_scripts.appraisal.appraisal.set_self_appraisal",]
     },
     "Event" :{
         "on_update":[


### PR DESCRIPTION
## Reason for PR
Score and Rating in Appraisal was vanishing on save

## Changes Made
- The issue was due to refetching the appraisal template to the tables on every single save, which is stupid
- Added validation for -ve score
- added client script to show rating for score in real time
- removed the refetching on save in hooks