### PR TITLE
fix: assumed fuel consumption changed

### DIFF
--- a/beams/beams/doctype/trip_sheet/trip_sheet.json
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.json
@@ -146,22 +146,24 @@
   {
    "fieldname": "distance_traveledkm",
    "fieldtype": "Float",
-   "label": "Distance Traveled(Km)",
+   "label": "Distance Traveled (Km)",
    "read_only": 1
   },
   {
    "fieldname": "fuel_consumed",
    "fieldtype": "Float",
-   "label": "Fuel Consumed(Ltr)"
+   "label": "Estimated Fuel Consumption (L)",
+   "read_only": 1
   },
   {
    "fieldname": "column_break_anpp",
    "fieldtype": "Column Break"
   },
   {
+   "fetch_from": "vehicle.average_mileage",
    "fieldname": "mileage",
    "fieldtype": "Float",
-   "label": "Mileage(kmpl)",
+   "label": "Estimated Mileage (km/L)",
    "read_only": 1
   },
   {
@@ -217,7 +219,7 @@
    "link_fieldname": "trip_sheet"
   }
  ],
- "modified": "2025-05-30 10:42:22.958496",
+ "modified": "2025-08-13 11:14:54.882492",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Trip Sheet",
@@ -238,6 +240,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "search_fields": "driver,vehicle,starting_date_and_time",
  "sort_field": "modified",
  "sort_order": "DESC",

--- a/beams/beams/doctype/trip_sheet/trip_sheet.py
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.py
@@ -120,10 +120,10 @@ class TripSheet(Document):
         else:
             self.distance_traveledkm = 0
 
-        if self.fuel_consumed and self.fuel_consumed != 0 and self.distance_traveledkm:
-            self.mileage = self.distance_traveledkm / self.fuel_consumed
+        if self.mileage and self.mileage != 0 and self.distance_traveledkm:
+            self.fuel_consumed = self.distance_traveledkm / self.mileage
         else:
-            self.mileage = 0
+            self.fuel_consumed = 0
 
     @frappe.whitelist()
     def validate_posting_date(self):

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -4900,10 +4900,16 @@ def get_vehicle_custom_fields():
 			"label": "Vehicle Safety Inspection",
 			"options": "Vehicle Safety Inspection",
 			"insert_after": "carbon_check_date"
+		},
+		{
+			"fieldname": "average_mileage",
+			"fieldtype": "Float",
+			"label": "Average Mileage(kmpl)",
+			"insert_after": "doors",
+			"default": 14.0
 		}
-
-		]
-	}
+	]
+}
 
 def get_hr_settings_custom_fields():
 	'''


### PR DESCRIPTION
## Feature description
added a new default mileage field in vehicle doctype and changed the fuel consumption logic . now the fuel is calculated by the default mileage field.  

## Solution description
added a new default mileage field in vehicle doctype and changed the fuel consumption logic . now the fuel is calculated by the default mileage field.  changed the setup file and trip sheet doctype for the changes

## Output screenshots (optional)
<img width="1566" height="675" alt="image" src="https://github.com/user-attachments/assets/f8ea5caf-c7c3-4ab0-85ac-8785ad2d756d" />
<img width="1768" height="551" alt="image" src="https://github.com/user-attachments/assets/b348daaa-c49c-454c-8e8a-88f42254111b" />


## Areas affected and ensured
- beams/beams/doctype/trip_sheet/trip_sheet.json
- beams/beams/doctype/trip_sheet/trip_sheet.py
- beams/setup.py
## Is there any existing behavior change of other features due to this code change?
yes
## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox -yes
  - Opera Mini
  - Safari
