### PR TITLE
feat:ensure employee is set in Required Employees before approval

### DIFF
--- a/beams/beams/doctype/technical_request/technical_request.py
+++ b/beams/beams/doctype/technical_request/technical_request.py
@@ -33,11 +33,13 @@ class TechnicalRequest(Document):
 		self.validate_required_from_and_required_to()
 
 	def validate_employee_before_approvel(self):
+	# validate employee field in Required Employees before approving Technical Request
+
 		if not self.required_employees:
 			frappe.throw(_("Please add at least one employee in 'Required Employees' before approving."))
 
 		for row in self.required_employees:
-			if not row.employee:  # Corrected condition
+			if not row.employee:
 				frappe.throw(
 					_("Employee is missing in row {0} of 'Required Employees'. Please fill it before approving.")
 					.format(row.idx)

--- a/beams/beams/doctype/technical_request/technical_request.py
+++ b/beams/beams/doctype/technical_request/technical_request.py
@@ -33,16 +33,19 @@ class TechnicalRequest(Document):
 		self.validate_required_from_and_required_to()
 
 	def validate_employee_before_approvel(self):
-	# validate employee field in Required Employees before approving Technical Request
-
+		"""Validate employee field in Required Employees before approving Technical Request"""
 		if not self.required_employees:
-			frappe.throw(_("Please add at least one employee in 'Required Employees' before approving."))
+			frappe.throw(
+				_("Please add at least one employee in 'Required Employees' before approving."),
+				title=_("Missing Employees")
+			)
 
 		for row in self.required_employees:
 			if not row.employee:
 				frappe.throw(
 					_("Employee is missing in row {0} of 'Required Employees'. Please fill it before approving.")
-					.format(row.idx)
+					.format(row.idx),
+					title=_("Missing Employees")
 				)
 
 	def update_project_allocated_resources(self):

--- a/beams/beams/doctype/technical_request/technical_request.py
+++ b/beams/beams/doctype/technical_request/technical_request.py
@@ -10,119 +10,133 @@ from frappe.utils import today
 from frappe.utils import get_datetime
 
 class TechnicalRequest(Document):
-    def before_save(self):
-        self.validate_posting_date()
+	def before_save(self):
+		self.validate_posting_date()
 
-    def on_cancel(self):
-        # Validate that "Reason for Rejection" is filled if the status is "Rejected"
-        if self.workflow_state == "Rejected" and not self.reason_for_rejection:
-            frappe.throw("Please provide a Reason for Rejection before rejecting this request.")
+	def on_cancel(self):
+		# Validate that "Reason for Rejection" is filled if the status is "Rejected"
+		if self.workflow_state == "Rejected" and not self.reason_for_rejection:
+			frappe.throw("Please provide a Reason for Rejection before rejecting this request.")
 
-    def on_update_after_submit(self):
-        # Validate that 'Reason for Rejection' is not filled if the status is 'Approved'
-        if self.workflow_state == "Approved" and self.reason_for_rejection:
-            frappe.throw(title="Approval Error", msg="You cannot approve this request if 'Reason for Rejection' is filled.")
-        if self.workflow_state == "Approved" and self.project:
-            self.update_project_allocated_resources()
-            update_allocated_field(self)
+	def on_update_after_submit(self):
+		if self.workflow_state == "Approved":
+			self.validate_employee_before_approvel()
 
-    def validate(self):
-        self.validate_required_from_and_required_to()
+		# Validate that 'Reason for Rejection' is not filled if the status is 'Approved'
+		if self.workflow_state == "Approved" and self.reason_for_rejection:
+			frappe.throw(title="Approval Error", msg="You cannot approve this request if 'Reason for Rejection' is filled.")
+		if self.workflow_state == "Approved" and self.project:
+			self.update_project_allocated_resources()
+			update_allocated_field(self)
 
-    def update_project_allocated_resources(self):
-        """Update the allocated_manpower_details table in Project when a Technical Request is Approved."""
-        if not frappe.db.exists('Project', self.project):
-            frappe.throw(_("Invalid Project ID: {0}").format(self.project))
+	def validate(self):
+		self.validate_required_from_and_required_to()
 
-        project = frappe.get_doc('Project', self.project)
+	def validate_employee_before_approvel(self):
+		if not self.required_employees:
+			frappe.throw(_("Please add at least one employee in 'Required Employees' before approving."))
 
-        allocated_resources = [
-            {
-                "department": emp.department,
-                "designation": emp.designation,
-                "employee": emp.employee,
-                "assigned_from": get_datetime(emp.required_from) if emp.required_from else None,
-                "assigned_to": get_datetime(emp.required_to) if emp.required_to else None,
-                "hired_personnel": "",
-                "hired_personnel_contact": ""
-            }
-            for emp in self.get("required_employees", []) if emp.employee
-        ]
+		for row in self.required_employees:
+			if not row.employee:  # Corrected condition
+				frappe.throw(
+					_("Employee is missing in row {0} of 'Required Employees'. Please fill it before approving.")
+					.format(row.idx)
+				)
 
-        if allocated_resources:
-            project.extend("allocated_manpower_details", allocated_resources)
-            project.save(ignore_permissions=True)
+	def update_project_allocated_resources(self):
+		"""Update the allocated_manpower_details table in Project when a Technical Request is Approved."""
+		if not frappe.db.exists('Project', self.project):
+			frappe.throw(_("Invalid Project ID: {0}").format(self.project))
 
-    @frappe.whitelist()
-    def validate_required_from_and_required_to(self):
-        """
-        Validates that required_from and required_to are properly set and checks
-        if required_from is not later than required_to.
-        """
-        if not self.required_from or not self.required_to:
-            return
-        # Convert dates to proper date objects
-        required_from = getdate(self.required_from)
-        required_to = getdate(self.required_to)
+		project = frappe.get_doc('Project', self.project)
 
-        if required_from > required_to:
-            frappe.throw(
-                msg=_("Required From cannot be after Required To."),
-                title=_("Message")
-            )
+		allocated_resources = [
+			{
+				"department": emp.department,
+				"designation": emp.designation,
+				"employee": emp.employee,
+				"assigned_from": get_datetime(emp.required_from) if emp.required_from else None,
+				"assigned_to": get_datetime(emp.required_to) if emp.required_to else None,
+				"hired_personnel": "",
+				"hired_personnel_contact": ""
+			}
+			for emp in self.get("required_employees", []) if emp.employee
+		]
 
-    @frappe.whitelist()
-    def validate_posting_date(self):
-        if self.posting_date:
-            if self.posting_date > today():
-                frappe.throw(_("Posting Date cannot be set after today's date."))
+		if allocated_resources:
+			project.extend("allocated_manpower_details", allocated_resources)
+			project.save(ignore_permissions=True)
+
+	@frappe.whitelist()
+	def validate_required_from_and_required_to(self):
+		"""
+		Validates that required_from and required_to are properly set and checks
+		if required_from is not later than required_to.
+		"""
+		if not self.required_from or not self.required_to:
+			return
+		# Convert dates to proper date objects
+		required_from = getdate(self.required_from)
+		required_to = getdate(self.required_to)
+
+		if required_from > required_to:
+			frappe.throw(
+				msg=_("Required From cannot be after Required To."),
+				title=_("Message")
+			)
+
+	@frappe.whitelist()
+	def validate_posting_date(self):
+		if self.posting_date:
+			if self.posting_date > today():
+				frappe.throw(_("Posting Date cannot be set after today's date."))
 
 @frappe.whitelist()
 def create_external_resource_request(technical_request):
-    tech_req = frappe.get_doc("Technical Request", technical_request)
+	tech_req = frappe.get_doc("Technical Request", technical_request)
 
-    # Create new External Resource Request
-    external_req = frappe.get_doc({
-        "doctype": "External Resource Request",
-        "project": tech_req.project,
-        "bureau": tech_req.bureau,
-        "location": tech_req.location,
-        "posting_date": tech_req.posting_date,
-        "required_from": tech_req.required_from,
-        "required_to": tech_req.required_to,
-        "required_resources": []
-    })
+	# Create new External Resource Request
+	external_req = frappe.get_doc({
+		"doctype": "External Resource Request",
+		"project": tech_req.project,
+		"bureau": tech_req.bureau,
+		"location": tech_req.location,
+		"posting_date": tech_req.posting_date,
+		"required_from": tech_req.required_from,
+		"required_to": tech_req.required_to,
+		"required_resources": []
+	})
 
-    for emp in tech_req.required_employees:
-        if not emp.employee:
-            external_req.append("required_resources", {
-                "department": emp.department,
-                "designation": emp.designation,
-                "required_from": emp.required_from,
-                "required_to": emp.required_to
-            })
+	for emp in tech_req.required_employees:
+		if not emp.employee:
+			external_req.append("required_resources", {
+				"department": emp.department,
+				"designation": emp.designation,
+				"required_from": emp.required_from,
+				"required_to": emp.required_to
+			})
 
-    external_req.insert(ignore_permissions=True)
-    return external_req.name
+	external_req.insert(ignore_permissions=True)
+	return external_req.name
 
 @frappe.whitelist()
 def update_allocated_field(doc):
-    if doc.workflow_state == "Approved" and doc.project:
-        project = frappe.get_doc("Project", doc.project)
+	if doc.workflow_state == "Approved" and doc.project:
+		project = frappe.get_doc("Project", doc.project)
 
-        # Ensure required tables exist in both doctypes
-        if not hasattr(doc, "required_employees") or not hasattr(project, "allocated_manpower_details"):
-            frappe.throw("Required tables are missing in the Technical Request or Project doctype.")
+		# Ensure required tables exist in both doctypes
+		if not hasattr(doc, "required_employees") or not hasattr(project, "allocated_manpower_details"):
+			frappe.throw("Required tables are missing in the Technical Request or Project doctype.")
 
-        for emp in doc.required_employees:
-            if emp.employee:
-                for mp in project.allocated_manpower_details:
-                    if (
-                        emp.designation == mp.designation
-                        and emp.required_from == mp.assigned_from
-                        and emp.required_to == mp.assigned_to
-                    ):
-                        mp.status = 'Allocated'
+		for emp in doc.required_employees:
+			if emp.employee:
+				for mp in project.allocated_manpower_details:
+					if (
+						emp.designation == mp.designation
+						and emp.required_from == mp.assigned_from
+						and emp.required_to == mp.assigned_to
+					):
+						mp.status = 'Allocated'
 
-        project.save(ignore_permissions=True)
-        frappe.msgprint(f"Allocated manpower updated for Project {doc.project}")
+		project.save(ignore_permissions=True)
+		frappe.msgprint(f"Allocated manpower updated for Project {doc.project}")


### PR DESCRIPTION
## Feature description
ensure employee is set in Required Employees before approval

## Solution description

- validate employee field in Required Employees before approving Technical Request
- The Required Employees child table is not empty when the Technical Request workflow state is set to Approved.
- Every row in the child table has the employee field filled.

## Output screenshots (optional)
[Screencast from 12-08-25 01:00:39 PM IST.webm](https://github.com/user-attachments/assets/df4b50ab-b59f-436f-a0e4-18b5750078d8)


## Areas affected and ensured
Project

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - yes
  - Opera Mini
  - Safari
