### PR TITLE
feat:Add Department field to Job Applicants in Employee Interview Tool

### DIFF
--- a/beams/beams/doctype/employee_interview_tool/employee_interview_tool.js
+++ b/beams/beams/doctype/employee_interview_tool/employee_interview_tool.js
@@ -5,6 +5,8 @@ frappe.ui.form.on('Employee Interview Tool', {
 	onload(frm) {
 		frm.set_value('date', frappe.datetime.get_today());
 		frm.toggle_display('job_applicants', false);
+		!frm.doc.company && frappe.db.get_single_value('Global Defaults','default_company')
+		.then(value => frm.set_value('company',value))
 	},
 	from_time: function (frm) {
 		validate_time_range(frm);
@@ -67,6 +69,7 @@ frappe.ui.form.on('Employee Interview Tool', {
 							row.applicant_name = app.applicant_name;
 							row.status = app.status;
 							row.designation = app.designation;
+							row.department = app.department;
 						});
 						frm.refresh_field('job_applicants');
 						frm.toggle_display('job_applicants', true);
@@ -150,6 +153,7 @@ function toggle_create_interview_button(frm) {
 						job_applicant: row.job_applicant,
 						applicant_name: row.applicant_name,
 						designation: row.designation,
+						department: row.department,
 						interview_round: frm.doc.interview_round,
 						scheduled_on: frm.doc.scheduled_on,
 						from_time: frm.doc.from_time,

--- a/beams/beams/doctype/employee_interview_tool/employee_interview_tool.py
+++ b/beams/beams/doctype/employee_interview_tool/employee_interview_tool.py
@@ -45,6 +45,7 @@ def create_bulk_interviews(applicants):
 			'job_applicant': app.get('job_applicant'),
 			'applicant_name': app.get('applicant_name'),
 			'designation': app.get('designation'),
+			'department': app.get('department'),
 			'interview_round': interview_round,
 			'scheduled_on': scheduled_on,
 			'from_time': from_time,
@@ -123,7 +124,7 @@ def fetch_filtered_job_applicants(filters=None):
 		applicants = frappe.get_all(
 			'Job Applicant',
 			filters=filters,
-			fields=['name', 'applicant_name', 'designation', 'status'],
+			fields=['name', 'applicant_name', 'designation', 'status','department'],
 			limit_page_length=50
 		)
 		return applicants

--- a/beams/beams/doctype/job_applicant_interview_detail/job_applicant_interview_detail.json
+++ b/beams/beams/doctype/job_applicant_interview_detail/job_applicant_interview_detail.json
@@ -9,7 +9,8 @@
   "job_applicant",
   "applicant_name",
   "designation",
-  "status"
+  "status",
+  "department"
  ],
  "fields": [
   {
@@ -39,13 +40,21 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Designation"
+  },
+  {
+   "fetch_from": "job_applicant.department",
+   "fieldname": "department",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Department",
+   "options": "Department"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-07-15 10:00:07.903323",
+ "modified": "2025-08-01 12:00:54.889396",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Job Applicant Interview Detail",

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -2021,6 +2021,7 @@ def get_interview_custom_fields():
 				"label": "Applicant Email ID",
 				"insert_after": "job_applicant",
 				"fetch_from": "job_applicant.email_id",
+				"options": "Email",
 				"hidden": 1
 			},
 			{
@@ -4457,8 +4458,15 @@ def get_property_setters():
 			"property": "set_only_once",
 			"property_type": "Check",
 			"value": 0
+		},
+		{
+			"doctype_or_field": "DocField",
+			"doc_type": "Employee",
+			"field_name": "assessment_officer",
+			"property": "ignore_user_permissions",
+			"property_type": "Check",
+			"value": 1
 		}
-
 	]
 
 def get_material_request_custom_fields():


### PR DESCRIPTION
## Feature description
Add Department field to Job Applicants in Employee Interview Tool

## Solution description
- Auto-set default company from Global Defaults on form load
- Added 'department' field to Job Applicant Interview Detail (fetched from Job Applicant)
- Included 'department' in backend job applicant fetch and bulk interview creation
- Updated child table JSON to show department in list view
- Added "options": "Email" to the applicant_email custom field in interview custom fields
- Added property setter to allow unrestricted access to the 'assessment_officer' field
- Auto-set company from Global Defaults in Employee Interview Tool

## Output screenshots (optional)
<img width="1339" height="966" alt="image" src="https://github.com/user-attachments/assets/ce13fe7e-7078-4960-96b3-90c3cec875c4" />
<img width="1339" height="966" alt="image" src="https://github.com/user-attachments/assets/970fd1e6-6398-436c-801b-36c952f35fbb" />


## Areas affected and ensured
List out the areas affected by your code changes.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
