### PR TITLE
feat:add location to interview tool

### DIFF
--- a/beams/beams/doctype/employee_interview_tool/employee_interview_tool.js
+++ b/beams/beams/doctype/employee_interview_tool/employee_interview_tool.js
@@ -27,7 +27,7 @@ frappe.ui.form.on('Employee Interview Tool', {
 		frm.set_value('department', '');
 		frm.set_value('designation', '');
 		frm.set_value('job_opening', '');
-		frm.set_value('branch', '');
+		frm.set_value('location', '');
 		frm.set_value('applicant_status', '');
 		frm.clear_table('job_applicants');
 		frm.refresh_field('job_applicants');
@@ -56,6 +56,9 @@ frappe.ui.form.on('Employee Interview Tool', {
 			if (frm.doc.applicant_status) {
 				filters.status = frm.doc.applicant_status;
 			}
+			if (frm.doc.location) {
+				filters.location = frm.doc.location;
+			}
 
 			frappe.call({
 				method: 'beams.beams.doctype.employee_interview_tool.employee_interview_tool.fetch_filtered_job_applicants',
@@ -70,6 +73,7 @@ frappe.ui.form.on('Employee Interview Tool', {
 							row.status = app.status;
 							row.designation = app.designation;
 							row.department = app.department;
+							row.location = app.location
 						});
 						frm.refresh_field('job_applicants');
 						frm.toggle_display('job_applicants', true);

--- a/beams/beams/doctype/employee_interview_tool/employee_interview_tool.json
+++ b/beams/beams/doctype/employee_interview_tool/employee_interview_tool.json
@@ -6,7 +6,6 @@
  "engine": "InnoDB",
  "field_order": [
   "date",
-  "branch",
   "column_break_zrwf",
   "company",
   "section_break_ndqh",
@@ -18,6 +17,7 @@
   "section_break_lgjw",
   "job_opening",
   "applicant_status",
+  "location",
   "column_break_kxyk",
   "department",
   "designation",
@@ -37,12 +37,6 @@
    "label": "Company",
    "options": "Company",
    "remember_last_selected_value": 1
-  },
-  {
-   "fieldname": "branch",
-   "fieldtype": "Link",
-   "label": "Branch",
-   "options": "Branch"
   },
   {
    "fieldname": "job_opening",
@@ -98,6 +92,7 @@
    "fieldtype": "Section Break"
   },
   {
+   "default": "Document Uploaded",
    "fieldname": "applicant_status",
    "fieldtype": "Select",
    "label": "Status",
@@ -123,13 +118,19 @@
   {
    "fieldname": "column_break_kxyk",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "location",
+   "fieldtype": "Link",
+   "label": "Location",
+   "options": "Location"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-08-01 10:34:28.563948",
+ "modified": "2025-08-02 12:31:43.951250",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Employee Interview Tool",

--- a/beams/beams/doctype/employee_interview_tool/employee_interview_tool.py
+++ b/beams/beams/doctype/employee_interview_tool/employee_interview_tool.py
@@ -124,7 +124,7 @@ def fetch_filtered_job_applicants(filters=None):
 		applicants = frappe.get_all(
 			'Job Applicant',
 			filters=filters,
-			fields=['name', 'applicant_name', 'designation', 'status','department'],
+			fields=['name', 'applicant_name', 'designation', 'status','department', 'location'],
 			limit_page_length=50
 		)
 		return applicants

--- a/beams/beams/doctype/job_applicant_interview_detail/job_applicant_interview_detail.json
+++ b/beams/beams/doctype/job_applicant_interview_detail/job_applicant_interview_detail.json
@@ -10,7 +10,8 @@
   "applicant_name",
   "designation",
   "status",
-  "department"
+  "department",
+  "location"
  ],
  "fields": [
   {
@@ -48,13 +49,21 @@
    "in_list_view": 1,
    "label": "Department",
    "options": "Department"
+  },
+  {
+   "fetch_from": "job_applicant.location",
+   "fieldname": "location",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Location",
+   "options": "Location"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-08-01 12:00:54.889396",
+ "modified": "2025-08-02 10:44:41.324584",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Job Applicant Interview Detail",


### PR DESCRIPTION
## Feature description
add location to interview tool

## Solution description

- Add Location in employee interview tool and filter job applicants based on selected location
- Replaced branch with location in Employee Interview Tool
- Added location to Job Applicant Interview Detail table
- Updated applicant fetch logic to include location filter

## Output screenshots (optional)
[Screencast from 02-08-25 04:19:55 PM IST.webm](https://github.com/user-attachments/assets/62d73583-c3f8-40b3-a926-25dd8ab14684)


## Areas affected and ensured
Employee Interview tool

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - Yes
  - Opera Mini
  - Safari
