### PR TITLE
fix: Incorrect Document Naming Rule

### DIFF
--- a/beams/beams/custom_scripts/employee/employee.py
+++ b/beams/beams/custom_scripts/employee/employee.py
@@ -133,19 +133,7 @@ def autoname(doc, method):
         Method to set Employee ID
     '''
     employee_naming_by_department = frappe.db.get_single_value('HR Settings', 'employee_naming_by_department')
-    if not employee_naming_by_department:
-        naming_method = frappe.db.get_single_value('HR Settings', 'emp_created_by')
-        if not naming_method:
-            frappe.throw(_('Please setup Employee Naming System in Human Resource > HR Settings'))
-        else:
-            if naming_method == 'Naming Series':
-                set_name_by_naming_series(doc)
-            elif naming_method == 'Employee Number':
-                doc.name = doc.employee_number
-            elif naming_method == 'Full Name':
-                doc.set_employee_name()
-                doc.name = doc.employee_name
-    else:
+    if employee_naming_by_department:
         if not doc.department:
             frappe.throw(_('Department is required to create Employee'))
         department_abbr = frappe.db.get_value('Department', doc.department, 'abbreviation')

--- a/beams/beams/custom_scripts/employee/employee.py
+++ b/beams/beams/custom_scripts/employee/employee.py
@@ -8,182 +8,182 @@ from frappe.utils import getdate, nowdate, add_days,today
 
 @frappe.whitelist()
 def create_event(employee_id=None, hod_user=None, target_doc=None):
-    """
-    Create an Event document mapped from an Employee record, adding both the Employee and the HOD
-    as participants in the Event.
-    """
-    user = frappe.session.user
-    if not employee_id:
-        employee_id = frappe.get_value("Employee", {"user_id": user}, "name")
-    hod_user = hod_user or user
-    hod_employee_id = frappe.get_value("Employee", {"user_id": hod_user}, "name")
-    doc = get_mapped_doc("Employee", employee_id, {
-        "Employee": {
-            "doctype": "Event"
-        }
-    }, target_doc)
-    employee_participant = doc.append("event_participants", {})
-    employee_participant.reference_docname = employee_id
-    employee_participant.reference_doctype = "Employee"
-    hod_participant = doc.append("event_participants", {})
-    hod_participant.reference_docname = hod_employee_id
-    hod_participant.reference_doctype = "Employee"
+	"""
+	Create an Event document mapped from an Employee record, adding both the Employee and the HOD
+	as participants in the Event.
+	"""
+	user = frappe.session.user
+	if not employee_id:
+		employee_id = frappe.get_value("Employee", {"user_id": user}, "name")
+	hod_user = hod_user or user
+	hod_employee_id = frappe.get_value("Employee", {"user_id": hod_user}, "name")
+	doc = get_mapped_doc("Employee", employee_id, {
+		"Employee": {
+			"doctype": "Event"
+		}
+	}, target_doc)
+	employee_participant = doc.append("event_participants", {})
+	employee_participant.reference_docname = employee_id
+	employee_participant.reference_doctype = "Employee"
+	hod_participant = doc.append("event_participants", {})
+	hod_participant.reference_docname = hod_employee_id
+	hod_participant.reference_doctype = "Employee"
 
-    return doc
+	return doc
 
 @frappe.whitelist()
 def get_employee_name_for_user(user_id):
-    '''
-    Fetch the Employee name associated with the given user_id.
-    '''
-    employee_name = frappe.db.get_value("Employee", {"user_id": user_id}, "name")
-    return employee_name
+	'''
+	Fetch the Employee name associated with the given user_id.
+	'''
+	employee_name = frappe.db.get_value("Employee", {"user_id": user_id}, "name")
+	return employee_name
 
 @frappe.whitelist()
 def after_insert(doc, method):
-    """
-        Triggered after an Employee record is created.
-        Fetches the default leave policy and leave period from Beams HR Settings,
-        validates the configurations, and creates & submits a Leave Policy Assignment.
-    """
-    # Fetch default leave policy and leave period from Beams HR Settings
-    leave_policy = frappe.db.get_single_value('Beams HR Settings', 'default_leave_policy')
-    leave_period = frappe.db.get_single_value('Beams HR Settings', 'leave_period')
+	"""
+		Triggered after an Employee record is created.
+		Fetches the default leave policy and leave period from Beams HR Settings,
+		validates the configurations, and creates & submits a Leave Policy Assignment.
+	"""
+	# Fetch default leave policy and leave period from Beams HR Settings
+	leave_policy = frappe.db.get_single_value('Beams HR Settings', 'default_leave_policy')
+	leave_period = frappe.db.get_single_value('Beams HR Settings', 'leave_period')
 
-    if not leave_policy or not leave_period:
-        return
+	if not leave_policy or not leave_period:
+		return
 
-    # Fetch leave period details
-    leave_period_details = frappe.db.get_value(
-        'Leave Period',
-        leave_period,
-        ['from_date', 'to_date'],
-        as_dict=True
-    )
+	# Fetch leave period details
+	leave_period_details = frappe.db.get_value(
+		'Leave Period',
+		leave_period,
+		['from_date', 'to_date'],
+		as_dict=True
+	)
 
-    # Skip if leave period details are missing
-    if not leave_period_details:
-        return
+	# Skip if leave period details are missing
+	if not leave_period_details:
+		return
 
-    if not doc.name:
-        return
+	if not doc.name:
+		return
 
-    # Create Leave Policy Assignment
-    leave_policy_assignment = frappe.get_doc({
-        'doctype': 'Leave Policy Assignment',
-        'employee': doc.name,
-        'leave_policy': leave_policy,
-        'leave_period': leave_period,
-        'assignment_based_on': 'Leave Period',
-        'effective_from': leave_period_details['from_date'],
-        'effective_to': leave_period_details['to_date'],
-    })
+	# Create Leave Policy Assignment
+	leave_policy_assignment = frappe.get_doc({
+		'doctype': 'Leave Policy Assignment',
+		'employee': doc.name,
+		'leave_policy': leave_policy,
+		'leave_period': leave_period,
+		'assignment_based_on': 'Leave Period',
+		'effective_from': leave_period_details['from_date'],
+		'effective_to': leave_period_details['to_date'],
+	})
 
-    # Save and submit the leave policy assignment
-    leave_policy_assignment.insert()
-    leave_policy_assignment.submit()
+	# Save and submit the leave policy assignment
+	leave_policy_assignment.insert()
+	leave_policy_assignment.submit()
 
 
 def validate(doc, method):
-    """
-        Automatically set the relieving_date based on resignation_letter_date and notice_number_of_days.
-    """
-    if doc.resignation_letter_date and doc.notice_number_of_days:
-        doc.relieving_date = add_days(getdate(doc.resignation_letter_date), doc.notice_number_of_days)
+	"""
+		Automatically set the relieving_date based on resignation_letter_date and notice_number_of_days.
+	"""
+	if doc.resignation_letter_date and doc.notice_number_of_days:
+		doc.relieving_date = add_days(getdate(doc.resignation_letter_date), doc.notice_number_of_days)
 
 @frappe.whitelist()
 def get_notice_period(employment_type, job_applicant=None, current_notice_period=None):
-    '''
-    Fetch the notice period based on the employment type and Beams HR Settings.
+	'''
+	Fetch the notice period based on the employment type and Beams HR Settings.
 
-    Conditions:
-    - If current notice_number_of_days is set, return the existing notice period
-    - If employment type matches Permanent Employment Type in Beams HR Settings:
-      - First check Appointment Letter
-      - If no Appointment Letter, fetch from Employment Type
-    - For other employment types :
-      - Fetch notice period directly from Employment Type
-    '''
+	Conditions:
+	- If current notice_number_of_days is set, return the existing notice period
+	- If employment type matches Permanent Employment Type in Beams HR Settings:
+	  - First check Appointment Letter
+	  - If no Appointment Letter, fetch from Employment Type
+	- For other employment types :
+	  - Fetch notice period directly from Employment Type
+	'''
 
-    # Get Permanent Employment Type from Beams HR Settings
-    permanent_emp_type = frappe.db.get_single_value('Beams HR Settings', 'permanent_employment_type')
+	# Get Permanent Employment Type from Beams HR Settings
+	permanent_emp_type = frappe.db.get_single_value('Beams HR Settings', 'permanent_employment_type')
 
-    notice_period = None
+	notice_period = None
 
-    # Check if the employment type matches Permanent Employment Type
-    if employment_type == permanent_emp_type and job_applicant:
-        # Check if an Appointment Letter exists for the Job Applicant
-        appointment_letter = frappe.get_value('Appointment Letter',
-            {'job_applicant': job_applicant}, 'notice_period')
+	# Check if the employment type matches Permanent Employment Type
+	if employment_type == permanent_emp_type and job_applicant:
+		# Check if an Appointment Letter exists for the Job Applicant
+		appointment_letter = frappe.get_value('Appointment Letter',
+			{'job_applicant': job_applicant}, 'notice_period')
 
-        if appointment_letter:
-            # Fetch the notice period from the Appointment Letter
-            notice_period = appointment_letter
+		if appointment_letter:
+			# Fetch the notice period from the Appointment Letter
+			notice_period = appointment_letter
 
-    # If no Appointment Letter notice period found or not Permanent Employment Type,
-    # fetch from Employment Type
-    if not notice_period:
-        notice_period = frappe.get_value('Employment Type',
-            {'name': employment_type}, 'notice_period')
+	# If no Appointment Letter notice period found or not Permanent Employment Type,
+	# fetch from Employment Type
+	if not notice_period:
+		notice_period = frappe.get_value('Employment Type',
+			{'name': employment_type}, 'notice_period')
 
-    return notice_period
+	return notice_period
 
 def autoname(doc, method):
-    '''
-        Method to set Employee ID
-    '''
-    employee_naming_by_department = frappe.db.get_single_value('HR Settings', 'employee_naming_by_department')
-    if employee_naming_by_department:
-        if not doc.department:
-            frappe.throw(_('Department is required to create Employee'))
-        department_abbr = frappe.db.get_value('Department', doc.department, 'abbreviation')
-        if not department_abbr:
-            frappe.throw(_('Abbreviation is missing for Department : {0} is required to create Employee'.format(doc.department)))
-        doc.name = get_next_employee_id(department_abbr)
-    doc.employee = doc.name
+	'''
+		Method to set Employee ID
+	'''
+	employee_naming_by_department = frappe.db.get_single_value('HR Settings', 'employee_naming_by_department')
+	if employee_naming_by_department:
+		if not doc.department:
+			frappe.throw(_('Department is required to create Employee'))
+		department_abbr = frappe.db.get_value('Department', doc.department, 'abbreviation')
+		if not department_abbr:
+			frappe.throw(_('Abbreviation is missing for Department : {0} is required to create Employee'.format(doc.department)))
+		doc.name = get_next_employee_id(department_abbr)
+	doc.employee = doc.name
 
 def get_next_employee_id(department_abbr):
-    '''
-        Method to get next Employee ID
-    '''
-    series_prefix = "MB/{0}/".format(department_abbr)
-    next_employee_id = '{0}1'.format(series_prefix)
-    employees = frappe.db.get_all('Employee', { 'name': ['like', '%{0}%'.format(series_prefix)] }, order_by='name desc', pluck='name')
-    if employees:
-        employee_id = employees[0]
-        employee_id = employee_id.replace(series_prefix, "")
-        employee_count = int(employee_id)
-        next_employee_id = '{0}{1}'.format(series_prefix, str(employee_count+1))
-    return next_employee_id
+	'''
+		Method to get next Employee ID
+	'''
+	series_prefix = "MB/{0}/".format(department_abbr)
+	next_employee_id = '{0}1'.format(series_prefix)
+	employees = frappe.db.get_all('Employee', { 'name': ['like', '%{0}%'.format(series_prefix)] }, order_by='name desc', pluck='name')
+	if employees:
+		employee_id = employees[0]
+		employee_id = employee_id.replace(series_prefix, "")
+		employee_count = int(employee_id)
+		next_employee_id = '{0}{1}'.format(series_prefix, str(employee_count+1))
+	return next_employee_id
 
 
 def validate_offer_dates(doc, method):
-    """Validate Employee fields before saving/submitting."""
+	"""Validate Employee fields before saving/submitting."""
 
-    today_date = getdate(today())
+	today_date = getdate(today())
 
-    # Ensure Final Confirmation Date is after Scheduled Confirmation Date
-    if doc.scheduled_confirmation_date and doc.final_confirmation_date:
-        if getdate(doc.final_confirmation_date) < getdate(doc.scheduled_confirmation_date):
-            frappe.throw(_("Confirmation Date must be after Offer Date."))
+	# Ensure Final Confirmation Date is after Scheduled Confirmation Date
+	if doc.scheduled_confirmation_date and doc.final_confirmation_date:
+		if getdate(doc.final_confirmation_date) < getdate(doc.scheduled_confirmation_date):
+			frappe.throw(_("Confirmation Date must be after Offer Date."))
 
 def manage_user_status(doc, method=None):
-    """
-    Automatically enable or disable a linked User account
-    based on the Employee's status.
-    - If Employee is 'Active' → Enable User
-    - If Employee is 'Inactive', 'Suspended', 'Left' → Disable User
-    """
+	"""
+	Automatically enable or disable a linked User account
+	based on the Employee's status.
+	- If Employee is 'Active' → Enable User
+	- If Employee is 'Inactive', 'Suspended', 'Left' → Disable User
+	"""
 
-    if not doc.user_id:
-        return
+	if not doc.user_id:
+		return
 
-    user_enabled_status = frappe.db.get_value("User", doc.user_id, "enabled")
+	user_enabled_status = frappe.db.get_value("User", doc.user_id, "enabled")
 
-    if doc.status == "Active":
-        if user_enabled_status == 0:
-            frappe.db.set_value("User", doc.user_id, "enabled", 1)
+	if doc.status == "Active":
+		if user_enabled_status == 0:
+			frappe.db.set_value("User", doc.user_id, "enabled", 1)
 
-    elif doc.status in ["Inactive", "Suspended", "Left"]:
-        if user_enabled_status == 1:
-            frappe.db.set_value("User", doc.user_id, "enabled", 0)
+	elif doc.status in ["Inactive", "Suspended", "Left"]:
+		if user_enabled_status == 1:
+			frappe.db.set_value("User", doc.user_id, "enabled", 0)


### PR DESCRIPTION
## Feature description
Currently, the naming series for the Employee document increments by 2, which is incorrect.
## Analysis and design (optional)
Frappe already runs the autoname function when the "Employee Naming by Department" option is turned on in HR Settings.
the custom code was also checking this setting and doing the same thing again. So the naming logic was running twice, causing the employee ID to skip numbers.


## Solution description
We removed the extra code that was doing the same naming logic again. Now we’re letting Frappe handle it the way it’s supposed to. This stops the ID from jumping by 2 and keeps the numbering correct
## Output screenshots (optional)
if employee_naming_by_department in HR Settings is not checked
<img width="1850" height="926" alt="image" src="https://github.com/user-attachments/assets/75094d69-c1e4-4831-9d26-2973a87d7045" />
<img width="1850" height="926" alt="image" src="https://github.com/user-attachments/assets/ab22bb57-f047-4817-9f09-24a31a8c1435" />
if employee_naming_by_department in HR Settings is checked
<img width="1850" height="926" alt="image" src="https://github.com/user-attachments/assets/d6ed3ab9-6238-4874-8a39-0ec2e44cabe1" />
<img width="1850" height="926" alt="image" src="https://github.com/user-attachments/assets/2d7062f3-4b6c-465f-8612-b7c8600e2f3c" />

## Areas affected and ensured
- Creating new Employees
- Employee ID generation using department abbreviation
## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
