### PR TITLE
fix : validate posting date

### DIFF
--- a/beams/beams/doctype/asset_transfer_request/asset_transfer_request.py
+++ b/beams/beams/doctype/asset_transfer_request/asset_transfer_request.py
@@ -3,11 +3,10 @@
 
 import frappe
 from frappe.model.document import Document
-from frappe.utils import today
+from frappe.utils import today,getdate
 from frappe import _
 from frappe.utils import now_datetime, get_url_to_form
 from datetime import datetime
-
 
 class AssetTransferRequest(Document):
     def before_save(self):
@@ -31,7 +30,7 @@ class AssetTransferRequest(Document):
     @frappe.whitelist()
     def validate_posting_date(self):
         if self.posting_date:
-            if self.posting_date > today():
+            if getdate(self.posting_date) > getdate(today()):
                 frappe.throw(_("Posting Date cannot be set after today's date."))
 
     def on_update_after_submit(self):


### PR DESCRIPTION
## Feature description
validate posting date used get date function

## Solution description
Fixed validation error in Asset Transfer Request where comparing posting_date with today() caused a type mismatch (datetime.date vs str). Updated the check to use getdate() for both values, ensuring consistent date objects and preventing the TypeError during save and workflow transitions.

## Output screenshots (optional)
<img width="1541" height="481" alt="image" src="https://github.com/user-attachments/assets/51bcff46-0518-4f2c-96ff-eb885ed37a08" />

## Areas affected and ensured
- beams/beams/doctype/asset_transfer_request/asset_transfer_request.py
## Is there any existing behavior change of other features due to this code change?
no
## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox-yes
  - Opera Mini
  - Safari
