### PR TITLE
TASK-2025-01849:Unchecked publish applications received field in Job Opening doctype

### DIFF
--- a/beams/setup.py
+++ b/beams/setup.py
@@ -2261,10 +2261,9 @@ def get_job_requisition_custom_fields():
 			{
 				"fieldname": "publish_on_job_opening",
 				"fieldtype": "Check",
-				"default": "1",
 				"label": "Publish on Job Opening",
 				"insert_after": "publish_on_job_section",
-				"permlevel":4
+				"depends_on": "eval: frappe.user_roles.includes('HR Manager') || frappe.user_roles.includes('CEO')",
 			},
 			{
 				"fieldname": "reason_for_request_section",
@@ -4486,7 +4485,15 @@ def get_property_setters():
 			"field_name": "status",
 			"property":"read_only_depends_on",
 			"value": "eval:!frappe.user.has_role('HR Manager')"
-		}
+		},
+		{
+			"doctype_or_field": "DocField",
+			"doc_type": "Job Opening",
+			"field_name": "publish_applications_received",
+			"property": "default",
+			"property_type": "Check",
+			"value": 0
+		},
 ]
 
 def get_material_request_custom_fields():


### PR DESCRIPTION
## Feature description

Need to: 

- Uncheck publish applications received field in Job Opening doctype
- Remove default and permlevel in publish on job opening field in job requisition doctype and add these field visibility for  users with roles 'HR Manager' or 'CEO'

## Solution description

- Unchecked publish applications received field in Job Opening doctype
- Removed default and permlevel in publish on job opening field in job requisition doctype and added these field visibility for  users with roles 'HR Manager' or 'CEO'

## Output screenshots (optional)
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0d7f28f6-0c91-493d-b600-a2c08930eee7" />

[Screencast from 07-08-25 12:47:39 PM IST.webm](https://github.com/user-attachments/assets/5f5b0586-c435-4fd8-a018-650955fedcdf)

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a53cd94e-f4be-455e-bc5d-74a2bb11ce84" />


## Areas affected and ensured
Job requisition ang job opening doctypes 

## Is there any existing behavior change of other features due to this code change?
No. 

## Was this feature tested on the browsers?
  - Chrome

