### PR TITLE
feat:fetch purpose of visit to event doctype's subject field

### DIFF
--- a/beams/beams/doctype/guest_appointment/guest_appointment.js
+++ b/beams/beams/doctype/guest_appointment/guest_appointment.js
@@ -8,7 +8,8 @@ frappe.ui.form.on('Guest Appointment', {
       frm.add_custom_button(__('Event'), function () {
         // Create a new Event DocType (empty Event)
         frappe.new_doc('Event', {
-          guest_appointment: frm.doc.name  // Optionally link the Event to this Guest Appointment
+          guest_appointment: frm.doc.name,
+          subject : frm.doc.purpose_of_visit,
         });
       }, 'Create');  // Add the button under the 'Create' group
 

--- a/beams/beams/doctype/guest_appointment/guest_appointment.json
+++ b/beams/beams/doctype/guest_appointment/guest_appointment.json
@@ -12,7 +12,6 @@
   "column_break_tpeg",
   "posting_date",
   "appointment_date",
-  "appointment_time",
   "section_break_yjog",
   "purpose_of_visit",
   "remarks",
@@ -58,8 +57,7 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": " Received By",
-   "options": "Employee",
-   "reqd": 1
+   "options": "Employee"
   },
   {
    "fieldname": "remarks",
@@ -76,21 +74,16 @@
   },
   {
    "fieldname": "appointment_date",
-   "fieldtype": "Date",
+   "fieldtype": "Datetime",
    "in_list_view": 1,
-   "label": "Appointment Date",
+   "label": "Appointment Date and Time",
    "reqd": 1
-  },
-  {
-   "fieldname": "appointment_time",
-   "fieldtype": "Time",
-   "label": "Appointment Time"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-01-26 11:11:10.182784",
+ "modified": "2025-08-07 17:19:52.507070",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Guest Appointment",
@@ -111,6 +104,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/beams/beams/doctype/guest_appointment/guest_appointment.py
+++ b/beams/beams/doctype/guest_appointment/guest_appointment.py
@@ -22,8 +22,6 @@ class GuestAppointment(Document):
         Validates if the employee associated with the document is available
         on the specified appointment date.
         '''
-        if not self.received_by or not self.appointment_date:
-            frappe.throw("Received By and Appointment Date are mandatory.")
 
         leave_applications = frappe.db.exists(
             "Leave Application",


### PR DESCRIPTION
## Feature description
Make changes in guest appointment doctype

## Solution description
1. requested by field mandatory field removed from guest appointment.
2. remove the field Appointment time and change the field appointment date and time
3. fetch purpose of visit to event doctype's subject field 
## Output screenshots (optional)
<img width="1366" height="768" alt="Screenshot from 2025-08-08 09-26-55" src="https://github.com/user-attachments/assets/5f743f8b-aaf8-4453-90a9-872e871c0163" />
<img width="1366" height="768" alt="Screenshot from 2025-08-08 09-27-13" src="https://github.com/user-attachments/assets/3d9b5b42-c3ea-46e7-8099-c0f2d6e1d6ea" />



## Is there any existing behavior change of other features due to this code change?
No
## Was this feature tested on the browsers?
  - Chrome
  
