### PR TITLE
feat: set Employee's date_of_appointment from Appointment Letter

### DIFF
--- a/beams/beams/custom_scripts/employee/employee.py
+++ b/beams/beams/custom_scripts/employee/employee.py
@@ -176,7 +176,7 @@ def validate_offer_dates(doc, method):
 
     # Ensure Final Confirmation Date is after Scheduled Confirmation Date
     if doc.scheduled_confirmation_date and doc.final_confirmation_date:
-        if getdate(doc.final_confirmation_date) <= getdate(doc.scheduled_confirmation_date):
+        if getdate(doc.final_confirmation_date) < getdate(doc.scheduled_confirmation_date):
             frappe.throw(_("Confirmation Date must be after Offer Date."))
 
 def manage_user_status(doc, method=None):

--- a/beams/beams/custom_scripts/job_offer/job_offer.py
+++ b/beams/beams/custom_scripts/job_offer/job_offer.py
@@ -42,6 +42,16 @@ def make_employee(source_name, target_doc=None):
 			set_missing_values,
 		)
 		job_offer = frappe.get_doc("Job Offer", source_name)
+
+		if job_offer.job_applicant:
+			appointment_date = frappe.db.get_value(
+				'Appointment Letter',
+				{'job_applicant':job_offer.job_applicant},
+				'appointment_date'
+			)
+			if appointment_date:
+				doc.date_of_appointment = appointment_date
+
 		# Only proceed if Job Applicant exists
 		if job_offer.job_applicant:
 			applicant_data = frappe.get_doc("Job Applicant", job_offer.job_applicant)

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -4856,7 +4856,7 @@ def get_appointment_letter():
 			{
 				"fieldname": "notice_period",
 				"fieldtype": "Int",
-				"label": "Notice Period",
+				"label": "Notice Period (In Days)",
 				"insert_after": "applicant_name"
 			}
 		]

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -37,8 +37,7 @@ def after_install():
 	create_custom_fields(get_leave_type_custom_fields(),ignore_validate=True)
 	create_custom_fields(get_leave_application_custom_fields(),ignore_validate=True)
 	create_custom_fields(get_employee_performance_feedback(),ignore_validate=True)
-	create_custom_fields(get_employment_type(),ignore_validate=True)
-	create_custom_fields(get_appointment_letter(),ignore_validate=True)
+	create_custom_fields(get_appointment_letter_custom_fields(),ignore_validate=True)
 	create_custom_fields(get_employment_type_custom_fields(),ignore_validate=True)
 	create_custom_fields(get_employee_separation_custom_fields(),ignore_validate=True)
 	create_custom_fields(get_appraisal_template_custom_fields(),ignore_validate=True)
@@ -109,8 +108,7 @@ def before_uninstall():
 	delete_custom_fields(get_leave_type_custom_fields())
 	delete_custom_fields(get_leave_application_custom_fields())
 	delete_custom_fields(get_employee_performance_feedback())
-	delete_custom_fields(get_employment_type())
-	delete_custom_fields(get_appointment_letter())
+	delete_custom_fields(get_appointment_letter_custom_fields())
 	delete_custom_fields(get_employment_type_custom_fields())
 	delete_custom_fields(get_employee_separation_custom_fields())
 	delete_custom_fields(get_appraisal_template_custom_fields())
@@ -421,6 +419,12 @@ def get_employment_type_custom_fields():
 				"label": "Penalty Leave Type",
 				"options": "Leave Type",
 				"insert_after": "employee_type_name"
+			},
+			{
+				"fieldname": "notice_period",
+				"fieldtype": "Int",
+				"label": "Notice Period",
+				"insert_after": "employment_type"
 			}
 		]
 	}
@@ -4832,22 +4836,7 @@ def get_email_templates():
 		}
 ]
 
-def get_employment_type():
-	'''
-	Custom fields to be added to the Employment Type Doctype
-	'''
-	return {
-		"Employment Type": [
-			{
-				"fieldname": "notice_period",
-				"fieldtype": "Int",
-				"label": "Notice Period",
-				"insert_after": "employment_type"
-			}
-		]
-	}
-
-def get_appointment_letter():
+def get_appointment_letter_custom_fields():
 	'''
 	Custom fields that need to be added to the Appointment Letter DocType
 	'''


### PR DESCRIPTION
## Feature description

- set Employee's date_of_appointment from Appointment Letter

## Solution description

- TASK-2025-01827
- Change the label of Notice Period in Appointment Letter to 'Notice Period (In Days)"

- When creating an Employee from a Job Offer, the system now checks if an Appointment Letter exists for the linked Job Applicant.

- If found, it fetches the appointment_date from the Appointment Letter and assigns it to the date_of_appointment field in the new Employee document.

- Updated the condition in validate_offer_dates  to ensure that Final Confirmation Date must be strictly greater than Scheduled Confirmation Date.

- This prevents users from setting the same or an earlier date for final confirmation compared to the scheduled one.

## Output screenshots (optional)
<img width="1396" height="956" alt="image" src="https://github.com/user-attachments/assets/a4908145-a3d1-4578-bce1-8356808d36c6" />

[Screencast from 06-08-25 11:40:09 AM IST.webm](https://github.com/user-attachments/assets/cf3bd51c-1206-4b47-9b51-04b3be3b97f8)


## Areas affected and ensured

Appointment Letter
Employee

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - Yes
  - Opera Mini
  - Safari
