### PR TITLE
fix:Hide Rating field of Employee Feedback Rating table in Appraisal doctype

### DIFF
--- a/beams/patches.txt
+++ b/beams/patches.txt
@@ -8,3 +8,4 @@ beams.patches.delete_custom_fields  #5-07-2025-
 beams.patches.set_account_in_cost_subhead  #14-02-20250
 beams.patches.set_company_in_budget_template  #20-02-2025
 beams.patches.update_budget_for_inr  #17-03-2025
+beams.patches.delete_property_setter #22-07-2025

--- a/beams/patches/delete_property_setter.py
+++ b/beams/patches/delete_property_setter.py
@@ -1,0 +1,18 @@
+import frappe
+
+def execute():
+    # Define the filter to find the Property Setter
+    filters = {
+        "doctype_or_field": "DocField",
+        "doc_type": "Employee Feedback Rating",
+        "field_name": "Rating",
+        "property": "read_only",
+        "property_type": "Check",
+        "value": "1"  
+    }
+
+    # Find and delete the property setter if it exists
+    property_setter_name = frappe.db.exists("Property Setter", filters)
+    if property_setter_name:
+        frappe.db.delete("Property Setter", {"name": property_setter_name})
+        frappe.db.commit()

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -3673,14 +3673,6 @@ def get_property_setters():
 		},
 		{
 			"doctype_or_field": "DocField",
-			"doc_type": "Employee Feedback Rating",
-			"field_name": "Rating",
-			"property": "read_only",
-			"property_type": "Check",
-			"value": 1
-		},
-		{
-			"doctype_or_field": "DocField",
 			"doc_type": "Employee Performance Feedback",
 			"field_name": "feedback_ratings",
 			"property": "label",
@@ -3731,7 +3723,7 @@ def get_property_setters():
 			"doctype_or_field": "DocField",
 			"doc_type": "Employee Feedback Rating",
 			"field_name": "rating",
-			"property": "read_only",
+			"property": "hidden",
 			"property_type": "Check",
 			"value": 1
 		},


### PR DESCRIPTION
## Feature description
Need to: 
- Hide Rating field of Employee Feedback Rating table in Appraisal doctype.
- Add patch to remove property setter for Rating field

## Solution description

- Hide Rating field of Employee Feedback Rating table in Appraisal doctype.
- Added patch to remove property setter for Rating field

## Output screenshots (optional)

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/48cfd98f-6e01-4f84-9958-205a6601d060" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/e262b2c4-3ce7-4662-97d9-be1ce4e5db9c" />

## Areas affected and ensured
Appraisal doctype

## Is there any existing behavior change of other features due to this code change?
No. 

## Was this feature tested on the browsers?
  - Chrome

