### PR TITLE
feat: generate and attach QR code for Job Opening linking to job portal

### DIFF
--- a/beams/beams/custom_scripts/job_opening/job_opening.py
+++ b/beams/beams/custom_scripts/job_opening/job_opening.py
@@ -1,0 +1,38 @@
+import frappe
+import qrcode
+import os
+from frappe.utils import get_files_path, get_url
+from io import BytesIO
+
+@frappe.whitelist()
+def generate_qr_for_job(doc, method=None):
+	"""
+		Generate a QR code for the Job Opening that links to its public portal page
+	"""
+	if isinstance(doc, str):
+		doc = frappe.get_doc("Job Opening", doc)
+
+	base_url = get_url()
+	job_url = f"{base_url}/job_portal?job_opening={doc.name}"
+	doc.job_url = job_url
+
+	qr = qrcode.make(job_url)
+	buffer = BytesIO()
+	qr.save(buffer)
+	buffer.seek(0)
+
+	file_name = f"qr_{doc.name}.png"
+	file_path = os.path.join(get_files_path(), file_name)
+	with open(file_path, "wb") as f:
+		f.write(buffer.read())
+
+	frappe.get_doc({
+		"doctype": "File",
+		"file_url": f"/files/{file_name}",
+		"attached_to_doctype": "Job Opening",
+		"attached_to_name": doc.name,
+		"is_private": 0
+	}).insert(ignore_permissions=True)
+
+	doc.qr_scan_to_apply = f"/files/{file_name}"
+

--- a/beams/beams/custom_scripts/job_opening/job_opening.py
+++ b/beams/beams/custom_scripts/job_opening/job_opening.py
@@ -35,5 +35,4 @@ def generate_qr_for_job(doc, method=None):
 	})
 	file_doc.insert(ignore_permissions=True)
 
-	doc.qr_scan_to_apply = f"/files/{file_name}"
-
+	doc.qr_scan_to_apply = file_doc.file_url

--- a/beams/beams/custom_scripts/job_opening/job_opening.py
+++ b/beams/beams/custom_scripts/job_opening/job_opening.py
@@ -26,13 +26,14 @@ def generate_qr_for_job(doc, method=None):
 	with open(file_path, "wb") as f:
 		f.write(buffer.read())
 
-	frappe.get_doc({
+	file_doc = frappe.get_doc({
 		"doctype": "File",
 		"file_url": f"/files/{file_name}",
 		"attached_to_doctype": "Job Opening",
 		"attached_to_name": doc.name,
 		"is_private": 0
-	}).insert(ignore_permissions=True)
+	})
+	file_doc.insert(ignore_permissions=True)
 
 	doc.qr_scan_to_apply = f"/files/{file_name}"
 

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -383,6 +383,9 @@ doc_events = {
 	},
 	"Vehicle" :{
 		"on_update":"beams.beams.custom_scripts.vehicle.vehicle.create_vehicle_documents_log"
+	},
+	"Job Opening": {
+		"validate": "beams.beams.custom_scripts.job_opening.job_opening.generate_qr_for_job"
 	}
 }
 

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -385,7 +385,7 @@ doc_events = {
 		"on_update":"beams.beams.custom_scripts.vehicle.vehicle.create_vehicle_documents_log"
 	},
 	"Job Opening": {
-		"validate": "beams.beams.custom_scripts.job_opening.job_opening.generate_qr_for_job"
+		"after_insert": "beams.beams.custom_scripts.job_opening.job_opening.generate_qr_for_job"
 	}
 }
 

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -2930,7 +2930,22 @@ def get_job_opening_custom_fields():
 				"label": "Interview Rounds",
 				'options':"Interview Rounds",
 				"insert_after": "interview_details_sb"
+			},
+			{
+				"fieldname": "qr_scan_to_apply",
+				"fieldtype": "Attach Image",
+				"label": "Scan QR to Apply",
+				"insert_after": "publish_salary_range"
+			},
+			{
+				"fieldname": "job_url",
+				"fieldtype": "Data",
+				"label": "Job URL",
+				"read_only": 1,
+				"hidden": 1,
+				"insert_after": "qr_scan_to_apply"
 			}
+
 		]
 	}
 


### PR DESCRIPTION
## Feature description

-  generate and attach QR code for Job Opening linking to job portal

## Solution description

- Include a QR code field in the Job Opening form. This QR code should be automatically generated and, when scanned, should redirect  to the respective Job Opening in Job Portal

## Output screenshots (optional)
<img width="1439" height="955" alt="image" src="https://github.com/user-attachments/assets/afb6c63d-5e24-4315-910a-5624ef0697de" />


## Areas affected and ensured
Job Opening 
Job portal

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox -Yes
  - Opera Mini
  - Safari
