### PR TITLE
feat: add validation for minimum consecutive leave

### DIFF
--- a/beams/beams/custom_scripts/leave_application/leave_application.py
+++ b/beams/beams/custom_scripts/leave_application/leave_application.py
@@ -160,7 +160,7 @@ def validate_notice_period(doc):
                 )
 
 def validate_min_days(doc):
-	'''Validate that the total consecutive leaves meet the minimum days set in the Leave Type.'''
+    '''Validate that the total consecutive leaves meet the minimum days set in the Leave Type.'''
     min_days = frappe.db.get_value("Leave Type", doc.leave_type, "min_continuous_days_allowed")
     if not min_days:
         return

--- a/beams/beams/custom_scripts/leave_application/leave_application.py
+++ b/beams/beams/custom_scripts/leave_application/leave_application.py
@@ -2,6 +2,8 @@ import frappe
 from frappe import _
 from frappe.utils import add_days, nowdate, getdate
 from hrms.hr.doctype.leave_application.leave_application import get_leave_details
+from frappe.utils import cint
+from frappe.utils import get_link_to_form
 
 
 def validate(doc, method):
@@ -9,7 +11,7 @@ def validate(doc, method):
     validate_leave_advance_days(doc.from_date, doc.leave_type)
     validate_sick_leave(doc)
     validate_leave_application(doc)
-
+    validate_min_days(doc)
 
 @frappe.whitelist()
 def validate_leave_advance_days(from_date, leave_type):
@@ -156,3 +158,23 @@ def validate_notice_period(doc):
                     _("You are not allowed to apply for {0} during the <b>Notice Period</b>.")
                     .format(frappe.bold(doc.leave_type))
                 )
+
+def validate_min_days(doc):
+    min_days = frappe.db.get_value("Leave Type", doc.leave_type, "min_continuous_days_allowed")
+    if not min_days:
+        return
+
+    details = doc.get_consecutive_leave_details()
+
+    if details.total_consecutive_leaves < cint(min_days):
+        msg = _("Leave of type {0} should be at least {1} day(s).").format(
+            get_link_to_form("Leave Type", doc.leave_type), min_days
+        )
+        if details.leave_applications:
+            msg += "<br><br>" + _("Reference: {0}").format(
+                ", ".join(
+                    get_link_to_form("Leave Application", name) for name in details.leave_applications
+                )
+            )
+
+        frappe.throw(msg, title=_("Minimum Consecutive Leaves Not Met"))

--- a/beams/beams/custom_scripts/leave_application/leave_application.py
+++ b/beams/beams/custom_scripts/leave_application/leave_application.py
@@ -160,6 +160,7 @@ def validate_notice_period(doc):
                 )
 
 def validate_min_days(doc):
+	'''Validate that the total consecutive leaves meet the minimum days set in the Leave Type.'''
     min_days = frappe.db.get_value("Leave Type", doc.leave_type, "min_continuous_days_allowed")
     if not min_days:
         return

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -3172,14 +3172,14 @@ def get_leave_type_custom_fields():
 			   "insert_after": "is_compensatory"
 
 			},
-			{
-				"fieldname": "min_continuous_days_allowed",
-				"fieldtype": "Int",
-				"label": "Minimum Consecutive Leaves Allowed",
-				"insert_after": "max_continuous_days_allowed"
-			}
-		]
-	}
+            {
+                "fieldname": "min_continuous_days_allowed",
+                "fieldtype": "Int",
+                "label": "Minimum Consecutive Leaves Allowed",
+                "insert_after": "max_continuous_days_allowed"
+            }
+        ]
+    }
 
 def get_employee_separation_custom_fields():
 	'''

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -3149,7 +3149,7 @@ def get_leave_type_custom_fields():
 				"fieldtype": "Int",
 				"label": "Minimum Advance Days",
 				"description": "Specifies the minimum number of days required to apply for this leave.",
-				"insert_after": "max_continuous_days_allowed"
+				"insert_after": "min_continuous_days_allowed"
 			},
 			{
 			   "fieldname": "is_proof_document",
@@ -3171,6 +3171,12 @@ def get_leave_type_custom_fields():
 			   "label": "Allow in Notice Period",
 			   "insert_after": "is_compensatory"
 
+			},
+			{
+				"fieldname": "min_continuous_days_allowed",
+				"fieldtype": "Int",
+				"label": "Minimum Consecutive Leaves Allowed",
+				"insert_after": "max_continuous_days_allowed"
 			}
 		]
 	}

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -3172,14 +3172,14 @@ def get_leave_type_custom_fields():
 			   "insert_after": "is_compensatory"
 
 			},
-            {
-                "fieldname": "min_continuous_days_allowed",
-                "fieldtype": "Int",
-                "label": "Minimum Consecutive Leaves Allowed",
-                "insert_after": "max_continuous_days_allowed"
-            }
-        ]
-    }
+			{
+				"fieldname": "min_continuous_days_allowed",
+				"fieldtype": "Int",
+				"label": "Minimum Consecutive Leaves Allowed",
+				"insert_after": "max_continuous_days_allowed"
+			}
+		]
+	}
 
 def get_employee_separation_custom_fields():
 	'''


### PR DESCRIPTION
## Feature description
issue (team2):
Add a new field "Minimum Consecutive Leaves Allowed" in Leave Type (it has work as "Maximum Consecutive Leaves Allowed")

## Solution description
Added new field "Minimum Consecutive Leaves Allowed" in Leave Type doctype
Validate Leave Application for a specific Leave Type meets the minimum consecutive leave days requirement defined in that leave type's master

## Output screenshots (optional)
<img width="1524" height="848" alt="image" src="https://github.com/user-attachments/assets/98c1a561-35bf-4cb6-9402-5f7a6573b284" />
<img width="1517" height="973" alt="image" src="https://github.com/user-attachments/assets/0ec656da-91bd-4164-a578-4418d801608f" />
<img width="1517" height="973" alt="image" src="https://github.com/user-attachments/assets/62e6797e-ad59-4c84-8fa3-dc2d3f319a33" />


## Areas affected and ensured
List out the areas affected by your code changes.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
