### PR TITLE
TASK-2025-02054:ToDo creation for Operations Users when a Project is created

### DIFF
--- a/beams/beams/doctype/program_request/program_request.json
+++ b/beams/beams/doctype/program_request/program_request.json
@@ -25,6 +25,8 @@
   "description",
   "requirements",
   "section_break_tzpl",
+  "reason_for_revision",
+  "reason_for_rejection",
   "amended_from"
  ],
  "fields": [
@@ -147,12 +149,27 @@
    "fieldtype": "Float",
    "label": "Expected Revenue",
    "mandatory_depends_on": "eval:doc.generates_revenue == 1\n"
+  },
+  {
+   "allow_on_submit": 1,
+   "depends_on": "eval: doc.workflow_state == 'Request for Approval' || doc.workflow_state == 'Rejected';",
+   "fieldname": "reason_for_rejection",
+   "fieldtype": "Small Text",
+   "label": "Reason for Rejection",
+   "read_only_depends_on": "eval: doc.workflow_state == 'Rejected';"
+  },
+  {
+   "depends_on": "eval:doc.workflow_state == 'Request for Approval' || \"doc.workflow_state == 'Draft'\"\n",
+   "fieldname": "reason_for_revision",
+   "fieldtype": "Small Text",
+   "label": "Reason for Revision",
+   "read_only_depends_on": "eval: doc.workflow_state !='Request for Approval';"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-04-05 15:48:07.334627",
+ "modified": "2025-08-27 12:55:29.768393",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Program Request",
@@ -173,6 +190,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []


### PR DESCRIPTION
## Feature description
Need to:

- Create ToDo for Operations Users when a Project is created from Program Request
- Update Program request doctype base program request workflow updation
- Add Reason for Rejection field in program request doctype and validate it 
- Add Reason for Revision in program request doctype and validate it 

## Solution description
- Create ToDo for Operations Users when a Project is created from Program Request
- Update Program request doctype base program request workflow updation
- Add Reason for Rejection field in program request doctype and validate it 
- Add Reason for Revision in program request doctype and validate it 

## Output screenshots (optional)
[Screencast from 27-08-25 03:21:15 PM IST.webm](https://github.com/user-attachments/assets/8b3a7038-4196-42d2-b392-52a76d87c39e)


## Areas affected and ensured
Program Request doctype

## Is there any existing behavior change of other features due to this code change?
No. 

## Was this feature tested on the browsers?
  - Chrome
