### PR TITLE
TASK-2025-01649:Updated payroll period automatically in Payroll Entry based on posting date

### DIFF
--- a/beams/beams/custom_scripts/payroll_entry/payroll_entry.js
+++ b/beams/beams/custom_scripts/payroll_entry/payroll_entry.js
@@ -1,0 +1,45 @@
+frappe.ui.form.on('Payroll Entry', {
+    refresh: function(frm) {
+        set_previous_month_dates(frm);
+    },
+    
+    posting_date: function(frm) {
+        set_previous_month_dates(frm);
+    },
+    
+    onload: function(frm) {
+        setTimeout(() => {
+            set_previous_month_dates(frm);
+        }, 500);
+    }
+});
+
+function set_previous_month_dates(frm) {
+    if (!frm.doc.posting_date) {
+        return;
+    }
+    
+    let posting_date = frappe.datetime.str_to_obj(frm.doc.posting_date);
+    
+    let prev_year = posting_date.getFullYear();
+    let prev_month = posting_date.getMonth() - 1;
+    
+    if (prev_month < 0) {
+        prev_month = 11;
+        prev_year = prev_year - 1;
+    }
+    
+    let start_date = new Date(prev_year, prev_month, 1);
+    let end_date = new Date(prev_year, prev_month + 1, 0);
+    
+    let start_date_formatted = frappe.datetime.obj_to_str(start_date);
+    let end_date_formatted = frappe.datetime.obj_to_str(end_date);
+    
+    if (frm.doc.start_date !== start_date_formatted) {
+        frm.set_value('start_date', start_date_formatted);
+    }
+    
+    if (frm.doc.end_date !== end_date_formatted) {
+        frm.set_value('end_date', end_date_formatted);
+    }
+}

--- a/beams/beams/custom_scripts/payroll_entry/payroll_entry.js
+++ b/beams/beams/custom_scripts/payroll_entry/payroll_entry.js
@@ -14,6 +14,10 @@ frappe.ui.form.on('Payroll Entry', {
     }
 });
 
+/**
+ * Set the start and end dates to cover the previous month
+ * relative to the selected `posting_date`.
+ */
 function set_previous_month_dates(frm) {
     if (!frm.doc.posting_date) {
         return;

--- a/beams/beams/custom_scripts/payroll_entry/payroll_entry.js
+++ b/beams/beams/custom_scripts/payroll_entry/payroll_entry.js
@@ -1,17 +1,17 @@
 frappe.ui.form.on('Payroll Entry', {
-    refresh: function(frm) {
-        set_previous_month_dates(frm);
-    },
-    
-    posting_date: function(frm) {
-        set_previous_month_dates(frm);
-    },
-    
-    onload: function(frm) {
-        setTimeout(() => {
-            set_previous_month_dates(frm);
-        }, 500);
-    }
+	refresh: function(frm) {
+		set_previous_month_dates(frm);
+	},
+	
+	posting_date: function(frm) {
+		set_previous_month_dates(frm);
+	},
+	
+	onload: function(frm) {
+		setTimeout(() => {
+			set_previous_month_dates(frm);
+		}, 500);
+	}
 });
 
 /**
@@ -19,31 +19,31 @@ frappe.ui.form.on('Payroll Entry', {
  * relative to the selected `posting_date`.
  */
 function set_previous_month_dates(frm) {
-    if (!frm.doc.posting_date) {
-        return;
-    }
-    
-    let posting_date = frappe.datetime.str_to_obj(frm.doc.posting_date);
-    
-    let prev_year = posting_date.getFullYear();
-    let prev_month = posting_date.getMonth() - 1;
-    
-    if (prev_month < 0) {
-        prev_month = 11;
-        prev_year = prev_year - 1;
-    }
-    
-    let start_date = new Date(prev_year, prev_month, 1);
-    let end_date = new Date(prev_year, prev_month + 1, 0);
-    
-    let start_date_formatted = frappe.datetime.obj_to_str(start_date);
-    let end_date_formatted = frappe.datetime.obj_to_str(end_date);
-    
-    if (frm.doc.start_date !== start_date_formatted) {
-        frm.set_value('start_date', start_date_formatted);
-    }
-    
-    if (frm.doc.end_date !== end_date_formatted) {
-        frm.set_value('end_date', end_date_formatted);
-    }
+	if (!frm.doc.posting_date) {
+		return;
+	}
+	
+	let posting_date = frappe.datetime.str_to_obj(frm.doc.posting_date);
+	
+	let prev_year = posting_date.getFullYear();
+	let prev_month = posting_date.getMonth() - 1;
+	
+	if (prev_month < 0) {
+		prev_month = 11;
+		prev_year = prev_year - 1;
+	}
+	
+	let start_date = new Date(prev_year, prev_month, 1);
+	let end_date = new Date(prev_year, prev_month + 1, 0);
+	
+	let start_date_formatted = frappe.datetime.obj_to_str(start_date);
+	let end_date_formatted = frappe.datetime.obj_to_str(end_date);
+	
+	if (frm.doc.start_date !== start_date_formatted) {
+		frm.set_value('start_date', start_date_formatted);
+	}
+	
+	if (frm.doc.end_date !== end_date_formatted) {
+		frm.set_value('end_date', end_date_formatted);
+	}
 }

--- a/beams/beams/custom_scripts/payroll_entry/payroll_entry.js
+++ b/beams/beams/custom_scripts/payroll_entry/payroll_entry.js
@@ -14,11 +14,11 @@ frappe.ui.form.on('Payroll Entry', {
 	}
 });
 
+/**
+* Set the start and end dates to cover the previous month
+* relative to the selected `posting_date`.
+*/
 function set_previous_month_dates(frm) {
-	/**
-	* Set the start and end dates to cover the previous month
-	* relative to the selected `posting_date`.
-	*/
 	if (!frm.doc.posting_date) {
 		return;
 	}

--- a/beams/beams/custom_scripts/payroll_entry/payroll_entry.js
+++ b/beams/beams/custom_scripts/payroll_entry/payroll_entry.js
@@ -14,17 +14,16 @@ frappe.ui.form.on('Payroll Entry', {
 	}
 });
 
-/**
- * Set the start and end dates to cover the previous month
- * relative to the selected `posting_date`.
- */
 function set_previous_month_dates(frm) {
+	/**
+	* Set the start and end dates to cover the previous month
+	* relative to the selected `posting_date`.
+	*/
 	if (!frm.doc.posting_date) {
 		return;
 	}
 	
 	let posting_date = frappe.datetime.str_to_obj(frm.doc.posting_date);
-	
 	let prev_year = posting_date.getFullYear();
 	let prev_month = posting_date.getMonth() - 1;
 	
@@ -35,7 +34,6 @@ function set_previous_month_dates(frm) {
 	
 	let start_date = new Date(prev_year, prev_month, 1);
 	let end_date = new Date(prev_year, prev_month + 1, 0);
-	
 	let start_date_formatted = frappe.datetime.obj_to_str(start_date);
 	let end_date_formatted = frappe.datetime.obj_to_str(end_date);
 	

--- a/beams/beams/custom_scripts/payroll_entry/payroll_entry.py
+++ b/beams/beams/custom_scripts/payroll_entry/payroll_entry.py
@@ -1,0 +1,20 @@
+import frappe
+from frappe.utils import add_months, get_first_day, get_last_day, getdate
+
+def set_previous_month_dates(doc, method=None):
+    """Auto-set start_date and end_date to PREVIOUS month based on posting_date"""
+    
+    if not doc.posting_date:
+        return
+    
+    # Convert posting_date to date object
+    posting_date = getdate(doc.posting_date)
+    
+    # Get PREVIOUS month's first and last day
+    prev_month_date = add_months(posting_date, -1)
+    start_date = get_first_day(prev_month_date)
+    end_date = get_last_day(prev_month_date)
+    
+    # Set the dates to previous month
+    doc.start_date = start_date
+    doc.end_date = end_date 

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -67,7 +67,8 @@ doctype_js = {
     "Full and Final Statement":"beams/custom_scripts/full_and_final_statement/full_and_final_statement.js",
     "Vehicle":"beams/custom_scripts/vehicle/vehicle.js",
     "Material Request":"beams/custom_scripts/material_request/material_request.js",
-    "Asset":"beams/custom_scripts/asset/asset.js"
+    "Asset":"beams/custom_scripts/asset/asset.js",
+	"Payroll Entry":"beams/custom_scripts/payroll_entry/payroll_entry.js"
 }
 doctype_list_js = {
     "Sales Invoice" : "beams/custom_scripts/sales_invoice/sales_invoice_list.js",

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -68,7 +68,7 @@ doctype_js = {
     "Vehicle":"beams/custom_scripts/vehicle/vehicle.js",
     "Material Request":"beams/custom_scripts/material_request/material_request.js",
     "Asset":"beams/custom_scripts/asset/asset.js",
-	"Payroll Entry":"beams/custom_scripts/payroll_entry/payroll_entry.js"
+    "Payroll Entry":"beams/custom_scripts/payroll_entry/payroll_entry.js"
 }
 doctype_list_js = {
     "Sales Invoice" : "beams/custom_scripts/sales_invoice/sales_invoice_list.js",


### PR DESCRIPTION
## Feature description
Need to: Auto-Set Previous Month's Start and End Dates in Payroll Entry based on posting date

## Solution description
- Added client script to automatically populate start_date and end_date
- Start date set to first day of previous month from posting_date
- End date set to last day of previous month from posting_date
- Triggers on form refresh, posting_date change, and onload events

## Output screenshots (optional)
[Screencast from 14-07-25 12:28:11 PM IST.webm](https://github.com/user-attachments/assets/0682d002-db0d-4d36-b1f2-d3d35ba6d02c)

## Areas affected and ensured
Payroll Entry

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Chrome
