### PR TITLE
feat:remove add row button in  Allocated  Details

### DIFF
--- a/beams/beams/custom_scripts/project/project.js
+++ b/beams/beams/custom_scripts/project/project.js
@@ -1,6 +1,19 @@
 frappe.ui.form.on('Project', {
     refresh(frm) {
 
+		//HIde Allocated Manpower Detail, Allocated Item Details, Allocated Vehicle Details
+		let tables = [
+			"allocated_manpower_details",
+			"allocated_item_details",
+			"allocated_vehicle_details"
+		];
+
+		tables.forEach(fieldname => {
+			let grid = frm.fields_dict[fieldname].grid;
+			grid.cannot_add_rows = true;
+			grid.refresh();
+		});
+
         // Hide Available Quantity , Return Date , Returned Count & Returned Reason in Allocated Item Details
         frm.fields_dict['allocated_item_details'].grid.toggle_display('available_quantity', false);
         frm.fields_dict['allocated_item_details'].grid.toggle_display('return_date', false);


### PR DESCRIPTION
## Feature description
remove add row button for Allocated Manpower Detail, Allocated Item Details, Allocated Vehicle Details in project

## Solution description

- [x] TASK-2025-01884

HIde Allocated Manpower Detail, Allocated Item Details, Allocated Vehicle Details in project
remove add row button for Allocated Manpower Detail, Allocated Item Details, Allocated Vehicle Details in project

## Output screenshots (optional)
<img width="1466" height="960" alt="image" src="https://github.com/user-attachments/assets/f66df806-4058-4342-9631-975abdea322f" />


## Areas affected and ensured
project

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - yes
  - Opera Mini
  - Safari
