### PR TITLE
refactor: Update Job Requisition

### DIFF
--- a/beams/beams/custom_scripts/job_requisition/job_requisition.js
+++ b/beams/beams/custom_scripts/job_requisition/job_requisition.js
@@ -26,9 +26,13 @@ frappe.ui.form.on('Job Requisition', {
 			}
 		}
 
-		if (frm.doc.workflow_state === 'Pending CEO Final Approval') {
+		if (frm.doc.workflow_state === 'Pending HR Approval') {
 			frm.set_df_property('designation', 'reqd', 1);
 			frm.set_df_property('description', 'reqd', 1);
+		}
+		else{
+			frm.set_df_property('designation', 'reqd', 0);
+			frm.set_df_property('description', 'reqd', 0);
 		}
 	},
 	request_for: function (frm) {

--- a/beams/patches.txt
+++ b/beams/patches.txt
@@ -9,3 +9,4 @@ beams.patches.set_account_in_cost_subhead  #14-02-20250
 beams.patches.set_company_in_budget_template  #20-02-2025
 beams.patches.update_budget_for_inr  #17-03-2025
 beams.patches.delete_property_setter #22-07-2025
+beams.patches.update_job_requisition_fields  #29-07-2025

--- a/beams/patches/update_job_requisition_fields.py
+++ b/beams/patches/update_job_requisition_fields.py
@@ -1,0 +1,58 @@
+import frappe
+
+def execute():
+    # Remove mandatory_depends_on for 'designation'
+    designation_filter = {
+        "doctype_or_field": "DocField",
+        "doc_type": "Job Requisition",
+        "field_name": "designation",
+        "property": "mandatory_depends_on",
+    }
+    designation_ps = frappe.db.exists("Property Setter", designation_filter)
+    if designation_ps:
+        frappe.db.delete("Property Setter", {"name": designation_ps})
+
+    # Update depends_on for 'description'
+    frappe.get_doc({
+        "doctype": "Property Setter",
+        "doctype_or_field": "DocField",
+        "doc_type": "Job Requisition",
+        "field_name": "description",
+        "property": "depends_on",
+        "value": "eval: !['Draft', 'Pending HOD Verification'].includes(doc.workflow_state)",
+        "property_type": "Data"
+    }).insert(ignore_if_duplicate=True)
+
+    # Add depends_on for 'department'
+    frappe.get_doc({
+        "doctype": "Property Setter",
+        "doctype_or_field": "DocField",
+        "doc_type": "Job Requisition",
+        "field_name": "department",
+        "property": "depends_on",
+        "value": "eval:doc.request_for=='Employee Replacement'",
+        "property_type": "Data"
+    }).insert(ignore_if_duplicate=True)
+
+    # Replace mandatory_depends_on with depends_on for 'job_description_template'
+    jdt_filter = {
+        "doctype_or_field": "DocField",
+        "doc_type": "Job Requisition",
+        "field_name": "job_description_template",
+        "property": "mandatory_depends_on",
+    }
+    jdt_ps = frappe.db.exists("Property Setter", jdt_filter)
+    if jdt_ps:
+        frappe.db.delete("Property Setter", {"name": jdt_ps})
+
+    frappe.get_doc({
+        "doctype": "Property Setter",
+        "doctype_or_field": "DocField",
+        "doc_type": "Job Requisition",
+        "field_name": "job_description_template",
+        "property": "depends_on",
+        "value": "eval: frappe.user_roles.includes('HR Manager') && doc.workflow_state == 'Pending HR Approval'",
+        "property_type": "Data"
+    }).insert(ignore_if_duplicate=True)
+
+    frappe.db.commit()

--- a/beams/patches/update_job_requisition_fields.py
+++ b/beams/patches/update_job_requisition_fields.py
@@ -1,58 +1,54 @@
 import frappe
 
 def execute():
-    # Remove mandatory_depends_on for 'designation'
-    designation_filter = {
-        "doctype_or_field": "DocField",
-        "doc_type": "Job Requisition",
-        "field_name": "designation",
-        "property": "mandatory_depends_on",
-    }
-    designation_ps = frappe.db.exists("Property Setter", designation_filter)
-    if designation_ps:
-        frappe.db.delete("Property Setter", {"name": designation_ps})
+    # List of property setters to delete: (DocType, Field Name, Property)
+    properties_to_delete = [
+        ("Job Requisition", "designation", "mandatory_depends_on"),
+        ("Job Requisition", "description", "depends_on"),
+        ("Job Requisition", "department", "depends_on"),
+        ("Job Requisition", "job_description_template", "mandatory_depends_on"),
+        ("Job Requisition", "job_description_template", "depends_on")
+    ]
 
-    # Update depends_on for 'description'
-    frappe.get_doc({
-        "doctype": "Property Setter",
-        "doctype_or_field": "DocField",
-        "doc_type": "Job Requisition",
-        "field_name": "description",
-        "property": "depends_on",
-        "value": "eval: !['Draft', 'Pending HOD Verification'].includes(doc.workflow_state)",
-        "property_type": "Data"
-    }).insert(ignore_if_duplicate=True)
+    # Delete existing property setters
+    for doctype, field_name, property in properties_to_delete:
+        filters = {
+            "doctype_or_field": "DocField",
+            "doc_type": doctype,
+            "field_name": field_name,
+            "property": property
+        }
+        if frappe.db.exists("Property Setter", filters):
+            frappe.db.delete("Property Setter", filters)
 
-    # Add depends_on for 'department'
-    frappe.get_doc({
-        "doctype": "Property Setter",
-        "doctype_or_field": "DocField",
-        "doc_type": "Job Requisition",
-        "field_name": "department",
-        "property": "depends_on",
-        "value": "eval:doc.request_for=='Employee Replacement'",
-        "property_type": "Data"
-    }).insert(ignore_if_duplicate=True)
+    # Create new property setters
+    new_properties = [
+        {
+            "field": "description",
+            "property": "depends_on",
+            "value": "eval: !['Draft', 'Pending HOD Verification'].includes(doc.workflow_state)"
+        },
+        {
+            "field": "department",
+            "property": "depends_on",
+            "value": "eval:doc.request_for=='Employee Replacement'"
+        },
+        {
+            "field": "job_description_template",
+            "property": "depends_on",
+            "value": "eval: frappe.user_roles.includes('HR Manager') && doc.workflow_state == 'Pending HR Approval'"
+        }
+    ]
 
-    # Replace mandatory_depends_on with depends_on for 'job_description_template'
-    jdt_filter = {
-        "doctype_or_field": "DocField",
-        "doc_type": "Job Requisition",
-        "field_name": "job_description_template",
-        "property": "mandatory_depends_on",
-    }
-    jdt_ps = frappe.db.exists("Property Setter", jdt_filter)
-    if jdt_ps:
-        frappe.db.delete("Property Setter", {"name": jdt_ps})
-
-    frappe.get_doc({
-        "doctype": "Property Setter",
-        "doctype_or_field": "DocField",
-        "doc_type": "Job Requisition",
-        "field_name": "job_description_template",
-        "property": "depends_on",
-        "value": "eval: frappe.user_roles.includes('HR Manager') && doc.workflow_state == 'Pending HR Approval'",
-        "property_type": "Data"
-    }).insert(ignore_if_duplicate=True)
+    for prop in new_properties:
+        frappe.get_doc({
+            "doctype": "Property Setter",
+            "doctype_or_field": "DocField",
+            "doc_type": "Job Requisition",
+            "field_name": prop["field"],
+            "property": prop["property"],
+            "value": prop["value"],
+            "property_type": "Data"
+        }).insert(ignore_if_duplicate=True)
 
     frappe.db.commit()

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -2144,7 +2144,7 @@ def get_job_requisition_custom_fields():
 				"options": "Job Description Template",
 				"insert_after": "job_description_tab",
 				"permlevel": 1,
-				"mandatory_depends_on": "eval: frappe.user_roles.includes('HR Manager') && doc.workflow_state == 'Pending HR Approval'"
+				"depends_on": "eval: frappe.user_roles.includes('HR Manager') && doc.workflow_state == 'Pending HR Approval'"
 			},
 			{
 				"fieldname": "request_for",
@@ -4115,6 +4115,13 @@ def get_property_setters():
 		{
 			"doctype_or_field": "DocField",
 			"doc_type": "Job Requisition",
+			"field_name": "department",
+			"property": "depends_on",
+			"value": "eval:doc.request_for=='Employee Replacement'"
+		},
+		{
+			"doctype_or_field": "DocField",
+			"doc_type": "Job Requisition",
 			"field_name": "section_break_7",
 			"property": "collapsible",
 			"property_type": "Check",
@@ -4367,7 +4374,7 @@ def get_property_setters():
 			"doc_type": "Job Requisition",
 			"field_name": "description",
 			"property": "depends_on",
-			"value": "eval: doc.workflow_state != 'Draft'",
+			"value": "eval: !['Draft', 'Pending HOD Verification'].includes(doc.workflow_state)"
 		},
 		{
 			"doctype_or_field": "DocField",
@@ -4375,13 +4382,6 @@ def get_property_setters():
 			"field_name": "description",
 			"property": "mandatory_depends_on",
 			"value": "eval: frappe.user_roles.includes('HR Manager') && doc.workflow_state == 'Pending HR Approval'",
-		},
-		{
-			"doctype_or_field": "DocField",
-			"doc_type": "Job Requisition",
-			"field_name": "designation",
-			"property": "mandatory_depends_on",
-			"value": "eval: !(doc.workflow_state == 'Draft' || doc.request_for == 'New Vacancy')"
 		},
 		{
 			"doctype_or_field": "DocField",


### PR DESCRIPTION
## Feature description
Update the Job Requisition form to dynamically show, hide, or require certain fields — namely designation, department, and job_description_template — based on the workflow state, request type, and logged-in user role.## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description
JavaScript (job_requisition.js)-->
In refresh event, dynamically require designation and description only when workflow_state == 'Pending HR Approval'.
Patch (update_job_requisition_fields.py)--->
Deletes outdated mandatory_depends_on rules for designation and job_description_template.
Adds depends_on rules:
description: shown unless in Draft or Pending HOD Verification.
department: shown only when request_for == 'Employee Replacement'.
job_description_template: shown only if user has HR Manager role and workflow is Pending HR Approval.
setup.py----->
Field definitions for job_description_template updated to use depends_on instead of mandatory_depends_on.
Reorganized and updated get_property_setters() accordingly.
patches.txt--------->
Added new patch: beams.patches.update_job_requisition_fields
## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.

## Areas affected and ensured
List out the areas affected by your code changes.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
