### PR TITLE
feat:link External Resource Request with Technical Request and improve validations

### DIFF
--- a/beams/beams/doctype/external_resource_request/external_resource_request.json
+++ b/beams/beams/doctype/external_resource_request/external_resource_request.json
@@ -10,6 +10,7 @@
   "project",
   "bureau",
   "location",
+  "technical_request",
   "column_break_fhpe",
   "posting_date",
   "required_from",
@@ -92,12 +93,19 @@
    "fieldtype": "Link",
    "label": "Location",
    "options": "Location"
+  },
+  {
+   "fieldname": "technical_request",
+   "fieldtype": "Link",
+   "label": "Technical Request",
+   "options": "Technical Request"
   }
  ],
+ "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-03-19 12:19:16.492067",
+ "modified": "2025-08-22 14:42:01.448872",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "External Resource Request",
@@ -118,6 +126,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/beams/beams/doctype/technical_request/technical_request.js
+++ b/beams/beams/doctype/technical_request/technical_request.js
@@ -12,7 +12,7 @@ frappe.ui.form.on('Technical Request', {
             frm.set_df_property(field, 'read_only', should_be_read_only);
         });
 
-        if (!frm.is_new() && frm.doc.workflow_state === "Approved") {
+        if (!frm.is_new() && frm.doc.workflow_state !== "Draft") {
             frm.add_custom_button("External Resource Request", function() {
                 frappe.call({
                     method: "beams.beams.doctype.technical_request.technical_request.create_external_resource_request",

--- a/beams/beams/doctype/technical_request/technical_request.json
+++ b/beams/beams/doctype/technical_request/technical_request.json
@@ -74,8 +74,7 @@
    "allow_on_submit": 1,
    "fieldname": "reason_for_rejection",
    "fieldtype": "Small Text",
-   "label": "Reason for Rejection",
-   "read_only_depends_on": "eval: [\"Rejected\", \"Draft\", \"Approved\"].includes(doc.workflow_state)"
+   "label": "Reason for Rejection"
   },
   {
    "fieldname": "amended_from",
@@ -111,7 +110,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-04-03 13:05:47.576627",
+ "modified": "2025-08-22 14:41:16.538224",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Technical Request",
@@ -131,6 +130,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/beams/beams/doctype/technical_request_details/technical_request_details.json
+++ b/beams/beams/doctype/technical_request_details/technical_request_details.json
@@ -10,7 +10,8 @@
   "designation",
   "employee",
   "required_from",
-  "required_to"
+  "required_to",
+  "hired_personnel"
  ],
  "fields": [
   {
@@ -46,17 +47,25 @@
    "fieldtype": "Datetime",
    "in_list_view": 1,
    "label": "Required To"
+  },
+  {
+   "fieldname": "hired_personnel",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Hired Personnel",
+   "options": "Supplier"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-04-03 16:36:22.668835",
+ "modified": "2025-08-22 17:27:46.695849",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Technical Request Details",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []


### PR DESCRIPTION
## Feature description

-  integrate External Resource Request with Technical Request and improve validations

## Solution description

- External Resource Request:
  * Added link to Technical Request in DocType
  * Synced hired personnel details to Technical Request on submit
  * Refactored hired field update into class method
  * Added row_format = Dynamic, grid page length config
  * Improved date validation and posting date check

- Technical Request:
  * Added hired_personnel field support in Required Employees
  * Allowed validation if either employee or hired_personnel is present
  * Refined posting_date validation with getdate()
  * Ensured Technical Request reference is stored in External Resource Request
  * Custom button appears for non-Draft states
  * Removed unnecessary read_only dependency on Reason for Rejection

- Technical Request Details:
  * Added new field `hired_personnel` (Link to Supplier)
  * Updated row_format to Dynamic

## Output screenshots (optional)
[Screencast from 23-08-25 09:32:25 AM IST.webm](https://github.com/user-attachments/assets/0947c320-2c0a-4371-9df1-79c7bae07e8c)

<img width="1483" height="971" alt="image" src="https://github.com/user-attachments/assets/689bba99-6497-456b-b336-dec8144c8cbb" />

<img width="1483" height="971" alt="image" src="https://github.com/user-attachments/assets/dcab2cb0-ba42-4fd2-a060-a4451cb29329" />


## Areas affected and ensured
Project
technical request
External Resource Request

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
