### PR TITLE
fix:Updated logic of set status in the local enquiry report doctype

### DIFF
--- a/beams/beams/custom_scripts/job_applicant/job_applicant.py
+++ b/beams/beams/custom_scripts/job_applicant/job_applicant.py
@@ -178,14 +178,7 @@ def fetch_designation(doc, method):
 		else:
 			frappe.throw(f"Designation not found for the selected Job Opening: {doc.job_title}")
 
-def fetch_department(doc, method):
-	if doc.job_title:
-		# Fetch the designation from the Job Opening
-		department = frappe.db.get_value('Job Opening', doc.job_title, 'department')
-		if department:
-			doc.department = department
-		else:
-			frappe.throw(f"Department not found for the selected Job Opening: {doc.job_title}")
+
 
 @frappe.whitelist()
 def calculate_and_validate_age(doc, method=None):

--- a/beams/beams/doctype/local_enquiry_checklist/local_enquiry_checklist.json
+++ b/beams/beams/doctype/local_enquiry_checklist/local_enquiry_checklist.json
@@ -20,9 +20,10 @@
   },
   {
    "fieldname": "value",
-   "fieldtype": "Small Text",
+   "fieldtype": "Select",
    "in_list_view": 1,
-   "label": "Value"
+   "label": "Value",
+   "options": "\nPassed\nFailed"
   },
   {
    "fieldname": "remarks",
@@ -33,12 +34,13 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-11-06 10:26:01.870601",
+ "modified": "2025-08-05 15:28:46.504784",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Local Enquiry Checklist",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/beams/beams/doctype/local_enquiry_report/local_enquiry_report.py
+++ b/beams/beams/doctype/local_enquiry_report/local_enquiry_report.py
@@ -14,6 +14,7 @@ class LocalEnquiryReport(Document):
         self.validate_informations_provided()
         self.validate_enquiry_officer()
         self.set_expected_completion_date()
+        self.set_status_complted()
 
     def on_submit(self):
        update_job_applicant_status(self.job_applicant, 'Local Enquiry Approved')
@@ -43,6 +44,13 @@ class LocalEnquiryReport(Document):
 
             if not self.enquiry_report:
                 frappe.throw('`Enquiry Report` is required before Sending for Approval')
+
+    def set_status_complted(self):
+        '''
+            Automatically set the status to 'Completed' when enquiry_completion_date is set.
+        '''
+        if self.enquiry_completion_date and self.status != 'Completed':
+            self.status = 'Completed'
 
     def on_update(self):
         '''
@@ -132,7 +140,7 @@ def set_status_to_overdue():
             completion_date = getdate(enquiry.enquiry_completion_date) if enquiry.enquiry_completion_date else None
             if not expected_date:
                 continue
-            if completion_date and completion_date > expected_date:
+            if expected_date and expected_date < today_date and not completion_date  :
                 frappe.db.set_value('Local Enquiry Report', enquiry.name, 'status', 'Overdue')
 
 

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -249,7 +249,6 @@ doc_events = {
 			"beams.beams.custom_scripts.job_applicant.job_applicant.validate",
 			"beams.beams.custom_scripts.job_applicant.job_applicant.validate_unique_application",
 			"beams.beams.custom_scripts.job_applicant.job_applicant.fetch_designation",
-			"beams.beams.custom_scripts.job_applicant.job_applicant.fetch_department",
 			"beams.beams.custom_scripts.job_applicant.job_applicant.calculate_and_validate_age"
 			],
 		"after_insert":"beams.beams.custom_scripts.job_applicant.job_applicant.set_interview_rounds",


### PR DESCRIPTION
## Issue description
1. Need to change the field type small text field to Select in local enquiry checklist child doctype
2. Need to Change the logic of set status of the local enquiry report 
3. Need to remove the function responsible for set the department in job applicant doctype

## Solution description
1. changed the field type small text field to Select in local enquiry checklist child doctype
- Value(small text) - value(select)(option-Failed,Success)

2. Changed the logic of set status of the local enquiry report 
- previously the status become overdue when the enquiry completed date become greater than enquiry expected date
- so changed the logic that if enquiry expected date is lesser than today date the set status become overdue through schedular
- when the enquiry completed date  is seted the status become Completed

3.removed the function responsible for set the department in job applicant doctype
-  selecting job opening the department is seted in job applicant doctype

## Output screenshots (optional)
[Screencast from 05-08-25 03:58:49 PM IST.webm](https://github.com/user-attachments/assets/b0cc1017-cccd-4a51-b8a0-5a44da9b57bc)
<img width="1829" height="1000" alt="image" src="https://github.com/user-attachments/assets/634932ec-ee0a-410d-a274-35f9bb0b9397" />

## Areas affected and ensured
local enquiry report doctype

## Is there any existing behavior change of other features due to this code change?
No. 

## Was this feature tested on the browsers?
  - Mozilla Firefox

