### PR TITLE
TASK-2025-01945:Set schedule date default to Today in Material Request

### DIFF
--- a/beams/setup.py
+++ b/beams/setup.py
@@ -4567,7 +4567,6 @@ def get_property_setters():
 			"value": 1
 		},
 		{
-
 			"doc_type": "Material Request",
 			"field_name": "schedule_date",
 			"property":"default",

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -4566,7 +4566,13 @@ def get_property_setters():
 			"property_type": "Section Break",
 			"value": 1
 		},
+		{
 
+			"doc_type": "Material Request",
+			"field_name": "schedule_date",
+			"property":"default",
+			"value": "Today"
+		}
 ]
 
 def get_material_request_custom_fields():
@@ -4877,7 +4883,7 @@ def get_beams_roles():
 	'''
 		Method to get BEAMS specific roles
 	'''
-	return ['Production Manager', 'CEO', 'Company Secretary', 'HOD','Enquiry Officer','Enquiry Manager','Shift Publisher','Program Producer','Operations Head','Operations User','Admin','Driver','Budget User','Technical Store Head','Budget Verifier','Budget Verifier Finance','Budget Approver','Admin User','Bureau User','Coordinating Editor','News Coordinator','Security']
+	return ['Production Manager', 'CEO', 'Company Secretary', 'HOD','Enquiry Officer','Enquiry Manager','Shift Publisher','Program Producer','Operations Head','Operations User','Admin','Driver','Budget User','Technical Store Head','Budget Verifier','Budget Verifier Finance','Budget Approver','Admin User','Bureau User','Coordinating Editor','News Coordinator','Security','Reporter']
 
 def get_custom_translations():
 	'''


### PR DESCRIPTION
## Feature description
Need to: 

- Set schedule date default to Today in Material Request
- Add Reporter role

 ## Solution description

- Set schedule date default to Today in Material Request using property setter in setup file
- Added Reporter role through setup file


## Output screenshots (optional)

[Screencast from 19-08-25 12:23:09 PM IST.webm](https://github.com/user-attachments/assets/9ebf2869-e9c9-429e-9128-262e022b9f66)

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/6db5ddcc-0634-4931-9aed-5e79eed6efa3" />


##Areas affected and ensured
Material Request doctype

## Is there any existing behavior change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?
  - Chrome
