### PR TITLE
fix: read only attribute for essential fields

### DIFF
--- a/beams/beams/doctype/equipment_request/equipment_request.js
+++ b/beams/beams/doctype/equipment_request/equipment_request.js
@@ -68,13 +68,15 @@ frappe.ui.form.on('Equipment Request', {
                                 label: "Available Quantity",
                                 fieldname: "available_qty",
                                 fieldtype: "Int",
-                                in_list_view: 1
+                                in_list_view: 1,
+                                read_only: 1
                             },
                             {
                                 label: "Required Quantity",
                                 fieldname: "required_qty",
                                 fieldtype: "Int",
-                                in_list_view: 1
+                                in_list_view: 1,
+                                read_only: 1
                             }
                         ],
                         data: default_items

--- a/beams/beams/doctype/required_acquiral_items_detail/required_acquiral_items_detail.json
+++ b/beams/beams/doctype/required_acquiral_items_detail/required_acquiral_items_detail.json
@@ -32,7 +32,8 @@
    "fieldname": "acquired_qty",
    "fieldtype": "Int",
    "in_list_view": 1,
-   "label": "Acquired Quantity"
+   "label": "Acquired Quantity",
+   "read_only": 1
   },
   {
    "fetch_from": "item.service_item",
@@ -44,13 +45,14 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-03-17 14:07:27.157005",
+ "modified": "2025-08-12 11:49:18.880051",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Required Acquiral Items Detail",
  "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []


### PR DESCRIPTION
## Feature description
read only attribute for essential fields in equipment request doctype for available quantity and acquired quantity

## Solution description
read only attribute for essential fields in equipment request doctype for available quantity and acquired quantity by editing the form

## Output screenshots (optional)
<img width="1050" height="671" alt="Screenshot from 2025-08-12 13-00-20" src="https://github.com/user-attachments/assets/cbd6ca0e-a575-411f-8b2a-958d7baaf649" />
<img width="1050" height="671" alt="Screenshot from 2025-08-12 12-59-33" src="https://github.com/user-attachments/assets/1dfa1f9d-b3e5-454b-ba5a-513fe9691e31" />
<img width="1050" height="671" alt="Screenshot from 2025-08-12 12-58-50" src="https://github.com/user-attachments/assets/4a742ef3-edd7-45f8-acb5-51c4829764a4" />

## Areas affected and ensured
- beams/beams/doctype/equipment_request/equipment_request.js
- beams/beams/doctype/required_acquiral_items_detail/required_acquiral_items_detail.json
## Is there any existing behavior change of other features due to this code change?
yes
## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - yes
  - Opera Mini
  - Safari
