### PR TITLE
feat:Set filters in employee separation template

### DIFF
--- a/beams/beams/custom_scripts/employee_separation/employee_separation.js
+++ b/beams/beams/custom_scripts/employee_separation/employee_separation.js
@@ -1,3 +1,6 @@
+// Copyright (c) 2025, efeone and contributors
+// For license information, please see license.txt
+
 frappe.ui.form.on('Employee Separation', {
 	refresh: function(frm) {
 		apply_template_filter(frm);
@@ -11,6 +14,8 @@ frappe.ui.form.on('Employee Separation', {
 		apply_template_filter(frm);
 	},
 });
+
+//  Added filters in employee separation template based on employee designation and department
 
 function apply_template_filter(frm) {
 	if (frm.doc.department && frm.doc.designation) {

--- a/beams/beams/custom_scripts/employee_separation/employee_separation.js
+++ b/beams/beams/custom_scripts/employee_separation/employee_separation.js
@@ -1,0 +1,26 @@
+frappe.ui.form.on('Employee Separation', {
+	refresh: function(frm) {
+		apply_template_filter(frm);
+	},
+
+	department: function(frm) {
+		apply_template_filter(frm);
+	},
+
+	designation: function(frm) {
+		apply_template_filter(frm);
+	},
+});
+
+function apply_template_filter(frm) {
+	if (frm.doc.department && frm.doc.designation) {
+		frm.set_query("employee_separation_template", function () {
+			return {
+				filters: {
+					department: frm.doc.department,
+					designation: frm.doc.designation
+				}
+			};
+		});
+	}
+}

--- a/beams/beams/custom_scripts/employee_separation/employee_separation.js
+++ b/beams/beams/custom_scripts/employee_separation/employee_separation.js
@@ -15,7 +15,9 @@ frappe.ui.form.on('Employee Separation', {
 	},
 });
 
-//  Added filters in employee separation template based on employee designation and department
+/**
+ * Added filters in employee separation template based on employee designation and department
+*/
 
 function apply_template_filter(frm) {
 	if (frm.doc.department && frm.doc.designation) {

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -68,7 +68,8 @@ doctype_js = {
     "Vehicle":"beams/custom_scripts/vehicle/vehicle.js",
     "Material Request":"beams/custom_scripts/material_request/material_request.js",
     "Asset":"beams/custom_scripts/asset/asset.js",
-    "Payroll Entry":"beams/custom_scripts/payroll_entry/payroll_entry.js"
+    "Payroll Entry":"beams/custom_scripts/payroll_entry/payroll_entry.js",
+    "Employee Separation": "beams/custom_scripts/employee_separation/employee_separation.js"
 }
 doctype_list_js = {
     "Sales Invoice" : "beams/custom_scripts/sales_invoice/sales_invoice_list.js",


### PR DESCRIPTION
# Feature description
Set filters in employee separation template according to employee designation and department

## Solution description
- Filters added based on employee designation and department in employee separation doctype
## Output screenshots (optional)
<img width="1366" height="768" alt="Screenshot from 2025-07-21 16-29-24" src="https://github.com/user-attachments/assets/779c76aa-5686-4490-b08e-605323e6ac9a" />
<img width="1366" height="768" alt="Screenshot from 2025-07-21 16-29-42" src="https://github.com/user-attachments/assets/3a0f02e5-2994-4a77-b063-1739141f2491" />

## Is there any existing behavior change of other features due to this code change?
No
## Was this feature tested on the browsers?
  - Chrome
