### PR TITLE
TASK-2025-01701:Automatically fetch and set the Employee field based on the logged-in user in the Company Policy Acceptance Log

### DIFF
--- a/beams/beams/doctype/company_policy_acceptance_log/company_policy_acceptance_log.js
+++ b/beams/beams/doctype/company_policy_acceptance_log/company_policy_acceptance_log.js
@@ -1,8 +1,30 @@
 // Copyright (c) 2024, efeone and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Company Policy Acceptance Log", {
-// 	refresh(frm) {
+frappe.ui.form.on('Company Policy Acceptance Log', {
+	onload: function (frm) {
+		if (frappe.session.user !== 'Administrator') {
+			frappe.db.get_value('Employee', { user_id: frappe.session.user }, 'name')
+				.then(r => {
+					if (r.message && r.message.name) {
+						const employee_id = r.message.name;
+						frm.set_value('employee', employee_id);
 
-// 	},
-// });
+						// Wait for fields to render, then make them editable
+						frappe.after_ajax(() => {
+							frm.set_df_property('read_and_accepted', 'read_only', false);
+							frm.set_df_property('digital_sign', 'read_only', false);
+						});
+					} else {
+						// No linked employee: keep fields read-only
+						frm.set_df_property('read_and_accepted', 'read_only', true);
+						frm.set_df_property('digital_sign', 'read_only', true);
+					}
+				});
+		} else {
+			// Administrator: read-only fields
+			frm.set_df_property('read_and_accepted', 'read_only', true);
+			frm.set_df_property('digital_sign', 'read_only', true);
+		}
+	}
+});


### PR DESCRIPTION
## Feature description

Need to:
-  Automatically fetch and set the Employee field based on the logged-in user in the Company Policy Acceptance Log
- Made 'Read and Accepted' checkbox editable only for the linked employee

## Solution description

- Automatically fetch and set the Employee field based on the logged-in user in the Company Policy Acceptance Log

- Made 'Read and Accepted' checkbox editable only for the linked employee
## Output screenshots (optional)

[Screencast from 19-07-25 03:48:59 PM IST.webm](https://github.com/user-attachments/assets/6d8c3237-3cd7-4fed-b688-9d2062c16d00)


## Areas affected and ensured
 Company Policy Acceptance Log doctype 

## Is there any existing behavior change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox

