### PR TITLE
feat:Added fuel card limit field both on fuel card and fuel card log

### DIFF
--- a/beams/beams/doctype/fuel_card/fuel_card.json
+++ b/beams/beams/doctype/fuel_card/fuel_card.json
@@ -27,13 +27,13 @@
   },
   {
    "fieldname": "fuel_card_limit",
-   "fieldtype": "Float",
+   "fieldtype": "Currency",
    "label": "Fuel Card Limit"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-08-19 15:17:40.326604",
+ "modified": "2025-08-20 16:02:10.561448",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Fuel Card",

--- a/beams/beams/doctype/fuel_card/fuel_card.json
+++ b/beams/beams/doctype/fuel_card/fuel_card.json
@@ -7,7 +7,8 @@
  "engine": "InnoDB",
  "field_order": [
   "provider",
-  "card_no"
+  "card_no",
+  "fuel_card_limit"
  ],
  "fields": [
   {
@@ -23,11 +24,16 @@
    "fieldtype": "Data",
    "label": "Card No.",
    "reqd": 1
+  },
+  {
+   "fieldname": "fuel_card_limit",
+   "fieldtype": "Float",
+   "label": "Fuel Card Limit"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-05-05 09:53:53.847042",
+ "modified": "2025-08-19 15:17:40.326604",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Fuel Card",
@@ -47,6 +53,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/beams/beams/doctype/fuel_card_log/fuel_card_log.js
+++ b/beams/beams/doctype/fuel_card_log/fuel_card_log.js
@@ -2,111 +2,127 @@
 // For license information, please see license.txt
 frappe.ui.form.on("Fuel Card Log", {
   setup(frm) {
-    frm.set_query("fuel_card", () => {
-      let used = [];
-      frappe.call({
-        method: "frappe.client.get_list",
-        async: false,
-        args: {
-          doctype: "Fuel Card Log",
-          fields: ["fuel_card"],
-          filters: { docstatus: ["!=", 2] }
-        },
-        callback(r) {
-          used = r.message.map(d => d.fuel_card);
-        }
-      });
-      return { filters: [["Fuel Card", "name", "not in", used]] };
-    });
+	frm.set_query("fuel_card", () => {
+	  let used = [];
+	  frappe.call({
+		method: "frappe.client.get_list",
+		async: false,
+		args: {
+		  doctype: "Fuel Card Log",
+		  fields: ["fuel_card"],
+		  filters: { docstatus: ["!=", 2] }
+		},
+		callback(r) {
+		  used = r.message.map(d => d.fuel_card);
+		}
+	  });
+	  return { filters: [["Fuel Card", "name", "not in", used]] };
+	});
   },
 
   refresh(frm) {
-    if (!frm.is_new()) {
-      frm.add_custom_button('Ownership Transaction', () => {
-        frappe.prompt([
-          {
-            label: 'New Owner',
-            fieldname: 'new_owner',
-            fieldtype: 'Link',
-            options: 'Employee',
-            reqd: 1
-          },
-          {
-            label: 'Date',
-            fieldname: 'date',
-            fieldtype: 'Date',
-            default: frappe.datetime.get_today(),
-            reqd: 1,
-            onchange: function() {
-              const selected_date = this.get_value();
-              const today_date = frappe.datetime.get_today();
-              if (selected_date > today_date) {
-                if (!this._show_date_error) {
-                  this._show_date_error = true;
-                  frappe.msgprint({
-                    title: 'Invalid Date',
-                    indicator: 'red',
-                    message: 'Future dates are not allowed. Please select today or a past date.'
-                  });
-                  this.set_value(today_date);
-                  setTimeout(() => {
-                    this._show_date_error = false;
-                  }, 100);
-                }
-              }
-            }
-          }
-        ], (values) => {
-          let last_row = frm.doc.ownered_by && frm.doc.ownered_by.slice(-1)[0];
+	if (!frm.is_new()) {
+	  frm.add_custom_button('Ownership Transaction', () => {
+		frappe.prompt([
+		  {
+			label: 'New Owner',
+			fieldname: 'new_owner',
+			fieldtype: 'Link',
+			options: 'Employee',
+			reqd: 1
+		  },
+		  {
+			label: 'Date',
+			fieldname: 'date',
+			fieldtype: 'Date',
+			default: frappe.datetime.get_today(),
+			reqd: 1,
+			onchange: function() {
+			  const selected_date = this.get_value();
+			  const today_date = frappe.datetime.get_today();
+			  if (selected_date > today_date) {
+				if (!this._show_date_error) {
+				  this._show_date_error = true;
+				  frappe.msgprint({
+					title: 'Invalid Date',
+					indicator: 'red',
+					message: 'Future dates are not allowed. Please select today or a past date.'
+				  });
+				  this.set_value(today_date);
+				  setTimeout(() => {
+					this._show_date_error = false;
+				  }, 100);
+				}
+			  }
+			}
+		  }
+		], (values) => {
+		  let last_row = frm.doc.ownered_by && frm.doc.ownered_by.slice(-1)[0];
 
-          if (last_row && last_row.ownership === values.new_owner) {
-            frappe.msgprint(`The last owner is already "${values.new_owner}". No new row added.`);
-            frm.set_value('current_holder', values.new_owner);
-            return;
-          }
+		  if (last_row && last_row.ownership === values.new_owner) {
+			frappe.msgprint(`The last owner is already "${values.new_owner}". No new row added.`);
+			frm.set_value('current_holder', values.new_owner);
+			return;
+		  }
 
-          let child = frm.add_child('ownered_by', {
-            ownership: values.new_owner,
-            date: values.date
-          });
-          frm.refresh_field('ownered_by');
-          frm.set_value('current_holder', values.new_owner);
-          frm.save();
-        }, 'Add', 'Save');
-      }, 'Add');
+		  let child = frm.add_child('ownered_by', {
+			ownership: values.new_owner,
+			date: values.date
+		  });
+		  frm.refresh_field('ownered_by');
+		  frm.set_value('current_holder', values.new_owner);
+		  frm.save();
+		}, 'Add', 'Save');
+	  }, 'Add');
 
-      // Button: Set Recharge History
-      frm.add_custom_button('Recharge', () => {
-        frappe.prompt([
-          {
-            label: 'Recharge Amount',
-            fieldname: 'recharge_amount',
-            fieldtype: 'Int',
-            reqd: 1
-          },
-          {
-            label: 'Recharged Date',
-            fieldname: 'recharged_date',
-            fieldtype: 'Date',
-            default: frappe.datetime.get_today(),
-            reqd: 1
-          },
-          {
-            label: 'Voucher No.',
-            fieldname: 'voucher_no',
-            fieldtype: 'Data',
-            reqd: 1
-          }
-        ], (values) => {
-          let child = frm.add_child('recharge_history', {
-            recharge_amount: values.recharge_amount,
-            recharged_date: values.recharged_date,
-            voucher_no: values.voucher_no
-          });
-          frm.refresh_field('recharge_history');
-          frm.save();
-        }, 'Add', 'Save');
-      }, 'Add');
-    }
+	  // Button: Set Recharge History
+	  frm.add_custom_button('Recharge', () => {
+		frappe.prompt([
+		  {
+			label: 'Refilling Amount',
+			fieldname: 'recharge_amount',
+			fieldtype: 'Float',
+			reqd: 1
+		  },
+		  {
+			label: 'Recharged Date',
+			fieldname: 'recharged_date',
+			fieldtype: 'Date',
+			default: frappe.datetime.get_today(),
+			reqd: 1
+		  },
+		  {
+			label: 'Voucher No.',
+			fieldname: 'voucher_no',
+			fieldtype: 'Data',
+		  },
+		  {
+			label: 'Vehicle',
+			fieldname: 'vehicle',
+			fieldtype: 'Link',
+			options: 'Vehicle'
+		  }
+		], (values) => {
+			if (values.recharge_amount > frm.doc.fuel_card_limit) {
+				frappe.msgprint({
+					title: __('Validation Error'),
+					message: __('Refilling Amount {0} is more than Fuel Card Limit {1}',
+						[values.recharge_amount, frm.doc.fuel_card_limit]),
+					indicator: 'red'
+				});
+				return;
+			}
+
+		  let child = frm.add_child('recharge_history', {
+			recharge_amount: values.recharge_amount,
+			recharged_date: values.recharged_date,
+			voucher_no: values.voucher_no,
+			vehicle:values.vehicle
+		  });
+		  frm.refresh_field('recharge_history');
+		  frm.save();
+		}, 'Add', 'Save');
+	  }, 'Add');
+	}
   }
 });

--- a/beams/beams/doctype/fuel_card_log/fuel_card_log.js
+++ b/beams/beams/doctype/fuel_card_log/fuel_card_log.js
@@ -81,7 +81,7 @@ frappe.ui.form.on("Fuel Card Log", {
 		  {
 			label: 'Refilling Amount',
 			fieldname: 'recharge_amount',
-			fieldtype: 'Float',
+			fieldtype: 'Currency',
 			reqd: 1
 		  },
 		  {

--- a/beams/beams/doctype/fuel_card_log/fuel_card_log.json
+++ b/beams/beams/doctype/fuel_card_log/fuel_card_log.json
@@ -53,13 +53,13 @@
   {
    "fetch_from": "fuel_card.fuel_card_limit",
    "fieldname": "fuel_card_limit",
-   "fieldtype": "Float",
+   "fieldtype": "Currency",
    "label": "Fuel Card Limit"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-08-19 15:21:55.494807",
+ "modified": "2025-08-20 16:03:58.604678",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Fuel Card Log",

--- a/beams/beams/doctype/fuel_card_log/fuel_card_log.json
+++ b/beams/beams/doctype/fuel_card_log/fuel_card_log.json
@@ -7,6 +7,7 @@
  "engine": "InnoDB",
  "field_order": [
   "fuel_card",
+  "fuel_card_limit",
   "column_break_yjyq",
   "current_holder",
   "section_break_6qhb",
@@ -48,11 +49,17 @@
    "label": "Ownership History",
    "options": "Ownered By",
    "read_only": 1
+  },
+  {
+   "fetch_from": "fuel_card.fuel_card_limit",
+   "fieldname": "fuel_card_limit",
+   "fieldtype": "Float",
+   "label": "Fuel Card Limit"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-05-06 12:57:16.601870",
+ "modified": "2025-08-19 15:21:55.494807",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Fuel Card Log",
@@ -72,6 +79,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/beams/beams/doctype/fuel_card_log/fuel_card_log.py
+++ b/beams/beams/doctype/fuel_card_log/fuel_card_log.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2025, efeone and contributors
-# For license information, please see license.tx
+# For license information, please see license.txt
 
 import frappe
 from frappe.model.document import Document
@@ -13,7 +13,9 @@ class FuelCardLog(Document):
 		for row in self.get("recharge_history"):
 			if row.recharge_amount:
 				if row.recharge_amount > self.fuel_card_limit:
-					continue
+					frappe.throw(
+						f"Refilling amount {row.refilling_amount} is more than available limit {self.fuel_card_limit}"
+					)
 				else:
 					total_used += row.recharge_amount
 

--- a/beams/beams/doctype/fuel_card_log/fuel_card_log.py
+++ b/beams/beams/doctype/fuel_card_log/fuel_card_log.py
@@ -1,9 +1,23 @@
 # Copyright (c) 2025, efeone and contributors
-# For license information, please see license.txt
+# For license information, please see license.tx
 
-# import frappe
+import frappe
 from frappe.model.document import Document
 
-
 class FuelCardLog(Document):
-	pass
+	"""
+	Reduce fuel_card_limit According to refilling_amount
+	"""
+	def validate(self):
+		total_used = 0
+		for row in self.get("recharge_history"):
+			if row.recharge_amount:
+				if row.recharge_amount > self.fuel_card_limit:
+					continue
+				else:
+					total_used += row.recharge_amount
+
+		# Reduce fuel card limit
+		if total_used > 0:
+			self.fuel_card_limit -= total_used
+

--- a/beams/beams/doctype/recharge_history/recharge_history.json
+++ b/beams/beams/doctype/recharge_history/recharge_history.json
@@ -8,15 +8,10 @@
  "field_order": [
   "recharge_amount",
   "recharged_date",
-  "voucher_no"
+  "voucher_no",
+  "vehicle"
  ],
  "fields": [
-  {
-   "fieldname": "recharge_amount",
-   "fieldtype": "Currency",
-   "in_list_view": 1,
-   "label": "Recharge Amount "
-  },
   {
    "fieldname": "recharged_date",
    "fieldtype": "Date",
@@ -28,17 +23,30 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Voucher No."
+  },
+  {
+   "fieldname": "vehicle",
+   "fieldtype": "Link",
+   "label": "Vehicle",
+   "options": "Vehicle"
+  },
+  {
+   "fieldname": "recharge_amount",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Refilling Amount "
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-01-23 13:12:57.907373",
+ "modified": "2025-08-20 12:38:46.412189",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Recharge History",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []


### PR DESCRIPTION
Changed the label recharge amount to refilling amount Reduced fuel card limit according to refilling amount

## Feature description
- Added fuel card limit field both on fuel card and fuel card log
- Reduce fuel card limit According to refilling amount
- Updates the amount both on recharge history child table and fuel card limit
- Refilling amount can't be greater than fuel card limt

## Output screenshots (optional)
<img width="1366" height="768" alt="Screenshot from 2025-08-20 13-12-28" src="https://github.com/user-attachments/assets/29a00da7-1ae0-4563-be95-c577ef7fe6ee" />
<img width="1366" height="768" alt="Screenshot from 2025-08-20 13-14-58" src="https://github.com/user-attachments/assets/d1381ff7-fcd7-47c8-8def-691d4c364dda" />


## Is there any existing behavior change of other features due to this code change?
No
## Was this feature tested on the browsers?
  - Chrome
