### PR TITLE
fix : Interview form turned to unsaved after submitting feedback

### DIFF
--- a/beams/beams/custom_scripts/interview/interview.js
+++ b/beams/beams/custom_scripts/interview/interview.js
@@ -304,9 +304,26 @@ var create_interview_feedback = function (frm, values, feedback_exists, save_sub
 	}
 	frappe.call({
 		method: 'beams.beams.custom_scripts.interview.interview.create_interview_feedback',
-		args: args
-	}).then(() => {
-		frm.refresh();
+		args: args,
+		callback: function (r) {
+			if (!r.exc) {
+				// Refresh the Interview form from DB to avoid "unsaved" state
+				frappe.call({
+					method: "frappe.client.get",
+					args: {
+						doctype: "Interview",
+						name: frm.doc.name
+					},
+					callback: function (res) {
+						if (res.message) {
+							frappe.model.sync(res.message);
+							frm.refresh();
+							frm.dirty = false;  // clear unsaved flag
+						}
+					}
+				});
+			}
+		}
 	});
 }
 


### PR DESCRIPTION
## Feature description
- After submitting feedback through dialog in interview the form become not saved

## Solution description
- After creating interview feedback form is refreshed and saved 

## Output screenshots (optional)
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/71e35f90-5e75-44e2-b176-ce0a7add2fa1" />