### PR TITLE
fix: refactor returned date validation in visitor pass

### DIFF
--- a/beams/beams/doctype/fuel_card_log/fuel_card_log.json
+++ b/beams/beams/doctype/fuel_card_log/fuel_card_log.json
@@ -24,7 +24,7 @@
   {
    "fieldname": "recharge_history",
    "fieldtype": "Table",
-   "label": "Recharge History",
+   "label": "Fuel Card Transactions",
    "options": "Recharge History",
    "read_only": 1
   },
@@ -54,12 +54,14 @@
    "fetch_from": "fuel_card.fuel_card_limit",
    "fieldname": "fuel_card_limit",
    "fieldtype": "Currency",
-   "label": "Fuel Card Limit"
+   "in_list_view": 1,
+   "label": "Fuel Card Limit",
+   "reqd": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-08-20 16:03:58.604678",
+ "modified": "2025-08-21 17:25:45.143558",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Fuel Card Log",

--- a/beams/beams/doctype/recharge_history/recharge_history.json
+++ b/beams/beams/doctype/recharge_history/recharge_history.json
@@ -27,6 +27,7 @@
   {
    "fieldname": "vehicle",
    "fieldtype": "Link",
+   "in_list_view": 1,
    "label": "Vehicle",
    "options": "Vehicle"
   },
@@ -40,7 +41,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-08-20 12:38:46.412189",
+ "modified": "2025-08-21 17:28:55.583885",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Recharge History",

--- a/beams/beams/doctype/visitor_pass/visitor_pass.py
+++ b/beams/beams/doctype/visitor_pass/visitor_pass.py
@@ -11,13 +11,15 @@ class VisitorPass(Document):
     def validate(self):
         self.validate_issued_date_and_expire_on()
         self.validate_issued_date_and_returned_date()
+
+    def on_update_after_submit(self):
         self.validate_returned_date_and_returned_time()
 
     def validate_returned_date_and_returned_time(self):
         '''
         Ensure Returned Date and Time selection based on workflow state
         '''
-        if self.workflow_state == 'Issued':
+        if self.workflow_state == 'Returned':
             if not self.returned_date:
                 frappe.throw(_('Please select a Returned Date and Time.'))
 
@@ -54,14 +56,14 @@ class VisitorPass(Document):
 
         if issued_date > returned_date:
             frappe.throw(
-                msg=_("Issued Date cannot be after Returned Date."),
+                msg=_("Returned Date cannot be before Issued Date."),
                 title=_("Validation Error")
             )
 
         if issued_date == returned_date:
-            if self.issued_time and self.returned_time:
+            if self.issued_time and self.returned_date:
                 issued_time = get_time(self.issued_time)
-                returned_time = get_time(self.returned_time)
+                returned_time = get_time(self.returned_date)
 
                 if issued_time >= returned_time:
                     frappe.throw(

--- a/beams/beams/doctype/visitor_pass/visitor_pass.py
+++ b/beams/beams/doctype/visitor_pass/visitor_pass.py
@@ -8,65 +8,65 @@ from frappe.model.document import Document
 
 class VisitorPass(Document):
 
-    def validate(self):
-        self.validate_issued_date_and_expire_on()
-        self.validate_issued_date_and_returned_date()
+	def validate(self):
+		self.validate_issued_date_and_expire_on()
+		self.validate_issued_date_and_returned_date()
 
-    def on_update_after_submit(self):
-        self.validate_returned_date_and_returned_time()
+	def on_update_after_submit(self):
+		self.validate_returned_date_and_returned_time()
 
-    def validate_returned_date_and_returned_time(self):
-        '''
-        Ensure Returned Date and Time selection based on workflow state
-        '''
-        if self.workflow_state == 'Returned':
-            if not self.returned_date:
-                frappe.throw(_('Please select a Returned Date and Time.'))
+	def validate_returned_date_and_returned_time(self):
+		'''
+		Ensure Returned Date and Time selection based on workflow state
+		'''
+		if self.workflow_state == 'Returned':
+			if not self.returned_date:
+				frappe.throw(_('Please select a Returned Date and Time.'))
 
-    @frappe.whitelist()
-    def validate_issued_date_and_expire_on(self):
-        '''
-        Validates that issued_date and expire_on are properly set and checks
-        if issued_date is not later than expire_on.
-        '''
-        if not self.issued_date or not self.expire_on:
-            return
+	@frappe.whitelist()
+	def validate_issued_date_and_expire_on(self):
+		'''
+		Validates that issued_date and expire_on are properly set and checks
+		if issued_date is not later than expire_on.
+		'''
+		if not self.issued_date or not self.expire_on:
+			return
 
-        issued_date = getdate(self.issued_date)
-        expire_on = getdate(self.expire_on)
+		issued_date = getdate(self.issued_date)
+		expire_on = getdate(self.expire_on)
 
-        if issued_date > expire_on:
-            frappe.throw(
-                msg=_("Issued Date cannot be after Expire On."),
-                title=_("Validation Error")
-            )
+		if issued_date > expire_on:
+			frappe.throw(
+				msg=_("Issued Date cannot be after Expire On."),
+				title=_("Validation Error")
+			)
 
-    @frappe.whitelist()
-    def validate_issued_date_and_returned_date(self):
-        '''
-        Validates that issued_date and returned_date are properly set and checks
-        if issued_date is not later than returned_date.
-        Also checks that issued_time is not later than returned_time if both dates are the same.
-        '''
-        if not self.issued_date or not self.returned_date:
-            return
+	@frappe.whitelist()
+	def validate_issued_date_and_returned_date(self):
+		'''
+		Validates that issued_date and returned_date are properly set and checks
+		if issued_date is not later than returned_date.
+		Also checks that issued_time is not later than returned_time if both dates are the same.
+		'''
+		if not self.issued_date or not self.returned_date:
+			return
 
-        issued_date = getdate(self.issued_date)
-        returned_date = getdate(self.returned_date)
+		issued_date = getdate(self.issued_date)
+		returned_date = getdate(self.returned_date)
 
-        if issued_date > returned_date:
-            frappe.throw(
-                msg=_("Returned Date cannot be before Issued Date."),
-                title=_("Validation Error")
-            )
+		if issued_date > returned_date:
+			frappe.throw(
+				msg=_("Returned Date cannot be before Issued Date."),
+				title=_("Validation Error")
+			)
 
-        if issued_date == returned_date:
-            if self.issued_time and self.returned_date:
-                issued_time = get_time(self.issued_time)
-                returned_time = get_time(self.returned_date)
+		if issued_date == returned_date:
+			if self.issued_time and self.returned_date:
+				issued_time = get_time(self.issued_time)
+				returned_time = get_time(self.returned_date)
 
-                if issued_time >= returned_time:
-                    frappe.throw(
-                        msg=_("Issued Time must be greater than Returned Time "),
-                        title=_("Validation Error")
-                    )
+				if issued_time >= returned_time:
+					frappe.throw(
+						msg=_("Issued Time must be greater than Returned Time "),
+						title=_("Validation Error")
+					)


### PR DESCRIPTION
## Feature description
Improved Visitor Pass validations and renamed Fuel Card child table for better clarity and consistency.
## Analysis and design (optional)
- Visitor Pass previously used a non-existent returned_time field, leading to validation errors.
- Fuel Card module used a generic name Recharge History which was unclear; renamed to Fuel Card Transactions to better represent its purpose.

## Solution description
Visitor Pass
-   Fixed validation to use returned_date (Datetime field) instead of returned_time.
-   Corrected workflow state check from Issued → Returned.
-   Improved validation messages for better readability.

Fuel Card
- Renamed child table label from Recharge History → Fuel Card Transactions.
- Made Vehicle field visible in list view.
- Marked Fuel Card Limit as required and added it to list view.

## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.

## Areas affected and ensured
List out the areas affected by your code changes.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
