### PR TITLE
feat:Add interview feedback to Interview on submit

### DIFF
--- a/beams/beams/custom_scripts/interview_feedback/interview_feedback.py
+++ b/beams/beams/custom_scripts/interview_feedback/interview_feedback.py
@@ -37,6 +37,23 @@ def on_interview_feedback_creation(doc):
         if current_status != 'Interview Ongoing':
             frappe.db.set_value('Job Applicant', doc.job_applicant, 'status', 'Interview Ongoing')
 
+def on_submit(doc, method):
+	'''
+		On submission of an Interview Feedback document,
+		append the feedback details to the corresponding Interview record
+	'''
+	interview_doc = frappe.get_doc('Interview', doc.interview)
+	existing_interviewers = [d.interviewer for d in interview_doc.interview_feedback_details]
+
+	if doc.interviewer not in existing_interviewers:
+		interview_doc.append('interview_feedback_details', {
+			'interviewer': doc.interviewer,
+			'result': doc.result,
+			'interview_feedback_reference': doc.name,
+			'remarks': doc.feedback
+		})
+		interview_doc.save(ignore_permissions=True)
+
 @frappe.whitelist()
 def get_interview_details(interview_round):
     '''

--- a/beams/beams/custom_scripts/interview_feedback/interview_feedback.py
+++ b/beams/beams/custom_scripts/interview_feedback/interview_feedback.py
@@ -43,9 +43,17 @@ def on_submit(doc, method):
 		append the feedback details to the corresponding Interview record
 	'''
 	interview_doc = frappe.get_doc('Interview', doc.interview)
-	existing_interviewers = [d.interviewer for d in interview_doc.interview_feedback_details]
+	exists = frappe.db.exists(
+		'interview Feedback Details',
+		{
+			'parent': doc.interview,
+			'parenttype': 'Interview',
+			'parentfield': 'interview_feedback_details',
+			'interviewer': doc.interviewer
+		}
+	)
 
-	if doc.interviewer not in existing_interviewers:
+	if not exists:
 		interview_doc.append('interview_feedback_details', {
 			'interviewer': doc.interviewer,
 			'result': doc.result,

--- a/beams/beams/doctype/interview_feedback_details/interview_feedback_details.json
+++ b/beams/beams/doctype/interview_feedback_details/interview_feedback_details.json
@@ -1,0 +1,57 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-08-04 11:57:46.354819",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "interviewer",
+  "result",
+  "interview_feedback_reference",
+  "remarks"
+ ],
+ "fields": [
+  {
+   "fieldname": "interviewer",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Interviewer",
+   "options": "User"
+  },
+  {
+   "fieldname": "result",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Result",
+   "options": "\nCleared\nRejected"
+  },
+  {
+   "fieldname": "interview_feedback_reference",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Interview Feedback Reference",
+   "options": "Interview Feedback"
+  },
+  {
+   "fieldname": "remarks",
+   "fieldtype": "Small Text",
+   "in_list_view": 1,
+   "label": "Remarks"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2025-08-04 13:05:29.235229",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "interview Feedback Details",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/beams/beams/doctype/interview_feedback_details/interview_feedback_details.py
+++ b/beams/beams/doctype/interview_feedback_details/interview_feedback_details.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class interviewFeedbackDetails(Document):
+	pass

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -270,8 +270,9 @@ doc_events = {
 		"after_insert": "beams.beams.custom_scripts.interview_feedback.interview_feedback.after_insert",
 		"validate": "beams.beams.custom_scripts.interview_feedback.interview_feedback.validate",
 		"on_submit": [
-		    "beams.beams.custom_scripts.interview_feedback.interview_feedback.update_applicant_interview_round_from_feedback",
-		    "beams.beams.custom_scripts.interview_feedback.interview_feedback.update_final_score"
+			"beams.beams.custom_scripts.interview_feedback.interview_feedback.update_applicant_interview_round_from_feedback",
+			"beams.beams.custom_scripts.interview_feedback.interview_feedback.update_final_score",
+			"beams.beams.custom_scripts.interview_feedback.interview_feedback.on_submit"
 			]
 	},
 	"Employee Checkin":{

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -2045,6 +2045,15 @@ def get_interview_custom_fields():
 				"fieldtype": "HTML",
 				"label": "Interview Html Field",
 				"insert_after": "interview_dashboard_section",
+			},
+			{
+				"fieldname": "interview_feedback_details",
+				"fieldtype": "Table",
+				"options": "interview Feedback Details",
+				"label": "Interview Feedback Details",
+				"insert_after": "average_final_score",
+				"allow_on_submit": 1,
+				"read_only": 1
 			}
 		]
 	}


### PR DESCRIPTION
## Feature description

- Add interview feedback to Interview on submit

## Solution description

- When an Interview Feedback is submitted, the feedback is added to the related Interview's child table (interview_feedback_details) if not already present.

## Output screenshots (optional)
[Screencast from 04-08-25 01:25:04 PM IST.webm](https://github.com/user-attachments/assets/44275770-38e4-4f7f-a96c-1c25293db38b)


## Areas affected and ensured
Interview

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - Yes
  - Opera Mini
  - Safari
