### PR TITLE
feat:use QRServer API to generate job QR code

### DIFF
--- a/beams/beams/custom_scripts/job_opening/job_opening.js
+++ b/beams/beams/custom_scripts/job_opening/job_opening.js
@@ -1,0 +1,43 @@
+frappe.ui.form.on('Job Opening', {
+	refresh: function(frm) {
+		// Show the button only after the doc is saved
+		if (!frm.is_new()) {
+			frm.add_custom_button(__('Generate QR Code'), function() {
+				if (frm.doc.qr_scan_to_apply) {
+					frappe.msgprint({
+						title: __('QR Code Already Generated'),
+						indicator: 'blue',
+						message: __('A QR Code is already generated for this Job Opening.')
+					});
+					return;
+				}
+				frappe.call({
+					method: 'beams.beams.custom_scripts.job_opening.job_opening.generate_qr_for_job',
+					args: {
+						doc: frm.doc.name
+					},
+					callback: function(r) {
+						if (r.message && r.message.success) {
+							frappe.msgprint(__('QR Code generated successfully'));
+							frm.reload_doc();
+						} else {
+							let errorMsg = r.message && r.message.error ? r.message.error : 'Unknown error';
+							frappe.msgprint({
+								title: __('Error'),
+								indicator: 'red',
+								message: __('Failed to generate QR Code: ') + errorMsg + __('. Please check the error log.')
+							});
+						}
+					},
+					error: function(err) {
+						frappe.msgprint({
+							title: __('Error'),
+							indicator: 'red',
+							message: __('Failed to generate QR Code due to a server error. Please check the error log.')
+						});
+					}
+				});
+			});
+		}
+	}
+});

--- a/beams/beams/custom_scripts/job_opening/job_opening.py
+++ b/beams/beams/custom_scripts/job_opening/job_opening.py
@@ -20,7 +20,9 @@ def generate_qr_for_job(doc, method=None):
 	response = requests.get(qr_api_url)
 
 	if response.status_code != 200:
-		frappe.throw(f"Failed to generate QR code: {response.status_code}")
+		frappe.log_error(f"Failed to generate QR code for Job Opening {doc.name}. URL: {qr_api_url}",
+						 f"QR API returned status code {response.status_code}")
+		return {"success": False, "error": f"QR API returned status code {response.status_code}"}
 
 	buffer = BytesIO(response.content)
 
@@ -40,3 +42,4 @@ def generate_qr_for_job(doc, method=None):
 
 	doc.qr_scan_to_apply = file_doc.file_url
 	doc.save()
+	return {"success": True, "file_url": file_doc.file_url}

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -69,7 +69,8 @@ doctype_js = {
 	"Material Request":"beams/custom_scripts/material_request/material_request.js",
 	"Asset":"beams/custom_scripts/asset/asset.js",
 	"Payroll Entry":"beams/custom_scripts/payroll_entry/payroll_entry.js",
-	"Employee Separation": "beams/custom_scripts/employee_separation/employee_separation.js"
+	"Employee Separation": "beams/custom_scripts/employee_separation/employee_separation.js",
+	"Job Opening": "beams/custom_scripts/job_opening/job_opening.js"
 }
 doctype_list_js = {
 	"Sales Invoice" : "beams/custom_scripts/sales_invoice/sales_invoice_list.js",


### PR DESCRIPTION
## Feature description
use QRServer API to generate job QR code instead of local qrcode lib

## Solution description
- Replaced the local qrcode Python library with QRServer external API for generating job QR codes
- Automatically saves the QR image to /files and links it to the Job Opening document
- Ensures QR code is generated even in environments where PIL is not available
- Add QR Code generation button for Job Opening with file attachment


## Output screenshots (optional)
<img width="1484" height="957" alt="image" src="https://github.com/user-attachments/assets/2778cbe0-c5f5-4dd4-a31a-2ff1bcbac389" />

<img width="1418" height="967" alt="image" src="https://github.com/user-attachments/assets/3d48c3c9-3ee1-4b27-8c61-245eed71ec20" />

<img width="1418" height="967" alt="image" src="https://github.com/user-attachments/assets/fca1acea-3cd0-4229-830f-444766c33aba" />

## Areas affected and ensured
Job Opening
job portal

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox  - yes
  - Opera Mini
  - Safari
