### PR TITLE
feat:populate manpower required from and required to with project dates

### DIFF
--- a/beams/beams/custom_scripts/project/project.js
+++ b/beams/beams/custom_scripts/project/project.js
@@ -296,11 +296,20 @@ frappe.ui.form.on('Project', {
       }
   });
 
-  frappe.ui.form.on('Required Manpower Details', {
-      required_to: function(frm, cdt, cdn) {
-          validate_dates(cdt, cdn);
-      }
-  });
+frappe.ui.form.on('Required Manpower Details', {
+	required_to: function(frm, cdt, cdn) {
+		validate_dates(cdt, cdn);
+	},
+	// Auto-set Required From & Required To in manpower details child table based on Project's Expected Start & End Dates
+	required_manpower_details_add: function(frm, cdt, cdn){
+		if (frm.doc.expected_start_date){
+			frappe.model.set_value(cdt, cdn, 'required_from', frm.doc.expected_start_date)
+		}
+		if (frm.doc.expected_end_date){
+			frappe.model.set_value(cdt, cdn, 'required_to', frm.doc.expected_end_date)
+		}
+	}
+});
 
   function validate_dates(cdt, cdn) {
       let row = locals[cdt][cdn];


### PR DESCRIPTION
## Feature description
populate manpower required_from and required_to with project dates

## Solution description

- [ ] TASK-2025-02031

- auto-set manpower required_from and required_to from project dates
- On adding a row in Required Manpower Details, set `required_from` = Project Expected Start Date
  and `required_to` = Project Expected End Date.
- Keeps child table aligned with project timeline by default.

## Output screenshots (optional)

[Screencast from 27-08-25 02:25:34 PM IST.webm](https://github.com/user-attachments/assets/f0b77e19-ac35-4420-aa05-c5644e716bc5)

## Areas affected and ensured

- project

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - yes
  - Opera Mini
  - Safari
