### PR TITLE
feat:Show Magic Link button for Pending Document Uploaded status

### DIFF
--- a/beams/beams/custom_scripts/job_applicant/job_applicant.js
+++ b/beams/beams/custom_scripts/job_applicant/job_applicant.js
@@ -118,7 +118,7 @@ function handle_custom_buttons(frm) {
 				});
 			}
 
-            if (frm.doc.status == 'Shortlisted') {
+            if (frm.doc.status == 'Shortlisted' || frm.doc.status == 'Pending Document Upload') {
                 frm.add_custom_button(__('Send Magic Link'), function () {
                     frappe.confirm('Are you sure you want to send the magic link to the candidate?', function () {
                         frappe.call({

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -4209,6 +4209,14 @@ def get_property_setters():
 			"property_type": "Select",
 			"value": 1
 		},
+		{
+			"doctype_or_field": "DocField",
+			"doc_type": "Job Applicant",
+			"field_name": "status",
+			"property": "read_only",
+			"property_type": "Select",
+			"value": 1
+		},
 	]
 
 def get_material_request_custom_fields():


### PR DESCRIPTION
## Feature description
Show Magic Link button for Pending for Document Upload status

## Solution description

- Magic Link button added even when the status is pending for document upload
-  Job Applicant doctype status field set to read only through property setter

## Output screenshots (optional)
<img width="1366" height="768" alt="Screenshot from 2025-07-22 15-55-50" src="https://github.com/user-attachments/assets/b83d9707-760b-40cb-bf36-250744354ed9" />


## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome

