### PR TITLE
fix:  fetched  the shift type from shift assignement in employee checkin permisssion 

### DIFF
--- a/beams/beams/doctype/employee_checkin_permission/employee_checkin_permission.js
+++ b/beams/beams/doctype/employee_checkin_permission/employee_checkin_permission.js
@@ -1,8 +1,46 @@
 // Copyright (c) 2025, efeone and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Employee Checkin Permission", {
-// 	refresh(frm) {
+frappe.ui.form.on("Employee Checkin Permission", {
+	onload(frm) {
+        if (!frm.is_new()|| frm.doc.employee) return;
+        if(frappe.session.user !== "Administrator"){
+            frappe.call({
+                method:'beams.beams.doctype.employee_checkin_permission.employee_checkin_permission.get_employee_for_current_user',
+                callback: function(r){
+                    if(r.message){
+                        frm.set_value('employee',r.message);
+                    }else {
+                        frappe.msgprint(__('No Employee record linked to this user.'));
+                    }
+                }
+            });
+        }
+	},
+    employee: function(frm){
+        set_shift_based_on_assignment(frm);
+    },
+    date: function(frm){
+        set_shift_based_on_assignment(frm);
+    }
+});
 
-// 	},
-// });
+function set_shift_based_on_assignment(frm) {
+    /**
+    * Sets the shift field on the form based on the employee and date by fetching the assigned shift using a server-side method.
+    */
+    if (frm.doc.employee && frm.doc.date) {
+        frappe.call({
+            method: 'beams.beams.doctype.employee_checkin_permission.employee_checkin_permission.get_shift_for_employee_on_date',
+            args: {
+                employee: frm.doc.employee,
+                date: frm.doc.date
+            },
+            callback: function(r) {
+                if (r.message) {
+                    frm.set_value('shift', r.message);
+                }           
+            }
+        });
+    }
+}

--- a/beams/beams/doctype/employee_checkin_permission/employee_checkin_permission.json
+++ b/beams/beams/doctype/employee_checkin_permission/employee_checkin_permission.json
@@ -44,7 +44,6 @@
    "reqd": 1
   },
   {
-   "fetch_from": "employee.default_shift",
    "fieldname": "shift",
    "fieldtype": "Link",
    "label": "Shift",
@@ -119,7 +118,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-07-19 14:48:12.549456",
+ "modified": "2025-07-21 11:15:32.170055",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Employee Checkin Permission",

--- a/beams/beams/doctype/employee_checkin_permission/employee_checkin_permission.py
+++ b/beams/beams/doctype/employee_checkin_permission/employee_checkin_permission.py
@@ -1,9 +1,37 @@
 # Copyright (c) 2025, efeone and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
 
 
 class EmployeeCheckinPermission(Document):
 	pass
+
+
+@frappe.whitelist()
+def get_employee_for_current_user():
+    """Fetches the Employee name linked to the currently logged-in user."""
+    employee = frappe.db.get_value("Employee", {"user_id": frappe.session.user}, "name")
+    return employee
+
+
+@frappe.whitelist()
+def get_shift_for_employee_on_date(employee, date):
+    """
+    Returns the assigned shift for the employee on the given date
+    if there is a Shift Assignment. Returns None if no assignment is found.
+    """
+    shift = frappe.db.get_value(
+        "Shift Assignment",
+        {
+            "employee": employee,
+            "status": "Active",
+            "start_date": ["<=", date],
+            "end_date": [">=", date]
+        },
+        "shift_type"
+    )
+    if not shift:
+         shift = frappe.db.get_value("Employee",employee,"default_shift")
+    return shift


### PR DESCRIPTION

## issue  description

1. need to fix The shift in the Employee Check in Permission form should be fetched from the Shift Assignment based on the selected employee 
2. need to fix  Employee check in permission , when I log in as a user and select an employee, it shows all employees
3. need to remove the shift in employee check in permission fetch from

## Solution description

1.implemented  fix The shift in the Employee Check in Permission form should be fetched from the Shift Assignment based on the selected employee  
- here if the employee has shift assignment in the date it fetch from shift assignment other wise from default shift in employee 
via employee check in permission.py and employee check in permission.js
2. implemented  Employee check in permission , when I log in as a user and select an employee, it shows all employees
- fetched the employee who is current user when if the field is empty  via employee check in permission.p and employee check in permission.js
3.removed the fetch from form employee to shift in employee check in permission 


## Output screenshots (optional)
[Screencast from 21-07-25 12:51:37 PM IST.webm](https://github.com/user-attachments/assets/ee698e98-3db3-4db5-9e02-0094e52c818a)


## Areas affected and ensured
employee check in permission doctype

## Is there any existing behavior change of other features due to this code change?
No
## Was this feature tested on the browsers?

  - Mozilla Firefox
  