### PR TITLE
refactor:Updated Transportation Request doctype with workflow and permission level

### DIFF
--- a/beams/beams/doctype/transportation_request/transportation_request.json
+++ b/beams/beams/doctype/transportation_request/transportation_request.json
@@ -68,7 +68,8 @@
    "fieldname": "vehicles",
    "fieldtype": "Table",
    "label": "Vehicles",
-   "options": "Vehicle Detail"
+   "options": "Vehicle Detail",
+   "permlevel": 1
   },
   {
    "allow_on_submit": 1,
@@ -151,7 +152,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-04-07 15:09:44.880644",
+ "modified": "2025-08-25 10:15:05.262951",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Transportation Request",
@@ -171,6 +172,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "search_fields": "project",
  "sort_field": "modified",
  "sort_order": "DESC",

--- a/beams/beams/doctype/transportation_request/transportation_request.json
+++ b/beams/beams/doctype/transportation_request/transportation_request.json
@@ -68,7 +68,8 @@
    "fieldname": "vehicles",
    "fieldtype": "Table",
    "label": "Vehicles",
-   "options": "Vehicle Detail"
+   "options": "Vehicle Detail",
+   "permlevel": 1
   },
   {
    "allow_on_submit": 1,
@@ -151,7 +152,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-08-25 15:00:58.490201",
+ "modified": "2025-08-25 16:01:41.180946",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Transportation Request",

--- a/beams/beams/doctype/transportation_request/transportation_request.json
+++ b/beams/beams/doctype/transportation_request/transportation_request.json
@@ -68,8 +68,7 @@
    "fieldname": "vehicles",
    "fieldtype": "Table",
    "label": "Vehicles",
-   "options": "Vehicle Detail",
-   "permlevel": 1
+   "options": "Vehicle Detail"
   },
   {
    "allow_on_submit": 1,
@@ -152,7 +151,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-08-25 10:15:05.262951",
+ "modified": "2025-08-25 15:00:58.490201",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Transportation Request",
@@ -168,6 +167,31 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Admin",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "permlevel": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Admin",
    "share": 1,
    "write": 1
   }

--- a/beams/beams/doctype/transportation_request/transportation_request.py
+++ b/beams/beams/doctype/transportation_request/transportation_request.py
@@ -13,6 +13,7 @@ class TransportationRequest(Document):
 	def validate(self):
 		if self.workflow_state == "Rejected" and not self.reason_for_rejection:
 			frappe.throw("Please provide a Reason for Rejection before rejecting this request.")
+		self.update_no_of_own_vehicles()
 
 	def before_update_after_submit(self):
 		self.update_no_of_own_vehicles()

--- a/beams/beams/doctype/vehicle_log_detail/vehicle_log_detail.json
+++ b/beams/beams/doctype/vehicle_log_detail/vehicle_log_detail.json
@@ -27,7 +27,6 @@
   {
    "fieldname": "vehicle_type",
    "fieldtype": "Data",
-   "in_list_view": 1,
    "label": "Vehicle Type"
   },
   {
@@ -79,13 +78,14 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-04-23 16:29:53.868218",
+ "modified": "2025-08-25 11:26:26.824290",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Vehicle Log Detail",
  "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []


### PR DESCRIPTION

## Feature description
Need to: 
- Adjust field permission of Vehicle Detail based on workflow state  Pending Approval  and user role Admin
- Ensure fields like No.of Own Vehicles is always visible 
- Remove the in list view  of  vehicle type field in Vehicle Log Detail  doctype

## Solution description
- Adjusted field permission of Vehicle Detail based on workflow state  Pending Approval  and user role Admin
- Ensured fields like No.of Own Vehicles is always visible 
- Removed the in list view  of  vehicle type field in Vehicle Log Detail  doctype

## Output screenshots (optional)
[Screencast from 25-08-25 11:50:27 AM IST.webm](https://github.com/user-attachments/assets/c2ab3958-7e5e-4955-b1ec-a0aca41082a5)

[Screencast from 25-08-25 11:51:18 AM IST.webm](https://github.com/user-attachments/assets/03980a0d-3e68-4a2c-8765-b7337cd14d83)


## Areas affected and ensured
Transportation Request doctype

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
