### PR TITLE
feat: ToDo Assignment for Vehicle Incident Records

### DIFF
--- a/beams/beams/doctype/vehicle_incident_record/vehicle_incident_record.py
+++ b/beams/beams/doctype/vehicle_incident_record/vehicle_incident_record.py
@@ -6,104 +6,135 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 from frappe.utils import today
-
+from frappe.utils.user import get_users_with_role
+from frappe.desk.form.assign_to import add as add_assign
 
 class VehicleIncidentRecord(Document):
-    def on_update(self):
-        if self.workflow_state == "Approved":
-            self.create_journal_entry_for_payable_items()
+	def on_update(self):
+		if self.workflow_state == "Approved":
+			self.create_journal_entry_for_payable_items()
 
-    def validate(self):
-        self.validate_offense_date_and_time()
+	def validate(self):
+		self.validate_offense_date_and_time()
 
-    @frappe.whitelist()
-    def validate_posting_date(self):
-        if self.posting_date:
-            if self.posting_date > today():
-                frappe.throw(_("Posting Date cannot be set after today's date."))
+	@frappe.whitelist()
+	def validate_posting_date(self):
+		if self.posting_date:
+			if self.posting_date > today():
+				frappe.throw(_("Posting Date cannot be set after today's date."))
 
-    @frappe.whitelist()
-    def validate_offense_date_and_time(self):
-        '''
-        Validates that the offense date is not in the future and falls within the trip start and end dates.
-        '''
-        if self.offense_date_and_time:
-            offense_date = frappe.utils.getdate(self.offense_date_and_time)
-            current_date = frappe.utils.getdate()
+	@frappe.whitelist()
+	def validate_offense_date_and_time(self):
+		'''
+		Validates that the offense date is not in the future and falls within the trip start and end dates.
+		'''
+		if self.offense_date_and_time:
+			offense_date = frappe.utils.getdate(self.offense_date_and_time)
+			current_date = frappe.utils.getdate()
 
-            if offense_date > current_date:
-                frappe.throw(_("Offense Date cannot be in the future."))
+			if offense_date > current_date:
+				frappe.throw(_("Offense Date cannot be in the future."))
 
-            offense_date = frappe.utils.getdate(self.offense_date_and_time)  
+			offense_date = frappe.utils.getdate(self.offense_date_and_time)
 
-            if self.trip_start_date and self.trip_end_date:
-                start_date = frappe.utils.getdate(self.trip_start_date)
-                end_date = frappe.utils.getdate(self.trip_end_date)
+			if self.trip_start_date and self.trip_end_date:
+				start_date = frappe.utils.getdate(self.trip_start_date)
+				end_date = frappe.utils.getdate(self.trip_end_date)
 
-                if not (start_date <= offense_date <= end_date):
-                    frappe.throw(_("Offense Date must be between Start Date and End Date of the trip."))
+				if not (start_date <= offense_date <= end_date):
+					frappe.throw(_("Offense Date must be between Start Date and End Date of the trip."))
 
-    def create_journal_entry_for_payable_items(self):
-        '''
-        Automatically creates and submits a Journal Entry for each payable vehicle incident
-        where the 'is_employee_payable' field is checked
-        '''
-        settings = frappe.get_single("BEAMS Admin Settings")
-        debit_account = settings.default_employee_payable_account
+	def create_journal_entry_for_payable_items(self):
+		'''
+		Automatically creates and submits a Journal Entry for each payable vehicle incident
+		where the 'is_employee_payable' field is checked
+		'''
+		settings = frappe.get_single("BEAMS Admin Settings")
+		debit_account = settings.default_employee_payable_account
 
-        if not debit_account:
-            frappe.throw("Default Employee Payable Account is not set in BEAMS Admin Settings.")
+		if not debit_account:
+			frappe.throw("Default Employee Payable Account is not set in BEAMS Admin Settings.")
 
-        employee_id = frappe.db.get_value("Driver", self.driver, "employee")
-        if not employee_id:
-            frappe.throw(f"Employee not linked to Driver {self.driver}")
+		employee_id = frappe.db.get_value("Driver", self.driver, "employee")
+		if not employee_id:
+			frappe.throw(f"Employee not linked to Driver {self.driver}")
 
-        for row in self.vehicle_incident_details:
-            if not row.get("journal_entry"):
-                # Fetch the default_account from the Expense Claim Type's accounts child table
-                credit_account = None
-                if row.expense_type:
-                    expense_type_doc = frappe.get_doc("Expense Claim Type", row.expense_type)
-                    for account_row in expense_type_doc.get("accounts", []):
-                        if account_row.default_account:
-                            credit_account = account_row.default_account
-                            break
+		for row in self.vehicle_incident_details:
+			if not row.get("journal_entry"):
+				# Fetch the default_account from the Expense Claim Type's accounts child table
+				credit_account = None
+				if row.expense_type:
+					expense_type_doc = frappe.get_doc("Expense Claim Type", row.expense_type)
+					for account_row in expense_type_doc.get("accounts", []):
+						if account_row.default_account:
+							credit_account = account_row.default_account
+							break
 
-                if not credit_account:
-                    frappe.throw(f"No default account found for Expense Claim Type {row.expense_type}")
+				if not credit_account:
+					frappe.throw(f"No default account found for Expense Claim Type {row.expense_type}")
 
-                journal_entry = frappe.new_doc("Journal Entry")
-                journal_entry.voucher_type = "Journal Entry"
-                journal_entry.posting_date = self.posting_date or nowdate()
-                journal_entry.company = frappe.defaults.get_user_default("Company")
-                journal_entry.remark = f"Payable offense recorded in Vehicle Incident Record {self.name}"
+				journal_entry = frappe.new_doc("Journal Entry")
+				journal_entry.voucher_type = "Journal Entry"
+				journal_entry.posting_date = self.posting_date or nowdate()
+				journal_entry.company = frappe.defaults.get_user_default("Company")
+				journal_entry.remark = f"Payable offense recorded in Vehicle Incident Record {self.name}"
+				journal_entry.vehicle_incident_record = self.name
 
-                if row.is_employee_payable:
-                    journal_entry.append("accounts", {
-                        "account": debit_account,
-                        "party_type": "Employee",
-                        "party": employee_id,
-                        "debit_in_account_currency": row.amount
-                    })
-                    journal_entry.append("accounts", {
-                        "account": credit_account,
-                        "credit_in_account_currency": row.amount
-                    })
-                else:
-                    journal_entry.append("accounts", {
-                        "account": credit_account,
-                        "debit_in_account_currency": row.amount
-                    })
-                    journal_entry.append("accounts", {
-                        "account": debit_account,
-                        "party_type": "Employee",
-                        "party": employee_id,
-                        "credit_in_account_currency": row.amount
-                    })
+				if row.is_employee_payable:
+					journal_entry.append("accounts", {
+						"account": debit_account,
+						"party_type": "Employee",
+						"party": employee_id,
+						"debit_in_account_currency": row.amount
+					})
+					journal_entry.append("accounts", {
+						"account": credit_account,
+						"credit_in_account_currency": row.amount
+					})
+				else:
+					journal_entry.append("accounts", {
+						"account": credit_account,
+						"debit_in_account_currency": row.amount
+					})
+					journal_entry.append("accounts", {
+						"account": debit_account,
+						"party_type": "Employee",
+						"party": employee_id,
+						"credit_in_account_currency": row.amount
+					})
 
+				journal_entry.insert(ignore_permissions=True)
+				row.journal_entry = journal_entry.name
+				self.assign_todo_for_accounts(journal_entry.name)
+				frappe.msgprint(f"Journal Entry {journal_entry.name} has been created successfully.", alert=True, indicator="green")
 
-                journal_entry.insert(ignore_permissions=True)
-                row.journal_entry = journal_entry.name
-                frappe.msgprint(f"Journal Entry {journal_entry.name} has been created successfully.", alert=True, indicator="green")
+		self.save(ignore_permissions=True)
 
-        self.save(ignore_permissions=True)
+	def assign_todo_for_accounts(self, journal_entry_name):
+		'''
+		Create a ToDo for Accounts User(s) when a Journal Entry
+		is created and linked to the Vehicle Incident Record.
+		'''
+		# Prevent duplicate ToDos
+		exists = frappe.db.exists("ToDo", {
+			"reference_type": "Journal Entry",
+			"reference_name": journal_entry_name
+		})
+		if exists:
+			return
+
+		# Get all Accounts Users
+		users = get_users_with_role("Accounts User")
+
+		if users:
+			description = (
+				f"Journal Entry <b>{journal_entry_name}</b> has been created "
+				f"for Vehicle Incident Record <b>{self.name}</b>.<br>"
+				"Please review and take necessary action."
+			)
+			add_assign({
+				"assign_to": users,
+				"doctype": "Journal Entry",
+				"name": journal_entry_name,
+				"description": description
+			})

--- a/beams/beams/doctype/vehicle_incident_record/vehicle_incident_record.py
+++ b/beams/beams/doctype/vehicle_incident_record/vehicle_incident_record.py
@@ -8,6 +8,7 @@ from frappe.model.document import Document
 from frappe.utils import today
 from frappe.utils.user import get_users_with_role
 from frappe.desk.form.assign_to import add as add_assign
+from frappe.utils import nowdate
 
 class VehicleIncidentRecord(Document):
 	def on_update(self):
@@ -49,9 +50,7 @@ class VehicleIncidentRecord(Document):
 		Automatically creates and submits a Journal Entry for each payable vehicle incident
 		where the 'is_employee_payable' field is checked
 		'''
-		settings = frappe.get_single("BEAMS Admin Settings")
-		debit_account = settings.default_employee_payable_account
-
+		debit_account = frappe.db.get_single_value("BEAMS Admin Settings", "default_employee_payable_account")
 		if not debit_account:
 			frappe.throw("Default Employee Payable Account is not set in BEAMS Admin Settings.")
 

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -4757,8 +4757,15 @@ def get_journal_entry_custom_fields():
 				"options": "Employee Travel Request",
 				"insert_after":"posting_date",
 				"read_only": 1
+			},
+			{
+				"fieldname": "vehicle_incident_record",
+				"fieldtype": "Link",
+				"label": "Vehicle Incident Record",
+				"options": "Vehicle Incident Record",
+				"insert_after": "reference_voucher_entry",
+				"read_only": 1
 			}
-
 		]
 	}
 


### PR DESCRIPTION
## Feature description
- When a Vehicle Incident Record (VIR) is approved, the system automatically creates a Journal Entry (JE). A ToDo should be assigned to the Accounts user only if the VIR is linked to a JE
- Done code cleanup(indentation corrected)
## Analysis and design (optional)
Add a reference field in Journal Entry to track back to the Vehicle Incident Record.
Trigger ToDo creation only when VIR approval leads to a JE.
## Solution description
Added reference of Vehicle Incident Record in Journal Entry for traceability.
Implemented logic to create ToDo for Accounts user only if VIR is linked with a JE.
## Output screenshots (optional)
<img width="1464" height="661" alt="image" src="https://github.com/user-attachments/assets/5178a093-c5b5-46a5-9071-1af21dd54274" />
<img width="1598" height="926" alt="image" src="https://github.com/user-attachments/assets/4fcec94e-b4e0-4695-ab4e-7e3daad62f77" />
<img width="1598" height="926" alt="image" src="https://github.com/user-attachments/assets/dd1dafa5-0efe-4bf5-9d7e-8a792b62f620" />


## Areas affected and ensured
Vehicle Incident Record approval flow
Journal Entry creation process
ToDo assignment for Account

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
