### PR TITLE
TASK-2025-01813:Made Interview status field as Read only except HR Manager role

### DIFF
--- a/beams/setup.py
+++ b/beams/setup.py
@@ -4475,8 +4475,15 @@ def get_property_setters():
 			"property": "ignore_user_permissions",
 			"property_type": "Check",
 			"value": 1
+		},
+		{
+			"doctype_or_field": "DocField",
+			"doc_type": "Interview",
+			"field_name": "status",
+			"property":"read_only_depends_on",
+			"value": "eval:!frappe.user.has_role('HR Manager')"
 		}
-	]
+]
 
 def get_material_request_custom_fields():
 	'''


### PR DESCRIPTION
## Feature description
Need to: Make Interview status field as Read only except HR Manager role

## Solution description
Made Interview status field as Read only except HR Manager role

## Output screenshots (optional)

[Screencast from 04-08-25 04:00:48 PM IST.webm](https://github.com/user-attachments/assets/fd696b03-9190-4a01-a761-87554b3173f0)

## Areas affected and ensured
Interview Doctype

## Is there any existing behavior change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?
  - Chrome
