### PR TITLE
refactor: remove ToDo creation for drivers on Inward Register submission

### DIFF
--- a/beams/beams/doctype/inward_register/inward_register.py
+++ b/beams/beams/doctype/inward_register/inward_register.py
@@ -13,27 +13,6 @@ class InwardRegister(Document):
     def before_save(self):
         self.validate_posting_date()
 
-    def on_submit(self, method=None):
-        """
-        Creates a ToDo task for the driver when the 'vehicle_key' checkbox is checked.
-        The notification message will be "Vehicle key handed over in Inward."
-        """
-        if self.vehicle_key:
-            driver_users = get_users_with_role("Driver")
-            if driver_users:
-                description = f"Vehicle key handed over in Inward for {self.visitor_name}."
-                if not frappe.db.exists('ToDo', {
-                    'reference_name': self.name,
-                    'reference_type': 'Inward Register',
-                    'description': description
-                }):
-                    add_assign({
-                        "assign_to": driver_users,
-                        "doctype": "Inward Register",
-                        "name": self.name,
-                        "description": description
-                    })
-
     def validate(self):
         if self.visitor_type == "Ex Employee":
             if not self.visitor_name or not self.visit_date:
@@ -50,7 +29,6 @@ class InwardRegister(Document):
 
             if not visit_request:
                 frappe.throw(f"No Visit Request found for {self.visitor_name} on {self.visit_date}.")
-
 
     @frappe.whitelist()
     def validate_posting_date(self):

--- a/beams/beams/doctype/inward_register/inward_register.py
+++ b/beams/beams/doctype/inward_register/inward_register.py
@@ -10,28 +10,27 @@ from frappe.utils.user import get_users_with_role
 
 class InwardRegister(Document):
 
-    def before_save(self):
-        self.validate_posting_date()
+	def before_save(self):
+		self.validate_posting_date()
 
-    def validate(self):
-        if self.visitor_type == "Ex Employee":
-            if not self.visitor_name or not self.visit_date:
-                frappe.throw("Visitor Name and Visit Date are required for Ex Employees.")
+	def validate(self):
+		if self.visitor_type == "Ex Employee":
+			if not self.visitor_name or not self.visit_date:
+				frappe.throw("Visitor Name and Visit Date are required for Ex Employees.")
 
-            # Check if a Visit Request exists
-            visit_request = frappe.db.exists(
-                "Visit Request",
-                {
-                    "visitor_name": self.visitor_name,
-                    "visit_date": self.visit_date
-                }
-            )
+			# Check if a Visit Request exists
+			visit_request = frappe.db.exists(
+				"Visit Request",
+				{
+					"visitor_name": self.visitor_name,
+					"visit_date": self.visit_date
+				}
+			)
+			if not visit_request:
+				frappe.throw(f"No Visit Request found for {self.visitor_name} on {self.visit_date}.")
 
-            if not visit_request:
-                frappe.throw(f"No Visit Request found for {self.visitor_name} on {self.visit_date}.")
-
-    @frappe.whitelist()
-    def validate_posting_date(self):
-        if self.posting_date:
-            if frappe.utils.get_datetime(self.posting_date) > frappe.utils.get_datetime():
-                frappe.throw(_("Posting Date cannot be set after Now date."))
+	@frappe.whitelist()
+	def validate_posting_date(self):
+		if self.posting_date:
+			if frappe.utils.get_datetime(self.posting_date) > frappe.utils.get_datetime():
+				frappe.throw(_("Posting Date cannot be set after Now date."))


### PR DESCRIPTION
## Feature description
- Removed invalid ToDo assignment to all Drivers on Inward Register submission
- Previously, the logic incorrectly created ToDos for every user with the "Driver" role when vehicle_key was checked.
- This was invalid behavior since notifications should not be sent to all drivers.
- Done code cleanup( indentation corrected)

## Analysis and design (optional)
## Solution description
Deleted the on_submit method in inward_register.py that was creating ToDos.
## Output screenshots (optional)
ToDos are no longer created for drivers on inward register submission
<img width="1663" height="863" alt="image" src="https://github.com/user-attachments/assets/e72e8ac8-7e19-48e0-ac95-4239720d91ee" />
## Areas affected and ensured
Inward Register doctype backend logic (inward_register.py).
## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
