### PR TITLE
feat:Show 'Notify Assessment Officers' button only to linked employee

### DIFF
--- a/beams/beams/custom_scripts/appraisal/appraisal.js
+++ b/beams/beams/custom_scripts/appraisal/appraisal.js
@@ -51,33 +51,39 @@ frappe.ui.form.on('Appraisal', {
 			});
 		}
 
+	if (!frm.is_new() && frm.doc.category_details.length <= 0) {
+		frappe.db.get_value("Employee", frm.doc.employee, "user_id", (r) => {
+			if (r && r.user_id === frappe.session.user) {
 
-		if (!frm.is_new() && frm.doc.category_details.length <= 0) {
-			frm.add_custom_button(__('Notify Assessment Officers'), function () {
-				if (frm.doc.__unsaved) {
-					frappe.msgprint(__('Please save the form before sending notification.'));
-					return;
-				}
-
-				frappe.confirm(
-					'Do you want to send the notification to your Assessment Officer?',
-					() => {
-						frappe.call({
-							method: "beams.beams.custom_scripts.appraisal.appraisal.notify_assestment_officer",
-							args: {
-								doc: frm.doc.name,
-								employee_id: frm.doc.employee
-							},
-							callback: (response) => {
-								if (!response.exc) {
-									frappe.msgprint('Notification sent and tasks assigned.');
-								}
-							}
-						});
+				frm.add_custom_button(__('Notify Assessment Officers'), function () {
+					if (frm.doc.__unsaved) {
+						frappe.msgprint(__('Please save the form before sending notification.'));
+						return;
 					}
-				);
-			}).addClass("btn-primary");
-		}
+
+					frappe.confirm(
+						'Do you want to send the notification to your Assessment Officer?',
+						() => {
+							frappe.call({
+								method: "beams.beams.custom_scripts.appraisal.appraisal.notify_assestment_officer",
+								args: {
+									doc: frm.doc.name,
+									employee_id: frm.doc.employee
+								},
+								callback: (response) => {
+									if (!response.exc) {
+										frappe.msgprint('Notification sent and tasks assigned.');
+									}
+								}
+							});
+						}
+					);
+				}).addClass("btn-primary");
+
+			}
+		});
+	}
+
 
 		if (frm.doc.name) {
 			// Check if appraisal_template is set before calling get_appraisal_summary

--- a/beams/beams/custom_scripts/appraisal/appraisal.js
+++ b/beams/beams/custom_scripts/appraisal/appraisal.js
@@ -51,39 +51,38 @@ frappe.ui.form.on('Appraisal', {
 			});
 		}
 
-	if (!frm.is_new() && frm.doc.category_details.length <= 0) {
-		frappe.db.get_value("Employee", frm.doc.employee, "user_id", (r) => {
-			if (r && r.user_id === frappe.session.user) {
+		if (!frm.is_new() && frm.doc.category_details.length <= 0) {
+			frappe.db.get_value("Employee", frm.doc.employee, "user_id", (r) => {
+				if (r && r.user_id === frappe.session.user) {
 
-				frm.add_custom_button(__('Notify Assessment Officers'), function () {
-					if (frm.doc.__unsaved) {
-						frappe.msgprint(__('Please save the form before sending notification.'));
-						return;
-					}
-
-					frappe.confirm(
-						'Do you want to send the notification to your Assessment Officer?',
-						() => {
-							frappe.call({
-								method: "beams.beams.custom_scripts.appraisal.appraisal.notify_assestment_officer",
-								args: {
-									doc: frm.doc.name,
-									employee_id: frm.doc.employee
-								},
-								callback: (response) => {
-									if (!response.exc) {
-										frappe.msgprint('Notification sent and tasks assigned.');
-									}
-								}
-							});
+					frm.add_custom_button(__('Notify Assessment Officers'), function () {
+						if (frm.doc.__unsaved) {
+							frappe.msgprint(__('Please save the form before sending notification.'));
+							return;
 						}
-					);
-				}).addClass("btn-primary");
 
-			}
-		});
-	}
+						frappe.confirm(
+							'Do you want to send the notification to your Assessment Officer?',
+							() => {
+								frappe.call({
+									method: "beams.beams.custom_scripts.appraisal.appraisal.notify_assestment_officer",
+									args: {
+										doc: frm.doc.name,
+										employee_id: frm.doc.employee
+									},
+									callback: (response) => {
+										if (!response.exc) {
+											frappe.msgprint('Notification sent and tasks assigned.');
+										}
+									}
+								});
+							}
+						);
+					}).addClass("btn-primary");
 
+				}
+			});
+		}
 
 		if (frm.doc.name) {
 			// Check if appraisal_template is set before calling get_appraisal_summary

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -4494,6 +4494,23 @@ def get_property_setters():
 			"property_type": "Check",
 			"value": 0
 		},
+		{
+			"doctype_or_field": "DocField",
+			"doc_type": "Appraisal KRA",
+			"field_name": "kra",
+			"property": "read_only",
+			"property_type": "Check",
+			"value": 1
+		},
+		{
+			"doctype_or_field": "DocField",
+			"doc_type": "Appraisal KRA",
+			"field_name": "per_weightage",
+			"property": "read_only",
+			"property_type": "Check",
+			"value": 1
+		}
+
 ]
 
 def get_material_request_custom_fields():


### PR DESCRIPTION
## Feature description
Show 'Notify Assessment Officers' button only to linked employee

## Solution description

- Show 'Notify Assessment Officers' button only to linked employee
- Added check to display the 'Notify Assessment Officers' button only if the logged-in user matches the employee's linked user_id.
- Prevents unauthorized users from triggering officer notifications.
- Added read-only restrictions to `kra` and `per_weightage` fields in 'Appraisal KRA' doctype via property setters.


## Output screenshots (optional)
<img width="1466" height="960" alt="image" src="https://github.com/user-attachments/assets/b0d16505-9d8b-4165-beca-e8d2548094f7" />
<img width="1466" height="960" alt="image" src="https://github.com/user-attachments/assets/281cabb3-9763-4252-be50-278bf5bfe749" />
<img width="1466" height="960" alt="image" src="https://github.com/user-attachments/assets/b40f5bf0-2a0c-46d5-a595-33bb1eae5077" />

## Areas affected and ensured
Appraisal

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox  - yes
  - Opera Mini
  - Safari
