### PR TITLE
feat:Added driver name field in  trip sheet doctype

### DIFF
--- a/beams/beams/doctype/trip_sheet/trip_sheet.json
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.json
@@ -8,9 +8,10 @@
  "field_order": [
   "section_break_wyyd",
   "driver",
+  "driver_name",
   "vehicle",
-  "posting_date",
   "column_break_abgb",
+  "posting_date",
   "starting_date_and_time",
   "ending_date_and_time",
   "section_break_ziua",
@@ -209,6 +210,12 @@
   {
    "fieldname": "section_break_kwfq",
    "fieldtype": "Section Break"
+  },
+  {
+   "fetch_from": "driver.full_name",
+   "fieldname": "driver_name",
+   "fieldtype": "Data",
+   "label": "Driver Name"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -219,7 +226,7 @@
    "link_fieldname": "trip_sheet"
   }
  ],
- "modified": "2025-08-22 16:45:19.217935",
+ "modified": "2025-08-23 10:13:36.284763",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Trip Sheet",


### PR DESCRIPTION
## Feature description
Need to: 
         -Add a field driver name in trip sheet doctype 

## Solution description
- Added a field driver name in trip sheet doctype

## Output screenshots (optional)

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/d8465a89-013b-4cbc-8320-057013bc1ee8" />

## Areas affected and ensured
Trip sheet doctype

## Is there any existing behavior change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?
  - Chrome

