### PR TITLE
feat:prevent scheduling interviews in the past

### DIFF
--- a/beams/beams/doctype/employee_interview_tool/employee_interview_tool.py
+++ b/beams/beams/doctype/employee_interview_tool/employee_interview_tool.py
@@ -5,6 +5,7 @@ import frappe
 from frappe.model.document import Document
 import json
 from frappe import _ 
+from frappe.utils import get_datetime, now_datetime
 
 class EmployeeInterviewTool(Document):
 	pass
@@ -24,6 +25,12 @@ def create_bulk_interviews(applicants):
 		scheduled_on = app.get('scheduled_on')
 		from_time = app.get('from_time')
 		to_time = app.get('to_time')
+
+		scheduled_datetime = get_datetime(f"{scheduled_on} {from_time}")
+		now = now_datetime()
+
+		if scheduled_datetime < now:
+			frappe.throw(_("Interview date and time cannot be in the past for applicant: {0}").format(app.get('applicant_name')))
 
 		if not (interview_round and scheduled_on and from_time and to_time):
 			frappe.throw(


### PR DESCRIPTION
## Feature description
Prevented scheduling interviews in the past

## Solution description

- TASK-2025-01821
- Prevent scheduling interviews in the past 

## Output screenshots (optional)

[Screencast from 05-08-25 12:50:32 PM IST.webm](https://github.com/user-attachments/assets/e45f3bf6-a220-4f59-bc10-95a78a8d735f)

## Areas affected and ensured

- Employee interview tool
- interview

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - Yes
  - Opera Mini
  - Safari
