### PR TITLE
fix: allow interview creation when other status in job applicant

### DIFF
--- a/beams/beams/custom_scripts/interview/interview.js
+++ b/beams/beams/custom_scripts/interview/interview.js
@@ -150,7 +150,7 @@ frappe.ui.form.on('Interview', {
 		d.show();
 		d.set_value('result', '');
 
-		frappe.db.get_value('Interview Feedback', { "job_applicant": frm.doc.job_applicant }, ['result', 'feedback'])
+		frappe.db.get_value('Interview Feedback', { "job_applicant": frm.doc.job_applicant,"interview": frm.doc.name,"interviewer": frappe.session.user}, ['result', 'feedback'])
 			.then(r => {
 				if (r && r.message) {
 					d.set_values({

--- a/beams/beams/custom_scripts/job_applicant/job_applicant.js
+++ b/beams/beams/custom_scripts/job_applicant/job_applicant.js
@@ -192,7 +192,7 @@ frappe.ui.form.on('Applicant Interview Round', {
             frappe.set_route('Form', 'Interview', row.interview_reference);
         }
         else {
-            if (frm.doc.status !== "Document Uploaded") {
+            if (!["Document Uploaded", "Interview Scheduled", "Interview Ongoing"].includes(frm.doc.status)){
                 frappe.msgprint(__('Please upload the required documents before creating or viewing an interview.'));
                 return;
             }

--- a/beams/beams/doctype/employee_checkin_permission/employee_checkin_permission.json
+++ b/beams/beams/doctype/employee_checkin_permission/employee_checkin_permission.json
@@ -117,8 +117,9 @@
   }
  ],
  "index_web_pages_for_search": 1,
+ "is_submittable": 1,
  "links": [],
- "modified": "2025-07-07 10:13:22.263951",
+ "modified": "2025-07-19 14:48:12.549456",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Employee Checkin Permission",


### PR DESCRIPTION
## issue description

 -need to allow interview creation when status is 'Document Uploaded', 'Interview Scheduled', or 'Interview Ongoing'
- need to fix As an Interviewer, when I attempt to submit feedback, the form is pre-populated with the result and feedback from a previous entry. 
- need to make a doctype employee check in permission is submittable 
## Solution description

included other status for create interview from interview rounds in job applicant doctype 
- when a interview create from the interview round  if one interview submitted the feedback  and result pre populated to next interviewer also
- also that repopulated to next interview creating from interview round  pre populated the previous inetrview in feedback 
-  added the employee checkin permission submittable 
## Output screenshots (optional)
[Screencast from 19-07-25 10:48:51 AM IST.webm](https://github.com/user-attachments/assets/e8fb859f-bfb2-40f0-b2e9-d20efbfc749d)
<img width="1580" height="1016" alt="image" src="https://github.com/user-attachments/assets/49a54363-3de8-4200-8ddd-136d3fca7960" />
![Uploading image.png…]()


## Areas affected and ensured

job applicant
## Is there any existing behavior change of other features due to this code change?
No. .

## Was this feature tested on the browsers?

  - Mozilla Firefox
  
