### PR TITLE
feat:set default status in employee interview tool

### DIFF
--- a/beams/beams/doctype/employee_interview_tool/employee_interview_tool.js
+++ b/beams/beams/doctype/employee_interview_tool/employee_interview_tool.js
@@ -8,6 +8,11 @@ frappe.ui.form.on('Employee Interview Tool', {
 		!frm.doc.company && frappe.db.get_single_value('Global Defaults','default_company')
 		.then(value => frm.set_value('company',value))
 	},
+	onload_post_render(frm) {
+		if(!frm.doc.applicant_status){
+			frm.set_value('applicant_status', 'Document Uploaded');
+		}
+	},
 	from_time: function (frm) {
 		validate_time_range(frm);
 	},


### PR DESCRIPTION
## Feature description

- Set default status in employee interview tool

## Solution description

- set 'document uploaded' as default status in employee interview tool

## Output screenshots (optional)
<img width="1330" height="968" alt="image" src="https://github.com/user-attachments/assets/f2111fdb-17af-46ef-ba7c-60b42a21add0" />


## Areas affected and ensured

- Employee Interview Tool

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - Yes
  - Opera Mini
  - Safari
