### PR TITLE
TASK-2025-01662 : enable and disable user based on employee status

### DIFF
--- a/beams/beams/custom_scripts/employee/employee.py
+++ b/beams/beams/custom_scripts/employee/employee.py
@@ -178,3 +178,24 @@ def validate_offer_dates(doc, method):
     if doc.scheduled_confirmation_date and doc.final_confirmation_date:
         if getdate(doc.final_confirmation_date) <= getdate(doc.scheduled_confirmation_date):
             frappe.throw(_("Confirmation Date must be after Offer Date."))
+
+def manage_user_status(doc, method=None):
+    """
+    Automatically enable or disable a linked User account
+    based on the Employee's status.
+    - If Employee is 'Active' → Enable User
+    - If Employee is 'Inactive', 'Suspended', 'Left' → Disable User
+    """
+
+    if not doc.user_id:
+        return
+
+    user_enabled_status = frappe.db.get_value("User", doc.user_id, "enabled")
+
+    if doc.status == "Active":
+        if user_enabled_status == 0:
+            frappe.db.set_value("User", doc.user_id, "enabled", 1)
+
+    elif doc.status in ["Inactive", "Suspended", "Left"]:
+        if user_enabled_status == 1:
+            frappe.db.set_value("User", doc.user_id, "enabled", 0)

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -287,10 +287,11 @@ doc_events = {
     "Employee" : {
         "autoname": "beams.beams.custom_scripts.employee.employee.autoname",
         "after_insert": "beams.beams.custom_scripts.employee.employee.after_insert",
+        "before_validate": "beams.beams.custom_scripts.employee.employee.manage_user_status",
         "validate":  [
             "beams.beams.custom_scripts.employee.employee.validate",
             "beams.beams.custom_scripts.employee.employee.validate_offer_dates"
-        ],
+        ]
     },
     "Job Offer" : {
         "on_submit":"beams.beams.custom_scripts.job_offer.job_offer.make_employee",


### PR DESCRIPTION
## Feature description
TASK-2025-01662 : enable and disable user based on employee status

## Solution description
Automatically enable or disable a linked User account  based on the Employee's status.
    - If Employee is 'Active' → Enable User
    - If Employee is 'Inactive', 'Suspended', 'Left' → Disable User

## Output screenshots (optional)
[Screencast from 15-07-25 12:14:23 PM IST.webm](https://github.com/user-attachments/assets/2b141922-6793-4bff-9af1-77109f3c6f32)


## Areas affected and ensured
List out the areas affected by your code changes.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
