### PR TITLE
refact:Renamed Spare Part Item Table as Material Request Item

### DIFF
--- a/beams/beams/custom_scripts/hd_ticket/hd_ticket.js
+++ b/beams/beams/custom_scripts/hd_ticket/hd_ticket.js
@@ -8,8 +8,6 @@ frappe.ui.form.on('HD Ticket', {
 
     refresh(frm) {
         frm.clear_custom_buttons();
-        handle_agent_visibility(frm);
-
         if (frm.doc.material_request_needed) {
             add_material_request_button(frm);
         }
@@ -32,31 +30,14 @@ frappe.ui.form.on('HD Ticket', {
 });
 
 /*
-   Restricts field visibility for users who do not have the "Agent" role.
-   Only the defined fields remain visible to non-Agents.
-*/
-function handle_agent_visibility(frm) {
-    if (!frappe.user.has_role('Agent')) {
-        const visible_fields = ['subject', 'raised_by','raised_for', 'description','ticket_type'];
-        frm.fields.forEach(field => {
-            const name = field.df.fieldname;
-            if (name && !['Section Break', 'Column Break'].includes(field.df.fieldtype)) {
-                frm.set_df_property(name, 'hidden', !visible_fields.includes(name));
-            }
-        });
-        frm.refresh_fields();
-    }
-}
-
-/*
   Adds a "Material Request" button under the "Create" group in the form.
   On click, it creates a new "Material Request" document.
-  Populates items from the 'spare_part_item_table' child table of HD Ticket.
+  Populates items from the 'material_request_items' child table of HD Ticket.
 */
 function add_material_request_button(frm) {
     frm.add_custom_button(__('Material Request'), () => {
         frappe.new_doc('Material Request', {
-            items: (frm.doc.spare_part_item_table || []).map(row => ({
+            items: (frm.doc.material_request_items || []).map(row => ({
                 item_code: row.item,
                 qty: row.quantity,
                 schedule_date: row.required_by

--- a/beams/beams/doctype/material_request_items/material_request_items.json
+++ b/beams/beams/doctype/material_request_items/material_request_items.json
@@ -39,7 +39,7 @@
  "modified": "2025-08-22 11:56:12.556651",
  "modified_by": "Administrator",
  "module": "BEAMS",
- "name": "Spare Part Item",
+ "name": "Material Request Items",
  "owner": "Administrator",
  "permissions": [],
  "row_format": "Dynamic",

--- a/beams/beams/doctype/material_request_items/material_request_items.py
+++ b/beams/beams/doctype/material_request_items/material_request_items.py
@@ -5,5 +5,5 @@
 from frappe.model.document import Document
 
 
-class SparePartItem(Document):
+class MaterialRequestItems(Document):
 	pass

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -205,11 +205,11 @@ def get_hd_ticket_custom_fields():
                 "insert_after": "ticket_section_break"
             },
             {
-                "fieldname": "spare_part_item_table",
+                "fieldname": "material_request_items",
                 "fieldtype": "Table",
-                "label": "Spare Part Items",
+                "label": "Material Request Items",
                 "insert_after": "material_request_needed",
-                "options": "Spare Part Item",
+                "options": "Material Request Items",
                 "depends_on": "eval:doc.material_request_needed == 1"
             }
         ]
@@ -4591,6 +4591,30 @@ def get_property_setters():
 			"field_name": "schedule_date",
 			"property":"default",
 			"value": "Today"
+		},
+		{
+			"doctype_or_field": "DocField",
+			"doc_type": "Project",
+			"field_name": "users_section",
+			"property": "hidden",
+			"property_type": "Section Break",
+			"value": 1
+		},
+		{
+			"doctype_or_field": "DocField",
+			"doc_type": "Project",
+			"field_name": "percent_complete_method",
+			"property": "hidden",
+			"property_type": "Select",
+			"value": 1
+		},
+		{
+			"doctype_or_field": "DocField",
+			"doc_type": "Project",
+			"field_name": "percent_complete",
+			"property": "hidden",
+			"property_type": "Percent",
+			"value": 1
 		}
 ]
 


### PR DESCRIPTION
## Feature description

1. Rename Spare Item Table as Material Request Item
2. Remove functionality that restrict visibility of fields for non agent users
3. Hide users section of Project doctype
4. hide fields Percent Complete Method and Percent Complete fields of Project doctype.

## Solution description
Child table renamed as Material Request Item and material request can be created for items selected in the child table.
Non Agent users are also made to see all fields of HD Ticket doctype.
fields were hidden from Project doctype.

## Output screenshots (optional)
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a7308597-15b6-46be-860d-e54705e9c87b" />


## Areas affected and ensured
HD Ticket doctype and Project doctype.

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox

