### PR TITLE
fix:Updated Job Applicant Details Dashboard visibility in Interview doctype

### DIFF
--- a/beams/beams/custom_scripts/interview/interview.js
+++ b/beams/beams/custom_scripts/interview/interview.js
@@ -63,6 +63,10 @@ frappe.ui.form.on('Interview', {
 					});
 			}, 'View');
 		}
+
+		if (!frm.is_new() && frm.doc.job_applicant) {
+			set_job_applicant_dashboard(frm);
+		}
 	},
 	job_applicant(frm) {
 		set_job_applicant_dashboard(frm);


### PR DESCRIPTION
## Feature description
Need to: Update Job Applicant Details Dashboard visibility in Interview doctype

## Solution description
Updated Job Applicant Details Dashboard visibility in Interview doctype.that is Job Applicant Details dashboard is visible after Submit Interview Feedback by Interviewer

## Output screenshots (optional)
[Screencast from 04-08-25 02:50:53 PM IST.webm](https://github.com/user-attachments/assets/2646e275-92d6-49f8-95a0-e065af42e607)

## Areas affected and ensured
Interview doctype

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Chrome
