### PR TITLE
fix:Fetched session user when the cpal created from employee onboarding

### DIFF
--- a/beams/beams/custom_scripts/employee_onboarding/employee_onboarding.py
+++ b/beams/beams/custom_scripts/employee_onboarding/employee_onboarding.py
@@ -18,6 +18,8 @@ def create_cpal(source_name):
 
     # Fetch the company_policy from the Company doctype
     company_policy = frappe.db.get_value('Company', onboarding_doc.company, 'company_policy')
+    if not frappe._strip_html_tags(company_policy):
+        frappe.throw(f"Please set the <b>Company Policy</b> in the Company <b>{onboarding_doc.company}</b> to create the  <b>Company Policy Acceptance Log</b>")
 
     # Create a mapped document using get_mapped_doc
     cpal_doc = get_mapped_doc(

--- a/beams/beams/doctype/company_policy_acceptance_log/company_policy_acceptance_log.js
+++ b/beams/beams/doctype/company_policy_acceptance_log/company_policy_acceptance_log.js
@@ -3,28 +3,28 @@
 
 frappe.ui.form.on('Company Policy Acceptance Log', {
 	onload: function (frm) {
-		if (frappe.session.user !== 'Administrator') {
 			frappe.db.get_value('Employee', { user_id: frappe.session.user }, 'name')
 				.then(r => {
 					if (r.message && r.message.name) {
 						const employee_id = r.message.name;
-						frm.set_value('employee', employee_id);
-
-						// Wait for fields to render, then make them editable
-						frappe.after_ajax(() => {
-							frm.set_df_property('read_and_accepted', 'read_only', false);
-							frm.set_df_property('digital_sign', 'read_only', false);
-						});
-					} else {
-						// No linked employee: keep fields read-only
+						if (!frm.doc.employee && frm.is_new()) {
+							frm.set_value('employee', employee_id);
+						}
+						if (frm.doc.employee === employee_id) {
+							frappe.after_ajax(() => {
+								frm.set_df_property('read_and_accepted', 'read_only', false);
+								frm.set_df_property('digital_sign', 'read_only', false);
+							});
+						}else {
+							frm.set_df_property('read_and_accepted', 'read_only', true);
+							frm.set_df_property('digital_sign', 'read_only', true);
+						}
+					}
+					else {
 						frm.set_df_property('read_and_accepted', 'read_only', true);
 						frm.set_df_property('digital_sign', 'read_only', true);
 					}
 				});
-		} else {
-			// Administrator: read-only fields
-			frm.set_df_property('read_and_accepted', 'read_only', true);
-			frm.set_df_property('digital_sign', 'read_only', true);
 		}
-	}
 });
+


### PR DESCRIPTION
## Issue description
1.Fetched the Employee in CPAL from the session user while creating it from Employee Onboarding, instead of using the Employee from the Onboarding record.
2. created the cpal from onboarding is in the not saved state
3. need to add proper throw message for missing company policy in company for creating cpal
4. Optimized the code
## Solution description

1Fetched the Employee in CPAL from the session user while creating it from Employee Onboarding, instead of using the Employee from the onboarding record.
- added condition when cpal created another user from onboarding it will fetch correct employee and when creating manually session user will set as employee
2.created the cpal from onboarding is in the not saved state 
-  removed the not saved state 
3.need to add proper throw message for missing company policy in company for creating cpal
 - added proper message when company policy is not set and the when creating cpal from the onboarding 
4.optimized the code
- removed the unwanted code that administrator can set read only read_and_accepted ,digital_sign  

## Output screenshots (optional)
.
[Screencast from 08-08-25 12:18:11 PM IST.webm](https://github.com/user-attachments/assets/8758cd9f-467e-42b4-b8d3-3dde06b832b0)
<img width="1801" height="1021" alt="image" src="https://github.com/user-attachments/assets/9af2be25-f571-4f37-afc0-97bc10b6ac7a" />
<img width="1801" height="1021" alt="image" src="https://github.com/user-attachments/assets/cf791346-abaf-484b-b3f6-9e517a22103f" />


## Areas affected and ensured
company acceptance log and employee onboarding doctype

## Is there any existing behavior change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?
 
  - Mozilla Firefox
  
