### PR TITLE
fix:sync hired personnel from ERR to TR

### DIFF
--- a/beams/beams/doctype/external_resource_request/external_resource_request.py
+++ b/beams/beams/doctype/external_resource_request/external_resource_request.py
@@ -112,5 +112,4 @@ class ExternalResourceRequest(Document):
 				emp_row.hired_personnel = resource.hired_personnel
 				emp_row.save(ignore_permissions=True)
 
-		tech_req.reload()
 		frappe.msgprint(f"Hired Personnel synced to Technical Request {tech_req.name}")

--- a/beams/beams/doctype/external_resource_request/external_resource_request.py
+++ b/beams/beams/doctype/external_resource_request/external_resource_request.py
@@ -107,13 +107,10 @@ class ExternalResourceRequest(Document):
 			frappe.throw("Required tables are missing in the External Resource Request or Technical Request doctype.")
 
 		for resource in self.required_resources:
-			for emp in tech_req.required_employees:
-				if (
-					resource.designation == emp.designation
-					and get_datetime(resource.required_from) == get_datetime(emp.required_from)
-					and get_datetime(resource.required_to) == get_datetime(emp.required_to)
-				):
-					emp.hired_personnel = resource.hired_personnel
+			if resource.hired_personnel and resource.technical_request_employee:
+				emp_row = frappe.get_doc("Technical Request Details", resource.technical_request_employee)
+				emp_row.hired_personnel = resource.hired_personnel
+				emp_row.save(ignore_permissions=True)
 
-		tech_req.save(ignore_permissions=True)
+		tech_req.reload()
 		frappe.msgprint(f"Hired Personnel synced to Technical Request {tech_req.name}")

--- a/beams/beams/doctype/external_resource_request/external_resource_request.py
+++ b/beams/beams/doctype/external_resource_request/external_resource_request.py
@@ -108,8 +108,11 @@ class ExternalResourceRequest(Document):
 
 		for resource in self.required_resources:
 			if resource.hired_personnel and resource.technical_request_employee:
-				emp_row = frappe.get_doc("Technical Request Details", resource.technical_request_employee)
-				emp_row.hired_personnel = resource.hired_personnel
-				emp_row.save(ignore_permissions=True)
+				frappe.db.set_value(
+					"Technical Request Details",
+					resource.technical_request_employee,
+					"hired_personnel",
+					resource.hired_personnel
+				)
 
 		frappe.msgprint(f"Hired Personnel synced to Technical Request {tech_req.name}")

--- a/beams/beams/doctype/external_resources_detail/external_resources_detail.json
+++ b/beams/beams/doctype/external_resources_detail/external_resources_detail.json
@@ -11,7 +11,8 @@
   "required_from",
   "required_to",
   "hired_personnel",
-  "contact_number"
+  "contact_number",
+  "technical_request_employee"
  ],
  "fields": [
   {
@@ -54,17 +55,25 @@
    "in_list_view": 1,
    "label": "Department",
    "options": "Department"
+  },
+  {
+   "fieldname": "technical_request_employee",
+   "fieldtype": "Link",
+   "label": "Technical Request Employee",
+   "options": "Technical Request Details",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-04-16 16:33:35.122701",
+ "modified": "2025-08-26 11:23:24.104844",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "External Resources Detail",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/beams/beams/doctype/external_resources_detail/external_resources_detail.json
+++ b/beams/beams/doctype/external_resources_detail/external_resources_detail.json
@@ -59,15 +59,15 @@
   {
    "fieldname": "technical_request_employee",
    "fieldtype": "Link",
+   "hidden": 1,
    "label": "Technical Request Employee",
-   "options": "Technical Request Details",
-   "read_only": 1
+   "options": "Technical Request Details"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-08-26 11:23:24.104844",
+ "modified": "2025-08-26 17:23:48.680658",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "External Resources Detail",

--- a/beams/beams/doctype/required_manpower_details/required_manpower_details.json
+++ b/beams/beams/doctype/required_manpower_details/required_manpower_details.json
@@ -20,7 +20,8 @@
    "ignore_user_permissions": 1,
    "in_list_view": 1,
    "label": "Department",
-   "options": "Department"
+   "options": "Department",
+   "reqd": 1
   },
   {
    "fieldname": "designation",
@@ -28,19 +29,22 @@
    "ignore_user_permissions": 1,
    "in_list_view": 1,
    "label": "Designation",
-   "options": "Designation"
+   "options": "Designation",
+   "reqd": 1
   },
   {
    "fieldname": "required_from",
    "fieldtype": "Datetime",
    "in_list_view": 1,
-   "label": "Required From"
+   "label": "Required From",
+   "reqd": 1
   },
   {
    "fieldname": "required_to",
    "fieldtype": "Datetime",
    "in_list_view": 1,
-   "label": "Required To"
+   "label": "Required To",
+   "reqd": 1
   },
   {
    "fieldname": "column_break_cott",
@@ -51,18 +55,20 @@
    "fieldname": "no_of_employees",
    "fieldtype": "Int",
    "in_list_view": 1,
-   "label": "No. of Employees"
+   "label": "No. of Employees",
+   "reqd": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-04-05 14:40:19.146465",
+ "modified": "2025-08-26 12:27:12.742223",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Required Manpower Details",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/beams/beams/doctype/technical_request/technical_request.py
+++ b/beams/beams/doctype/technical_request/technical_request.py
@@ -117,7 +117,8 @@ def create_external_resource_request(technical_request):
 				"department": emp.department,
 				"designation": emp.designation,
 				"required_from": emp.required_from,
-				"required_to": emp.required_to
+				"required_to": emp.required_to,
+				"technical_request_employee": emp.name
 			})
 
 	external_req.insert(ignore_permissions=True)

--- a/beams/beams/doctype/technical_request_details/technical_request_details.json
+++ b/beams/beams/doctype/technical_request_details/technical_request_details.json
@@ -53,13 +53,14 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Hired Personnel",
-   "options": "Supplier"
+   "options": "Supplier",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-08-22 17:27:46.695849",
+ "modified": "2025-08-26 11:24:06.330505",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Technical Request Details",


### PR DESCRIPTION
## Feature description
sync hired personnel from External Resource Request to Technical Request via linked row

## Solution description
TASK-2025-02033
issue:
In the Technical Request, we can directly add employees.
If employees are not added, then we use the Create button to generate an External Resource Request.
Through the External Resource Request, the required personnel are hired, and the supplier is added there.
When the External Resource Request is submitted, the hired employees should be updated in the corresponding rows of the Technical Request. previously hired person adding every row against the designation or department 

-sync hired personnel from External Resource Request to Technical Request via linked row

- Matching by designation and dates can cause issues (duplicates, mismatched rows, multiple employees with same designation). 
- The direct link (resource.technical_request_employee) is much more reliable, because it points exactly to the Technical Request child row.

- Added technical_request_employee link field in External Resources Detail to track the originating Technical Request Details row.
- Updated create_external_resource_request to store the emp.name (child row ID from Technical Request) in this link field.
- Modified update_technical_req to update hired_personnel in the corresponding Technical Request row by looking up this link instead of matching designation and dates.
- Made hired_personnel field in Technical Request Details read-only since it is now system-updated.
- Adjusted validations in Required Manpower Details to mark department, designation, required_from, required_to, and no_of_employees as required.
- Ensured External Resource Request → submit will now properly sync all hired personnel back to Technical Request.

## Output screenshots (optional)
<img width="1431" height="873" alt="image" src="https://github.com/user-attachments/assets/a55f1c4e-3d4f-4cdb-8b6d-ad9ccc6f0335" />

<img width="1431" height="873" alt="image" src="https://github.com/user-attachments/assets/477be45c-b131-478c-a88e-768f22486390" />

[Screencast from 26-08-25 01:12:29 PM IST.webm](https://github.com/user-attachments/assets/57124107-601d-4798-88ab-1416e0d687bf)

<img width="1431" height="873" alt="image" src="https://github.com/user-attachments/assets/bc55f903-2987-4e62-86c4-2584964c8304" />


## Areas affected and ensured

- project
-  External Resource Request 
-  Technical Request

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - yes
  - Opera Mini
  - Safari
