### PR TITLE
feat:Assign HD ticket to Active Agents

### DIFF
--- a/beams/beams/custom_scripts/employee_checkin/employee_checkin.py
+++ b/beams/beams/custom_scripts/employee_checkin/employee_checkin.py
@@ -74,3 +74,42 @@ def handle_employee_checkin_out(doc, method):
             url=get_url_to_form("Leave Allocation", allocation_name),
             name=allocation_name
         ),alert=True,indicator='green')
+
+def set_hd_agent_active_status(doc, method=None):
+
+    '''Update HD Agent's active status based on today's latest employee check-in'''
+
+    employee = doc.employee
+
+    # Get user linked to the employee
+    user = frappe.db.get_value("Employee", {"name": employee}, "user_id")
+
+    if not user:
+        return
+
+    start = get_datetime(nowdate() + " 00:00:00")
+    end = get_datetime(nowdate() + " 23:59:59")
+
+    # Get the latest check-in today
+    latest_checkin = frappe.db.get_all(
+        "Employee Checkin",
+        filters={
+            "employee": employee,
+            "time": ["between", [start, end]]
+        },
+        fields=["name", "log_type", "time"],
+        order_by="time desc",
+        limit=1
+    )
+
+    if latest_checkin:
+        latest_log_type = latest_checkin[0].log_type
+        new_status = 1 if latest_log_type == "IN" else 0
+    else:
+        # No check-ins today
+        new_status = 0
+
+    # Update HD Agent status
+    if frappe.db.exists("HD Agent", {"user": user}):
+        frappe.db.set_value("HD Agent", {"user": user}, "is_active", new_status)
+

--- a/beams/beams/custom_scripts/hd_ticket/hd_ticket.js
+++ b/beams/beams/custom_scripts/hd_ticket/hd_ticket.js
@@ -1,14 +1,4 @@
 frappe.ui.form.on('HD Ticket', {
-       /**
-    onload(frm) {
-     * Adds the 'Material Request' button under the 'Create' group
-        if (frm.is_new() && !frm.doc.raised_by) {
-     * if 'spare_part_needed' is checked.
-            frm.set_value('raised_by', frappe.session.user);
-     *Runs when the form loads to show or hide fields based on user role
-        }
-     */
-
     // Called when form is loaded
     onload(frm) {
         if (frm.is_new() && !frm.doc.raised_by) {
@@ -18,7 +8,6 @@ frappe.ui.form.on('HD Ticket', {
     },
 
     refresh(frm) {
-        // Called every time the form is refreshed
         handle_agent_visibility(frm);
         frm.clear_custom_buttons();
 

--- a/beams/beams/custom_scripts/hd_ticket/hd_ticket.js
+++ b/beams/beams/custom_scripts/hd_ticket/hd_ticket.js
@@ -1,0 +1,75 @@
+frappe.ui.form.on('HD Ticket', {
+       /**
+    onload(frm) {
+     * Adds the 'Material Request' button under the 'Create' group
+        if (frm.is_new() && !frm.doc.raised_by) {
+     * if 'spare_part_needed' is checked.
+            frm.set_value('raised_by', frappe.session.user);
+     *Runs when the form loads to show or hide fields based on user role
+        }
+     */
+
+    // Called when form is loaded
+    onload(frm) {
+        if (frm.is_new() && !frm.doc.raised_by) {
+            frm.set_value('raised_by', frappe.session.user);
+        }
+        handle_agent_visibility(frm);
+    },
+
+    refresh(frm) {
+        // Called every time the form is refreshed
+        handle_agent_visibility(frm);
+        frm.clear_custom_buttons();
+
+        if (frm.doc.spare_part_needed) {
+            frm.page.set_inner_btn_group_as_primary(__('Create'));
+            add_material_request_button(frm);
+        }
+    },
+
+    // // Called when the 'spare_part_needed' checkbox is changed
+    // spare_part_needed(frm) {
+    //     frm.clear_custom_buttons();
+    //     if (frm.doc.spare_part_needed) {
+    //         frm.page.set_inner_btn_group_as_primary(__('Create'));
+    //         add_material_request_button(frm);
+    //     }
+    // },
+
+    ticket_type(frm) {
+        if (!frm.doc.ticket_type) return frm.set_value('agent_group', '');
+
+        frappe.db.get_value('HD Ticket Type', frm.doc.ticket_type, 'team_name')
+            .then(r => frm.set_value('agent_group', r.message?.team_name || ''))
+            .catch(() => frm.set_value('agent_group', ''));
+    }
+});
+
+// Function to show/hide fields based on user's role
+function handle_agent_visibility(frm) {
+    if (!frappe.user.has_role('Agent')) {
+        const visible_fields = ['subject', 'raised_by','raised_for', 'description','ticket_type'];
+        frm.fields.forEach(field => {
+            const name = field.df.fieldname;
+            if (name && !['Section Break', 'Column Break'].includes(field.df.fieldtype)) {
+                frm.set_df_property(name, 'hidden', !visible_fields.includes(name));
+            }
+        });
+        frm.refresh_fields();
+    }
+}
+
+function add_material_request_button(frm) {
+    frm.add_custom_button(__('Material Request'), function () {
+        // Create a new Material Request document
+        const mr = frappe.model.get_new_doc('Material Request');
+        (frm.doc.spare_part_item_table || []).forEach(row => {
+            const item = frappe.model.add_child(mr, 'Material Request Item', 'items');
+            item.item_code = row.item;
+            item.qty = row.quantity;
+            item.schedule_date = row.required_by;
+        });
+        frappe.set_route('Form', 'Material Request', mr.name);
+    }, __('Create'));
+}

--- a/beams/beams/custom_scripts/hd_ticket/hd_ticket.js
+++ b/beams/beams/custom_scripts/hd_ticket/hd_ticket.js
@@ -24,18 +24,8 @@ frappe.ui.form.on('HD Ticket', {
 
         if (frm.doc.spare_part_needed) {
             frm.page.set_inner_btn_group_as_primary(__('Create'));
-            add_material_request_button(frm);
         }
     },
-
-    // // Called when the 'spare_part_needed' checkbox is changed
-    // spare_part_needed(frm) {
-    //     frm.clear_custom_buttons();
-    //     if (frm.doc.spare_part_needed) {
-    //         frm.page.set_inner_btn_group_as_primary(__('Create'));
-    //         add_material_request_button(frm);
-    //     }
-    // },
 
     ticket_type(frm) {
         if (!frm.doc.ticket_type) return frm.set_value('agent_group', '');
@@ -60,16 +50,3 @@ function handle_agent_visibility(frm) {
     }
 }
 
-function add_material_request_button(frm) {
-    frm.add_custom_button(__('Material Request'), function () {
-        // Create a new Material Request document
-        const mr = frappe.model.get_new_doc('Material Request');
-        (frm.doc.spare_part_item_table || []).forEach(row => {
-            const item = frappe.model.add_child(mr, 'Material Request Item', 'items');
-            item.item_code = row.item;
-            item.qty = row.quantity;
-            item.schedule_date = row.required_by;
-        });
-        frappe.set_route('Form', 'Material Request', mr.name);
-    }, __('Create'));
-}

--- a/beams/beams/custom_scripts/hd_ticket/hd_ticket.py
+++ b/beams/beams/custom_scripts/hd_ticket/hd_ticket.py
@@ -20,40 +20,33 @@ class HDTicketOverride(HDTicket):
     def handle_assignment_by_team(self):
         '''Assign ticket to all active agents in the selected agent group.'''
 
-        try:
-            if not self.agent_group:
-                return
+        if not self.agent_group:
+            return
 
-            if not frappe.db.exists('HD Team', self.agent_group):
-                return
+        if not frappe.db.exists('HD Team', self.agent_group):
+            return
 
-            # Fetch all active users from the team
-            active_users = self.get_active_users_from_team(self.agent_group)
-            if not active_users:
-                return
+        # Fetch all active users from the team
+        active_users = self.get_active_users_from_team(self.agent_group)
+        if not active_users:
+            return
 
-            # Assign to ALL active agents
-            for user in active_users:
-                existing_todo = frappe.db.exists('ToDo', {
-                    'reference_type': self.doctype,
-                    'reference_name': self.name,
-                    'owner': user,
-                    'status': ['!=', 'Cancelled'],
+        # Assign to ALL active agents
+        for user in active_users:
+            existing_todo = frappe.db.exists('ToDo', {
+                'reference_type': self.doctype,
+                'reference_name': self.name,
+                'owner': user,
+                'status': ['!=', 'Cancelled'],
+            })
+
+            if not existing_todo:
+                assign_to_user({
+                    'doctype': self.doctype,
+                    'name': self.name,
+                    'assign_to': [user],
+                    'description': f'You have been assigned a ticket by  team {self.agent_group}',
                 })
-
-                if not existing_todo:
-                    assign_to_user({
-                        'doctype': self.doctype,
-                        'name': self.name,
-                        'assign_to': [user],
-                        'description': f'You have been assigned a ticket by  team {self.agent_group}',
-                    })
-
-            # Save the list of all assigned agents on the ticket
-            self.db_set('agent', ', '.join(active_users))
-
-        except Exception:
-            frappe.log_error(frappe.get_traceback(), 'handle_assignment_by_team')
 
     def get_active_users_from_team(self, team_name):
         '''Return active users (User IDs) from HD Team based on active HD Agent mapping.'''
@@ -73,6 +66,7 @@ class HDTicketOverride(HDTicket):
             filters={'is_active': 1, 'user': ['in', team_users]},
             pluck='user'
         )
+        print("aZSXDCFVGNHJKL;",active_agents)
 
         return active_agents
 

--- a/beams/beams/custom_scripts/hd_ticket/hd_ticket.py
+++ b/beams/beams/custom_scripts/hd_ticket/hd_ticket.py
@@ -1,0 +1,69 @@
+import frappe
+from frappe.desk.form.assign_to import add as assign_to_user
+from helpdesk.helpdesk.doctype.hd_ticket.hd_ticket import HDTicket
+
+
+class HDTicketOverride(HDTicket):
+
+    def on_update(self):
+        super().on_update()
+        if self.agent_group and self.status == "Open":
+            self.handle_assignment_by_team()
+
+    def validate(self):
+        super().validate()
+
+    def handle_assignment_by_team(self):
+        """Auto-assign the ticket to all active agents in the agent group team."""
+        try:
+            if not self.agent_group:
+                return
+
+            team_exists = frappe.db.exists("HD Team", self.agent_group)
+            if not team_exists:
+                return
+
+            active_users = self.get_active_users_from_team(self.agent_group)
+            if not active_users:
+                return
+
+            for user in active_users:
+                existing_todo = frappe.db.exists("ToDo", {
+                    "reference_type": self.doctype,
+                    "reference_name": self.name,
+                    "owner": user,
+                    "status": ["!=", "Cancelled"],
+                })
+
+                if not existing_todo:
+                    assign_to_user({
+                        'doctype': self.doctype,
+                        'name': self.name,
+                        'assign_to': [user],
+                        'description': 'Auto-assigned to active HD Agent from team',
+                    })
+
+        except Exception:
+            frappe.log_error(frappe.get_traceback(), "handle_assignment_by_team")
+
+    def get_active_users_from_team(self, team_name):
+        """Get list of active HD Agents from a given HD Team."""
+        try:
+            if not team_name or not frappe.db.exists("HD Team", team_name):
+                return []
+
+            team = frappe.get_doc("HD Team", team_name)
+            users = []
+
+            for row in team.users:
+                for user in row.user.split(","):
+                    user = user.strip()
+                    if frappe.db.exists("HD Agent", {"user": user, "is_active": 1}):
+                        users.append(user)
+
+            return users
+
+                                                                                                                     
+        except Exception:
+            frappe.log_error(frappe.get_traceback(), "get_active_users_from_team")
+            return []

--- a/beams/beams/custom_scripts/hd_ticket/hd_ticket.py
+++ b/beams/beams/custom_scripts/hd_ticket/hd_ticket.py
@@ -12,6 +12,8 @@ class HDTicketOverride(HDTicket):
 
     def validate(self):
         super().validate()
+        self.set_agent_group()
+
 
     def handle_assignment_by_team(self):
         """Auto-assign the ticket to all active agents in the agent group team."""
@@ -67,3 +69,12 @@ class HDTicketOverride(HDTicket):
         except Exception:
             frappe.log_error(frappe.get_traceback(), "get_active_users_from_team")
             return []
+
+    def set_agent_group(self):
+        """Set agent_group based on selected ticket_type"""
+        if not self.ticket_type:
+            self.agent_group = ""
+            return
+
+        team_name = frappe.db.get_value("HD Ticket Type", self.ticket_type, "team_name")
+        self.agent_group = team_name or ""

--- a/beams/beams/custom_scripts/hd_ticket/hd_ticket.py
+++ b/beams/beams/custom_scripts/hd_ticket/hd_ticket.py
@@ -66,8 +66,6 @@ class HDTicketOverride(HDTicket):
             filters={'is_active': 1, 'user': ['in', team_users]},
             pluck='user'
         )
-        print("aZSXDCFVGNHJKL;",active_agents)
-
         return active_agents
 
     def set_agent_group(self):

--- a/beams/beams/custom_scripts/hd_ticket/hd_ticket.py
+++ b/beams/beams/custom_scripts/hd_ticket/hd_ticket.py
@@ -2,39 +2,43 @@ import frappe
 from frappe.desk.form.assign_to import add as assign_to_user
 from helpdesk.helpdesk.doctype.hd_ticket.hd_ticket import HDTicket
 
-
 class HDTicketOverride(HDTicket):
 
     def on_update(self):
+        '''Extend on_update to auto-assign when ticket is Open.'''
+
         super().on_update()
-        if self.agent_group and self.status == "Open":
+        if self.agent_group and self.status == 'Open':
             self.handle_assignment_by_team()
 
     def validate(self):
+        '''Extend validate to set agent group automatically.'''
+
         super().validate()
         self.set_agent_group()
 
-
     def handle_assignment_by_team(self):
-        """Auto-assign the ticket to all active agents in the agent group team."""
+        '''Assign ticket to all active agents in the selected agent group.'''
+
         try:
             if not self.agent_group:
                 return
 
-            team_exists = frappe.db.exists("HD Team", self.agent_group)
-            if not team_exists:
+            if not frappe.db.exists('HD Team', self.agent_group):
                 return
 
+            # Fetch all active users from the team
             active_users = self.get_active_users_from_team(self.agent_group)
             if not active_users:
                 return
 
+            # Assign to ALL active agents
             for user in active_users:
-                existing_todo = frappe.db.exists("ToDo", {
-                    "reference_type": self.doctype,
-                    "reference_name": self.name,
-                    "owner": user,
-                    "status": ["!=", "Cancelled"],
+                existing_todo = frappe.db.exists('ToDo', {
+                    'reference_type': self.doctype,
+                    'reference_name': self.name,
+                    'owner': user,
+                    'status': ['!=', 'Cancelled'],
                 })
 
                 if not existing_todo:
@@ -42,39 +46,45 @@ class HDTicketOverride(HDTicket):
                         'doctype': self.doctype,
                         'name': self.name,
                         'assign_to': [user],
-                        'description': 'Auto-assigned to active HD Agent from team',
+                        'description': f'You have been assigned a ticket by  team {self.agent_group}',
                     })
 
+            # Save the list of all assigned agents on the ticket
+            self.db_set('agent', ', '.join(active_users))
+
         except Exception:
-            frappe.log_error(frappe.get_traceback(), "handle_assignment_by_team")
+            frappe.log_error(frappe.get_traceback(), 'handle_assignment_by_team')
 
     def get_active_users_from_team(self, team_name):
-        """Get list of active HD Agents from a given HD Team."""
-        try:
-            if not team_name or not frappe.db.exists("HD Team", team_name):
-                return []
+        '''Return active users (User IDs) from HD Team based on active HD Agent mapping.'''
 
-            team = frappe.get_doc("HD Team", team_name)
-            users = []
-
-            for row in team.users:
-                for user in row.user.split(","):
-                    user = user.strip()
-                    if frappe.db.exists("HD Agent", {"user": user, "is_active": 1}):
-                        users.append(user)
-
-            return users
-
-                                                                                                                     
-        except Exception:
-            frappe.log_error(frappe.get_traceback(), "get_active_users_from_team")
-            return []
-
-    def set_agent_group(self):
-        """Set agent_group based on selected ticket_type"""
-        if not self.ticket_type:
-            self.agent_group = ""
+        if not frappe.db.exists('HD Team', self.agent_group):
             return
 
-        team_name = frappe.db.get_value("HD Ticket Type", self.ticket_type, "team_name")
-        self.agent_group = team_name or ""
+        team = frappe.get_doc('HD Team', team_name)
+        team_users = [row.user for row in team.users if row.user]
+
+        if not team_users:
+            return []
+
+        # Fetch active agents among these team users
+        active_agents = frappe.get_all(
+            'HD Agent',
+            filters={'is_active': 1, 'user': ['in', team_users]},
+            pluck='user'
+        )
+
+        return active_agents
+
+    def set_agent_group(self):
+        '''Set agent_group based on selected ticket_type.'''
+
+        if not self.ticket_type:
+            self.agent_group = ''
+            return
+
+        team_name = frappe.db.get_value('HD Ticket Type', self.ticket_type, 'team_name')
+        if team_name:
+            self.agent_group = team_name
+        else:
+            self.agent_group = ''

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -70,7 +70,8 @@ doctype_js = {
 	"Asset":"beams/custom_scripts/asset/asset.js",
 	"Payroll Entry":"beams/custom_scripts/payroll_entry/payroll_entry.js",
 	"Employee Separation": "beams/custom_scripts/employee_separation/employee_separation.js",
-	"Job Opening": "beams/custom_scripts/job_opening/job_opening.js"
+	"Job Opening": "beams/custom_scripts/job_opening/job_opening.js",
+	"HD Ticket":"beams/custom_scripts/hd_ticket/hd_ticket.js" 
 }
 doctype_list_js = {
 	"Sales Invoice" : "beams/custom_scripts/sales_invoice/sales_invoice_list.js",
@@ -166,6 +167,7 @@ override_doctype_class = {
 	"Attendance Request": "beams.beams.custom_scripts.attendance_request.attendance_request.AttendanceRequestOverride",
 	"Shift Type": "beams.beams.custom_scripts.shift_type.shift_type.ShiftTypeOverride",
 	"Interview": "beams.beams.custom_scripts.interview.interview.InterviewOverride",
+	"HD Ticket" :"beams.beams.custom_scripts.hd_ticket.hd_ticket.HDTicketOverride"
 }
 
 # Document Events
@@ -276,8 +278,10 @@ doc_events = {
 	},
 	"Employee Checkin":{
 		"after_insert": [
-			"beams.beams.custom_scripts.employee_checkin.employee_checkin.handle_employee_checkin_out"
-		]
+			"beams.beams.custom_scripts.employee_checkin.employee_checkin.handle_employee_checkin_out",
+			"beams.beams.custom_scripts.employee_checkin.employee_checkin.set_hd_agent_active_status"
+		],
+		"on_update" : "beams.beams.custom_scripts.employee_checkin.employee_checkin.set_hd_agent_active_status"
 	},
 	"Leave Allocation":{
 		"on_submit":"beams.beams.custom_scripts.leave_allocation.leave_allocation.create_new_compensatory_leave_log",

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -281,7 +281,6 @@ doc_events = {
 			"beams.beams.custom_scripts.employee_checkin.employee_checkin.handle_employee_checkin_out",
 			"beams.beams.custom_scripts.employee_checkin.employee_checkin.set_hd_agent_active_status"
 		],
-		"on_update" : "beams.beams.custom_scripts.employee_checkin.employee_checkin.set_hd_agent_active_status"
 	},
 	"Leave Allocation":{
 		"on_submit":"beams.beams.custom_scripts.leave_allocation.leave_allocation.create_new_compensatory_leave_log",

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -59,6 +59,9 @@ def after_install():
 	create_custom_fields(get_expense_claim_type_custom_fields(),ignore_validate=True)
 	create_custom_fields(get_supplier_quotation_custom_fields(), ignore_validate=True)
 	create_custom_fields(get_training_event_custom_fields(), ignore_validate=True)
+	create_custom_fields(get_hd_ticket_custom_fields(), ignore_validate=True)
+	create_custom_fields(get_hd_ticket_type_custom_fields(), ignore_validate=True)
+
 
 
 	#Creating BEAMS specific Property Setters
@@ -130,6 +133,9 @@ def before_uninstall():
 	delete_custom_fields(get_expense_claim_type_custom_fields())
 	delete_custom_fields(get_supplier_quotation_custom_fields())
 	delete_custom_fields(get_training_event_custom_fields())
+	delete_custom_fields(get_hd_ticket_custom_fields())
+	delete_custom_fields(get_hd_ticket_type_custom_fields())
+
 
 
 def delete_custom_fields(custom_fields: dict):
@@ -147,6 +153,48 @@ def delete_custom_fields(custom_fields: dict):
 			},
 		)
 		frappe.clear_cache(doctype=doctype)
+
+
+def get_hd_ticket_type_custom_fields():
+    '''
+    Custom fields that need to be added to the HD Ticket Type DocType
+    '''
+    return {
+        "HD Ticket Type": [
+            {
+                "fieldname": "team_name",
+                "fieldtype": "Link",
+                "label": "Team Name",
+                "options":"HD Team",
+                "insert_after": "is_system"
+            }
+        ]
+    }
+
+
+def get_hd_ticket_custom_fields():
+	'''
+	Custom fields that need to be added to the HD Ticket DocType
+	'''
+	return {
+		"HD Ticket": [
+			{
+				"fieldname": "raised_for",
+				"fieldtype": "Link",
+				"label": "Raised For(Email)",
+				"options":"User",
+				"insert_after": "raised_by"
+			},
+			{
+				"fieldname": "attach",
+				"label": "Attachments",
+				"fieldtype": "Attach",
+				"insert_after": "agent_group",
+
+			}
+
+		]
+	}
 
 def get_shift_assignment_custom_fields():
 	'''

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -4954,7 +4954,7 @@ def get_vehicle_custom_fields():
 			"fieldtype": "Float",
 			"label": "Average Mileage(kmpl)",
 			"insert_after": "doors",
-			"default": 14.0
+			"default": '14.0'
 		}
 	]
 }


### PR DESCRIPTION
## Feature description
Assign tickets to only Active Agents.

## Solution description
When a ticket is created assign ticket to only Agents who are Active.For this when an Employee (who is an Agent) checks in their Is Active checkbox is made to 1.The existing Ticket Assignment is overridden and assigned to only active agents.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/e06073f3-a12b-420f-892b-9f73bc8914b0)

## Areas affected and ensured
HD Ticket doctype
HD Team
HD Agent
HD Ticket Type

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
