### PR TITLE
feat: update Job Requisition with new fields and layout changes

### DIFF
--- a/beams/beams/doctype/designation_activities/designation_activities.json
+++ b/beams/beams/doctype/designation_activities/designation_activities.json
@@ -1,0 +1,40 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-07-24 16:17:44.309356",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "activity",
+  "description"
+ ],
+ "fields": [
+  {
+   "fieldname": "activity",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Activity"
+  },
+  {
+   "fieldname": "description",
+   "fieldtype": "Small Text",
+   "in_list_view": 1,
+   "label": "Description"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2025-07-24 16:18:52.662725",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "Designation Activities",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/beams/beams/doctype/designation_activities/designation_activities.py
+++ b/beams/beams/doctype/designation_activities/designation_activities.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class DesignationActivities(Document):
+	pass

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -2237,6 +2237,20 @@ def get_job_requisition_custom_fields():
 				"fieldtype": "Section Break",
 			},
 			{
+				"fieldname": "designation_activities_section",
+				"insert_after": "reason_for_requesting",
+				"fieldtype": "Section Break",
+				"permlevel": 2
+			},
+			{
+				"fieldname": "designation_wise_activities",
+				"fieldtype": "Table",
+				"label": "Designation-wise Activities",
+				"options": "Designation Activities",
+				"insert_after": "designation_activities_section",
+				"permlevel" : 2
+			},
+			{
 				"label": "Unwated Fields",
 				"fieldname": "custom_unwated_fields",
 				"insert_after": "status",
@@ -4015,6 +4029,13 @@ def get_property_setters():
 		{
 			"doctype_or_field": "DocField",
 			"doc_type": "Job Requisition",
+			"field_name": "expected_compensation",
+			"property": "label",
+			"value": "Expected Compensation (Yearly)"
+		},
+		{
+			"doctype_or_field": "DocField",
+			"doc_type": "Job Requisition",
 			"field_name": "employee_left",
 			"property": "ignore_user_permissions",
 			"value": 1
@@ -4286,7 +4307,7 @@ def get_property_setters():
 			"doctype_or_field": "DocType",
 			"doc_type": "Job Requisition",
 			"property": "field_order",
-			"value": '["workflow_state", "naming_series", "request_for", "employee_left", "relieving_date", "suggested_designation", "designation", "department", "location", "employment_type", "column_break_qkna", "no_of_positions", "expected_compensation", "company", "status", "custom_unwated_fields", "column_break_4", "reason_for_request_section", "reason_for_requesting", "section_break_7", "requested_by", "requested_by_name", "column_break_10", "requested_by_dept", "requested_by_designation", "interview", "interview_rounds", "work_details", "no_of_days_off", "min_experience", "work_details_column_break", "is_work_shift_needed", "travel_required", "driving_license_needed", "license_type", "education", "min_education_qual", "education_column_break", "reset_column", "language_proficiency", "skill_proficiency", "publish_on_job_section", "publish_on_job_opening", "timelines_tab", "posting_date", "completed_on", "column_break_15", "expected_by", "time_to_fill", "job_description_tab", "job_description_template", "job_title", "description", "suggestions", "connections_tab"]'
+			"value": '["workflow_state", "naming_series", "request_for", "employee_left", "relieving_date", "suggested_designation", "designation", "department", "location", "employment_type", "column_break_qkna", "no_of_positions", "expected_compensation", "company", "status", "custom_unwated_fields", "column_break_4", "reason_for_request_section", "reason_for_requesting", "designation_activities_section", "designation_wise_activities", "section_break_7", "requested_by", "requested_by_name", "column_break_10", "requested_by_dept", "requested_by_designation", "interview", "interview_rounds", "work_details", "no_of_days_off", "min_experience", "work_details_column_break", "is_work_shift_needed", "travel_required", "driving_license_needed", "license_type", "education", "min_education_qual", "reset_column", "language_proficiency", "skill_proficiency", "publish_on_job_section", "publish_on_job_opening", "timelines_tab", "posting_date", "completed_on", "column_break_15", "expected_by", "time_to_fill", "job_description_tab", "job_description_template", "job_title", "description", "suggestions", "connections_tab"]'
 		},
 		{
 			"doctype_or_field": "DocField",


### PR DESCRIPTION
## Feature description
Add a new section in the Job Requisition form to capture Designation-wise Activities, which allows specifying tasks or responsibilities mapped to each designation. This helps streamline role-specific activity tracking during requisition creation.
## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description
- Added two new custom fields in the Job Requisition DocType:
    - designation_activities_section: A Section Break 
    - designation_wise_activities: A Table field
- Updated the field_order property to insert the new fields after reason_for_requesting field
- Changed the label of the expected_compensation field to "Expected Compensation (Yearly)"
- Set permlevel: 2 for the new section and table fields to make them read-only for non-privileged users

## Output screenshots (optional)
<img width="1840" height="931" alt="image" src="https://github.com/user-attachments/assets/496aa2b6-e679-4c8f-8732-4fab2067cbbd" />
<img width="1840" height="931" alt="image" src="https://github.com/user-attachments/assets/6ae899b9-7f75-47d0-a897-b7a80fa9d3c4" />

## Areas affected and ensured
- Job Requisition form layout
- Field visibility and labeling


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
