### PR TITLE
feat: update custom field configurations in Job Requisition

### DIFF
--- a/beams/setup.py
+++ b/beams/setup.py
@@ -2199,13 +2199,13 @@ def get_job_requisition_custom_fields():
 				"fieldtype": "Data",
 				"label": "Job Title",
 				"insert_after": "job_description_template",
-				"reqd": 1,
+				"depends_on": "eval: frappe.user_roles.includes('HR Manager')",
+				"mandatory_depends_on": "eval: frappe.user_roles.includes('HR Manager')"
 			},
 			{
 				"fieldname": "suggested_designation",
-				"fieldtype": "Link",
+				"fieldtype": "Data",
 				"label": "Suggested Designation",
-				"options": "Designation",
 				"insert_after": "request_for",
 				"permlevel": 2,
 				"depends_on": "eval:doc.request_for == 'New Vacancy'"


### PR DESCRIPTION
## Feature description
The "Job Title" field will now only show up and be required for HR Managers, since they are the ones who usually set the job title when creating a job requisition.
The 'Suggested Designation' field was changed from a Link field to a simple Data field so that users can type any suggestion. Based on this suggestion, the CEO will review and either approve or reject the designation.

## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description

- Modified the job_title field to include:
      -   depends_on = eval: frappe.user_roles.includes('HR Manager') — shows the field only to HR Managers.
      -   mandatory_depends_on = eval: frappe.user_roles.includes('HR Manager') — makes it required only for HR Managers.
- Updated the suggested_designation field:
      - Changed fieldtype from Link to Data to allow free text input.
      - Removed the options attribute since it no longer links to the Designation DocType.

## Output screenshots (optional)
A Department head created a job requisition.
<img width="1852" height="932" alt="image" src="https://github.com/user-attachments/assets/c421e06d-1eed-4340-950b-f2769e9a3c71" />
When user with HR Manager role logged-in
<img width="1852" height="932" alt="image" src="https://github.com/user-attachments/assets/d6258860-e769-48b4-81fc-653e59a3aa4c" />

## Areas affected and ensured
Job Requisition form
## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
