### PR TITLE
fix: Validation of rejection reason  on workflow change

### DIFF
--- a/beams/beams/doctype/trip_sheet/trip_sheet.py
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.py
@@ -9,9 +9,6 @@ from frappe.utils import getdate
 
 class TripSheet(Document):
 	def validate(self):
-		if not self.travel_requests and not self.transportation_requests:
-			frappe.throw("Please provide at least one of Travel Requests or Transportation Requests.")
-
 		self.validate_start_datetime_and_end_datetime()
 		self.calculate_and_validate_fuel_data()
 		self.calculate_hours()


### PR DESCRIPTION
## Issue description
1. Need to remove the validate the start date is not past date 
2. need to change  the  logic of validation of reason for rejection in employee travel request
3. need to remove the unwanted validation in trip sheet

## Solution description
1. Removed the validate the start date is not past date 

2. changed the  logic of validation of reason for rejection in employee travel request
-Moved "Reason for Rejection" validation from 'on_cancel' to 'validate' 
3. removed the unwanted validation in the trip sheet
- if the trip sheet create without travall requests and transport request in trip sheet


## Output screenshots (optional)

[Screencast from 21-08-25 01:12:33 PM IST.webm](https://github.com/user-attachments/assets/c6132c1e-eed7-4bcd-994e-f6792fdf5c09)
[Screencast from 21-08-25 01:12:33 PM IST.webm](https://github.com/user-attachments/assets/f1e9a24b-c951-409f-a554-25d9c25de4e6)




## Areas affected and ensured
employee travel request and trip sheet doctype

## Is there any existing behavior change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?
  
  - Mozilla Firefox
 
