### PR TITLE
fix : interview form getting unsaved solved

### DIFF
--- a/beams/beams/custom_scripts/interview/interview.js
+++ b/beams/beams/custom_scripts/interview/interview.js
@@ -1,10 +1,12 @@
 frappe.ui.form.on('Interview', {
 	refresh: function (frm) {
 		if (frm.doc.average_final_score) {
-				frm.set_value('average_final_score',
-						parseFloat(frm.doc.average_final_score).toFixed(2)
-				);
+		    let formatted = parseFloat(frm.doc.average_final_score).toFixed(2);
+		    if (frm.doc.average_final_score != formatted) {
+		        frm.set_value('average_final_score', formatted);
+		    }
 		}
+
 		handle_hrms_custom_buttons(frm);
 
 		let allowed_interviewers = [];


### PR DESCRIPTION
## Feature description
- The interview form become unsaved after reloading when score updated 

## Solution description
- set value is called only if current value is different from the existing value 

## Output screenshots (optional)
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/02b81725-0a3f-4e43-9bda-8d3bfe712de4" />



