### PR TITLE
fix: appraisal not fetching on auto creation

### DIFF
--- a/beams/beams/custom_scripts/appraisal/appraisal.py
+++ b/beams/beams/custom_scripts/appraisal/appraisal.py
@@ -502,28 +502,27 @@ def set_self_appraisal(doc, method=None):
 		template_doc = frappe.get_doc("Appraisal Template", doc.appraisal_template)
 	except frappe.DoesNotExistError:
 		frappe.throw(f"Appraisal Template {doc.appraisal_template} not found")
-		
-	doc.employee_self_kra_rating = []
-	doc.dept_self_kra_rating = []
-	doc.company_self_kra_rating = []
 
 	# --- Employee Rating Criteria
-	for row in template_doc.rating_criteria:
-		doc.append("employee_self_kra_rating", {
-			"criteria": row.criteria,
-			"per_weightage": row.per_weightage
-		})
+	if doc.employee_self_kra_rating == []:
+		for row in template_doc.rating_criteria:
+			doc.append("employee_self_kra_rating", {
+				"criteria": row.criteria,
+				"per_weightage": row.per_weightage
+			})
 
 	# --- Department Rating Criteria 
-	for row in template_doc.department_rating_criteria:
-		doc.append("dept_self_kra_rating", {
-			"criteria": row.criteria,
-			"per_weightage": row.per_weightage
-		})
+	if doc.dept_self_kra_rating == []:
+		for row in template_doc.department_rating_criteria:
+			doc.append("dept_self_kra_rating", {
+				"criteria": row.criteria,
+				"per_weightage": row.per_weightage
+			})
 
 	# --- Company Rating Criteria
-	for row in template_doc.company_rating_criteria:
-		doc.append("company_self_kra_rating", {
-			"criteria": row.criteria,
-			"per_weightage": row.per_weightage
-		})
+	if doc.company_self_kra_rating == []:
+		for row in template_doc.company_rating_criteria:
+			doc.append("company_self_kra_rating", {
+				"criteria": row.criteria,
+				"per_weightage": row.per_weightage
+			})

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -316,6 +316,9 @@ doc_events = {
             "beams.beams.custom_scripts.appraisal.appraisal.set_category_based_on_marks",
             "beams.beams.custom_scripts.appraisal.appraisal.validate_kra_marks",
         ],
+        "before_insert": [
+            "beams.beams.custom_scripts.appraisal.appraisal.set_self_appraisal",
+        ],
     },
     "Event" :{
         "on_update":[


### PR DESCRIPTION
## Reason for PR
Appraisal Data not getting fetched from Template when created via backend even though the template is selected 

## Changes Made
Setup the script that used to fetch and add the template rows to work before insert if the rows don't already exist