### PR TITLE
feat: fetch department from job opening in job applicant

### DIFF
--- a/beams/beams/custom_scripts/job_applicant/job_applicant.js
+++ b/beams/beams/custom_scripts/job_applicant/job_applicant.js
@@ -46,6 +46,15 @@ frappe.ui.form.on('Job Applicant', {
 			frm.page.remove_inner_button('Local Enquiry Report', 'Create');
 		}
 	},
+	job_title: function(frm) {
+		if (frm.doc.job_title) {
+			frappe.db.get_value('Job Opening', frm.doc.job_title, 'department', function (r) {
+				if (r && r.department) {
+					frm.set_value('department', r.department);
+				}
+			});
+		}
+	},
 	status: function (frm) {
 		frm.trigger('refresh');
 	},

--- a/beams/patches.txt
+++ b/beams/patches.txt
@@ -1,7 +1,7 @@
 [pre_model_sync]
 beams.patches.rename_hod_role #30-10-2024
 beams.patches.no_of_children_patch  #06-03-2025
-beams.patches.delete_custom_fields  #25-07-2025-2
+beams.patches.delete_custom_fields  #07-08-2025
 
 [post_model_sync]
 # Patches added in this section will be executed after doctypes are migrated

--- a/beams/patches/delete_custom_fields.py
+++ b/beams/patches/delete_custom_fields.py
@@ -173,6 +173,10 @@ fields_to_remove = [
 		'dt':'Interview',
 		'fieldname':'final_score'
 	},
+	{
+		'dt':'Job Applicant',
+		'fieldname': 'department'
+	}
 ]
 
 def execute():

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -2601,7 +2601,7 @@ def get_job_applicant_custom_fields():
 				"insert_after": "name_of_employer"
 			},
 			{
-				"fieldname": "department",
+				"fieldname": "cdepartment",
 				"fieldtype": "Data",
 				"label": "Department",
 				"insert_after": "column_break_1"
@@ -2610,7 +2610,7 @@ def get_job_applicant_custom_fields():
 				"fieldname": "column_break_2",
 				"fieldtype": "Column Break",
 				"label": "",
-				"insert_after": "department"
+				"insert_after": "cdepartment"
 			},
 			{
 				"fieldname": "cdesignation",

--- a/beams/www/job_application_upload/upload_doc.py
+++ b/beams/www/job_application_upload/upload_doc.py
@@ -101,7 +101,7 @@ def update_register_form(docname, form_data=None):
 		doc.ppin_code = sanitize('permanent_pin')
 
 		doc.name_of_employer = sanitize('name_of_employer')
-		doc.department = sanitize('current_department')
+		doc.cdepartment = sanitize('current_department')
 		doc.cdesignation = sanitize('current_designation')
 		doc.reports_to = sanitize('reports_to')
 		doc.cname = sanitize('manager_name')


### PR DESCRIPTION
## Feature description
- Department should be fetched from job opening in job applicant
- Resolved a conflict with the department field in the Job Applicant DocType that was preventing job applicant data from being fetched from job application form correctly and blocking interview creation.This issue is due to duplicate fieldnames for a field.
## Analysis and design (optional)
- Identified that the custom department field was conflicting with the core department field in Frappe.
- Decided to rename the custom field to cdepartment to avoid conflicts and ensure data integrity.
- Reviewed and updated all references to the field across scripts, setup, patches, and form data handling.
## Solution description
- Renamed the custom field department to cdepartment in the Job Applicant DocType.
- Updated:
      - setup.py to reflect the new field name and correct positioning.
      - job_applicant.js to set cdepartment from the related Job Opening.
      - upload_doc.py to map current_department input to cdepartment.
      - delete_custom_fields.py to remove the old conflicting department field.
- Ensured that interview creation now works without any errors.
- Removed any dependencies or references to the old field.
## Output screenshots (optional)
[Screencast from 08-07-2025 11:24:19 AM.webm](https://github.com/user-attachments/assets/fed870ea-d38f-4ec7-83b0-c2e6845178a1)

## Areas affected and ensured
Job Applicant DocType custom fields
Interview creation 
Document upload via /job_application_upload/upload_doc.py
Patch for deleting deprecated custom fields
Custom client-side logic (job_applicant.js)
## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
