### PR TITLE
fix:QR code to point to specific job detail page

### DIFF
--- a/beams/beams/custom_scripts/job_opening/job_opening.py
+++ b/beams/beams/custom_scripts/job_opening/job_opening.py
@@ -13,7 +13,7 @@ def generate_qr_for_job(doc, method=None):
 		doc = frappe.get_doc("Job Opening", doc)
 
 	base_url = get_url()
-	job_url = f"{base_url}/job_portal?job_opening={doc.name}"
+	job_url = f"{base_url}/job_portal/job?job_opening={doc.name}"
 	doc.job_url = job_url
 
 	qr_api_url = f"https://api.qrserver.com/v1/create-qr-code/?size=300x300&data={job_url}"


### PR DESCRIPTION
## Feature description
 update job portal URL in QR code to point to specific job detail page

## Solution description

- [x] TASK-2025-01779

- Previously, the generate_qr_for_job function generated a QR code URL that linked to the generic job portal page, that's fixed to:
- The QR code now links directly to the correct job details page.
- Users scanning the QR code are taken to the intended job application view.

## Output screenshots (optional)
<img width="1470" height="813" alt="image" src="https://github.com/user-attachments/assets/dd587932-d449-40ad-9423-6aaa87653963" />


## Areas affected and ensured
Job portal
job openiing

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - yes
  - Opera Mini
  - Safari
