### PR TITLE
TASK-2025-02041:Validate employee allocation

### DIFF
--- a/beams/beams/custom_scripts/project/project.py
+++ b/beams/beams/custom_scripts/project/project.py
@@ -312,55 +312,6 @@ def update_program_request_status_on_project_completion(doc, method):
 				program_request.save()  # Save the document
 
 @frappe.whitelist()
-def validate_employee_assignment(doc, method):
-	"""
-	Validate that an employee is not assigned to multiple projects during the same time period.
-	"""
-	for row in doc.allocated_manpower_details:
-		if not row.employee:
-			continue
-		overlapping_projects = frappe.get_all(
-			"Allocated Manpower Detail",
-			filters={
-				"employee": row.employee,
-				"parent": ["!=", doc.name],
-				"assigned_from": ["<=", row.assigned_to],
-				"assigned_to": [">=", row.assigned_from],
-				"parenttype": "Technical Request",
-				"parentfield": "allocated_manpower_details",
-			},
-			pluck="parent"
-		)
-		if overlapping_projects:
-			employee_name = frappe.get_value("Employee", row.employee, "employee_name")
-			frappe.throw(f"Employee {employee_name} ({row.employee}) is already assigned to another project ({', '.join(overlapping_projects)}) within the same time period.")
-
-@frappe.whitelist()
-def validate_employee_assignment_in_same_project(doc, method):
-	'''
-	Validate that an employee is not assigned to multiple roles/tasks within the same project during the same time period.
-	'''
-	employee_assignments = {}
-
-	for row in doc.allocated_manpower_details:
-		if not row.employee:
-			continue
-
-		if row.employee not in employee_assignments:
-			employee_assignments[row.employee] = []
-
-		for existing_row in employee_assignments[row.employee]:
-			if (
-				(existing_row.assigned_from <= row.assigned_to) and
-				(existing_row.assigned_to >= row.assigned_from)
-			):
-				employee_name = frappe.get_value("Employee", row.employee, "employee_name")
-				frappe.throw(f"Employee {employee_name} ({row.employee}) is already assigned to another task or role within the same project ({doc.name}) during the same time period.")
-
-		employee_assignments[row.employee].append(row)
-
-
-@frappe.whitelist()
 def create_equipment_request(source_name, equipment_data, required_from, required_to):
 	"""Creates an Equipment Request for a project with multiple items."""
 

--- a/beams/beams/doctype/technical_request/technical_request.js
+++ b/beams/beams/doctype/technical_request/technical_request.js
@@ -2,83 +2,83 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Technical Request', {
-    refresh: function(frm) {
-        set_employee_field_read_only(frm);
-        set_employee_query(frm);
+	refresh: function(frm) {
+		set_employee_field_read_only(frm);
+		set_employee_query(frm);
 
-        const read_only_fields = ['project','bureau', 'location','posting_date', 'required_from', 'required_to'];
-        const should_be_read_only = !frm.is_new() && frm.doc.workflow_state === 'Draft';
-        read_only_fields.forEach(field => {
-            frm.set_df_property(field, 'read_only', should_be_read_only);
-        });
+		const read_only_fields = ['project','bureau', 'location','posting_date', 'required_from', 'required_to'];
+		const should_be_read_only = !frm.is_new() && frm.doc.workflow_state === 'Draft';
+		read_only_fields.forEach(field => {
+			frm.set_df_property(field, 'read_only', should_be_read_only);
+		});
 
-        if (!frm.is_new() && frm.doc.workflow_state !== "Draft") {
-            frm.add_custom_button("External Resource Request", function() {
-                frappe.call({
-                    method: "beams.beams.doctype.technical_request.technical_request.create_external_resource_request",
-                    args: {
-                          technical_request: frm.doc.name
-                      },
-                      callback: function(response) {
-                          if (response.message) {
-                              frappe.set_route("Form", "External Resource Request", response.message);
-                          }
-                      }
-                  });
-              }, __("Create"));
-        }
-      },
-      workflow_state: function(frm) {
-        set_employee_field_read_only(frm);
-    },
+		if (!frm.is_new() && frm.doc.workflow_state === "Pending Allocation" || frm.doc.workflow_state === "Allocated by HOD") {
+			frm.add_custom_button("External Resource Request", function() {
+				frappe.call({
+					method: "beams.beams.doctype.technical_request.technical_request.create_external_resource_request",
+					args: {
+						  technical_request: frm.doc.name
+					  },
+					  callback: function(response) {
+						  if (response.message) {
+							  frappe.set_route("Form", "External Resource Request", response.message);
+						  }
+					  }
+				  });
+			  }, __("Create"));
+		}
+	  },
+	  workflow_state: function(frm) {
+		set_employee_field_read_only(frm);
+	},
 
-    posting_date:function (frm){
-        frm.call("validate_posting_date");
-      },
+	posting_date:function (frm){
+		frm.call("validate_posting_date");
+	  },
 
-    required_employees: function(frm) {
-        set_employee_query(frm);
-    },
+	required_employees: function(frm) {
+		set_employee_query(frm);
+	},
 
-    designation: function(frm) {
-        set_employee_query(frm);
-    },
+	designation: function(frm) {
+		set_employee_query(frm);
+	},
 
-    // Trigger validation when the "required_from" field is updated
-    required_from: function(frm) {
-        frm.call("validate_required_from_and_required_to");
-    },
+	// Trigger validation when the "required_from" field is updated
+	required_from: function(frm) {
+		frm.call("validate_required_from_and_required_to");
+	},
 
-    required_to: function(frm) {
-        frm.call("validate_required_from_and_required_to");
-    }
+	required_to: function(frm) {
+		frm.call("validate_required_from_and_required_to");
+	}
 });
 
 function set_employee_query(frm) {
-    let current_user = frappe.session.user;
+	let current_user = frappe.session.user;
 
-    frm.fields_dict['required_employees'].grid.get_field("employee").get_query = function(doc, cdt, cdn) {
-        let child = locals[cdt][cdn];
+	frm.fields_dict['required_employees'].grid.get_field("employee").get_query = function(doc, cdt, cdn) {
+		let child = locals[cdt][cdn];
 
-        // Get all selected employees
-        let selected_employees = (doc.required_employees || []).map(row => row.employee).filter(emp => emp);
+		// Get all selected employees
+		let selected_employees = (doc.required_employees || []).map(row => row.employee).filter(emp => emp);
 
-        return {
-            filters: {
-                department: child.department,
-                designation: child.designation,
-                name: ["not in", selected_employees] // Exclude already selected employees
-            }
-        };
-    };
+		return {
+			filters: {
+				department: child.department,
+				designation: child.designation,
+				name: ["not in", selected_employees] // Exclude already selected employees
+			}
+		};
+	};
 }
 
 
 function set_employee_field_read_only(frm) {
-    if (frm.doc.workflow_state === "Draft") {
-        frm.fields_dict["required_employees"].grid.update_docfield_property("employee", "read_only", 1);
-    } else {
-        frm.fields_dict["required_employees"].grid.update_docfield_property("employee", "read_only", 0);
-    }
-    frm.refresh_field("required_employees");
+	if (frm.doc.workflow_state === "Draft") {
+		frm.fields_dict["required_employees"].grid.update_docfield_property("employee", "read_only", 1);
+	} else {
+		frm.fields_dict["required_employees"].grid.update_docfield_property("employee", "read_only", 0);
+	}
+	frm.refresh_field("required_employees");
 }

--- a/beams/beams/doctype/technical_request/technical_request.js
+++ b/beams/beams/doctype/technical_request/technical_request.js
@@ -12,7 +12,7 @@ frappe.ui.form.on('Technical Request', {
 			frm.set_df_property(field, 'read_only', should_be_read_only);
 		});
 
-		if (!frm.is_new() && frm.doc.workflow_state === "Pending Allocation" || frm.doc.workflow_state === "Allocated by HOD") {
+		if (!frm.is_new() && frm.doc.workflow_state === "Pending Allocation") {
 			frm.add_custom_button("External Resource Request", function() {
 				frappe.call({
 					method: "beams.beams.doctype.technical_request.technical_request.create_external_resource_request",

--- a/beams/beams/doctype/technical_request/technical_request.json
+++ b/beams/beams/doctype/technical_request/technical_request.json
@@ -72,9 +72,11 @@
   },
   {
    "allow_on_submit": 1,
+   "depends_on": "eval: doc.workflow_state == 'Allocated by HOD' || doc.workflow_state == 'Rejected';",
    "fieldname": "reason_for_rejection",
    "fieldtype": "Small Text",
-   "label": "Reason for Rejection"
+   "label": "Reason for Rejection",
+   "read_only_depends_on": "eval: doc.workflow_state == 'Rejected';"
   },
   {
    "fieldname": "amended_from",
@@ -110,7 +112,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-08-22 14:41:16.538224",
+ "modified": "2025-08-27 04:23:20.799096",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Technical Request",

--- a/beams/beams/doctype/technical_request/technical_request.py
+++ b/beams/beams/doctype/technical_request/technical_request.py
@@ -128,10 +128,14 @@ class TechnicalRequest(Document):
 						"Employee", row.employee, "employee_name"
 					)
 					frappe.throw(
-						f"Employee {employee_name} ({row.employee}) is already allocated "
-						f"in Project {self.project} during the same time period "
-						f"({alloc.assigned_from} to {alloc.assigned_to})."
+						title="Allocation Error",
+						msg=(
+							f"Employee {employee_name} ({row.employee}) is already allocated "
+							f"in Project {self.project} during the same time period "
+							f"({alloc.assigned_from} to {alloc.assigned_to})."
+						)
 					)
+
 
 	@frappe.whitelist()
 	def validate_employee_assignment_in_projects(self):
@@ -164,10 +168,14 @@ class TechnicalRequest(Document):
 				if (alloc.assigned_from <= row.required_to) and (alloc.assigned_to >= row.required_from):
 					employee_name = frappe.get_value("Employee", row.employee, "employee_name")
 					frappe.throw(
-						f"Employee {employee_name} ({row.employee}) is already allocated "
-						f"in Project {alloc.parent} during the same time period "
-						f"({alloc.assigned_from} to {alloc.assigned_to})."
+						title="Allocation Error",
+						msg=(
+							f"Employee {employee_name} ({row.employee}) is already allocated "
+							f"in Project {alloc.parent} during the same time period "
+							f"({alloc.assigned_from} to {alloc.assigned_to})."
+						)
 					)
+
 
 @frappe.whitelist()
 def create_external_resource_request(technical_request):

--- a/beams/beams/doctype/technical_request/technical_request.py
+++ b/beams/beams/doctype/technical_request/technical_request.py
@@ -132,6 +132,7 @@ class TechnicalRequest(Document):
 						f"in Project {self.project} during the same time period "
 						f"({alloc.assigned_from} to {alloc.assigned_to})."
 					)
+
 	@frappe.whitelist()
 	def validate_employee_assignment_in_projects(self):
 		"""

--- a/beams/beams/doctype/technical_request/technical_request.py
+++ b/beams/beams/doctype/technical_request/technical_request.py
@@ -8,20 +8,18 @@ from frappe import _
 from frappe.model.mapper import get_mapped_doc
 from frappe.utils import today
 from frappe.utils import get_datetime
+from datetime import datetime
 
 class TechnicalRequest(Document):
 	def before_save(self):
 		self.validate_posting_date()
 
-	def on_cancel(self):
-		# Validate that "Reason for Rejection" is filled if the status is "Rejected"
-		if self.workflow_state == "Rejected" and not self.reason_for_rejection:
-			frappe.throw("Please provide a Reason for Rejection before rejecting this request.")
-
 	def validate(self):
 		self.validate_required_from_and_required_to()
-		if self.workflow_state == "Approved":
+		if self.workflow_state == "Allocated by HOD":
 			self.validate_employee_before_approvel()
+			self.validate_employee_assignment()
+			self.validate_employee_assignment_in_projects()
 
 		# Validate that 'Reason for Rejection' is not filled if the status is 'Approved'
 		if self.workflow_state == "Approved" and self.reason_for_rejection:
@@ -29,6 +27,9 @@ class TechnicalRequest(Document):
 		if self.workflow_state == "Approved" and self.project:
 			self.update_project_allocated_resources()
 			update_allocated_field(self)
+		# Validate that "Reason for Rejection" is filled if the status is "Rejected"
+		if self.workflow_state == "Rejected" and not self.reason_for_rejection:
+			frappe.throw("Please provide a Reason for Rejection before rejecting this request.")
 
 	def validate_employee_before_approvel(self):
 		"""Validate employee field in Required Employees before approving Technical Request"""
@@ -93,6 +94,79 @@ class TechnicalRequest(Document):
 		if self.posting_date:
 			if getdate(self.posting_date) > getdate(today()):
 				frappe.throw(_("Posting Date cannot be set after today's date."))
+
+	@frappe.whitelist()
+	def validate_employee_assignment(self):
+		"""
+		Check if employees required in Technical Request are already
+		allocated in the same project (in Project -> Allocated Manpower Details).
+		"""
+		if not self.project:
+			return
+
+		# Get existing allocations from Project's child table
+		allocated_rows = frappe.get_all(
+			"Allocated Manpower Detail",
+			filters={"parent": self.project},
+			fields=["employee", "assigned_from", "assigned_to"]
+		)
+
+		for row in self.required_employees:
+			if not row.employee:
+				continue
+
+			for alloc in allocated_rows:
+				if alloc.employee != row.employee:
+					continue
+
+				# Check overlapping date ranges
+				if (
+					(alloc.assigned_from <= row.required_to)
+					and (alloc.assigned_to >= row.required_from)
+				):
+					employee_name = frappe.get_value(
+						"Employee", row.employee, "employee_name"
+					)
+					frappe.throw(
+						f"Employee {employee_name} ({row.employee}) is already allocated "
+						f"in Project {self.project} during the same time period "
+						f"({alloc.assigned_from} to {alloc.assigned_to})."
+					)
+	@frappe.whitelist()
+	def validate_employee_assignment_in_projects(self):
+		"""
+		Validate that an employee is not assigned to multiple projects
+		during the same time period.
+		"""
+		if not self.project:
+			return
+
+		# Get allocated manpower for all projects
+		allocated_rows = frappe.get_all(
+			"Allocated Manpower Detail",
+			fields=["parent", "employee", "assigned_from", "assigned_to"]
+		)
+
+		for row in self.required_employees:
+			if not row.employee:
+				continue
+
+			for alloc in allocated_rows:
+				# Skip if same project
+				if alloc.parent == self.project:
+					continue
+
+				if alloc.employee != row.employee:
+					continue
+
+				# Check overlapping dates
+				if (alloc.assigned_from <= row.required_to) and (alloc.assigned_to >= row.required_from):
+					employee_name = frappe.get_value("Employee", row.employee, "employee_name")
+					frappe.throw(
+						f"Employee {employee_name} ({row.employee}) is already allocated "
+						f"in Project {alloc.parent} during the same time period "
+						f"({alloc.assigned_from} to {alloc.assigned_to})."
+					)
 
 @frappe.whitelist()
 def create_external_resource_request(technical_request):

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -355,8 +355,6 @@ doc_events = {
 			"beams.beams.custom_scripts.project.project.auto_return_equipment_on_project_completion"
 		],
 		"validate": [
-		   "beams.beams.custom_scripts.project.project.validate_employee_assignment",
-		   "beams.beams.custom_scripts.project.project.validate_employee_assignment_in_same_project",
 		   "beams.beams.custom_scripts.project.project.validate_vehicle_assignment_in_same_project"
 		],
 	},


### PR DESCRIPTION
## Feature description
Need to:
- Validate that an employee is not assigned to multiple roles within the same project during  the same time period. 
- Validate that an employee is not assigned to multiple projects during the same time period.
- ensure External Resource Request button is visible only for Pending Allocation workflow state

## Solution description
- Validated that an employee is not assigned to multiple roles within the same project during  the same time period. (here the code is removed from project.py and hooks and it coded in technical request.py)

- Validate that an employee is not assigned to multiple projects during the same time period.(here the code is removed from project.py and hooks and it coded in technical request.py)

- ensure External Resource Request button is visible only for Pending Allocation  workflow state
- Converted codes into indentation tab space

## Output screenshots (optional)
[Screencast from 27-08-25 04:54:57 AM IST.webm](https://github.com/user-attachments/assets/10d29b1f-4f7c-4d6d-8062-f7fd854a9082)

[Screencast from 27-08-25 04:56:53 AM IST.webm](https://github.com/user-attachments/assets/0821916a-9727-4742-8960-60d67833af57)

[Screencast from 27-08-25 05:06:01 AM IST.webm](https://github.com/user-attachments/assets/0a30ec4d-5c07-41d1-8683-e629366cf99c)


## Areas affected and ensured
Technical Request doctype

## Is there any existing behavior change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?
  - Chrome
 
