### PR TITLE
feat: Add Asset Movement to Material Request dashboard

### DIFF
--- a/beams/beams/custom_scripts/material_request/material_request_dashboard.py
+++ b/beams/beams/custom_scripts/material_request/material_request_dashboard.py
@@ -1,0 +1,13 @@
+from frappe import _
+from erpnext.stock.doctype.material_request.material_request_dashboard import get_data as original_get_data
+
+def get_data(data=None):
+	# Call the original dashboard function
+	dashboard_data = original_get_data()
+	dashboard_data["transactions"].append(
+		{
+			"label": _("Assets"),
+			"items": ["Asset Movement"]
+		}
+	)
+	return dashboard_data

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -445,7 +445,7 @@ scheduler_events = {
 # generated from the base implementation of the doctype dashboard,
 # along with any modifications made in other Frappe apps
 override_doctype_dashboards = {
-'Item': 'beams.beams.custom_scripts.item_dashboard.item_dashboard.get_data',
+	'Item': 'beams.beams.custom_scripts.item_dashboard.item_dashboard.get_data',
 	'Customer': 'beams.beams.custom_scripts.customer_dashboard.customer_dashboard.get_data',
 	'Sales Invoice': 'beams.beams.custom_scripts.sales_invoice_dashboard.sales_invoice_dashboard.get_data',
 	'Sales Order': 'beams.beams.custom_scripts.sales_order_dashboard.sales_order_dashboard.get_data',
@@ -455,6 +455,7 @@ override_doctype_dashboards = {
 	'Department': 'beams.beams.custom_scripts.department.department_dashboard.get_data',
 	'Vehicle': 'beams.beams.custom_scripts.vehicle_dashboard.vehicle_dashboard.get_data',
 	'Driver': 'beams.beams.custom_scripts.driver_dashboard.driver_dashboard.get_data',
+	'Material Request': 'beams.beams.custom_scripts.material_request.material_request_dashboard.get_data',
 }
 
 # exempt linked doctypes from being automatically cancelled

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -4946,6 +4946,14 @@ def get_asset_movement_custom_fields():
 				"insert_after": "new_custodian",
 				"options": "Email",
 				"read_only": 1
+			},
+			{
+				"fieldname": "material_request",
+				"fieldtype": "Link",
+				"label": "Material Request",
+				"options": "Material Request",
+				"insert_after": "user_id",
+				"hidden": 1
 			}
 		],
 		"Asset Movement Item": [


### PR DESCRIPTION
## Feature description
Added an Assets section in the Material Request dashboard to display linked Asset Movement documents, even though there is no direct link field between Material Request and Asset Movement.
## Analysis and design (optional)
The original Material Request dashboard was extended by importing the existing dashboard function and appending the custom Assets transaction group
## Solution description
- A linked field was added in Asset Movement for Material Request, as no direct link existed.
- Imported the original get_data function from ERPNext’s Material Request dashboard.
- Appended a new transaction group

## Output screenshots (optional)
<img width="1367" height="647" alt="image" src="https://github.com/user-attachments/assets/a211e0f9-7bd0-4858-8d80-ae8db463b6c5" />

## Areas affected and ensured
Material Request dashboard
## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
