### PR TITLE
feat:Set status to Accepted on submit of Company Policy Acceptance Log

### DIFF
--- a/beams/beams/doctype/company_policy_acceptance_log/company_policy_acceptance_log.json
+++ b/beams/beams/doctype/company_policy_acceptance_log/company_policy_acceptance_log.json
@@ -9,18 +9,20 @@
   "section_break_za7i",
   "employee",
   "employee_name",
-  "department",
   "designation",
-  "date_of_joining",
   "column_break_ohlh",
+  "date",
+  "date_of_joining",
+  "department",
+  "section_break_xlns",
   "company",
   "company_policy",
-  "date",
+  "amended_from",
   "section_break_nxcd",
-  "digital_sign",
-  "column_break_qvpd",
   "read_and_accepted",
-  "amended_from"
+  "status",
+  "column_break_qvpd",
+  "digital_sign"
  ],
  "fields": [
   {
@@ -113,12 +115,23 @@
    "print_hide": 1,
    "read_only": 1,
    "search_index": 1
+  },
+  {
+   "fieldname": "section_break_xlns",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "hidden": 1,
+   "label": "Status",
+   "options": "Draft\nAccepted"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-11-14 13:55:03.631141",
+ "modified": "2025-07-19 10:14:30.035277",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Company Policy Acceptance Log",
@@ -139,7 +152,13 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
- "states": []
+ "states": [
+  {
+   "color": "Blue",
+   "title": "Accepted"
+  }
+ ]
 }

--- a/beams/beams/doctype/company_policy_acceptance_log/company_policy_acceptance_log.py
+++ b/beams/beams/doctype/company_policy_acceptance_log/company_policy_acceptance_log.py
@@ -28,3 +28,6 @@ class CompanyPolicyAcceptanceLog(Document):
         # Ensure only the selected employee can submit
         if frappe.session.user != employee_user_id:
             frappe.throw(_("Only the selected employee can submit this document."))
+
+		# ✅ Set status to Accepted
+        self.status = "Accepted"


### PR DESCRIPTION
## Feature description
Need to: 

- Show the “Read and Accepted” checkbox only after the user scrolls through the company policy
- Set status to Accepted on submit of Company Policy Acceptance Log

## Solution description
- Show the “Read and Accepted” checkbox only after the user scrolls through the company policy
- Set status to Accepted on submit of Company Policy Acceptance Log

## Output screenshots (optional)

[Screencast from 19-07-25 10:34:31 AM IST.webm](https://github.com/user-attachments/assets/6fb4c27f-6fec-4e54-9a4e-3b7d3bb8f013)

## Areas affected and ensured
Company Policy Acceptance Log

## Is there any existing behavior change of other features due to this code change?
No. 

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
