### PR TITLE
refactor: reset key fields on form refresh in Employee Interview Tool

### DIFF
--- a/beams/beams/doctype/employee_interview_tool/employee_interview_tool.js
+++ b/beams/beams/doctype/employee_interview_tool/employee_interview_tool.js
@@ -18,6 +18,11 @@ frappe.ui.form.on('Employee Interview Tool', {
 		frm.set_value('scheduled_on', '');
 		frm.set_value('from_time', '');
 		frm.set_value('to_time', '');
+		frm.set_value('department', '');
+		frm.set_value('designation', '');
+		frm.set_value('job_opening', '');
+		frm.set_value('branch', '');
+		frm.set_value('applicant_status', '');
 		frm.clear_table('job_applicants');
 		frm.refresh_field('job_applicants');
 		frm.toggle_display('job_applicants', false);


### PR DESCRIPTION
## Feature description
When the Employee Interview Tool form is refreshed, it should reset key fields like Department, Designation, Job Opening, Branch, and Applicant Status to ensure a clean and consistent state.
Previously, only Interview Scheduling fields (scheduled_on, from_time, to_time) were cleared on refresh

## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description
- Enhanced the refresh method in employee_interview_tool.js to clear additional fields such as department,designation,job_opening,branch and applicant_status.
- Maintained the existing logic to clear scheduling fields and the job applicants table.

## Output screenshots (optional)

- Before form refresh
<img width="1818" height="885" alt="image" src="https://github.com/user-attachments/assets/181c6ec3-6f4e-4a5e-84f3-53f7c40aeeb6" />

- after form refresh
<img width="1818" height="885" alt="image" src="https://github.com/user-attachments/assets/430f5e5a-1e18-43f8-ac7d-2f33ee9bef23" />


## Areas affected and ensured
- Client-side logic for Employee Interview Tool
- Affects form behavior during refresh

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
