### PR TITLE
refactor:Created attendance requests for tripsheet

### DIFF
--- a/beams/beams/doctype/trip_sheet/trip_sheet.js
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.js
@@ -25,7 +25,7 @@ frappe.ui.form.on('Trip Sheet', {
 	},
 
 	refresh: function (frm) {
-		if (!frm.is_new() && frm.doc.workflow_state !== "Closed"){
+		if (!frm.is_new()){
 			frm.add_custom_button(__('Vehicle Incident Record'), function () {
 				frappe.call({
 					method: "beams.beams.doctype.trip_sheet.trip_sheet.create_vehicle_incident_record",

--- a/beams/beams/doctype/trip_sheet/trip_sheet.json
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.json
@@ -30,8 +30,8 @@
   "final_odometer_reading",
   "distance_traveledkm",
   "column_break_anpp",
-  "fuel_consumed",
   "mileage",
+  "fuel_consumed",
   "amended_from",
   "section_break_kwfq",
   "remarks"
@@ -219,7 +219,7 @@
    "link_fieldname": "trip_sheet"
   }
  ],
- "modified": "2025-08-13 11:14:54.882492",
+ "modified": "2025-08-22 16:45:19.217935",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Trip Sheet",


### PR DESCRIPTION
## Feature description
Need to: 

- Currently, attendance requests created from trip sheets fail if overlapping attendance requests already exist.  
This enhancement ensures attendance is created **only for the remaining free days**, skipping already covered periods in Employee Travel Request doctype

- change the alignment of trip sheet doctype
- Change function name  validate vehicle allocation from validate hod vehicle allocation and throw message


## Solution description

- Created attendance requests when travel requests are approved
Handle overlapping attendance periods intelligently, only created attendance for dates that don't already have coverage in Employee Travel Request doctype
- changed the alignment of trip sheet doctype
- Changed function name  validate vehicle allocation from validate hod vehicle allocation and throw message


## Output screenshots (optional)

[Screencast from 22-08-25 05:07:05 PM IST.webm](https://github.com/user-attachments/assets/4e30ffef-8963-433b-921b-d82c6f1573b6)


[Screencast from 22-08-25 05:08:25 PM IST.webm](https://github.com/user-attachments/assets/9dce123f-ce77-49a8-ab6c-935502179193)


## Areas affected and ensured

- Employee Travel Request doctype
- Trip sheet doctype

## Is there any existing behavior change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?
  - Chrome
