### PR TITLE
feat:interview rescheduling

### DIFF
--- a/beams/beams/custom_scripts/job_applicant/job_applicant.py
+++ b/beams/beams/custom_scripts/job_applicant/job_applicant.py
@@ -210,5 +210,5 @@ def calculate_and_validate_age(doc, method=None):
 
 	if age < 18:
 		frappe.throw(_("Applicants must be at least 18 years old to apply."))
-
+	doc.age = age
 	return age

--- a/beams/beams/doctype/employee_interview_tool/employee_interview_tool.js
+++ b/beams/beams/doctype/employee_interview_tool/employee_interview_tool.js
@@ -12,6 +12,10 @@ frappe.ui.form.on('Employee Interview Tool', {
 	to_time: function (frm) {
 		validate_time_range(frm);
 	},
+    applicant_status: function(frm) {
+        toggle_create_interview_button(frm);
+        toggle_local_enquiry_button(frm);
+    },
 	refresh: function (frm) {
 		frm.disable_save()
 		frm.set_value('interview_round', '');
@@ -51,7 +55,6 @@ frappe.ui.form.on('Employee Interview Tool', {
 				filters.status = frm.doc.applicant_status;
 			}
 
-
 			frappe.call({
 				method: 'beams.beams.doctype.employee_interview_tool.employee_interview_tool.fetch_filtered_job_applicants',
 				args: { filters },
@@ -68,108 +71,26 @@ frappe.ui.form.on('Employee Interview Tool', {
 						frm.refresh_field('job_applicants');
 						frm.toggle_display('job_applicants', true);
 						get_btn.removeClass('btn-primary').addClass('btn-default');
-
-						// Button to create interview
-						let create_interview_btn = frm.add_custom_button('Create Interview', function () {
-							let selected_rows = frm.fields_dict.job_applicants.grid.get_selected_children();
-
-							if (!selected_rows.length) {
-								frappe.msgprint(__('Please select one or more rows in the Job Applicants table.'));
-								return;
-							}
-							let missing_fields = [];
-							if (!frm.doc.interview_round) missing_fields.push(__('Interview Round'));
-							if (!frm.doc.scheduled_on) missing_fields.push(__('Scheduled On'));
-							if (!frm.doc.from_time) missing_fields.push(__('From Time'));
-							if (!frm.doc.to_time) missing_fields.push(__('To Time'));
-
-							if (missing_fields.length) {
-								frappe.msgprint({
-									title: __('Missing Required Scheduling Fields'),
-									message: __('Please ensure the following fields are filled:') +
-										'<br><b>' + missing_fields.join(', ') + '</b>',
-									indicator: 'orange'
-								});
-								return;
-							}
-
-							frappe.call({
-								method: 'beams.beams.doctype.employee_interview_tool.employee_interview_tool.create_bulk_interviews',
-								args: {
-									applicants: selected_rows.map(row => ({
-										job_applicant: row.job_applicant,
-										applicant_name: row.applicant_name,
-										designation: row.designation,
-										interview_round: frm.doc.interview_round,
-										scheduled_on: frm.doc.scheduled_on,
-										from_time: frm.doc.from_time,
-										to_time: frm.doc.to_time
-									}))
-								},
-								callback: function (r) {
-									if (!r.exc) {
-										const data = r.message || {};
-										let any_message = false;
-										// Show success if interviews were created
-										if (Array.isArray(data.created) && data.created.length > 0) {
-											const created_ids = data.created.map(c => c.job_applicant).join(', ');
-											frappe.msgprint(__('Interviews created successfully for: ') + created_ids);
-										}
-										// Show warning if some were skipped
-										if (Array.isArray(data.skipped_applicants) && data.skipped_applicants.length > 0) {
-											frappe.msgprint({
-												title: __('Note'),
-												message: __('Interviews already exist for the following applicants: ') + data.skipped_applicants.join(', '),
-												indicator: 'orange'
-											});
-										}
-									}
-								}
-							});
-						});
-						create_interview_btn.removeClass('btn-default').addClass('btn-primary');
-
-						// Button to create local enquiry report
-						let create_ler_btn = frm.add_custom_button('Create Local Enquiry Report', function () {
-							let selected_rows = frm.fields_dict.job_applicants.grid.get_selected_children();
-
-							if (!selected_rows.length) {
-								frappe.msgprint(__('Please select one or more rows in the Job Applicants table.'));
-								return;
-							}
-
-							frappe.call({
-								method: 'beams.beams.doctype.employee_interview_tool.employee_interview_tool.create_bulk_ler',
-								args: {
-									applicants: selected_rows.map(row => ({
-										job_applicant: row.job_applicant,
-										applicant_name: row.applicant_name,
-									}))
-								},
-								callback: function (r) {
-									if (!r.exc) {
-										const data = r.message || {};
-										if (Array.isArray(data.created) && data.created.length > 0) {
-											let created_ids = data.created.map(c => c.job_applicant).join(', ');
-											frappe.msgprint(__('Local Enquiry Report created successfully for: ') + created_ids);
-										}
-										if (Array.isArray(data.skipped_applicants) && data.skipped_applicants.length > 0) {
-											frappe.msgprint({
-												title: __('Note'),
-												message: __('Local Enquiry Report already exists for: ') + data.skipped_applicants.join(', '),
-												indicator: 'orange'
-											});
-										}
-									}
-								}
-							});
-						});
-						create_ler_btn.removeClass('btn-default').addClass('btn-primary');
+                        toggle_create_interview_button(frm);
+						toggle_local_enquiry_button(frm);
 					}
 				}
 			});
 		});
+
 		get_btn.removeClass('btn-default').addClass('btn-primary');
+		// Trigger auto-click when status changes
+		if (frm.fields_dict.applicant_status) {
+			frm.fields_dict.applicant_status.$input.on('change', function () {
+				if (frm.fields_dict.get_btn) {
+					frm.fields_dict.get_btn.click();
+				}
+				toggle_local_enquiry_button(frm);
+                toggle_create_interview_button(frm);
+			});
+		}
+		toggle_local_enquiry_button(frm);
+        toggle_create_interview_button(frm);
 	}
 });
 
@@ -184,5 +105,166 @@ function validate_time_range(frm) {
 				message: __('The <b>From Time</b> must be earlier than the <b>To Time</b>. Please correct the time range.')
 			});
 		}
+	}
+}
+
+let create_interview_btn = null;
+function toggle_create_interview_button(frm) {
+	if (create_interview_btn) {
+		create_interview_btn.remove();
+		create_interview_btn = null;
+	}
+
+	if (["Document Uploaded", "Interview Scheduled", "Interview Ongoing"].includes(frm.doc.applicant_status)) {
+		create_interview_btn = frm.add_custom_button('Create Interview', function () {
+			let selected_rows = frm.fields_dict.job_applicants.grid.get_selected_children();
+			if (!selected_rows.length) {
+				frappe.msgprint(__('Please select one or more rows in the Job Applicants table.'));
+				return;
+			}
+
+			let missing_fields = [];
+			if (!frm.doc.interview_round) missing_fields.push(__('Interview Round'));
+			if (!frm.doc.scheduled_on) missing_fields.push(__('Scheduled On'));
+			if (!frm.doc.from_time) missing_fields.push(__('From Time'));
+			if (!frm.doc.to_time) missing_fields.push(__('To Time'));
+
+			if (missing_fields.length) {
+				frappe.msgprint({
+					title: __('Missing Required Scheduling Fields'),
+					message: __('Please ensure the following fields are filled:') +
+						'<br><b>' + missing_fields.join(', ') + '</b>',
+					indicator: 'orange'
+				});
+				return;
+			}
+
+			frappe.call({
+				method: 'beams.beams.doctype.employee_interview_tool.employee_interview_tool.create_bulk_interviews',
+				args: {
+					applicants: selected_rows.map(row => ({
+						job_applicant: row.job_applicant,
+						applicant_name: row.applicant_name,
+						designation: row.designation,
+						interview_round: frm.doc.interview_round,
+						scheduled_on: frm.doc.scheduled_on,
+						from_time: frm.doc.from_time,
+						to_time: frm.doc.to_time
+					}))
+				},
+				callback: function (r) {
+					if (!r.exc) {
+						let data = r.message || {};
+
+						if (Array.isArray(data.created) && data.created.length > 0) {
+							const created_ids = data.created.map(c => c.job_applicant).join(', ');
+							frappe.msgprint(__('Interviews created successfully for: ') + created_ids);
+						}
+
+						if (Array.isArray(data.skipped_applicants) && data.skipped_applicants.length > 0) {
+							frappe.confirm(
+								__('Interviews already exist for: {0}.<br>Do you want to reschedule?', [data.skipped_applicants.join(', ')]),
+								() => {
+									//  reschedule interview
+									frappe.prompt([
+										{
+											label: 'Scheduled On',
+											fieldname: 'scheduled_on',
+											fieldtype: 'Date',
+											default: frm.doc.scheduled_on,
+											reqd: 1
+										},
+										{
+											label: 'From Time',
+											fieldname: 'from_time',
+											fieldtype: 'Time',
+											default: frm.doc.from_time,
+											reqd: 1
+										},
+										{
+											label: 'To Time',
+											fieldname: 'to_time',
+											fieldtype: 'Time',
+											default: frm.doc.to_time,
+											reqd: 1
+										}
+									], (values) => {
+                                        frappe.call({
+                                            method: "beams.beams.doctype.employee_interview_tool.employee_interview_tool.reschedule_interviews",
+                                            args: {
+                                                applicants: data.skipped_applicants,
+                                                interview_round: frm.doc.interview_round,
+                                                scheduled_on: values.scheduled_on,
+                                                from_time: values.from_time,
+                                                to_time: values.to_time,
+                                            },
+                                            callback: function(r) {
+                                                if (!r.exc) {
+                                                    frappe.msgprint(__('Interview(s) rescheduled successfully.'));
+                                                    frm.refresh();
+                                                }
+                                            }
+
+                                        });
+									}, __('Reschedule Interviews'));
+								},
+								() => {
+									frappe.msgprint(__('Reschedule cancelled.'));
+								}
+							);
+						}
+					}
+				}
+			});
+		});
+		create_interview_btn.removeClass('btn-default').addClass('btn-primary');
+	}
+}
+
+
+function toggle_local_enquiry_button(frm) {
+	// Remove existing button first to avoid duplication
+	frm.remove_custom_button('Create Local Enquiry Report');
+
+	const valid_statuses = ['Shortlisted from Interview', 'Local Enquiry Started'];
+	const current_status = frm.doc.applicant_status;
+
+	if (valid_statuses.includes(current_status)) {
+		let btn = frm.add_custom_button('Create Local Enquiry Report', function () {
+			let selected_rows = frm.fields_dict.job_applicants.grid.get_selected_children();
+
+			if (!selected_rows.length) {
+				frappe.msgprint(__('Please select one or more rows in the Job Applicants table.'));
+				return;
+			}
+
+			frappe.call({
+				method: 'beams.beams.doctype.employee_interview_tool.employee_interview_tool.create_bulk_ler',
+				args: {
+					applicants: selected_rows.map(row => ({
+						job_applicant: row.job_applicant,
+						applicant_name: row.applicant_name,
+					}))
+				},
+				callback: function (r) {
+					if (!r.exc) {
+						const data = r.message || {};
+						if (Array.isArray(data.created) && data.created.length > 0) {
+							let created_ids = data.created.map(c => c.job_applicant).join(', ');
+							frappe.msgprint(__('Local Enquiry Report created successfully for: ') + created_ids);
+						}
+						if (Array.isArray(data.skipped_applicants) && data.skipped_applicants.length > 0) {
+							frappe.msgprint({
+								title: __('Note'),
+								message: __('Local Enquiry Report already exists for: ') + data.skipped_applicants.join(', '),
+								indicator: 'orange'
+							});
+						}
+					}
+				}
+			});
+		});
+
+		btn.removeClass('btn-default').addClass('btn-primary');
 	}
 }

--- a/beams/beams/doctype/employee_interview_tool/employee_interview_tool.js
+++ b/beams/beams/doctype/employee_interview_tool/employee_interview_tool.js
@@ -71,7 +71,7 @@ frappe.ui.form.on('Employee Interview Tool', {
 						frm.refresh_field('job_applicants');
 						frm.toggle_display('job_applicants', true);
 						get_btn.removeClass('btn-primary').addClass('btn-default');
-                        toggle_create_interview_button(frm);
+						toggle_create_interview_button(frm);
 						toggle_local_enquiry_button(frm);
 					}
 				}

--- a/beams/beams/doctype/employee_interview_tool/employee_interview_tool.js
+++ b/beams/beams/doctype/employee_interview_tool/employee_interview_tool.js
@@ -12,10 +12,10 @@ frappe.ui.form.on('Employee Interview Tool', {
 	to_time: function (frm) {
 		validate_time_range(frm);
 	},
-    applicant_status: function(frm) {
-        toggle_create_interview_button(frm);
-        toggle_local_enquiry_button(frm);
-    },
+	applicant_status: function(frm) {
+		toggle_create_interview_button(frm);
+		toggle_local_enquiry_button(frm);
+	},
 	refresh: function (frm) {
 		frm.disable_save()
 		frm.set_value('interview_round', '');
@@ -86,11 +86,11 @@ frappe.ui.form.on('Employee Interview Tool', {
 					frm.fields_dict.get_btn.click();
 				}
 				toggle_local_enquiry_button(frm);
-                toggle_create_interview_button(frm);
+				toggle_create_interview_button(frm);
 			});
 		}
 		toggle_local_enquiry_button(frm);
-        toggle_create_interview_button(frm);
+		toggle_create_interview_button(frm);
 	}
 });
 
@@ -108,6 +108,10 @@ function validate_time_range(frm) {
 	}
 }
 
+/**
+ * Toggles the 'Create Interview' button based on applicant status - 'Document Uploaded', 'Interview Scheduled', 'Interview Ongoing'.
+ * On click, creates interviews or prompts for rescheduling if already exists.
+ */
 let create_interview_btn = null;
 function toggle_create_interview_button(frm) {
 	if (create_interview_btn) {
@@ -115,7 +119,7 @@ function toggle_create_interview_button(frm) {
 		create_interview_btn = null;
 	}
 
-	if (["Document Uploaded", "Interview Scheduled", "Interview Ongoing"].includes(frm.doc.applicant_status)) {
+	if (['Document Uploaded', 'Interview Scheduled', 'Interview Ongoing'].includes(frm.doc.applicant_status)) {
 		create_interview_btn = frm.add_custom_button('Create Interview', function () {
 			let selected_rows = frm.fields_dict.job_applicants.grid.get_selected_children();
 			if (!selected_rows.length) {
@@ -189,23 +193,22 @@ function toggle_create_interview_button(frm) {
 											reqd: 1
 										}
 									], (values) => {
-                                        frappe.call({
-                                            method: "beams.beams.doctype.employee_interview_tool.employee_interview_tool.reschedule_interviews",
-                                            args: {
-                                                applicants: data.skipped_applicants,
-                                                interview_round: frm.doc.interview_round,
-                                                scheduled_on: values.scheduled_on,
-                                                from_time: values.from_time,
-                                                to_time: values.to_time,
-                                            },
-                                            callback: function(r) {
-                                                if (!r.exc) {
-                                                    frappe.msgprint(__('Interview(s) rescheduled successfully.'));
-                                                    frm.refresh();
-                                                }
-                                            }
-
-                                        });
+										frappe.call({
+											method: 'beams.beams.doctype.employee_interview_tool.employee_interview_tool.reschedule_interviews',
+											args: {
+												applicants: data.skipped_applicants,
+												interview_round: frm.doc.interview_round,
+												scheduled_on: values.scheduled_on,
+												from_time: values.from_time,
+												to_time: values.to_time,
+											},
+											callback: function(r) {
+												if (!r.exc) {
+													frappe.msgprint(__('Interview(s) rescheduled successfully.'));
+													frm.refresh();
+												}
+											}
+										});
 									}, __('Reschedule Interviews'));
 								},
 								() => {
@@ -221,9 +224,11 @@ function toggle_create_interview_button(frm) {
 	}
 }
 
-
+/**
+ * Adds 'Create Local Enquiry Report' button when applicant status matches - 'Shortlisted from Interview', 'Local Enquiry Started'
+ * Button triggers bulk LER creation for selected job applicants.
+ */
 function toggle_local_enquiry_button(frm) {
-	// Remove existing button first to avoid duplication
 	frm.remove_custom_button('Create Local Enquiry Report');
 
 	const valid_statuses = ['Shortlisted from Interview', 'Local Enquiry Started'];

--- a/beams/beams/doctype/employee_interview_tool/employee_interview_tool.json
+++ b/beams/beams/doctype/employee_interview_tool/employee_interview_tool.json
@@ -35,7 +35,8 @@
    "fieldname": "company",
    "fieldtype": "Link",
    "label": "Company",
-   "options": "Company"
+   "options": "Company",
+   "remember_last_selected_value": 1
   },
   {
    "fieldname": "branch",
@@ -128,7 +129,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-07-24 17:33:51.986164",
+ "modified": "2025-08-01 10:34:28.563948",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Employee Interview Tool",

--- a/beams/beams/doctype/employee_interview_tool/employee_interview_tool.py
+++ b/beams/beams/doctype/employee_interview_tool/employee_interview_tool.py
@@ -136,12 +136,17 @@ def reschedule_interviews(applicants, interview_round, scheduled_on, from_time, 
 	"""
 		Reschedules existing Interview documents for given job applicants and interview round.
 	"""
+	if isinstance(applicants, str):
+		applicants = json.loads(applicants)
+
 	rescheduled = []
+
 	for app_id in applicants:
 		interviews = frappe.get_all("Interview", filters={
 			"job_applicant": app_id,
 			"interview_round": interview_round
 		})
+
 		for i in interviews:
 			doc = frappe.get_doc("Interview", i.name)
 			doc.scheduled_on = scheduled_on

--- a/beams/beams/doctype/employee_interview_tool/employee_interview_tool.py
+++ b/beams/beams/doctype/employee_interview_tool/employee_interview_tool.py
@@ -37,7 +37,7 @@ def create_bulk_interviews(applicants):
 			'job_applicant': app.get('job_applicant'),
 			'interview_round': interview_round
 		}):
-			existing_interviews.append(app.get('applicant_name') or app.get('job_applicant'))
+			existing_interviews.append(app.get('job_applicant'))
 			continue
 
 		interview = frappe.get_doc({
@@ -130,3 +130,22 @@ def fetch_filtered_job_applicants(filters=None):
 
 	except Exception as e:
 		frappe.log_error(frappe.get_traceback(), _("Failed to fetch job applicants"))
+
+@frappe.whitelist()
+def reschedule_interviews(applicants, interview_round, scheduled_on, from_time, to_time):
+	"""
+		Reschedules existing Interview documents for given job applicants and interview round.
+	"""
+	rescheduled = []
+	for app_id in applicants:
+		interviews = frappe.get_all("Interview", filters={
+			"job_applicant": app_id,
+			"interview_round": interview_round
+		})
+		for i in interviews:
+			doc = frappe.get_doc("Interview", i.name)
+			doc.scheduled_on = scheduled_on
+			doc.from_time = from_time
+			doc.to_time = to_time
+			doc.save()
+			rescheduled.append(i.name)

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -4413,6 +4413,31 @@ def get_property_setters():
 			"property_type": "Select",
 			"value": 1
 		},
+		{
+			"doctype_or_field": "DocField",
+			"doc_type": "Interview",
+			"field_name": "scheduled_on",
+			"property": "set_only_once",
+			"property_type": "Check",
+			"value": 0
+		},
+		{
+			"doctype_or_field": "DocField",
+			"doc_type": "Interview",
+			"field_name": "from_time",
+			"property": "set_only_once",
+			"property_type": "Check",
+			"value": 0
+		},
+		{
+			"doctype_or_field": "DocField",
+			"doc_type": "Interview",
+			"field_name": "to_time",
+			"property": "set_only_once",
+			"property_type": "Check",
+			"value": 0
+		}
+
 	]
 
 def get_material_request_custom_fields():


### PR DESCRIPTION
## Feature description
Add rescheduling  for Interviews in Employee Interview Tool

## Solution description

- TASK-2025-01777
- User is informed if interviews already exist.
- A reschedule prompt is shown, allowing date/time to be updated.
- Interview documents get rescheduled without manual editing.

- Currently, interviews can be created regardless of the Job Applicant's status. However, this should not be the case. Interviews should only be created when the status is one of the following: Document Uploaded, Interview Scheduled, or Interview Ongoing.

- Local Enquiry Report  only be created when the status is one of the following: Shortlisted from Interview ,Local Enquiry Started

- Set the age field before returning in job applicant
- set remember_last_selected_value to 1 for company

## Output screenshots (optional)
<img width="1339" height="966" alt="image" src="https://github.com/user-attachments/assets/816414cd-7b66-4a9e-8ea9-ec35c68e090f" />
<img width="1339" height="966" alt="image" src="https://github.com/user-attachments/assets/57deae24-78a5-477f-81a8-296331361fdb" />
<img width="1339" height="966" alt="image" src="https://github.com/user-attachments/assets/ff5a75dc-902f-47cb-9f72-14ccc6abcfdc" />
<img width="1339" height="966" alt="image" src="https://github.com/user-attachments/assets/36c76640-e4c9-46d8-aba0-a4ba9e04f7c2" />
<img width="1339" height="966" alt="image" src="https://github.com/user-attachments/assets/ad3f98f3-cb63-49ac-baaf-218ad174a44d" />

[Screencast from 01-08-25 09:51:24 AM IST.webm](https://github.com/user-attachments/assets/ac7b98ea-37f3-4ebe-85ac-abd5a098a9e3)

<img width="1339" height="966" alt="image" src="https://github.com/user-attachments/assets/aa20cc03-0598-43c2-8a35-69cffd5f2643" />


## Areas affected and ensured
List out the areas affected by your code changes.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
