### PR TITLE
fix: Cleared job description template and apply filter based on selected designation

### DIFF
--- a/beams/beams/custom_scripts/job_requisition/job_requisition.js
+++ b/beams/beams/custom_scripts/job_requisition/job_requisition.js
@@ -85,6 +85,10 @@ frappe.ui.form.on('Job Requisition', {
 			frm.set_value('license_type', '');
 		}
 	},
+	designation: function (frm) {
+		frm.set_value('job_description_template', null);
+		frm.refresh_field('job_description_template');
+	}
 });
 
 function set_filters(frm) {

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -2166,7 +2166,7 @@ def get_job_requisition_custom_fields():
 				"options": "Job Description Template",
 				"insert_after": "job_description_tab",
 				"permlevel": 1,
-				"depends_on": "eval: frappe.user_roles.includes('HR Manager') && doc.workflow_state == 'Pending HR Approval'"
+				"depends_on": "eval: frappe.user_roles.includes('HR Manager')  || frappe.user_roles.includes('CEO')"
 			},
 			{
 				"fieldname": "request_for",


### PR DESCRIPTION


## Issue description
1. Need to clear job description template on changing the designation in job requisition
2. Need to change depends on the job description template in job requisition doctype

## Solution description
1. cleared the job description template on changing of designation in job requisition doctype via job requisition.js
2. changed the depends on the job description template 
- added condition user with role ceo can visible job description template in job requisition doctype 
- and removed the condition with only pending hr approval state 

## Output screenshots (optional)
[Screencast from 04-08-25 03:24:47 PM IST.webm](https://github.com/user-attachments/assets/98d49bbb-1700-428c-b3e1-93d752d289b4)



## Areas affected and ensured
job requisition doctype

## Is there any existing behavior change of other features due to this code change?
  No

## Was this feature tested on the browsers?
  
  - Mozilla Firefox
 
