### PR TITLE
feat:crete asset movement and stockentry from material req.

### DIFF
--- a/beams/beams/custom_scripts/material_request/material_request.js
+++ b/beams/beams/custom_scripts/material_request/material_request.js
@@ -9,6 +9,215 @@ frappe.ui.form.on('Material Request', {
                     }
                 });
         }
-    }
+    },
+	refresh(frm) {
+		// Show buttons only if workflow_state is Approved by HOD or Approved by Admin
+		if (["Approved by HOD", "Approved by Admin"].includes(frm.doc.workflow_state)) {
+
+			frm.add_custom_button(__("Asset Movement"), () => {
+				const item_codes = (frm.doc.items || []).map(row => row.item_code);
+
+				if (!item_codes.length) {
+					frappe.msgprint(__("No items in this Material Request."));
+					return;
+				}
+
+				frappe.db.get_list("Item", {
+					filters: { name: ["in", item_codes], is_fixed_asset: 1 },
+					fields: ["name"]
+				}).then(items => {
+					if (!items?.length) {
+						frappe.msgprint(__("No Fixed Asset items found in this Material Request."));
+						return;
+					}
+
+					const fixed_asset_items = frm.doc.items.filter(row =>
+						items.some(i => i.name === row.item_code)
+					);
+
+					const default_items = fixed_asset_items.flatMap(row =>
+						Array.from({ length: row.qty }, () => ({
+							item: row.item_code,
+							qty: 1,
+							asset: ""
+						}))
+					);
+
+					const fields = [
+						{
+							label: __("Assigned To"),
+							fieldname: "assigned_to",
+							fieldtype: "Link",
+							options: "User",
+							reqd: 1
+						},
+						{
+							label: __("Purpose"),
+							fieldname: "purpose",
+							fieldtype: "Select",
+							options: ["Issue", "Transfer", "Receipt", "Return"],
+							default: "Issue",
+							reqd: 1
+						},
+						{
+							fieldname: "asset_movement_details",
+							label: __("Asset Movement Details"),
+							fieldtype: "Table",
+							reqd: 1,
+							data: default_items,
+							fields: [
+								{
+									label: __("Item"),
+									fieldname: "item",
+									fieldtype: "Link",
+									options: "Item",
+									in_list_view: 1,
+									reqd: 1
+								},
+								{
+									label: __("Quantity"),
+									fieldname: "qty",
+									fieldtype: "Int",
+									in_list_view: 1,
+									reqd: 1
+								},
+								{
+									label: __("Asset"),
+									fieldname: "asset",
+									fieldtype: "Link",
+									options: "Asset",
+									reqd: 1,
+									in_list_view: 1,
+									get_query: () => ({
+										filters: { location: frm.doc.location }
+									})
+								}
+							]
+						}
+					];
+
+					const dialog = new frappe.ui.Dialog({
+						title: __("Asset Movement"),
+						fields,
+						primary_action_label: __("Submit"),
+						primary_action(values) {
+							frappe.call({
+								method: "beams.beams.custom_scripts.material_request.material_request.map_asset_movement_from_mr",
+								args: {
+									source_name: frm.doc.name,
+									assigned_to: values.assigned_to,
+									items: values.asset_movement_details,
+									purpose: values.purpose
+								},
+								callback(r) {
+									if (!r.exc) {
+										frappe.msgprint(__("Asset Movement {0} created and submitted", [r.message]));
+										frappe.set_route("Form", "Asset Movement", r.message);
+									}
+								}
+							});
+						}
+					});
+
+					// Auto-set Assigned To
+					const fallback_user = frappe.session.user;
+					if (frm.doc.requested_by) {
+						frappe.db.get_value("Employee", frm.doc.requested_by, "user_id").then(r => {
+							dialog.set_value("assigned_to", r.message?.user_id || fallback_user);
+						});
+					} else {
+						dialog.set_value("assigned_to", fallback_user);
+					}
+
+					dialog.show();
+				});
+			}, __("Create"));
+
+			frm.add_custom_button(__('Create Stock Entry'), () => {
+				if (!frm.doc.items?.length) {
+					frappe.msgprint(__('No items in this Material Request.'));
+					return;
+				}
+
+				let item_codes = frm.doc.items.map(d => d.item_code);
+
+				frappe.db.get_list('Item', {
+					filters: {
+						name: ['in', item_codes],
+						is_fixed_asset: 0,
+						is_stock_item: 1
+					},
+					fields: ['name', 'stock_uom']
+				}).then(items_data => {
+					if (!items_data?.length) {
+						frappe.msgprint(__('No stock-managed items to create Stock Entry.'));
+						return;
+					}
+
+					let stock_items = frm.doc.items
+						.filter(row => items_data.some(i => i.name === row.item_code))
+						.map(row => {
+							let item = items_data.find(i => i.name === row.item_code);
+							return {
+								item_code: row.item_code,
+								qty: row.qty,
+								uom: item.stock_uom
+							};
+						});
+
+					frappe.db.get_single_value('BEAMS Admin Settings', 'default_source_warehouse')
+						.then(default_warehouse => {
+							let d = new frappe.ui.Dialog({
+								title: __('Create Stock Entry'),
+								fields: [
+									{
+										fieldtype: 'Link',
+										fieldname: 'source_warehouse',
+										options: 'Warehouse',
+										label: __('Source Warehouse'),
+										default: default_warehouse,
+										reqd: 1
+									},
+									{
+										fieldtype: 'Table',
+										fieldname: 'items',
+										label: __('Items'),
+										in_place_edit: true,
+										data: stock_items,
+										fields: [
+											{fieldtype: 'Data', fieldname: 'item_code', label: __('Item'), read_only: 1, in_list_view: 1},
+											{fieldtype: 'Float', fieldname: 'qty', label: __('Qty'), in_list_view: 1},
+											{fieldtype: 'Data', fieldname: 'uom', label: __('UOM'), read_only: 1, in_list_view: 1}
+										]
+									}
+								],
+								primary_action_label: __('Create Stock Entry'),
+								primary_action(values) {
+									frappe.call({
+										method: "beams.beams.custom_scripts.material_request.material_request.create_stock_entry_from_mr",
+										args: {
+											material_request: frm.doc.name,
+											source_warehouse: values.source_warehouse,
+											items: values.items
+										},
+										callback(r) {
+											if (r.message) {
+												frappe.show_alert({
+													message: __('Stock Entry Created: {0}', [r.message]),
+													indicator: 'green'
+												});
+												d.hide();
+											}
+										}
+									});
+								}
+							});
+							d.show();
+						});
+				});
+			}, __("Create"));
+		}
+	}
+
 });
 

--- a/beams/beams/custom_scripts/material_request/material_request.js
+++ b/beams/beams/custom_scripts/material_request/material_request.js
@@ -13,211 +13,244 @@ frappe.ui.form.on('Material Request', {
 	refresh(frm) {
 		// Show buttons only if workflow_state is Approved by HOD or Approved by Admin
 		if (["Approved by HOD", "Approved by Admin"].includes(frm.doc.workflow_state)) {
+			add_asset_movement_button(frm);
+			add_stock_entry_button(frm);
+		}
+	}
+});
 
-			frm.add_custom_button(__("Asset Movement"), () => {
-				const item_codes = (frm.doc.items || []).map(row => row.item_code);
+/**
+ * Add "Asset Movement" button to Material Request
+ * → Allows user to create an Asset Movement for fixed asset items
+ */
+function add_asset_movement_button(frm) {
+	frm.add_custom_button(__("Asset Movement"), () => {
+		const item_codes = (frm.doc.items || []).map(row => row.item_code);
 
-				if (!item_codes.length) {
-					frappe.msgprint(__("No items in this Material Request."));
-					return;
-				}
+		if (!item_codes.length) {
+			frappe.msgprint({
+				title: __("Missing Items"),
+				message: __("No items in this Material Request."),
+				indicator: "red"
+			});
+			return;
+		}
 
-				frappe.db.get_list("Item", {
-					filters: { name: ["in", item_codes], is_fixed_asset: 1 },
-					fields: ["name"]
-				}).then(items => {
-					if (!items?.length) {
-						frappe.msgprint(__("No Fixed Asset items found in this Material Request."));
-						return;
-					}
+		frappe.db.get_list("Item", {
+			filters: { name: ["in", item_codes], is_fixed_asset: 1 },
+			fields: ["name"]
+		}).then(items => {
+			if (!items?.length) {
+				frappe.msgprint({
+					title: __("No Fixed Assets"),
+					message: __("No Fixed Asset items found in this Material Request."),
+					indicator: "orange"
+				});
+				return;
+			}
 
-					const fixed_asset_items = frm.doc.items.filter(row =>
-						items.some(i => i.name === row.item_code)
-					);
+			const fixed_asset_items = frm.doc.items.filter(row =>
+				items.some(i => i.name === row.item_code)
+			);
 
-					const default_items = fixed_asset_items.flatMap(row =>
-						Array.from({ length: row.qty }, () => ({
-							item: row.item_code,
-							qty: 1,
-							asset: ""
-						}))
-					);
+			const default_items = fixed_asset_items.flatMap(row =>
+				Array.from({ length: row.qty }, () => ({
+					item: row.item_code,
+					qty: 1,
+					asset: ""
+				}))
+			);
 
-					const fields = [
+			const fields = [
+				{
+					label: __("Assigned To"),
+					fieldname: "assigned_to",
+					fieldtype: "Link",
+					options: "User",
+					reqd: 1
+				},
+				{
+					label: __("Purpose"),
+					fieldname: "purpose",
+					fieldtype: "Select",
+					options: ["Issue", "Transfer", "Receipt", "Return"],
+					default: "Issue",
+					reqd: 1
+				},
+				{
+					fieldname: "asset_movement_details",
+					label: __("Asset Movement Details"),
+					fieldtype: "Table",
+					reqd: 1,
+					data: default_items,
+					fields: [
 						{
-							label: __("Assigned To"),
-							fieldname: "assigned_to",
+							label: __("Item"),
+							fieldname: "item",
 							fieldtype: "Link",
-							options: "User",
+							options: "Item",
+							in_list_view: 1,
 							reqd: 1
 						},
 						{
-							label: __("Purpose"),
-							fieldname: "purpose",
-							fieldtype: "Select",
-							options: ["Issue", "Transfer", "Receipt", "Return"],
-							default: "Issue",
+							label: __("Quantity"),
+							fieldname: "qty",
+							fieldtype: "Int",
+							in_list_view: 1,
 							reqd: 1
 						},
 						{
-							fieldname: "asset_movement_details",
-							label: __("Asset Movement Details"),
-							fieldtype: "Table",
+							label: __("Asset"),
+							fieldname: "asset",
+							fieldtype: "Link",
+							options: "Asset",
 							reqd: 1,
-							data: default_items,
-							fields: [
-								{
-									label: __("Item"),
-									fieldname: "item",
-									fieldtype: "Link",
-									options: "Item",
-									in_list_view: 1,
-									reqd: 1
-								},
-								{
-									label: __("Quantity"),
-									fieldname: "qty",
-									fieldtype: "Int",
-									in_list_view: 1,
-									reqd: 1
-								},
-								{
-									label: __("Asset"),
-									fieldname: "asset",
-									fieldtype: "Link",
-									options: "Asset",
-									reqd: 1,
-									in_list_view: 1,
-									get_query: () => ({
-										filters: { location: frm.doc.location }
-									})
-								}
-							]
+							in_list_view: 1,
+							get_query: () => ({
+								filters: { location: frm.doc.location }
+							})
 						}
-					];
+					]
+				}
+			];
 
-					const dialog = new frappe.ui.Dialog({
-						title: __("Asset Movement"),
-						fields,
-						primary_action_label: __("Submit"),
+			const dialog = new frappe.ui.Dialog({
+				title: __("Asset Movement"),
+				fields,
+				primary_action_label: __("Submit"),
+				primary_action(values) {
+					frappe.call({
+						method: "beams.beams.custom_scripts.material_request.material_request.map_asset_movement_from_mr",
+						args: {
+							source_name: frm.doc.name,
+							assigned_to: values.assigned_to,
+							items: values.asset_movement_details,
+							purpose: values.purpose
+						},
+						callback(r) {
+							if (!r.exc) {
+								frappe.show_alert({
+									message: __('Asset Movement {0} created and submitted', [r.message]),
+									indicator: 'green'
+								});
+								frappe.set_route("Form", "Asset Movement", r.message);
+							}
+						}
+					});
+				}
+			});
+
+			// Auto-set Assigned To
+			const fallback_user = frappe.session.user;
+			if (frm.doc.requested_by) {
+				frappe.db.get_value("Employee", frm.doc.requested_by, "user_id").then(r => {
+					dialog.set_value("assigned_to", r.message?.user_id || fallback_user);
+				});
+			} else {
+				dialog.set_value("assigned_to", fallback_user);
+			}
+
+			dialog.show();
+		});
+	}, __("Create"));
+}
+
+/**
+ * Add "Create Stock Entry" button to Material Request
+ * → Allows user to create a Stock Entry for non-fixed-asset stock items
+ */
+function add_stock_entry_button(frm) {
+	frm.add_custom_button(__('Create Stock Entry'), () => {
+		if (!frm.doc.items?.length) {
+			frappe.msgprint({
+				title: __("Missing Items"),
+				message: __("No items in this Material Request."),
+				indicator: "red"
+			});
+			return;
+		}
+
+		let item_codes = frm.doc.items.map(d => d.item_code);
+
+		frappe.db.get_list('Item', {
+			filters: {
+				name: ['in', item_codes],
+				is_fixed_asset: 0,
+				is_stock_item: 1
+			},
+			fields: ['name', 'stock_uom']
+		}).then(items_data => {
+			if (!items_data?.length) {
+				frappe.msgprint({
+					title: __("No Stock Items"),
+					message: __("No stock-managed items to create Stock Entry."),
+					indicator: "orange"
+				});
+				return;
+			}
+
+			let stock_items = frm.doc.items
+				.filter(row => items_data.some(i => i.name === row.item_code))
+				.map(row => {
+					let item = items_data.find(i => i.name === row.item_code);
+					return {
+						item_code: row.item_code,
+						qty: row.qty,
+						uom: item.stock_uom
+					};
+				});
+
+			frappe.db.get_single_value('BEAMS Admin Settings', 'default_source_warehouse')
+				.then(default_warehouse => {
+					let d = new frappe.ui.Dialog({
+						title: __('Create Stock Entry'),
+						fields: [
+							{
+								fieldtype: 'Link',
+								fieldname: 'source_warehouse',
+								options: 'Warehouse',
+								label: __('Source Warehouse'),
+								default: default_warehouse,
+								reqd: 1
+							},
+							{
+								fieldtype: 'Table',
+								fieldname: 'items',
+								label: __('Items'),
+								in_place_edit: true,
+								data: stock_items,
+								fields: [
+									{fieldtype: 'Data', fieldname: 'item_code', label: __('Item'), read_only: 1, in_list_view: 1},
+									{fieldtype: 'Float', fieldname: 'qty', label: __('Qty'), in_list_view: 1},
+									{fieldtype: 'Data', fieldname: 'uom', label: __('UOM'), read_only: 1, in_list_view: 1}
+								]
+							}
+						],
+						primary_action_label: __('Create Stock Entry'),
 						primary_action(values) {
 							frappe.call({
-								method: "beams.beams.custom_scripts.material_request.material_request.map_asset_movement_from_mr",
+								method: "beams.beams.custom_scripts.material_request.material_request.create_stock_entry_from_mr",
 								args: {
-									source_name: frm.doc.name,
-									assigned_to: values.assigned_to,
-									items: values.asset_movement_details,
-									purpose: values.purpose
+									material_request: frm.doc.name,
+									source_warehouse: values.source_warehouse,
+									items: values.items
 								},
 								callback(r) {
-									if (!r.exc) {
-										frappe.msgprint(__("Asset Movement {0} created and submitted", [r.message]));
-										frappe.set_route("Form", "Asset Movement", r.message);
+									if (r.message) {
+										frappe.show_alert({
+											message: __('Stock Entry Created: {0}', [r.message]),
+											indicator: 'green'
+										});
+										d.hide();
 									}
 								}
 							});
 						}
 					});
-
-					// Auto-set Assigned To
-					const fallback_user = frappe.session.user;
-					if (frm.doc.requested_by) {
-						frappe.db.get_value("Employee", frm.doc.requested_by, "user_id").then(r => {
-							dialog.set_value("assigned_to", r.message?.user_id || fallback_user);
-						});
-					} else {
-						dialog.set_value("assigned_to", fallback_user);
-					}
-
-					dialog.show();
+					d.show();
 				});
-			}, __("Create"));
+		});
+	}, __("Create"));
+}
 
-			frm.add_custom_button(__('Create Stock Entry'), () => {
-				if (!frm.doc.items?.length) {
-					frappe.msgprint(__('No items in this Material Request.'));
-					return;
-				}
-
-				let item_codes = frm.doc.items.map(d => d.item_code);
-
-				frappe.db.get_list('Item', {
-					filters: {
-						name: ['in', item_codes],
-						is_fixed_asset: 0,
-						is_stock_item: 1
-					},
-					fields: ['name', 'stock_uom']
-				}).then(items_data => {
-					if (!items_data?.length) {
-						frappe.msgprint(__('No stock-managed items to create Stock Entry.'));
-						return;
-					}
-
-					let stock_items = frm.doc.items
-						.filter(row => items_data.some(i => i.name === row.item_code))
-						.map(row => {
-							let item = items_data.find(i => i.name === row.item_code);
-							return {
-								item_code: row.item_code,
-								qty: row.qty,
-								uom: item.stock_uom
-							};
-						});
-
-					frappe.db.get_single_value('BEAMS Admin Settings', 'default_source_warehouse')
-						.then(default_warehouse => {
-							let d = new frappe.ui.Dialog({
-								title: __('Create Stock Entry'),
-								fields: [
-									{
-										fieldtype: 'Link',
-										fieldname: 'source_warehouse',
-										options: 'Warehouse',
-										label: __('Source Warehouse'),
-										default: default_warehouse,
-										reqd: 1
-									},
-									{
-										fieldtype: 'Table',
-										fieldname: 'items',
-										label: __('Items'),
-										in_place_edit: true,
-										data: stock_items,
-										fields: [
-											{fieldtype: 'Data', fieldname: 'item_code', label: __('Item'), read_only: 1, in_list_view: 1},
-											{fieldtype: 'Float', fieldname: 'qty', label: __('Qty'), in_list_view: 1},
-											{fieldtype: 'Data', fieldname: 'uom', label: __('UOM'), read_only: 1, in_list_view: 1}
-										]
-									}
-								],
-								primary_action_label: __('Create Stock Entry'),
-								primary_action(values) {
-									frappe.call({
-										method: "beams.beams.custom_scripts.material_request.material_request.create_stock_entry_from_mr",
-										args: {
-											material_request: frm.doc.name,
-											source_warehouse: values.source_warehouse,
-											items: values.items
-										},
-										callback(r) {
-											if (r.message) {
-												frappe.show_alert({
-													message: __('Stock Entry Created: {0}', [r.message]),
-													indicator: 'green'
-												});
-												d.hide();
-											}
-										}
-									});
-								}
-							});
-							d.show();
-						});
-				});
-			}, __("Create"));
-		}
-	}
-
-});
 

--- a/beams/beams/custom_scripts/material_request/material_request.py
+++ b/beams/beams/custom_scripts/material_request/material_request.py
@@ -1,5 +1,7 @@
 import frappe
-
+import json
+from frappe.utils import flt
+from frappe.model.mapper import get_mapped_doc
 
 @frappe.whitelist()
 def notify_stock_managers(doc=None, method=None):
@@ -49,3 +51,89 @@ def notify_stock_managers(doc=None, method=None):
         reference_doctype="Material Request",
         reference_name=doc.name
     )
+
+@frappe.whitelist()
+def create_stock_entry_from_mr(material_request, source_warehouse, items):
+    """
+		Create and submit a Stock Entry (Material Issue) from a Material Request
+    """
+	if isinstance(items, str):
+		items = json.loads(items or "[]")
+
+	if not items:
+		frappe.throw("No items provided to create Stock Entry")
+
+	stock_entry = frappe.get_doc({
+		"doctype": "Stock Entry",
+		"stock_entry_type": "Material Issue",
+		"material_request": material_request,
+		"from_warehouse": source_warehouse,
+		"items": []
+	})
+
+	for row in items:
+		item_code = row.get("item_code")
+		qty = flt(row.get("qty"))
+		uom = row.get("uom")
+
+		if not (item_code and qty > 0):
+			continue
+
+		if frappe.get_value("Item", item_code, "is_stock_item"):
+			stock_entry.append("items", {
+				"item_code": item_code,
+				"qty": qty,
+				"s_warehouse": source_warehouse,
+				"uom": uom
+			})
+
+	stock_entry.insert(ignore_permissions=True)
+	stock_entry.submit()
+
+	return stock_entry.name
+
+@frappe.whitelist()
+def map_asset_movement_from_mr(source_name, assigned_to=None, items=None, purpose="Issue", target_doc=None):
+    """
+		Create and submit an Asset Movement document from a Material Request.
+    """
+	if isinstance(items, str):
+		items = json.loads(items or "[]")
+
+	employee_id = frappe.get_value("Employee", {"user_id": assigned_to})
+	if not employee_id:
+		frappe.throw(f"No Employee linked to User '{assigned_to}'")
+
+	def postprocess(source, target):
+		target.to_employee = employee_id
+		target.reference_doctype = "Material Request"
+		target.reference_name = source.name
+		target.purpose = purpose or "Issue"
+
+		for row in (items or []):
+			item_code = row.get("item")
+			asset_name = row.get("asset")
+			qty = frappe.utils.flt(row.get("qty"))
+
+			if not (item_code and asset_name and qty > 0):
+				continue
+
+			target.append("assets", {
+				"asset": asset_name,
+				"source_location": frappe.get_value("Asset", asset_name, "location"),
+				"to_employee": employee_id,
+				"reference_name": row.get("name")
+			})
+
+	asset_movement = get_mapped_doc(
+		"Material Request",
+		source_name,
+		{"Material Request": {"doctype": "Asset Movement"}},
+		target_doc,
+		postprocess
+	)
+
+	asset_movement.insert(ignore_permissions=True)
+	asset_movement.submit()
+
+	return asset_movement.name

--- a/beams/beams/doctype/beams_admin_settings/beams_admin_settings.json
+++ b/beams/beams/doctype/beams_admin_settings/beams_admin_settings.json
@@ -22,7 +22,8 @@
   "notification_for_asset_reservation_before",
   "default_employee_payable_account",
   "item_group",
-  "employee_travel_request_approved_template"
+  "employee_travel_request_approved_template",
+  "default_source_warehouse"
  ],
  "fields": [
   {
@@ -145,6 +146,12 @@
    "fieldtype": "Link",
    "label": "Employee Travel Request Approved Template",
    "options": "Email Template"
+  },
+  {
+   "fieldname": "default_source_warehouse",
+   "fieldtype": "Link",
+   "label": "Default Source Warehouse",
+   "options": "Warehouse"
   }
  ],
  "index_web_pages_for_search": 1,

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -4535,6 +4535,13 @@ def get_material_request_custom_fields():
 				"label": "Requested By",
 				"insert_after": "material_request_type",
 				"options": "Employee"
+			},
+			{
+				"fieldname": "location",
+				"fieldtype": "Link",
+				"label": "Location",
+				"insert_after": "schedule_date",
+				"options": "Location"
 			}
 		]
 	}


### PR DESCRIPTION
## Feature description
crete asset movement and stockentry from material req

## Solution description

- Add a custom button labeled "Asset Movement" on the Material Request form.
- When clicked, a popup dialog opens with the following fields:
- Assigned To → User field (default = requested_by or current session user).
- Purpose → Select field with options: Issue, Transfer, Receipt, Return (default = Issue).
- Asset Movement Details → Table field where assets are listed.
- Child Table Logic:
- For each item row in the Material Request, generate as many rows in the popup child table as the qty value.
- Each generated row should have:
- Item = Item Code
- Quantity = 1
- Asset 
- add filters in the popup while creating from Material Request, and also add validation for fetching items from the Material Request. Only fixed assets should be allowed to create an Asset Movement.
- Add location material request through setup
- added Default Source Warehouse in beams admin settings 
- A new Stock Entry is created from a Material Request (only with valid stock item) through the popup

## Output screenshots (optional)
<img width="1424" height="940" alt="image" src="https://github.com/user-attachments/assets/aecd62d8-ccb0-439f-bef5-4e20a9ed7556" />

[Screencast from 19-08-25 10:21:32 AM IST.webm](https://github.com/user-attachments/assets/5440b98c-0478-40b9-830f-ec526237148a)

<img width="1424" height="940" alt="image" src="https://github.com/user-attachments/assets/1b9b2a68-1f40-454f-b0ba-310ce85e5e57" />

## Areas affected and ensured
asset movement
stock entry

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - yes
  - Opera Mini
  - Safari
