### PR TITLE
feat:validate posting_date with getdate to avoid TypeError

### DIFF
--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.py
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.py
@@ -7,7 +7,7 @@ from datetime import datetime
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import get_url_to_form, today
+from frappe.utils import get_url_to_form, today, getdate
 from frappe.utils import nowdate
 from beams.beams.doctype.trip_sheet.trip_sheet import get_last_odometer
 from frappe.utils.user import get_users_with_role
@@ -299,9 +299,8 @@ class EmployeeTravelRequest(Document):
 	@frappe.whitelist()
 	def validate_posting_date(self):
 		if self.posting_date:
-			if self.posting_date > today():
+			if getdate(self.posting_date) > getdate(today()):
 				frappe.throw(_("Posting Date cannot be set after today's date."))
-
 
 	def validate_expected_time(self):
 		"""Ensure Expected Check-out Time is not earlier than Expected Check-in Time."""


### PR DESCRIPTION
## Feature description
validate posting_date with getdate to avoid TypeError

## Solution description
- Ensure both posting_date and today() are converted to date objects
- Prevents comparison between datetime.date and str
- Throws validation error if posting_date is set in the future

## Output screenshots (optional)
<img width="1424" height="940" alt="image" src="https://github.com/user-attachments/assets/97b6c90f-9ffe-451e-bb7c-d32498adc92c" />


## Areas affected and ensured

Employee Travel Request


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - YES
  - Opera Mini
  - Safari
