### PR TITLE
refactor:Courier Log logic

### DIFF
--- a/beams/beams/doctype/inward_register/inward_register.js
+++ b/beams/beams/doctype/inward_register/inward_register.js
@@ -1,39 +1,46 @@
 // Copyright (c) 2025, efeone and contributors
 // For license information, please see license.txt
 frappe.ui.form.on('Inward Register', {
-    refresh: function (frm) {
-        if (frm.doc.docstatus === 1) {
-            frm.add_custom_button(__('Outward Register'), function () {
-                frappe.new_doc("Outward Register", {
-                    inward_register: frm.doc.name,
-                });
-            }, __("Create"));
+	refresh: function (frm) {
+		if (frm.doc.docstatus === 1) {
+			frm.add_custom_button(__('Outward Register'), function () {
+				frappe.new_doc("Outward Register", {
+					inward_register: frm.doc.name,
+				});
+			}, __("Create"));
 
-            if (!frappe.user.has_role('Security') || frappe.user.has_role('Administrator')) {
-                frm.add_custom_button(__(' Visitor Pass'), function () {
-                    frappe.new_doc("Visitor Pass", {
-                        inward_register: frm.doc.name,
-                        issued_date: frappe.datetime.now_date(),
-                        issued_time: frappe.datetime.now_time(),
-                        issued_to: frm.doc.visitor_name
-                    });
-                }, __("Create"));
-                if (frm.doc.visitor_type === 'Courier') {
-                    frm.add_custom_button(__('Courier Log'), function () {
-                        frappe.new_doc("Courier Log", {
-                            inward_register: frm.doc.name,
-                            sender: frm.doc.visitor_name,
-                            recipient: frm.doc.received_by,
-                            courier_service: frm.doc.courier_service,
-                            date: frm.doc.visit_date,
-                            description: frm.doc.purpose_of_visit
-                        });
-                    }, __("Create"));
-                }
-            }
-        }
-    },
-    posting_date: function (frm) {
-    frm.call("validate_posting_date");
-    }
+			if (!frappe.user.has_role('Security') || frappe.user.has_role('Administrator')) {
+				frm.add_custom_button(__(' Visitor Pass'), function () {
+					frappe.new_doc("Visitor Pass", {
+						inward_register: frm.doc.name,
+						issued_date: frappe.datetime.now_date(),
+						issued_time: frappe.datetime.now_time(),
+						issued_to: frm.doc.visitor_name
+					});
+				}, __("Create"));
+				if (frm.doc.visitor_type === 'Courier') {
+					frm.add_custom_button(__('Courier Log'), function () {
+						frappe.model.with_doctype("Courier Log", function () {
+							let doc = frappe.model.get_new_doc("Courier Log");
+
+							doc.courier_service = frm.doc.courier_service;
+							doc.date = frm.doc.visit_date;
+							doc.status = "Received";
+
+							let inward_row = frappe.model.add_child(doc, "inward_register");
+							inward_row.inward_register = frm.doc.name;
+
+							let recipient_row = frappe.model.add_child(doc, "recipients");
+							recipient_row.recepient = frm.doc.received_by;
+
+							frappe.set_route("Form", "Courier Log", doc.name);
+						});
+					}, __("Create"));
+				}
+			}
+		}
+	},
+	posting_date: function (frm) {
+	frm.call("validate_posting_date");
+	}
 });


### PR DESCRIPTION
## Feature description

- add Courier Log creation from Inward Register with prefilled fields and child rows

## Solution description

- Added a Courier Log custom button in Inward Register (only visible if visitor type is Courier and docstatus = 1).

- When clicked, it creates a new Courier Log document with the following:

- Prefills simple fields (courier_service, date, status = Received).

- Appends one child row in Inward Register child table linking back to the current Inward Register document.

- Appends one child row in Recipients child table with the received_by user.

## Output screenshots (optional)
[Screencast from 22-08-25 11:30:26 AM IST.webm](https://github.com/user-attachments/assets/26546038-1d9d-4255-9993-426471e8dd00)


## Areas affected and ensured

- Courier Log

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox -yes
  - Opera Mini
  - Safari
