### PR TITLE
feat:prevent duplicate asset selection & disable row addition in dialogs

### DIFF
--- a/beams/beams/custom_scripts/material_request/material_request.js
+++ b/beams/beams/custom_scripts/material_request/material_request.js
@@ -82,6 +82,7 @@ function add_asset_movement_button(frm) {
 					label: __("Asset Movement Details"),
 					fieldtype: "Table",
 					reqd: 1,
+					cannot_add_rows: true,
 					data: default_items,
 					fields: [
 						{
@@ -106,9 +107,18 @@ function add_asset_movement_button(frm) {
 							options: "Asset",
 							reqd: 1,
 							in_list_view: 1,
-							get_query: () => ({
-								filters: { location: frm.doc.location }
-							})
+							get_query: () => {
+								let selected_assets = (dialog.get_value("asset_movement_details") || [])
+									.map(row => row.asset)
+									.filter(a => a);
+
+								return {
+									filters: {
+										 location: frm.doc.location,
+										 name:  ["not in",selected_assets]
+										}
+								};
+							}
 						}
 					]
 				}
@@ -218,6 +228,7 @@ function add_stock_entry_button(frm) {
 								fieldname: 'items',
 								label: __('Items'),
 								in_place_edit: true,
+								cannot_add_rows: true,
 								data: stock_items,
 								fields: [
 									{fieldtype: 'Data', fieldname: 'item_code', label: __('Item'), read_only: 1, in_list_view: 1},

--- a/beams/beams/custom_scripts/material_request/material_request.js
+++ b/beams/beams/custom_scripts/material_request/material_request.js
@@ -114,9 +114,9 @@ function add_asset_movement_button(frm) {
 
 								return {
 									filters: {
-										 location: frm.doc.location,
-										 name:  ["not in",selected_assets]
-										}
+										location: frm.doc.location,
+										name: ["not in", selected_assets]
+									}
 								};
 							}
 						}


### PR DESCRIPTION
## Feature description
prevent duplicate asset selection & disable row addition in dialogs


## Solution description
- Added `cannot_add_rows: true` to Asset Movement and Stock Entry dialog tables  
  → prevents users from manually adding extra rows.  
- Enhanced Asset field `get_query` in Asset Movement dialog to exclude already selected assets  
  → ensures each asset can only be selected once across rows.  

## Output screenshots (optional)
<img width="1424" height="940" alt="image" src="https://github.com/user-attachments/assets/7fa22a94-4826-49c7-a3eb-46532164299b" />

<img width="1424" height="940" alt="image" src="https://github.com/user-attachments/assets/ae5046ef-a3c9-4522-8a4d-ba0301a2a330" />


## Areas affected and ensured
Material Request

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - yest
  - Opera Mini
  - Safari
