### PR TITLE
refactor: move proposed_ctc validation to whitelisted

### DIFF
--- a/beams/beams/doctype/compensation_proposal/compensation_proposal.js
+++ b/beams/beams/doctype/compensation_proposal/compensation_proposal.js
@@ -11,7 +11,12 @@ frappe.ui.form.on('Compensation Proposal', {
             };
         });
     },
-    proposed_ctc:function (frm){
-        frm.call("validate_proposed_ctc");
+    proposed_ctc: function(frm) {
+        frappe.call({
+            method: 'beams.beams.doctype.compensation_proposal.compensation_proposal.validate_proposed_ctc_value',
+            args: {
+                proposed_ctc: frm.doc.proposed_ctc
+            }
+        });
     }
 });

--- a/beams/beams/doctype/compensation_proposal/compensation_proposal.js
+++ b/beams/beams/doctype/compensation_proposal/compensation_proposal.js
@@ -11,12 +11,7 @@ frappe.ui.form.on('Compensation Proposal', {
             };
         });
     },
-    proposed_ctc: function(frm) {
-        frappe.call({
-            method: 'beams.beams.doctype.compensation_proposal.compensation_proposal.validate_proposed_ctc_value',
-            args: {
-                proposed_ctc: frm.doc.proposed_ctc
-            }
-        });
+    proposed_ctc: function (frm) {
+        frm.call("validate_proposed_ctc");
     }
 });

--- a/beams/beams/doctype/compensation_proposal/compensation_proposal.py
+++ b/beams/beams/doctype/compensation_proposal/compensation_proposal.py
@@ -165,7 +165,6 @@ class CompensationProposal(Document):
 		if self.proposed_ctc < 0:
 			frappe.throw("Proposed CTC cannot be a Negative value")
 
-
 	def set_payslips_from_job_applicant(self):
 		"""
 		Fetch payslip_month_1, payslip_month_2, and payslip_month_3 from Job Applicant

--- a/beams/beams/doctype/compensation_proposal/compensation_proposal.py
+++ b/beams/beams/doctype/compensation_proposal/compensation_proposal.py
@@ -14,7 +14,7 @@ class CompensationProposal(Document):
 		self.create_todo_on_pending_approval()
 
 	def validate(self):
-		self.validate_proposed_ctc()
+		validate_proposed_ctc_value(self.proposed_ctc)
 		self.set_payslips_from_job_applicant()
 
 	def create_offer_from_compensation_proposal(self):
@@ -157,13 +157,6 @@ class CompensationProposal(Document):
 						"description": description
 					})
 
-	def validate_proposed_ctc(self):
-		"""
-		Validate that the proposed CTC value is not negative.
-		"""
-		if self.proposed_ctc < 0:
-			frappe.throw("Proposed CTC cannot be a Negative value")
-
 	def set_payslips_from_job_applicant(self):
 		"""
 		Fetch payslip_month_1, payslip_month_2, and payslip_month_3 from Job Applicant
@@ -194,3 +187,9 @@ def remove_assignment_by_role(doc, role):
 					name=doc.name,
 					assign_to=user
 				)
+
+@frappe.whitelist()
+def validate_proposed_ctc_value(proposed_ctc):
+	"""Check if the proposed CTC is a non-negative value."""
+	if float(proposed_ctc) < 0:
+		frappe.throw("Proposed CTC cannot be a Negative value.")

--- a/beams/beams/doctype/compensation_proposal/compensation_proposal.py
+++ b/beams/beams/doctype/compensation_proposal/compensation_proposal.py
@@ -14,8 +14,8 @@ class CompensationProposal(Document):
 		self.create_todo_on_pending_approval()
 
 	def validate(self):
-		validate_proposed_ctc_value(self.proposed_ctc)
 		self.set_payslips_from_job_applicant()
+		self.validate_proposed_ctc()
 
 	def create_offer_from_compensation_proposal(self):
 		'''
@@ -157,6 +157,15 @@ class CompensationProposal(Document):
 						"description": description
 					})
 
+	@frappe.whitelist()
+	def validate_proposed_ctc(self):
+		"""
+		Validate that the proposed CTC value is not negative.
+		"""
+		if self.proposed_ctc < 0:
+			frappe.throw("Proposed CTC cannot be a Negative value")
+
+
 	def set_payslips_from_job_applicant(self):
 		"""
 		Fetch payslip_month_1, payslip_month_2, and payslip_month_3 from Job Applicant
@@ -188,8 +197,3 @@ def remove_assignment_by_role(doc, role):
 					assign_to=user
 				)
 
-@frappe.whitelist()
-def validate_proposed_ctc_value(proposed_ctc):
-	"""Check if the proposed CTC is a non-negative value."""
-	if float(proposed_ctc) < 0:
-		frappe.throw("Proposed CTC cannot be a Negative value.")

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -2273,11 +2273,18 @@ def get_job_applicant_custom_fields():
 				"insert_after": "email_id"
 			},
 			{
+				"fieldname": "age",
+				"fieldtype": "Int",
+				"label": "Age",
+				"insert_after": "date_of_birth",
+				"read_only": 1
+			},
+			{
 				"fieldname": "gender",
 				"fieldtype": "Link",
 				"label": "Gender",
 				"options": "Gender",
-				"insert_after": "date_of_birth"
+				"insert_after": "age"
 			},
 			{
 				"fieldname": "father_name",


### PR DESCRIPTION
## Feature description
move proposed_ctc validation to whitelisted

## Solution description
TASK-2025-01752
Issue Fixed:

- When trying to save a new Compensation Proposal, a popup appears:
- "Method Not Allowed – You are not permitted to access this resource. Login to access."
- .showing Message - Field age not found. in job Applicant 

## Output screenshots (optional)
<img width="1418" height="967" alt="image" src="https://github.com/user-attachments/assets/47f855d7-56f6-4cd6-b703-276d59962a9e" />


## Areas affected and ensured
Compensation Proposal

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - Yes
  - Opera Mini
  - Safari
