### PR TITLE
chore: Changed the allignment in employee travel request

### DIFF
--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.json
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.json
@@ -27,9 +27,9 @@
   "column_break_xmae",
   "start_date",
   "end_date",
+  "total_days",
   "expected_check_in_time",
   "expected_check_out_time",
-  "total_days",
   "amended_from",
   "section_break_ktsj",
   "mark_attendance",
@@ -283,7 +283,7 @@
    "link_fieldname": "employee_travel_request"
   }
  ],
- "modified": "2025-08-18 16:52:12.855757",
+ "modified": "2025-08-19 10:14:47.244103",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Employee Travel Request",


### PR DESCRIPTION
## Feature description
1. need to change the allignment of the total days field in employee travel request doctype

## Solution description

changed the allignment of the total days in employee travel request doctype
- changed the position of the total days under end date in employee travel request doctype

## Output screenshots (optional)
<img width="1487" height="938" alt="image" src="https://github.com/user-attachments/assets/db9efde3-9df1-40cc-86b9-3c5200bc90e4" />

## Areas affected and ensured
employee travel request doctype

## Is there any existing behavior change of other features due to this code change?
 No

## Was this feature tested on the browsers?
 
  - Mozilla Firefox
  
