### PR TITLE
fix: Job Applicants not visible to Interviewers

### DIFF
--- a/beams/beams/custom_scripts/job_applicant/job_applicant.py
+++ b/beams/beams/custom_scripts/job_applicant/job_applicant.py
@@ -12,20 +12,6 @@ import os
 def autoname(doc, method):
     doc.name = make_autoname("JOB-APP-" + ".YYYY.-.####")
 
-def get_permission_query_conditions(user):
-	if not user:
-		user = frappe.session.user
-
-	user_roles = frappe.get_roles(user)
-
-	if 'Administrator' in user_roles:
-		return None
-
-	if 'Interviewer' in user_roles:
-		conditions = """(`tabJob Applicant`._assign like '%{user}%')""".format(user=user)
-		return conditions
-	return None
-
 @frappe.whitelist()
 def validate(doc, method):
 	'''

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -37,44 +37,44 @@ app_license = "mit"
 
 # include js in doctype views
 doctype_js = {
-    "Sales Invoice": "beams/custom_scripts/sales_invoice/sales_invoice.js",
-    "Quotation": "beams/custom_scripts/quotation/quotation.js",
-    "Purchase Invoice": "beams/custom_scripts/purchase_invoice/purchase_invoice.js",
-    "Driver":"beams/custom_scripts/driver/driver.js",
-    "Sales Order": "beams/custom_scripts/sales_order/sales_order.js",
-    "Voucher Entry": "beams/custom_scripts/voucher_entry/voucher_entry.js",
-    "Contract":"beams/custom_scripts/contract/contract.js",
-    "Department":"beams/custom_scripts/department/department.js",
-    "Job Requisition":"beams/custom_scripts/job_requisition/job_requisition.js",
-    "Job Applicant" :"beams/custom_scripts/job_applicant/job_applicant.js",
-    "Budget":"beams/custom_scripts/budget/budget.js",
-    "Interview Feedback":"beams/custom_scripts/interview_feedback/interview_feedback.js",
-    "Interview":"beams/custom_scripts/interview/interview.js",
-    "Employee":"beams/custom_scripts/employee/employee.js",
-    "Event":"beams/custom_scripts/event/event.js",
-    "Training Event":"beams/custom_scripts/training_event/training_event.js",
-    "Employee Onboarding":"beams/custom_scripts/employee_onboarding/employee_onboarding.js",
-    "Leave Application":"beams/custom_scripts/leave_application/leave_application.js",
-    "Job Offer": "beams/custom_scripts/job_offer/job_offer.js",
-    "Appraisal":"beams/custom_scripts/appraisal/appraisal.js",
-    "Project":"beams/custom_scripts/project/project.js",
-    "Asset Movement":"beams/custom_scripts/asset_movement/asset_movement.js",
-    "Training Feedback":"beams/custom_scripts/training_feedback/training_feedback.js",
-    "Appraisal Template":"beams/custom_scripts/appraisal_template/appraisal_template.js",
-    "Opportunity":"beams/custom_scripts/opportunity/opportunity.js",
-    "Lead":"beams/custom_scripts/lead/lead.js",
-    "Payment Entry":"beams/custom_scripts/payment_entry/payment_entry.js",
-    "Full and Final Statement":"beams/custom_scripts/full_and_final_statement/full_and_final_statement.js",
-    "Vehicle":"beams/custom_scripts/vehicle/vehicle.js",
-    "Material Request":"beams/custom_scripts/material_request/material_request.js",
-    "Asset":"beams/custom_scripts/asset/asset.js",
-    "Payroll Entry":"beams/custom_scripts/payroll_entry/payroll_entry.js",
-    "Employee Separation": "beams/custom_scripts/employee_separation/employee_separation.js"
+	"Sales Invoice": "beams/custom_scripts/sales_invoice/sales_invoice.js",
+	"Quotation": "beams/custom_scripts/quotation/quotation.js",
+	"Purchase Invoice": "beams/custom_scripts/purchase_invoice/purchase_invoice.js",
+	"Driver":"beams/custom_scripts/driver/driver.js",
+	"Sales Order": "beams/custom_scripts/sales_order/sales_order.js",
+	"Voucher Entry": "beams/custom_scripts/voucher_entry/voucher_entry.js",
+	"Contract":"beams/custom_scripts/contract/contract.js",
+	"Department":"beams/custom_scripts/department/department.js",
+	"Job Requisition":"beams/custom_scripts/job_requisition/job_requisition.js",
+	"Job Applicant" :"beams/custom_scripts/job_applicant/job_applicant.js",
+	"Budget":"beams/custom_scripts/budget/budget.js",
+	"Interview Feedback":"beams/custom_scripts/interview_feedback/interview_feedback.js",
+	"Interview":"beams/custom_scripts/interview/interview.js",
+	"Employee":"beams/custom_scripts/employee/employee.js",
+	"Event":"beams/custom_scripts/event/event.js",
+	"Training Event":"beams/custom_scripts/training_event/training_event.js",
+	"Employee Onboarding":"beams/custom_scripts/employee_onboarding/employee_onboarding.js",
+	"Leave Application":"beams/custom_scripts/leave_application/leave_application.js",
+	"Job Offer": "beams/custom_scripts/job_offer/job_offer.js",
+	"Appraisal":"beams/custom_scripts/appraisal/appraisal.js",
+	"Project":"beams/custom_scripts/project/project.js",
+	"Asset Movement":"beams/custom_scripts/asset_movement/asset_movement.js",
+	"Training Feedback":"beams/custom_scripts/training_feedback/training_feedback.js",
+	"Appraisal Template":"beams/custom_scripts/appraisal_template/appraisal_template.js",
+	"Opportunity":"beams/custom_scripts/opportunity/opportunity.js",
+	"Lead":"beams/custom_scripts/lead/lead.js",
+	"Payment Entry":"beams/custom_scripts/payment_entry/payment_entry.js",
+	"Full and Final Statement":"beams/custom_scripts/full_and_final_statement/full_and_final_statement.js",
+	"Vehicle":"beams/custom_scripts/vehicle/vehicle.js",
+	"Material Request":"beams/custom_scripts/material_request/material_request.js",
+	"Asset":"beams/custom_scripts/asset/asset.js",
+	"Payroll Entry":"beams/custom_scripts/payroll_entry/payroll_entry.js",
+	"Employee Separation": "beams/custom_scripts/employee_separation/employee_separation.js"
 }
 doctype_list_js = {
-    "Sales Invoice" : "beams/custom_scripts/sales_invoice/sales_invoice_list.js",
-    "Purchase Invoice":"beams/custom_scripts/purchase_invoice/purchase_invoice_list.js",
-    "Job Applicant":"beams/custom_scripts/job_applicant/job_applicant_list.js"
+	"Sales Invoice" : "beams/custom_scripts/sales_invoice/sales_invoice_list.js",
+	"Purchase Invoice":"beams/custom_scripts/purchase_invoice/purchase_invoice_list.js",
+	"Job Applicant":"beams/custom_scripts/job_applicant/job_applicant_list.js"
 }
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}
 # doctype_calendar_js = {"doctype" : "public/js/doctype_calendar.js"}
@@ -149,9 +149,8 @@ before_uninstall = "beams.setup.before_uninstall"
 # Permissions evaluated in scripted ways
 
 permission_query_conditions = {
-"Job Applicant": "beams.beams.custom_scripts.job_applicant.job_applicant.get_permission_query_conditions",
-"Interview": "beams.beams.custom_scripts.interview.interview.get_permission_query_conditions",
-"Employee Travel Request": "beams.beams.doctype.employee_travel_request.employee_travel_request.get_permission_query_conditions"
+	"Interview": "beams.beams.custom_scripts.interview.interview.get_permission_query_conditions",
+	"Employee Travel Request": "beams.beams.doctype.employee_travel_request.employee_travel_request.get_permission_query_conditions"
 }
 
 # has_permission = {
@@ -163,9 +162,9 @@ permission_query_conditions = {
 # Override standard doctype classes
 
 override_doctype_class = {
-    "Attendance Request": "beams.beams.custom_scripts.attendance_request.attendance_request.AttendanceRequestOverride",
-    "Shift Type": "beams.beams.custom_scripts.shift_type.shift_type.ShiftTypeOverride",
-    "Interview": "beams.beams.custom_scripts.interview.interview.InterviewOverride",
+	"Attendance Request": "beams.beams.custom_scripts.attendance_request.attendance_request.AttendanceRequestOverride",
+	"Shift Type": "beams.beams.custom_scripts.shift_type.shift_type.ShiftTypeOverride",
+	"Interview": "beams.beams.custom_scripts.interview.interview.InterviewOverride",
 }
 
 # Document Events
@@ -173,235 +172,235 @@ override_doctype_class = {
 # Hook on document methods and events
 
 doc_events = {
-    "Sales Invoice": {
-        "on_update_after_submit":"beams.beams.custom_scripts.sales_invoice.sales_invoice.on_update_after_submit",
-        "autoname": "beams.beams.custom_scripts.sales_invoice.sales_invoice.autoname",
-        "validate": "beams.beams.custom_scripts.sales_invoice.sales_invoice.validate_sales_invoice_for_barter"
-    },
-    "Quotation": {
-        "validate": "beams.beams.custom_scripts.quotation.quotation.validate_is_barter",
-        "on_submit": "beams.beams.custom_scripts.quotation.quotation.create_tasks_for_production_items",
-        "autoname": "beams.beams.custom_scripts.quotation.quotation.autoname"
-    },
-    "Purchase Invoice": {
-        "before_save": "beams.beams.custom_scripts.purchase_invoice.purchase_invoice.before_save"
-    },
-    "Account": {
-        "after_insert": "beams.beams.custom_scripts.account.account.create_todo_on_creation_for_account"
-    },
-    "Customer": {
-        "after_insert": "beams.beams.custom_scripts.account.account.create_todo_on_creation_for_customer",
-        "validate": [
-            "beams.beams.custom_scripts.customer.customer.mark_as_edited_if_approved",
-            "beams.beams.custom_scripts.customer.customer.duplicate_customer"
-            ]
-    },
-    "Training Event": {
-         "on_update": "beams.beams.custom_scripts.training_event.training_event.on_update",
-          "on_update_after_submit": "beams.beams.custom_scripts.training_event.training_event.on_update",
-          "on_cancel": "beams.beams.custom_scripts.training_event.training_event.on_cancel"
-    },
-    "Supplier": {
-        "after_insert": "beams.beams.custom_scripts.account.account.create_todo_on_creation_for_supplier"
-    },
-    "Purchase Order": {
-        "on_update": "beams.beams.custom_scripts.purchase_order.purchase_order.create_todo_on_finance_verification",
-        "after_insert": "beams.beams.custom_scripts.purchase_order.purchase_order.create_todo_on_purchase_order_creation",
-        "before_save": "beams.beams.custom_scripts.purchase_order.purchase_order.validate_budget",
-        # "validate": "beams.beams.custom_scripts.purchase_order.purchase_order.fetch_department_from_cost_center",
-        "on_change":"beams.beams.custom_scripts.purchase_order.purchase_order.update_equipment_quantities"
-    },
-    "Material Request":{
-        "before_save":"beams.beams.custom_scripts.purchase_order.purchase_order.validate_budget",
-        "after_insert":"beams.beams.custom_scripts.material_request.material_request.notify_stock_managers"
-        # "validate":"beams.beams.custom_scripts.purchase_order.purchase_order.fetch_department_from_cost_center"
-    },
-    "Sales Order": {
-        "autoname": "beams.beams.custom_scripts.sales_order.sales_order.autoname",
-        "before_save": "beams.beams.custom_scripts.sales_order.sales_order.validate_sales_order_amount_with_quotation",
-        "before_insert": "beams.beams.custom_scripts.sales_order.sales_order.set_region_from_quotation"
-    },
-    "Contract": {
-        "on_update": "beams.beams.custom_scripts.contract.contract.create_todo_on_contract_verified_by_finance",
-        "after_insert": "beams.beams.custom_scripts.contract.contract.create_todo_on_contract_creation",
-        "on_submit":"beams.beams.custom_scripts.contract.contract.on_submit"
-    },
-    "Batta Claim": {
-        "onchange": ["beams.beams.doctype.batta_claim.batta_claim.calculate_batta_allowance",
-                    "beams.beams.doctype.batta_claim.batta_claim.calculate_batta"]
-    },
-    "Job Requisition": {
-        "on_update": [
-            "beams.beams.custom_scripts.job_requisition.job_requisition.create_job_opening_from_job_requisition",
-            "beams.beams.custom_scripts.job_requisition.job_requisition.on_update"
-        ],
-        "validate": "beams.beams.custom_scripts.job_requisition.job_requisition.validate_expected_by"
-    },
+	"Sales Invoice": {
+		"on_update_after_submit":"beams.beams.custom_scripts.sales_invoice.sales_invoice.on_update_after_submit",
+		"autoname": "beams.beams.custom_scripts.sales_invoice.sales_invoice.autoname",
+		"validate": "beams.beams.custom_scripts.sales_invoice.sales_invoice.validate_sales_invoice_for_barter"
+	},
+	"Quotation": {
+		"validate": "beams.beams.custom_scripts.quotation.quotation.validate_is_barter",
+		"on_submit": "beams.beams.custom_scripts.quotation.quotation.create_tasks_for_production_items",
+		"autoname": "beams.beams.custom_scripts.quotation.quotation.autoname"
+	},
+	"Purchase Invoice": {
+		"before_save": "beams.beams.custom_scripts.purchase_invoice.purchase_invoice.before_save"
+	},
+	"Account": {
+		"after_insert": "beams.beams.custom_scripts.account.account.create_todo_on_creation_for_account"
+	},
+	"Customer": {
+		"after_insert": "beams.beams.custom_scripts.account.account.create_todo_on_creation_for_customer",
+		"validate": [
+			"beams.beams.custom_scripts.customer.customer.mark_as_edited_if_approved",
+			"beams.beams.custom_scripts.customer.customer.duplicate_customer"
+			]
+	},
+	"Training Event": {
+		 "on_update": "beams.beams.custom_scripts.training_event.training_event.on_update",
+		  "on_update_after_submit": "beams.beams.custom_scripts.training_event.training_event.on_update",
+		  "on_cancel": "beams.beams.custom_scripts.training_event.training_event.on_cancel"
+	},
+	"Supplier": {
+		"after_insert": "beams.beams.custom_scripts.account.account.create_todo_on_creation_for_supplier"
+	},
+	"Purchase Order": {
+		"on_update": "beams.beams.custom_scripts.purchase_order.purchase_order.create_todo_on_finance_verification",
+		"after_insert": "beams.beams.custom_scripts.purchase_order.purchase_order.create_todo_on_purchase_order_creation",
+		"before_save": "beams.beams.custom_scripts.purchase_order.purchase_order.validate_budget",
+		# "validate": "beams.beams.custom_scripts.purchase_order.purchase_order.fetch_department_from_cost_center",
+		"on_change":"beams.beams.custom_scripts.purchase_order.purchase_order.update_equipment_quantities"
+	},
+	"Material Request":{
+		"before_save":"beams.beams.custom_scripts.purchase_order.purchase_order.validate_budget",
+		"after_insert":"beams.beams.custom_scripts.material_request.material_request.notify_stock_managers"
+		# "validate":"beams.beams.custom_scripts.purchase_order.purchase_order.fetch_department_from_cost_center"
+	},
+	"Sales Order": {
+		"autoname": "beams.beams.custom_scripts.sales_order.sales_order.autoname",
+		"before_save": "beams.beams.custom_scripts.sales_order.sales_order.validate_sales_order_amount_with_quotation",
+		"before_insert": "beams.beams.custom_scripts.sales_order.sales_order.set_region_from_quotation"
+	},
+	"Contract": {
+		"on_update": "beams.beams.custom_scripts.contract.contract.create_todo_on_contract_verified_by_finance",
+		"after_insert": "beams.beams.custom_scripts.contract.contract.create_todo_on_contract_creation",
+		"on_submit":"beams.beams.custom_scripts.contract.contract.on_submit"
+	},
+	"Batta Claim": {
+		"onchange": ["beams.beams.doctype.batta_claim.batta_claim.calculate_batta_allowance",
+					"beams.beams.doctype.batta_claim.batta_claim.calculate_batta"]
+	},
+	"Job Requisition": {
+		"on_update": [
+			"beams.beams.custom_scripts.job_requisition.job_requisition.create_job_opening_from_job_requisition",
+			"beams.beams.custom_scripts.job_requisition.job_requisition.on_update"
+		],
+		"validate": "beams.beams.custom_scripts.job_requisition.job_requisition.validate_expected_by"
+	},
 
-    "Journal Entry": {
-        "on_cancel": "beams.beams.custom_scripts.journal_entry.journal_entry.on_cancel"
-    },
-    "Job Applicant": {
-        "validate": [
-            "beams.beams.custom_scripts.job_applicant.job_applicant.validate",
-            "beams.beams.custom_scripts.job_applicant.job_applicant.validate_unique_application",
-            "beams.beams.custom_scripts.job_applicant.job_applicant.fetch_designation",
-            "beams.beams.custom_scripts.job_applicant.job_applicant.fetch_department",
-            ],
-        "after_insert":"beams.beams.custom_scripts.job_applicant.job_applicant.set_interview_rounds",
-        "autoname":"beams.beams.custom_scripts.job_applicant.job_applicant.autoname"
-    },
-    "Interview": {
-        "on_submit": [
-                        "beams.beams.custom_scripts.interview.interview.mark_interview_completed",
-                        "beams.beams.custom_scripts.interview.interview.update_job_applicant_status"
-                    ],
-        "after_insert": [
-            "beams.beams.custom_scripts.interview.interview.on_interview_creation",
-            "beams.beams.custom_scripts.interview.interview.update_applicant_interview_rounds"
-        ],
-        "on_update": "beams.beams.custom_scripts.interview.interview.update_applicant_interview_round"
-    },
-    "Interview Feedback": {
-        "after_insert": "beams.beams.custom_scripts.interview_feedback.interview_feedback.after_insert",
-        "validate": "beams.beams.custom_scripts.interview_feedback.interview_feedback.validate",
-        "on_submit": "beams.beams.custom_scripts.interview_feedback.interview_feedback.update_applicant_interview_round_from_feedback"
-    },
-    "Employee Checkin":{
-        "after_insert": [
-            "beams.beams.custom_scripts.employee_checkin.employee_checkin.handle_employee_checkin_out"
-        ]
-    },
-    "Leave Allocation":{
-        "on_submit":"beams.beams.custom_scripts.leave_allocation.leave_allocation.create_new_compensatory_leave_log",
-        "on_update_after_submit":"beams.beams.custom_scripts.leave_allocation.leave_allocation.create_new_log_on_update",
-        "validate": "beams.beams.custom_scripts.leave_allocation.leave_allocation.validate"
+	"Journal Entry": {
+		"on_cancel": "beams.beams.custom_scripts.journal_entry.journal_entry.on_cancel"
+	},
+	"Job Applicant": {
+		"validate": [
+			"beams.beams.custom_scripts.job_applicant.job_applicant.validate",
+			"beams.beams.custom_scripts.job_applicant.job_applicant.validate_unique_application",
+			"beams.beams.custom_scripts.job_applicant.job_applicant.fetch_designation",
+			"beams.beams.custom_scripts.job_applicant.job_applicant.fetch_department",
+			],
+		"after_insert":"beams.beams.custom_scripts.job_applicant.job_applicant.set_interview_rounds",
+		"autoname":"beams.beams.custom_scripts.job_applicant.job_applicant.autoname"
+	},
+	"Interview": {
+		"on_submit": [
+						"beams.beams.custom_scripts.interview.interview.mark_interview_completed",
+						"beams.beams.custom_scripts.interview.interview.update_job_applicant_status"
+					],
+		"after_insert": [
+			"beams.beams.custom_scripts.interview.interview.on_interview_creation",
+			"beams.beams.custom_scripts.interview.interview.update_applicant_interview_rounds"
+		],
+		"on_update": "beams.beams.custom_scripts.interview.interview.update_applicant_interview_round"
+	},
+	"Interview Feedback": {
+		"after_insert": "beams.beams.custom_scripts.interview_feedback.interview_feedback.after_insert",
+		"validate": "beams.beams.custom_scripts.interview_feedback.interview_feedback.validate",
+		"on_submit": "beams.beams.custom_scripts.interview_feedback.interview_feedback.update_applicant_interview_round_from_feedback"
+	},
+	"Employee Checkin":{
+		"after_insert": [
+			"beams.beams.custom_scripts.employee_checkin.employee_checkin.handle_employee_checkin_out"
+		]
+	},
+	"Leave Allocation":{
+		"on_submit":"beams.beams.custom_scripts.leave_allocation.leave_allocation.create_new_compensatory_leave_log",
+		"on_update_after_submit":"beams.beams.custom_scripts.leave_allocation.leave_allocation.create_new_log_on_update",
+		"validate": "beams.beams.custom_scripts.leave_allocation.leave_allocation.validate"
 
-    },
-    "Leave Application" : {
-        "validate": "beams.beams.custom_scripts.leave_application.leave_application.validate"
-    },
-    "Employee" : {
-        "autoname": "beams.beams.custom_scripts.employee.employee.autoname",
-        "after_insert": "beams.beams.custom_scripts.employee.employee.after_insert",
-        "before_validate": "beams.beams.custom_scripts.employee.employee.manage_user_status",
-        "validate":  [
-            "beams.beams.custom_scripts.employee.employee.validate",
-            "beams.beams.custom_scripts.employee.employee.validate_offer_dates"
-        ]
-    },
-    "Job Offer" : {
-        "on_submit":"beams.beams.custom_scripts.job_offer.job_offer.make_employee",
-        "validate":"beams.beams.custom_scripts.job_offer.job_offer.validate_ctc"
-    },
-    "Employee Separation": {
-        "on_update": "beams.beams.custom_scripts.employee_separation.employee_separation.create_exit_clearance"
-        },
-    "Task":{
-        "on_update":"beams.beams.custom_scripts.task.task.on_task_update"
-    },
-    "Appraisal Template" : {
-        "before_save": "beams.beams.custom_scripts.appraisal_template.appraisal_template.create_feedback_criteria",
-        "validate": "beams.beams.custom_scripts.appraisal_template.appraisal_template.validate_rating_criteria"
-    },
-    "Employee Performance Feedback":{
-        "before_save": "beams.beams.custom_scripts.employee_performance_feedback.employee_performance_feedback.update_criteria",
-        "validate":"beams.beams.custom_scripts.employee_performance_feedback.employee_performance_feedback.validate"
-    },
-    "Appraisal":{
-        "validate": [
-            "beams.beams.custom_scripts.appraisal.appraisal.validate_appraisal",
-            "beams.beams.custom_scripts.appraisal.appraisal.set_category_based_on_marks",
-            "beams.beams.custom_scripts.appraisal.appraisal.validate_kra_marks",
-        ],
-        "before_insert": [
-            "beams.beams.custom_scripts.appraisal.appraisal.set_self_appraisal",
-        ],
-    },
-    "Event" :{
-        "on_update":[
-                    "beams.beams.custom_scripts.event.event.validate_reason_for_rejection"
-        ],
-        "validate":[
-                    "beams.beams.custom_scripts.event.event.validate_event_conflict",
-                    "beams.beams.custom_scripts.event.event.validate_event_before_approval"
-        ],
-    },
-    "Salary Slip": {
-        "on_submit": [
-            "beams.beams.custom_scripts.salary_slip.salary_slip.create_journal_entry_pf",
-            "beams.beams.custom_scripts.salary_slip.salary_slip.create_journal_entry_for_esi"
-        ]
-    },
-    "Project": {
-         "on_update":  [
-            "beams.beams.custom_scripts.project.project.update_program_request_status_on_project_completion",
-            "beams.beams.custom_scripts.project.project.validate_project",
-            "beams.beams.custom_scripts.project.project.sync_manpower_logs",
-            "beams.beams.custom_scripts.project.project.on_update_project",
-            "beams.beams.custom_scripts.project.project.sync_vehicle_logs",
-            "beams.beams.custom_scripts.project.project.auto_return_vehicles_on_project_completion",
-            "beams.beams.custom_scripts.project.project.sync_equipment_logs",
-            "beams.beams.custom_scripts.project.project.auto_return_equipment_on_project_completion"
-        ],
-        "validate": [
-           "beams.beams.custom_scripts.project.project.validate_employee_assignment",
-           "beams.beams.custom_scripts.project.project.validate_employee_assignment_in_same_project",
-           "beams.beams.custom_scripts.project.project.validate_vehicle_assignment_in_same_project"
-        ],
-    },
-    "Item": {
-        "before_insert": [
-            "beams.beams.custom_scripts.item.item.before_insert"
-        ]
-    },
-    "Asset Movement": {
-        "on_submit": [
-            "beams.beams.custom_scripts.asset_movement.asset_movement.update_issued_quantity",
-            "beams.beams.custom_scripts.asset_movement.asset_movement.update_asset_location_from_movement"
-            ],
-        "before_save": "beams.beams.custom_scripts.asset_movement.asset_movement.before_save",
-    },
-    "Asset":{
-        "on_submit": [
-            "beams.beams.custom_scripts.asset.asset.generate_asset_qr",
-            "beams.beams.custom_scripts.asset.asset.generate_asset_details_qr"
-        ],
-        "on_update_after_submit":"beams.beams.custom_scripts.asset.asset.create_asset_location_log"
-    },
-    "Budget":{
-        "validate":"beams.beams.custom_scripts.budget.budget.beams_budget_validate",
-        "before_validate":"beams.beams.custom_scripts.budget.budget.populate_og_accounts"
-     },
-    "Training Program": {
-        "validate": "beams.beams.custom_scripts.training_program.training_program.validate_training_program"
-    },
-    "Voucher Entry Type": {
-        "validate" :"beams.beams.custom_scripts.voucher_entry_type.voucher_entry_type.validate_repeating_companies"
-    },
-    "Expense Claim": {
-        "after_insert": "beams.beams.custom_scripts.expense_claim.expense_claim.notify_expense_approver_on_creation"
-    },
-    "Vehicle" :{
-        "on_update":"beams.beams.custom_scripts.vehicle.vehicle.create_vehicle_documents_log"
-    }
+	},
+	"Leave Application" : {
+		"validate": "beams.beams.custom_scripts.leave_application.leave_application.validate"
+	},
+	"Employee" : {
+		"autoname": "beams.beams.custom_scripts.employee.employee.autoname",
+		"after_insert": "beams.beams.custom_scripts.employee.employee.after_insert",
+		"before_validate": "beams.beams.custom_scripts.employee.employee.manage_user_status",
+		"validate":  [
+			"beams.beams.custom_scripts.employee.employee.validate",
+			"beams.beams.custom_scripts.employee.employee.validate_offer_dates"
+		]
+	},
+	"Job Offer" : {
+		"on_submit":"beams.beams.custom_scripts.job_offer.job_offer.make_employee",
+		"validate":"beams.beams.custom_scripts.job_offer.job_offer.validate_ctc"
+	},
+	"Employee Separation": {
+		"on_update": "beams.beams.custom_scripts.employee_separation.employee_separation.create_exit_clearance"
+		},
+	"Task":{
+		"on_update":"beams.beams.custom_scripts.task.task.on_task_update"
+	},
+	"Appraisal Template" : {
+		"before_save": "beams.beams.custom_scripts.appraisal_template.appraisal_template.create_feedback_criteria",
+		"validate": "beams.beams.custom_scripts.appraisal_template.appraisal_template.validate_rating_criteria"
+	},
+	"Employee Performance Feedback":{
+		"before_save": "beams.beams.custom_scripts.employee_performance_feedback.employee_performance_feedback.update_criteria",
+		"validate":"beams.beams.custom_scripts.employee_performance_feedback.employee_performance_feedback.validate"
+	},
+	"Appraisal":{
+		"validate": [
+			"beams.beams.custom_scripts.appraisal.appraisal.validate_appraisal",
+			"beams.beams.custom_scripts.appraisal.appraisal.set_category_based_on_marks",
+			"beams.beams.custom_scripts.appraisal.appraisal.validate_kra_marks",
+		],
+		"before_insert": [
+			"beams.beams.custom_scripts.appraisal.appraisal.set_self_appraisal",
+		],
+	},
+	"Event" :{
+		"on_update":[
+					"beams.beams.custom_scripts.event.event.validate_reason_for_rejection"
+		],
+		"validate":[
+					"beams.beams.custom_scripts.event.event.validate_event_conflict",
+					"beams.beams.custom_scripts.event.event.validate_event_before_approval"
+		],
+	},
+	"Salary Slip": {
+		"on_submit": [
+			"beams.beams.custom_scripts.salary_slip.salary_slip.create_journal_entry_pf",
+			"beams.beams.custom_scripts.salary_slip.salary_slip.create_journal_entry_for_esi"
+		]
+	},
+	"Project": {
+		 "on_update":  [
+			"beams.beams.custom_scripts.project.project.update_program_request_status_on_project_completion",
+			"beams.beams.custom_scripts.project.project.validate_project",
+			"beams.beams.custom_scripts.project.project.sync_manpower_logs",
+			"beams.beams.custom_scripts.project.project.on_update_project",
+			"beams.beams.custom_scripts.project.project.sync_vehicle_logs",
+			"beams.beams.custom_scripts.project.project.auto_return_vehicles_on_project_completion",
+			"beams.beams.custom_scripts.project.project.sync_equipment_logs",
+			"beams.beams.custom_scripts.project.project.auto_return_equipment_on_project_completion"
+		],
+		"validate": [
+		   "beams.beams.custom_scripts.project.project.validate_employee_assignment",
+		   "beams.beams.custom_scripts.project.project.validate_employee_assignment_in_same_project",
+		   "beams.beams.custom_scripts.project.project.validate_vehicle_assignment_in_same_project"
+		],
+	},
+	"Item": {
+		"before_insert": [
+			"beams.beams.custom_scripts.item.item.before_insert"
+		]
+	},
+	"Asset Movement": {
+		"on_submit": [
+			"beams.beams.custom_scripts.asset_movement.asset_movement.update_issued_quantity",
+			"beams.beams.custom_scripts.asset_movement.asset_movement.update_asset_location_from_movement"
+			],
+		"before_save": "beams.beams.custom_scripts.asset_movement.asset_movement.before_save",
+	},
+	"Asset":{
+		"on_submit": [
+			"beams.beams.custom_scripts.asset.asset.generate_asset_qr",
+			"beams.beams.custom_scripts.asset.asset.generate_asset_details_qr"
+		],
+		"on_update_after_submit":"beams.beams.custom_scripts.asset.asset.create_asset_location_log"
+	},
+	"Budget":{
+		"validate":"beams.beams.custom_scripts.budget.budget.beams_budget_validate",
+		"before_validate":"beams.beams.custom_scripts.budget.budget.populate_og_accounts"
+	 },
+	"Training Program": {
+		"validate": "beams.beams.custom_scripts.training_program.training_program.validate_training_program"
+	},
+	"Voucher Entry Type": {
+		"validate" :"beams.beams.custom_scripts.voucher_entry_type.voucher_entry_type.validate_repeating_companies"
+	},
+	"Expense Claim": {
+		"after_insert": "beams.beams.custom_scripts.expense_claim.expense_claim.notify_expense_approver_on_creation"
+	},
+	"Vehicle" :{
+		"on_update":"beams.beams.custom_scripts.vehicle.vehicle.create_vehicle_documents_log"
+	}
 }
 
 # Scheduled Tasks
 # ---------------
 
 scheduler_events = {
-    "daily": [
-        "beams.beams.doctype.local_enquiry_report.local_enquiry_report.set_status_to_overdue",
-        "beams.beams.custom_scripts.attendance.attendance.send_absence_reminder",
-        "beams.beams.custom_scripts.attendance.attendance.send_absent_reminder",
-        "beams.beams.doctype.compensatory_leave_log.compensatory_leave_log.expire_leave_allocation",
-        "beams.beams.doctype.beams_hr_settings.beams_hr_settings.send_shift_publication_notifications",
-        "beams.beams.doctype.beams_hr_settings.beams_hr_settings.send_appraisal_reminders",
-        "beams.beams.custom_scripts.vehicle.vehicle.send_vehicle_document_reminders",
-        "beams.beams.doctype.beams_admin_settings.beams_admin_settings.send_asset_audit_reminder",
-        "beams.beams.doctype.beams_admin_settings.beams_admin_settings.send_asset_reservation_notifications"
-    ],
+	"daily": [
+		"beams.beams.doctype.local_enquiry_report.local_enquiry_report.set_status_to_overdue",
+		"beams.beams.custom_scripts.attendance.attendance.send_absence_reminder",
+		"beams.beams.custom_scripts.attendance.attendance.send_absent_reminder",
+		"beams.beams.doctype.compensatory_leave_log.compensatory_leave_log.expire_leave_allocation",
+		"beams.beams.doctype.beams_hr_settings.beams_hr_settings.send_shift_publication_notifications",
+		"beams.beams.doctype.beams_hr_settings.beams_hr_settings.send_appraisal_reminders",
+		"beams.beams.custom_scripts.vehicle.vehicle.send_vehicle_document_reminders",
+		"beams.beams.doctype.beams_admin_settings.beams_admin_settings.send_asset_audit_reminder",
+		"beams.beams.doctype.beams_admin_settings.beams_admin_settings.send_asset_reservation_notifications"
+	],
 # "all": [
 # "beams.tasks.all"
 # ],
@@ -414,9 +413,9 @@ scheduler_events = {
 # "weekly": [
 # "beams.tasks.weekly"
 # ],
-    "monthly": [
-        "beams.beams.custom_scripts.asset.asset.asset_notifications"
-    ],
+	"monthly": [
+		"beams.beams.custom_scripts.asset.asset.asset_notifications"
+	],
   }
 
 # Testing
@@ -436,15 +435,15 @@ scheduler_events = {
 # along with any modifications made in other Frappe apps
 override_doctype_dashboards = {
 'Item': 'beams.beams.custom_scripts.item_dashboard.item_dashboard.get_data',
-    'Customer': 'beams.beams.custom_scripts.customer_dashboard.customer_dashboard.get_data',
-    'Sales Invoice': 'beams.beams.custom_scripts.sales_invoice_dashboard.sales_invoice_dashboard.get_data',
-    'Sales Order': 'beams.beams.custom_scripts.sales_order_dashboard.sales_order_dashboard.get_data',
-    'Employee':'beams.beams.custom_scripts.employee_dashboard.employee_dashboard.get_data',
-    'Job Applicant': 'beams.beams.custom_scripts.job_applicant.job_applicant_dashboard.get_data',
-    'Project':'beams.beams.custom_scripts.project_dashboard.project_dashboard.get_data',
-    'Department': 'beams.beams.custom_scripts.department.department_dashboard.get_data',
-    'Vehicle': 'beams.beams.custom_scripts.vehicle_dashboard.vehicle_dashboard.get_data',
-    'Driver': 'beams.beams.custom_scripts.driver_dashboard.driver_dashboard.get_data',
+	'Customer': 'beams.beams.custom_scripts.customer_dashboard.customer_dashboard.get_data',
+	'Sales Invoice': 'beams.beams.custom_scripts.sales_invoice_dashboard.sales_invoice_dashboard.get_data',
+	'Sales Order': 'beams.beams.custom_scripts.sales_order_dashboard.sales_order_dashboard.get_data',
+	'Employee':'beams.beams.custom_scripts.employee_dashboard.employee_dashboard.get_data',
+	'Job Applicant': 'beams.beams.custom_scripts.job_applicant.job_applicant_dashboard.get_data',
+	'Project':'beams.beams.custom_scripts.project_dashboard.project_dashboard.get_data',
+	'Department': 'beams.beams.custom_scripts.department.department_dashboard.get_data',
+	'Vehicle': 'beams.beams.custom_scripts.vehicle_dashboard.vehicle_dashboard.get_data',
+	'Driver': 'beams.beams.custom_scripts.driver_dashboard.driver_dashboard.get_data',
 }
 
 # exempt linked doctypes from being automatically cancelled
@@ -504,10 +503,10 @@ override_doctype_dashboards = {
 # "Logging DocType Name": 30  # days to retain logs
 # }
 fixtures = [
-    {
-        "dt": "Custom HTML Block",
-        "filters": [
-            ["name", "in", ["Media One HR", "Employee View"]]
-        ]
-    }
+	{
+		"dt": "Custom HTML Block",
+		"filters": [
+			["name", "in", ["Media One HR", "Employee View"]]
+		]
+	}
 ]


### PR DESCRIPTION
## Feature description

- Fix issue where users with the "Interviewer" role could not view Job Applicants due to a incorrect permission query condition.
- Done code cleanup also
 ## Analysis and design (optional)

The previous implementation added a custom permission_query_conditions that filtered Job Applicants based on whether the logged-in user was assigned to the record via _assign. Later team mentioned that this requirement is no longer needed .
This condition mistakenly hid all Job Applicants from users with only the "Interviewer" role, even when they had appropriate role permissions.

## Solution description
- Removed the custom get_permission_query_conditions logic for the Job Applicant DocType.
- Deleted the permission condition from the Python hook and the function that checked for _assign.

## Output screenshots (optional)

- User with interviewer role
<img width="1838" height="930" alt="image" src="https://github.com/user-attachments/assets/2551e07c-aa36-4d36-9cd7-0bcb83f13b3d" />

- the user has logged-in and can view all job applicants
<img width="1838" height="930" alt="image" src="https://github.com/user-attachments/assets/df073cc2-4915-4a83-bd93-aeacc3fbcc76" />

## Areas affected and ensured
- Job Applicant DocType: Visibility for Interviewers
- Permissions: Now fallback to standard Role Permission system

## Is there any existing behavior change of other features due to this code change?
No. This fix removes the wrong restriction and lets permissions work as expected.

## Was this feature tested on the browsers?
  - Chrome
  