### PR TITLE
Make child table  Journal Entry Expenses Table non editable.

### DIFF
--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.js
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.js
@@ -218,6 +218,15 @@ frappe.ui.form.on('Employee Travel Request', {
         } else {
             frm.set_df_property("attachments", "read_only", 1);
         }
+
+        // Hide Add Row button of child table Journal Entry Expenses Table
+        const cab_field = frm.get_field('journal_entry_expenses_table');
+
+            const field = frm.get_field(table);
+            if (field?.grid) {
+                field.grid.cannot_add_rows = true;
+                field.grid.wrapper.find('.grid-add-row, .grid-remove-rows').hide();
+            }
     },
 
     requested_by: function (frm) {
@@ -239,7 +248,7 @@ frappe.ui.form.on('Employee Travel Request', {
             }
         });
     },
-
+    
     accommodation_required: function (frm) {
         set_room_criteria_filter(frm);
     },

--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.json
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.json
@@ -265,7 +265,8 @@
    "fieldname": "journal_entry_expenses_table",
    "fieldtype": "Table",
    "label": "Journal Entry Expenses Table",
-   "options": "Journal Entry Expenses"
+   "options": "Journal Entry Expenses",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
@@ -284,7 +285,7 @@
    "link_fieldname": "employee_travel_request"
   }
  ],
- "modified": "2025-05-29 17:01:51.710862",
+ "modified": "2025-08-11 15:13:43.844859",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Employee Travel Request",
@@ -305,6 +306,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "search_fields": "requested_by",
  "sort_field": "modified",
  "sort_order": "DESC",


### PR DESCRIPTION
## Feature description
Hide add row button of expense implementation table.

## Analysis and design (optional)
Add row button of expense implementation table was hidden.

## Output screenshots (optional)
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/720f6631-a113-4b82-b576-4c9b5bc95211" />

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
