### PR TITLE
fix:change the logic of button visibility of the new feedback in appraisal doctype

### DIFF
--- a/beams/beams/custom_scripts/appraisal/appraisal.js
+++ b/beams/beams/custom_scripts/appraisal/appraisal.js
@@ -1,461 +1,454 @@
 frappe.ui.form.on('Appraisal', {
-    refresh: function (frm) {
-        frm.trigger('update_self_kra_rating_list_view');
-        frm.remove_custom_button(__('View Goals'));
-        set_table_properties(frm, 'employee_self_kra_rating');
-        set_table_properties(frm, 'dept_self_kra_rating');
-        set_table_properties(frm, 'company_self_kra_rating');
-        // Remove the button by targeting its full class list
-        setTimeout(() => {
-            $('.new-feedback-btn.btn.btn-sm.d-inline-flex.align-items-center.justify-content-center.px-3.py-2.border').remove();
-        }, 500);
-        // Hide dashboard
-        $('.form-dashboard-section').hide();
-        setTimeout(() => {
-            $('.new-feedback-btn.btn.btn-sm.d-inline-flex.align-items-center.justify-content-center.px-3.py-2.border').remove();
-        }, 500);
+	refresh: function (frm) {
+		frm.trigger('update_self_kra_rating_list_view');
+		frm.remove_custom_button(__('View Goals'));
+		set_table_properties(frm, 'employee_self_kra_rating');
+		set_table_properties(frm, 'dept_self_kra_rating');
+		set_table_properties(frm, 'company_self_kra_rating');
+		// Remove the button by targeting its full class list
+		setTimeout(() => {
+			$('.new-feedback-btn.btn.btn-sm.d-inline-flex.align-items-center.justify-content-center.px-3.py-2.border').remove();
+		}, 500);
+		// Hide dashboard
+		$('.form-dashboard-section').hide();
+		setTimeout(() => {
+			$('.new-feedback-btn.btn.btn-sm.d-inline-flex.align-items-center.justify-content-center.px-3.py-2.border').remove();
+		}, 500);
 
-        frm.set_df_property('final_score', 'hidden', 1);
+		frm.set_df_property('final_score', 'hidden', 1);
 
-        // Show "New Feedback" button only if the user is an assessment officer and not the appraised employee, before submission
-        if (!frm.is_new() && frm.doc.docstatus !== 1) {
-    let user = frappe.session.user;
-
-    frappe.db.get_value('Employee', { 'user_id': user }, ['name', 'assessment_officer']).then(res => {
-        let employee = res.message?.name;
-        let is_assessment_officer = res.message?.assessment_officer;
-
-        if (frm.doc.employee !== employee && is_assessment_officer) {
-            // Check if feedback exists
-            frappe.call({
-                method: 'beams.beams.custom_scripts.appraisal.appraisal.get_feedback_for_appraisal',
-                args: { appraisal_name: frm.doc.name },
-                callback: function (r) {
-                    const feedback_name = r.message;
-
-                    if (!feedback_name) {
-                        // No feedback exists → show New Feedback button
-                        frm.add_custom_button(__('New Feedback'), () => {
-                            frm.events.show_feedback_dialog(frm);
-                        });
-                    } else {
-                        // Check docstatus of existing feedback
-                        frappe.db.get_value('Employee Performance Feedback', feedback_name, 'docstatus').then(val => {
-                            const docstatus = val.message?.docstatus;
-
-                            if (docstatus === 0) {
-                                // Draft feedback exists → show Edit button
-                                frm.add_custom_button(__('Edit Feedback'), () => {
-                                    frm.events.show_feedback_dialog(frm);
-                                });
-                            }
-                            // If docstatus === 1 (submitted), show nothing
-                        });
-                    }
-                }
-            });
-        }
-    });
-}
+		// Show "New Feedback" button only if the user is an assessment officer and not the appraised employee, before submission
+		if (!frm.is_new() && frm.doc.docstatus !== 1) {
+			let user = frappe.session.user;
+			frappe.db.get_value('Employee', { 'user_id': user }, ['name']).then(res => {
+				let logged_in_employee = res.message?.name;
+				frappe.db.get_value('Employee', frm.doc.employee, 'assessment_officer').then(emp_res => {
+					let appraisal_assessment_officer = emp_res.message?.assessment_officer;
+					if (appraisal_assessment_officer === logged_in_employee) {
+						frappe.call({
+							method: 'beams.beams.custom_scripts.appraisal.appraisal.get_feedback_for_appraisal',
+							args: { appraisal_name: frm.doc.name },
+							callback: function (r) {
+								const feedback_name = r.message;
+								if (!feedback_name) {
+									frm.add_custom_button(__('New Feedback'), () => {
+										frm.events.show_feedback_dialog(frm);
+									});
+								} else {
+									frappe.db.get_value('Employee Performance Feedback', feedback_name, 'docstatus').then(val => {
+										const docstatus = val.message?.docstatus;
+										if (docstatus === 0) {
+											frm.add_custom_button(__('Edit Feedback'), () => {
+												frm.events.show_feedback_dialog(frm);
+											});
+										}
+									});
+								}
+							}
+						});
+					}
+				});
+			});
+		}
 
 
-        if (!frm.is_new() && frm.doc.category_details.length <= 0) {
-            frm.add_custom_button(__('Notify Assessment Officers'), function () {
-                if (frm.doc.__unsaved) {
-                    frappe.msgprint(__('Please save the form before sending notification.'));
-                    return;
-                }
+		if (!frm.is_new() && frm.doc.category_details.length <= 0) {
+			frm.add_custom_button(__('Notify Assessment Officers'), function () {
+				if (frm.doc.__unsaved) {
+					frappe.msgprint(__('Please save the form before sending notification.'));
+					return;
+				}
 
-                frappe.confirm(
-                    'Do you want to send the notification to your Assessment Officer?',
-                    () => {
-                        frappe.call({
-                            method: "beams.beams.custom_scripts.appraisal.appraisal.notify_assestment_officer",
-                            args: {
-                                doc: frm.doc.name,
-                                employee_id: frm.doc.employee
-                            },
-                            callback: (response) => {
-                                if (!response.exc) {
-                                    frappe.msgprint('Notification sent and tasks assigned.');
-                                }
-                            }
-                        });
-                    }
-                );
-            }).addClass("btn-primary");
-        }
+				frappe.confirm(
+					'Do you want to send the notification to your Assessment Officer?',
+					() => {
+						frappe.call({
+							method: "beams.beams.custom_scripts.appraisal.appraisal.notify_assestment_officer",
+							args: {
+								doc: frm.doc.name,
+								employee_id: frm.doc.employee
+							},
+							callback: (response) => {
+								if (!response.exc) {
+									frappe.msgprint('Notification sent and tasks assigned.');
+								}
+							}
+						});
+					}
+				);
+			}).addClass("btn-primary");
+		}
 
-        if (frm.doc.name) {
-            // Check if appraisal_template is set before calling get_appraisal_summary
-            if (frm.doc.appraisal_template) {
-                // Fetch the Employee Performance Feedback related to the Appraisal
-                frappe.call({
-                    method: "beams.beams.custom_scripts.appraisal.appraisal.get_feedback_for_appraisal",
-                    args: {
-                        appraisal_name: frm.doc.name
-                    },
-                    callback: function (res) {
-                        if (res.message) {
-                            const employee_feedback = res.message;
+		if (frm.doc.name) {
+			// Check if appraisal_template is set before calling get_appraisal_summary
+			if (frm.doc.appraisal_template) {
+				// Fetch the Employee Performance Feedback related to the Appraisal
+				frappe.call({
+					method: "beams.beams.custom_scripts.appraisal.appraisal.get_feedback_for_appraisal",
+					args: {
+						appraisal_name: frm.doc.name
+					},
+					callback: function (res) {
+						if (res.message) {
+							const employee_feedback = res.message;
 
-                            frappe.call({
-                                method: "beams.beams.custom_scripts.appraisal.appraisal.get_appraisal_summary",
-                                args: {
-                                    appraisal_template: frm.doc.appraisal_template,
-                                    employee_feedback: employee_feedback
-                                },
-                                callback: function (r) {
-                                    if (r.message) {
-                                        $(frm.fields_dict['appraisal_summary'].wrapper).html(r.message[0]);
-                                        if (frm.doc.final_average_score != r.message[1]) {
-                                            frm.set_value("final_average_score", r.message[1])
-                                            frm.refresh_field("final_average_score")
-                                        }
-                                    }
-                                }
-                            });
-                        } else {
-                            $(frm.fields_dict['appraisal_summary'].wrapper).html('<p>No Employee Performance Feedback found for this appraisal.</p>');
-                        }
-                    }
-                });
-            } else {
-                $(frm.fields_dict['appraisal_summary'].wrapper).html('<p>No Employee Performance Feedback is found.</p>');
-            }
-        } else {
-            $(frm.fields_dict['appraisal_summary'].wrapper).html('<p>Please save the Appraisal to view the summary.</p>');
-        }
+							frappe.call({
+								method: "beams.beams.custom_scripts.appraisal.appraisal.get_appraisal_summary",
+								args: {
+									appraisal_template: frm.doc.appraisal_template,
+									employee_feedback: employee_feedback
+								},
+								callback: function (r) {
+									if (r.message) {
+										$(frm.fields_dict['appraisal_summary'].wrapper).html(r.message[0]);
+										if (frm.doc.final_average_score != r.message[1]) {
+											frm.set_value("final_average_score", r.message[1])
+											frm.refresh_field("final_average_score")
+										}
+									}
+								}
+							});
+						} else {
+							$(frm.fields_dict['appraisal_summary'].wrapper).html('<p>No Employee Performance Feedback found for this appraisal.</p>');
+						}
+					}
+				});
+			} else {
+				$(frm.fields_dict['appraisal_summary'].wrapper).html('<p>No Employee Performance Feedback is found.</p>');
+			}
+		} else {
+			$(frm.fields_dict['appraisal_summary'].wrapper).html('<p>Please save the Appraisal to view the summary.</p>');
+		}
 
-        if (frm.doc.employee) {
-            frappe.call({
-                method: "beams.beams.custom_scripts.appraisal.appraisal.check_existing_event",
-                args: { appraisal_reference: frm.doc.name },
-                callback: function (r) {
-                    if (r.message) {
-                        // Remove existing "View Event" button before adding a new one
-                        frm.fields_dict["view_event_button"]?.$wrapper.find('button').remove();
+		if (frm.doc.employee) {
+			frappe.call({
+				method: "beams.beams.custom_scripts.appraisal.appraisal.check_existing_event",
+				args: { appraisal_reference: frm.doc.name },
+				callback: function (r) {
+					if (r.message) {
+						// Remove existing "View Event" button before adding a new one
+						frm.fields_dict["view_event_button"]?.$wrapper.find('button').remove();
 
-                        // Add "View Event" as a separate button
-                        frm.add_custom_button(__('View Event'), function () {
-                            frappe.set_route('Form', 'Event', r.message);
-                        });
-                    }
-                }
-            });
-            // Add "One to One Meeting" inside the "Create" dropdown
-            const allowed_roles = ['HR Manager', 'HOD'];
-            const user_has_access = frappe.user_roles.some(role => allowed_roles.includes(role));
-            if (user_has_access) {
-                frm.add_custom_button(__('One to One Meeting'), function () {
-                    frappe.model.open_mapped_doc({
-                        method: "beams.beams.custom_scripts.appraisal.appraisal.map_appraisal_to_event",
-                        args: { source_name: frm.doc.name },
-                        frm: frm
-                    });
-                }, __('Create'));
-            }
-        }
+						// Add "View Event" as a separate button
+						frm.add_custom_button(__('View Event'), function () {
+							frappe.set_route('Form', 'Event', r.message);
+						});
+					}
+				}
+			});
+			// Add "One to One Meeting" inside the "Create" dropdown
+			const allowed_roles = ['HR Manager', 'HOD'];
+			const user_has_access = frappe.user_roles.some(role => allowed_roles.includes(role));
+			if (user_has_access) {
+				frm.add_custom_button(__('One to One Meeting'), function () {
+					frappe.model.open_mapped_doc({
+						method: "beams.beams.custom_scripts.appraisal.appraisal.map_appraisal_to_event",
+						args: { source_name: frm.doc.name },
+						frm: frm
+					});
+				}, __('Create'));
+			}
+		}
 
-        frappe.call({
-            method: "beams.beams.custom_scripts.appraisal.appraisal.get_categories_table",
-            callback: function (res) {
-                if (res.message) {
-                    frm.set_df_property('category_html', 'options', res.message);
-                } else {
-                    frm.set_df_property('category_html', 'options', '<p>No categories found.</p>');
-                }
-            }
-        });
+		frappe.call({
+			method: "beams.beams.custom_scripts.appraisal.appraisal.get_categories_table",
+			callback: function (res) {
+				if (res.message) {
+					frm.set_df_property('category_html', 'options', res.message);
+				} else {
+					frm.set_df_property('category_html', 'options', '<p>No categories found.</p>');
+				}
+			}
+		});
 
-        // Dynamically add the "Add Category" button only once
-        if (!frm.category_button_added) {
-            const button_html = `
-                <button class="btn btn-primary" id="add_category_button" style="margin-top: 10px;">Add Category</button><br><br>
-            `;
-            $(frm.fields_dict['category_html'].wrapper).after(button_html);
-            frm.category_button_added = true;
+		// Dynamically add the "Add Category" button only once
+		if (!frm.category_button_added) {
+			const button_html = `
+				<button class="btn btn-primary" id="add_category_button" style="margin-top: 10px;">Add Category</button><br><br>
+			`;
+			$(frm.fields_dict['category_html'].wrapper).after(button_html);
+			frm.category_button_added = true;
 
-            // Button click event for adding a category
-            $('#add_category_button').on('click', function () {
-                frm.events.show_add_category_dialog(frm);
-            });
-        }
-        // Hide the chart by targeting its container
-        if (frm.dashboard.wrapper) {
-            frm.dashboard.wrapper.find('.chart-container').hide(); // Adjust selector as needed
-        }
+			// Button click event for adding a category
+			$('#add_category_button').on('click', function () {
+				frm.events.show_add_category_dialog(frm);
+			});
+		}
+		// Hide the chart by targeting its container
+		if (frm.dashboard.wrapper) {
+			frm.dashboard.wrapper.find('.chart-container').hide(); // Adjust selector as needed
+		}
 
-        ['employee_self_kra_rating', 'dept_self_kra_rating', 'company_self_kra_rating'].forEach(field => {
-            frm.fields_dict[field].grid.wrapper.on('change', 'input[data-fieldname="marks"]', function () {
-                let value = parseFloat($(this).val());
-                if (value > 5) {
-                    frappe.msgprint(__('Marks cannot be greater than 5.'));
-                    $(this).val('');  // Reset invalid value
-                }
-            });
-        });
-    },
+		['employee_self_kra_rating', 'dept_self_kra_rating', 'company_self_kra_rating'].forEach(field => {
+			frm.fields_dict[field].grid.wrapper.on('change', 'input[data-fieldname="marks"]', function () {
+				let value = parseFloat($(this).val());
+				if (value > 5) {
+					frappe.msgprint(__('Marks cannot be greater than 5.'));
+					$(this).val('');  // Reset invalid value
+				}
+			});
+		});
+	},
 
-    validate: function (frm) {
-        for (let field of ['employee_self_kra_rating', 'dept_self_kra_rating', 'company_self_kra_rating']) {
-            if (frm.doc[field] && frm.doc[field].some(row => row.marks > 5)) {
-                frappe.throw(__('Marks cannot be greater than 5.'));
-            }
-        }
-    },
+	validate: function (frm) {
+		for (let field of ['employee_self_kra_rating', 'dept_self_kra_rating', 'company_self_kra_rating']) {
+			if (frm.doc[field] && frm.doc[field].some(row => row.marks > 5)) {
+				frappe.throw(__('Marks cannot be greater than 5.'));
+			}
+		}
+	},
 
    show_feedback_dialog: function (frm) {
-    let dialog = new frappe.ui.Dialog({
-        title: 'New Feedback',
-        fields: [
-            {
-                label: 'Employee Criteria',
-                fieldname: 'employee_criteria',
-                fieldtype: 'Table',
-                fields: [
-                    {
-                        label: 'Criteria',
-                        fieldname: 'criteria',
-                        fieldtype: 'Link',
-                        options: 'Employee Feedback Criteria',
-                        in_list_view: 1,
-                        reqd: 1,
-                        read_only: 1,
-                        columns: 3
-                    },
-                    {
-                        label: 'Goals',
-                        fieldname: 'goals',
-                        fieldtype: 'Text Editor',
-                        in_list_view: 1,
-                        read_only: 1,
-                        columns: 3
-                    },
-                    {
-                        label: 'Weightage(%)',
-                        fieldname: 'per_weightage',
-                        fieldtype: 'Percent',
-                        in_list_view: 1,
-                        columns: 2,
-                        read_only: 1,
-                        reqd: 1
-                    },
-                    {
-                        label: 'Marks (out of 5)',
-                        fieldname: 'marks',
-                        fieldtype: 'Float',
-                        in_list_view: 1,
-                        reqd: 1,
-                        columns: 2,
-                        description: 'Enter Marks (0 - 5)'
-                    },
-                ],
-                cannot_add_rows: true,
-            },
-            {
-                label: 'Department Criteria',
-                fieldname: 'department_criteria',
-                fieldtype: 'Table',
-                fields: [
-                    {
-                        label: 'Criteria',
-                        fieldname: 'criteria',
-                        fieldtype: 'Link',
-                        options: 'Employee Feedback Criteria',
-                        in_list_view: 1,
-                        read_only: 1,
-                        reqd: 1,
-                    },
-                    {
-                        label: 'Weightage(%)',
-                        fieldname: 'per_weightage',
-                        fieldtype: 'Percent',
-                        in_list_view: 1,
-                        read_only: 1,
-                        reqd: 1,
-                    },
-                    {
-                        label: 'Marks (out of 5)',
-                        fieldname: 'marks',
-                        fieldtype: 'Float',
-                        in_list_view: 1,
-                        reqd: 1,
-                        description: 'Enter Marks (0 - 5)',
-                    },
-                ],
-                cannot_add_rows: true,
-            },
-            {
-                label: 'Company Criteria',
-                fieldname: 'company_criteria',
-                fieldtype: 'Table',
-                fields: [
-                    {
-                        label: 'Criteria',
-                        fieldname: 'criteria',
-                        fieldtype: 'Link',
-                        options: 'Employee Feedback Criteria',
-                        in_list_view: 1,
-                        read_only: 1,
-                        reqd: 1,
-                    },
-                    {
-                        label: 'Weightage(%)',
-                        fieldname: 'per_weightage',
-                        fieldtype: 'Percent',
-                        in_list_view: 1,
-                        read_only: 1,
-                        reqd: 1,
-                    },
-                    {
-                        label: 'Marks (out of 5)',
-                        fieldname: 'marks',
-                        fieldtype: 'Float',
-                        in_list_view: 1,
-                        reqd: 1,
-                        description: 'Enter Marks (0 - 5)',
-                    },
-                ],
-                cannot_add_rows: true,
-            },
-            {
-                label: 'Feedback',
-                fieldname: 'feedback',
-                fieldtype: 'Text Editor',
-                enable_mentions: true,
-            },
-        ],
-        size: 'extra-large',
-        primary_action_label: 'Submit',
-        primary_action(values) {
-            const validate_marks = (table) => {
-                let is_valid = true;
-                table.forEach(row => {
-                    if (row.marks === '' || row.marks == null) {
-                        frappe.msgprint(__('Marks cannot be empty.'));
-                        is_valid = false;
-                    } else if (row.marks < 0 || row.marks > 5) {
-                        frappe.msgprint(__('Marks must be between 0 and 5.'));
-                        is_valid = false;
-                    }
-                });
-                return is_valid;
-            };
-            const feedback_is_empty = !values.feedback || values.feedback.replace(/<[^>]*>/g, '').trim() === '';
-            if (feedback_is_empty) {
-                frappe.msgprint(__('Please enter feedback before submitting.'));
-                return;
-            }
+	let dialog = new frappe.ui.Dialog({
+		title: 'New Feedback',
+		fields: [
+			{
+				label: 'Employee Criteria',
+				fieldname: 'employee_criteria',
+				fieldtype: 'Table',
+				fields: [
+					{
+						label: 'Criteria',
+						fieldname: 'criteria',
+						fieldtype: 'Link',
+						options: 'Employee Feedback Criteria',
+						in_list_view: 1,
+						reqd: 1,
+						read_only: 1,
+						columns: 3
+					},
+					{
+						label: 'Goals',
+						fieldname: 'goals',
+						fieldtype: 'Text Editor',
+						in_list_view: 1,
+						read_only: 1,
+						columns: 3
+					},
+					{
+						label: 'Weightage(%)',
+						fieldname: 'per_weightage',
+						fieldtype: 'Percent',
+						in_list_view: 1,
+						columns: 2,
+						read_only: 1,
+						reqd: 1
+					},
+					{
+						label: 'Marks (out of 5)',
+						fieldname: 'marks',
+						fieldtype: 'Float',
+						in_list_view: 1,
+						reqd: 1,
+						columns: 2,
+						description: 'Enter Marks (0 - 5)'
+					},
+				],
+				cannot_add_rows: true,
+			},
+			{
+				label: 'Department Criteria',
+				fieldname: 'department_criteria',
+				fieldtype: 'Table',
+				fields: [
+					{
+						label: 'Criteria',
+						fieldname: 'criteria',
+						fieldtype: 'Link',
+						options: 'Employee Feedback Criteria',
+						in_list_view: 1,
+						read_only: 1,
+						reqd: 1,
+					},
+					{
+						label: 'Weightage(%)',
+						fieldname: 'per_weightage',
+						fieldtype: 'Percent',
+						in_list_view: 1,
+						read_only: 1,
+						reqd: 1,
+					},
+					{
+						label: 'Marks (out of 5)',
+						fieldname: 'marks',
+						fieldtype: 'Float',
+						in_list_view: 1,
+						reqd: 1,
+						description: 'Enter Marks (0 - 5)',
+					},
+				],
+				cannot_add_rows: true,
+			},
+			{
+				label: 'Company Criteria',
+				fieldname: 'company_criteria',
+				fieldtype: 'Table',
+				fields: [
+					{
+						label: 'Criteria',
+						fieldname: 'criteria',
+						fieldtype: 'Link',
+						options: 'Employee Feedback Criteria',
+						in_list_view: 1,
+						read_only: 1,
+						reqd: 1,
+					},
+					{
+						label: 'Weightage(%)',
+						fieldname: 'per_weightage',
+						fieldtype: 'Percent',
+						in_list_view: 1,
+						read_only: 1,
+						reqd: 1,
+					},
+					{
+						label: 'Marks (out of 5)',
+						fieldname: 'marks',
+						fieldtype: 'Float',
+						in_list_view: 1,
+						reqd: 1,
+						description: 'Enter Marks (0 - 5)',
+					},
+				],
+				cannot_add_rows: true,
+			},
+			{
+				label: 'Feedback',
+				fieldname: 'feedback',
+				fieldtype: 'Text Editor',
+				enable_mentions: true,
+			},
+		],
+		size: 'extra-large',
+		primary_action_label: 'Submit',
+		primary_action(values) {
+			const validate_marks = (table) => {
+				let is_valid = true;
+				table.forEach(row => {
+					if (row.marks === '' || row.marks == null) {
+						frappe.msgprint(__('Marks cannot be empty.'));
+						is_valid = false;
+					} else if (row.marks < 0 || row.marks > 5) {
+						frappe.msgprint(__('Marks must be between 0 and 5.'));
+						is_valid = false;
+					}
+				});
+				return is_valid;
+			};
+			const feedback_is_empty = !values.feedback || values.feedback.replace(/<[^>]*>/g, '').trim() === '';
+			if (feedback_is_empty) {
+				frappe.msgprint(__('Please enter feedback before submitting.'));
+				return;
+			}
 
-            if (
-                validate_marks(values.employee_criteria) &&
-                validate_marks(values.department_criteria) &&
-                validate_marks(values.company_criteria)
-            ) {
-                frappe.call({
-                    method: "beams.beams.custom_scripts.appraisal.appraisal.create_employee_feedback",
-                    args: {
-                        data: values,
-                        appraisal_name: frm.doc.name,
-                        employee: frm.doc.employee,
-                        method: 'submit',
-                        feedback_exists: dialog.feedback_exists || null
-                    },
-                    callback: function () {
-                        frappe.msgprint(__('Feedback has been submitted successfully.'));
-                        frm.refresh();
-                        dialog.hide();
-                    }
-                });
-            }
-        },
-        secondary_action_label: 'Save',
-        secondary_action() {
-        const values = dialog.get_values();
-        if (!values) return;
+			if (
+				validate_marks(values.employee_criteria) &&
+				validate_marks(values.department_criteria) &&
+				validate_marks(values.company_criteria)
+			) {
+				frappe.call({
+					method: "beams.beams.custom_scripts.appraisal.appraisal.create_employee_feedback",
+					args: {
+						data: values,
+						appraisal_name: frm.doc.name,
+						employee: frm.doc.employee,
+						method: 'submit',
+						feedback_exists: dialog.feedback_exists || null
+					},
+					callback: function () {
+						frappe.msgprint(__('Feedback has been submitted successfully.'));
+						frm.refresh();
+						dialog.hide();
+					}
+				});
+			}
+		},
+		secondary_action_label: 'Save',
+		secondary_action() {
+		const values = dialog.get_values();
+		if (!values) return;
 
 
-        frappe.call({
-            method: "beams.beams.custom_scripts.appraisal.appraisal.create_employee_feedback",
-            args: {
-                data: JSON.stringify(values),
-                appraisal_name: frm.doc.name,
-                employee: frm.doc.employee,
-                method: 'save',
-                feedback_exists: dialog.feedback_exists || null
-            },
-            callback: function () {
-                frappe.msgprint(__('Feedback has been saved successfully.'));
-                frm.refresh();
-                dialog.hide();
-            }
-        });
-    }
+		frappe.call({
+			method: "beams.beams.custom_scripts.appraisal.appraisal.create_employee_feedback",
+			args: {
+				data: JSON.stringify(values),
+				appraisal_name: frm.doc.name,
+				employee: frm.doc.employee,
+				method: 'save',
+				feedback_exists: dialog.feedback_exists || null
+			},
+			callback: function () {
+				frappe.msgprint(__('Feedback has been saved successfully.'));
+				frm.refresh();
+				dialog.hide();
+			}
+		});
+	}
 
-    });
+	});
 
-    dialog.fields_dict.employee_criteria.df.data = frm.doc.appraisal_kra.map(row => ({
-        criteria: row.kra,
-        goals: row.kra_goals,
-        per_weightage: row.per_weightage,
-    }));
-    dialog.fields_dict.employee_criteria.refresh();
+	dialog.fields_dict.employee_criteria.df.data = frm.doc.appraisal_kra.map(row => ({
+		criteria: row.kra,
+		goals: row.kra_goals,
+		per_weightage: row.per_weightage,
+	}));
+	dialog.fields_dict.employee_criteria.refresh();
 
-    if (frm.doc.appraisal_template) {
-        frappe.call({
-            method: "frappe.client.get",
-            args: {
-                doctype: "Appraisal Template",
-                name: frm.doc.appraisal_template
-            },
-            callback: function (res) {
-                if (res.message) {
-                    dialog.fields_dict.department_criteria.df.data = res.message.department_rating_criteria.map(row => ({
-                        criteria: row.criteria,
-                        per_weightage: row.per_weightage
-                    }));
-                    dialog.fields_dict.company_criteria.df.data = res.message.company_rating_criteria.map(row => ({
-                        criteria: row.criteria,
-                        per_weightage: row.per_weightage
-                    }));
-                    dialog.fields_dict.department_criteria.refresh();
-                    dialog.fields_dict.company_criteria.refresh();
-                }
-            }
-        });
-    }
+	if (frm.doc.appraisal_template) {
+		frappe.call({
+			method: "frappe.client.get",
+			args: {
+				doctype: "Appraisal Template",
+				name: frm.doc.appraisal_template
+			},
+			callback: function (res) {
+				if (res.message) {
+					dialog.fields_dict.department_criteria.df.data = res.message.department_rating_criteria.map(row => ({
+						criteria: row.criteria,
+						per_weightage: row.per_weightage
+					}));
+					dialog.fields_dict.company_criteria.df.data = res.message.company_rating_criteria.map(row => ({
+						criteria: row.criteria,
+						per_weightage: row.per_weightage
+					}));
+					dialog.fields_dict.department_criteria.refresh();
+					dialog.fields_dict.company_criteria.refresh();
+				}
+			}
+		});
+	}
 
-    frappe.call({
-        method: "beams.beams.custom_scripts.appraisal.appraisal.get_existing_feedback_data",
-        args: { appraisal_name: frm.doc.name },
-        callback: function (r) {
-            if (r.message) {
-                const feedback = r.message;
-                dialog.feedback_exists = feedback.name;
+	frappe.call({
+		method: "beams.beams.custom_scripts.appraisal.appraisal.get_existing_feedback_data",
+		args: { appraisal_name: frm.doc.name },
+		callback: function (r) {
+			if (r.message) {
+				const feedback = r.message;
+				dialog.feedback_exists = feedback.name;
 
-                const set_marks = (source_list, fieldname) => {
-                    const table = dialog.fields_dict[fieldname].df.data;
-                    source_list.forEach(src => {
-                        const row = table.find(r => r.criteria === src.criteria);
-                        if (row) row.marks = src.marks;
-                    });
-                    dialog.fields_dict[fieldname].refresh();
-                };
+				const set_marks = (source_list, fieldname) => {
+					const table = dialog.fields_dict[fieldname].df.data;
+					source_list.forEach(src => {
+						const row = table.find(r => r.criteria === src.criteria);
+						if (row) row.marks = src.marks;
+					});
+					dialog.fields_dict[fieldname].refresh();
+				};
 
-                if (feedback.employee_criteria && feedback.employee_criteria.length) {
-                    dialog.fields_dict.employee_criteria.df.data = feedback.employee_criteria;
-                }
-                dialog.fields_dict.employee_criteria.refresh();
-                set_marks(feedback.employee_criteria || [], "employee_criteria");
-                set_marks(feedback.department_criteria || [], "department_criteria");
-                set_marks(feedback.company_criteria || [], "company_criteria");
+				if (feedback.employee_criteria && feedback.employee_criteria.length) {
+					dialog.fields_dict.employee_criteria.df.data = feedback.employee_criteria;
+				}
+				dialog.fields_dict.employee_criteria.refresh();
+				set_marks(feedback.employee_criteria || [], "employee_criteria");
+				set_marks(feedback.department_criteria || [], "department_criteria");
+				set_marks(feedback.company_criteria || [], "company_criteria");
 
-                dialog.set_value("feedback", feedback.feedback || '');
-            }
-        }
-    });
-    dialog.show();
+				dialog.set_value("feedback", feedback.feedback || '');
+			}
+		}
+	});
+	dialog.show();
 },
 
 


### PR DESCRIPTION

## Issue description
1. need to change the logic of button visibility of the new feedback in the appraisal doctype

## Solution description
1. changed the logic of button visibility of the new feedback in the appraisal doctype
- the new  feedback  button will only visible the employee's assessment officer only and previously only check the assessment officer not properly checking the employee's assessment officer 
- optimized the code and correct the indentation to tab
## Output screenshots (optional)

[Screencast from 08-08-25 12:18:11 PM IST.webm](https://github.com/user-attachments/assets/e6b78e75-5f47-417f-b364-82374a67e100)


## Areas affected and ensured
appraisal doctype

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?

  - Mozilla Firefox

