### PR TITLE
feat:BOM info section hide through property setters

### DIFF
--- a/beams/setup.py
+++ b/beams/setup.py
@@ -2029,12 +2029,12 @@ def get_interview_custom_fields():
 				"hidden": 1
 			},
 			{
-			    "fieldname": "average_final_score",
-			    "fieldtype": "Data",
-			    "label": "Final Score",
-			    "insert_after": "feedback_html",
-			    "read_only": 1,
-			    "read_only_depends_on": "eval:!frappe.user.has_role('HR Manager')"
+				"fieldname": "average_final_score",
+				"fieldtype": "Data",
+				"label": "Final Score",
+				"insert_after": "feedback_html",
+				"read_only": 1,
+				"read_only_depends_on": "eval:!frappe.user.has_role('HR Manager')"
 			},
 			{
 				"fieldname": "interview_dashboard_section",
@@ -4509,7 +4509,15 @@ def get_property_setters():
 			"property": "read_only",
 			"property_type": "Check",
 			"value": 1
-		}
+		},
+		{
+			"doctype_or_field": "DocField",
+			"doc_type": "Stock Entry",
+			"field_name": "bom_info_section",
+			"property": "hidden",
+			"property_type": "Section Break",
+			"value": 1
+		},
 
 ]
 


### PR DESCRIPTION
## Feature description
In Stock Entry Doctype need to hide BOM Info section

## Solution description
The section hide through property setters through setup

## Output screenshots (optional)
<img width="1366" height="768" alt="Screenshot from 2025-08-19 10-04-37" src="https://github.com/user-attachments/assets/b76b5bcf-8385-4cc6-9c52-7e44fe9cb3aa" />


## Is there any existing behavior change of other features due to this code change?
No
## Was this feature tested on the browsers?
  - Chrome

