### PR TITLE
fix:source and destination field changed from link field to data field

### DIFF
--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.json
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.json
@@ -128,7 +128,6 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Source",
-   "options": "Location",
    "reqd": 1
   },
   {
@@ -136,7 +135,6 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Destination",
-   "options": "Location",
    "reqd": 1
   },
   {
@@ -285,7 +283,7 @@
    "link_fieldname": "employee_travel_request"
   }
  ],
- "modified": "2025-08-18 16:06:20.137005",
+ "modified": "2025-08-18 16:52:12.855757",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Employee Travel Request",

--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.json
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.json
@@ -125,7 +125,7 @@
   },
   {
    "fieldname": "source",
-   "fieldtype": "Link",
+   "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Source",
    "options": "Location",
@@ -133,7 +133,7 @@
   },
   {
    "fieldname": "destination",
-   "fieldtype": "Link",
+   "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Destination",
    "options": "Location",
@@ -285,7 +285,7 @@
    "link_fieldname": "employee_travel_request"
   }
  ],
- "modified": "2025-08-11 15:13:43.844859",
+ "modified": "2025-08-18 16:06:20.137005",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Employee Travel Request",


### PR DESCRIPTION
## Feature description
In Employee Travel Request source and destination field changed from link field to data field

## Solution description
Edit the doctype employee travel request

## Output screenshots (optional)
<img width="1366" height="768" alt="Screenshot from 2025-08-18 16-02-14" src="https://github.com/user-attachments/assets/ec1dd82f-7936-402b-8884-c22b3e31c50d" />

## Areas affected and ensured
Areas affected is source and destination (Link to Data)

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
 
