### PR TITLE
TASK-2025-01650:Made Employee Criteria table and Final Average Score field read-only

### DIFF
--- a/beams/beams/custom_scripts/appraisal_template/appraisal_template.js
+++ b/beams/beams/custom_scripts/appraisal_template/appraisal_template.js
@@ -2,15 +2,14 @@ frappe.ui.form.on("Appraisal Template", {
     refresh: function(frm) {
         hide_marks_field(frm);
         make_rating_criteria_readonly(frm);
-
     }
 });
 
+/**
+ * Dynamically updates the "rating" and "marks" fields to be hidden
+ * for multiple child tables in the Appraisal  Template doctype.
+ */
 function hide_marks_field(frm) {
-   /**
-   * Dynamically updates the "rating" and "marks" fields to be hidden 
-   * for multiple child tables in the Appraisal  Template doctype.
-   */
     ["company_rating_criteria", "department_rating_criteria", "rating_criteria"].forEach(table_name => {
         if (frm.fields_dict[table_name]) {
             frm.fields_dict[table_name].grid.update_docfield_property("marks", "hidden", 1);
@@ -21,10 +20,12 @@ function hide_marks_field(frm) {
         }
     });
 }
+
+/**
+ * Makes the rating_criteria table read-only in the Appraisal Template doctype.
+ */
 function make_rating_criteria_readonly(frm) {
-    /**
-     * Makes the rating_criteria table read-only in the Appraisal Template doctype.
-     */
+
     if (frm.fields_dict["rating_criteria"]) {
         frm.fields_dict["rating_criteria"].grid.cannot_add_rows = true;
         frm.fields_dict["rating_criteria"].grid.cannot_delete_rows = true;

--- a/beams/beams/custom_scripts/appraisal_template/appraisal_template.js
+++ b/beams/beams/custom_scripts/appraisal_template/appraisal_template.js
@@ -1,6 +1,8 @@
 frappe.ui.form.on("Appraisal Template", {
     refresh: function(frm) {
         hide_marks_field(frm);
+        make_rating_criteria_readonly(frm);
+
     }
 });
 
@@ -18,4 +20,15 @@ function hide_marks_field(frm) {
             frm.refresh_field(table_name);
         }
     });
+}
+function make_rating_criteria_readonly(frm) {
+    /**
+     * Makes the rating_criteria table read-only in the Appraisal Template doctype.
+     */
+    if (frm.fields_dict["rating_criteria"]) {
+        frm.fields_dict["rating_criteria"].grid.cannot_add_rows = true;
+        frm.fields_dict["rating_criteria"].grid.cannot_delete_rows = true;
+        frm.fields_dict["rating_criteria"].grid.df.read_only = 1;
+        frm.refresh_field("rating_criteria");
+    }
 }

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -3301,7 +3301,8 @@ def get_appraisal_custom_fields():
 				"fieldtype": "Float",
 				"label": "Final Average Score",
 				"insert_after": "employee_image",
-				"precision": 3
+				"precision": 3,
+				"read_only": 1
 			}
 		]
 	}


### PR DESCRIPTION
## Feature description
Need to:

- Make  Employee Criteria table in the Appraisal Template doctype is read-only 
- Make Final Average Score field in the Appraisal doctype is read-only 

## Solution description
- Made  Employee Criteria table in the Appraisal Template doctype is read-only 
- Made Final Average Score field in the Appraisal doctype is read-only 

## Output screenshots (optional)
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/66587157-9b40-4b68-a0ca-2b613ae2eaed" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/5a3bc13a-27cf-4e4d-95ba-443edfcf707d" />


## Areas affected and ensured
Appraisal Template doctype and Appraisal doctype

## Is there any existing behavior change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?
  - Chrome

