### PR TITLE
refactor :travel request validation and attendance creation

### DIFF
--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.py
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.py
@@ -26,6 +26,7 @@ class EmployeeTravelRequest(Document):
 		self.validate_dates()
 		self.validate_expected_time()
 		self.total_days_calculate()
+		self.validate_hod_vehicle_allocation()
 
 	def before_save(self):
 		self.validate_posting_date()
@@ -286,22 +287,6 @@ class EmployeeTravelRequest(Document):
 
 				attendance.insert(ignore_permissions=True)
 				frappe.msgprint(f"Attendance Request created for {emp}", alert=True, indicator='green')
-
-	def validate_hod_vehicle_allocation(self):
-		"""Validate vehicle & driver allocation at HOD approval stage"""
-		if self.is_vehicle_required and self.workflow_state == "Approved by HOD" and self.mode_of_travel not in ["Train", "Plain"]:
-					if not self.travel_vehicle_allocation:
-						frappe.throw(title="Approval Error", msg="Vehicle allocation is required before final approval.")
-
-					has_complete_allocation = False
-					for allocation in self.travel_vehicle_allocation:
-						if allocation.vehicle and allocation.driver:
-							has_complete_allocation = True
-							break
-
-					if not has_complete_allocation:
-						frappe.throw(title="Approval Error",
-									msg="You must allocate driver and vehicle before final approval.")
 
 	@frappe.whitelist()
 	def validate_posting_date(self):

--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.py
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.py
@@ -237,10 +237,9 @@ class EmployeeTravelRequest(Document):
 						)
 
 	def create_attendance_requests(self):
-	"""
-		Create attendance requests for all travellers when mark_attendance is enabled
-	"""
-
+		"""
+			Create attendance requests for all travellers when mark_attendance is enabled
+		"""
 		old_doc = self.get_doc_before_save()
 		if old_doc and old_doc.workflow_state != self.workflow_state and  self.workflow_state == "Approved":
 			if not self.mark_attendance:

--- a/beams/beams/doctype/vehicle_incident_record/vehicle_incident_record.json
+++ b/beams/beams/doctype/vehicle_incident_record/vehicle_incident_record.json
@@ -58,6 +58,7 @@
    "fieldname": "posting_date",
    "fieldtype": "Date",
    "label": "Posting Date ",
+   "read_only": 1,
    "reqd": 1
   },
   {
@@ -123,7 +124,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-05-22 11:26:14.062368",
+ "modified": "2025-08-21 16:14:21.982949",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Vehicle Incident Record",
@@ -144,6 +145,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []


### PR DESCRIPTION
## Feature description
Clearly and concisely describe the feature.

## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description
Moved validate_hod_vehicle_allocation() call into validate() to ensure checks are applied before workflow transition to Approved.

Prevents approval if is_vehicle_required is enabled and no complete vehicle/driver allocation exists.

This ensures validation happens at the Pending Approval → Approved stage, blocking approval until allocation requirements are met.

Extracted vehicle allocation validation into validate_hod_vehicle_allocation() for both HOD approval and final approval stages.

Added create_attendance_requests() to auto-generate Attendance Requests when workflow state changes to Approved.

Removed duplicate inline validation/attendance code from on_update_after_submit.

Updated vehicle_incident_record.json with  set read only for posting date

## Output screenshots (optional)
[Screencast from 21-08-25 05:10:05 PM IST.webm](https://github.com/user-attachments/assets/94ae3c46-8b7f-4610-a6c4-f861501a78d9)


## Areas affected and ensured
Trip Sheet
Attendance Regularisation

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - yes
  - Opera Mini
  - Safari
