### PR TITLE
fix:enforce rejection reason and align workflow state handling

### DIFF
--- a/beams/beams/doctype/equipment_acquiral_request/equipment_acquiral_request.js
+++ b/beams/beams/doctype/equipment_acquiral_request/equipment_acquiral_request.js
@@ -3,7 +3,7 @@
 
 frappe.ui.form.on("Equipment Acquiral Request", {
     refresh(frm) {
-        if (frm.doc.docstatus === 1 && frm.doc.workflow_state === 'Approved') {
+        if (frm.doc.docstatus === 1 && frm.doc.workflow_state === 'Initiate a Purchase Order') {
             // Check if all required_items are fully acquired
             let all_acquired = frm.doc.required_items.every(row => row.quantity == row.acquired_qty);
 

--- a/beams/beams/doctype/equipment_acquiral_request/equipment_acquiral_request.json
+++ b/beams/beams/doctype/equipment_acquiral_request/equipment_acquiral_request.json
@@ -89,11 +89,12 @@
   },
   {
    "allow_on_submit": 1,
-   "depends_on": "eval: doc.workflow_state == \"Pending Approval\" || doc.workflow_state == \"Rejected\";",
+   "depends_on": "eval: doc.workflow_state == \"Pending Admin Approval\" || doc.workflow_state == \"Rejected\";",
    "fieldname": "reason_for_rejection",
    "fieldtype": "Small Text",
    "label": "Reason for Rejection",
-   "read_only_depends_on": "eval: doc.workflow_state != \"Pending Approval\";"
+   "read_only": 1,
+   "read_only_depends_on": "eval: doc.workflow_state != \"Pending Admin Approval\";"
   },
   {
    "fetch_from": "project.location",
@@ -111,10 +112,11 @@
    "read_only": 1
   }
  ],
+ "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-03-19 12:11:50.645046",
+ "modified": "2025-08-28 11:59:57.337797",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Equipment Acquiral Request",
@@ -135,6 +137,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/beams/beams/doctype/equipment_acquiral_request/equipment_acquiral_request.py
+++ b/beams/beams/doctype/equipment_acquiral_request/equipment_acquiral_request.py
@@ -3,42 +3,41 @@
 
 import frappe
 from frappe.model.document import Document
-from frappe.utils import getdate  # Import getdate function
-from frappe import _  # Import _ for translations
+from frappe.utils import getdate
+from frappe import _
 from frappe.utils import today
 
 class EquipmentAcquiralRequest(Document):
-    def validate(self):
-        self.validate_required_from_and_required_to()
+	def validate(self):
+		self.validate_required_from_and_required_to()
 
-    def before_save(self):
-        self.validate_posting_date()
+	def before_save(self):
+		self.validate_posting_date()
 
-    def on_update_after_submit(self):
-        # Validate that 'Reason for Rejection' is not filled if the status is 'Approved'
-        if self.workflow_state == "Approved" and self.reason_for_rejection:
-            frappe.throw(title="Approval Error", msg="You cannot approve this request if 'Reason for Rejection' is filled.")
+	def on_update_after_submit(self):
+		if self.workflow_state == "Rejected" and not self.reason_for_rejection:
+			frappe.throw("Please provide a Reason for Rejection before rejecting this request.")
 
-    @frappe.whitelist()
-    def validate_required_from_and_required_to(self):
-        """
-        Validates that required_from and required_to are properly set and checks
-        if required_from is not later than required_to.
-        """
-        if not self.required_from or not self.required_to:
-            return
-        required_from = getdate(self.required_from)
-        required_to = getdate(self.required_to)
+	@frappe.whitelist()
+	def validate_required_from_and_required_to(self):
+		"""
+		Validates that required_from and required_to are properly set and checks
+		if required_from is not later than required_to.
+		"""
+		if not self.required_from or not self.required_to:
+			return
+		required_from = getdate(self.required_from)
+		required_to = getdate(self.required_to)
 
-        if required_from > required_to:
-            frappe.throw(
-                msg=_('The "Required From" date cannot be after the "Required To" date.'),
-                title=_('Validation Error')
-            )
+		if required_from > required_to:
+			frappe.throw(
+				msg=_('The "Required From" date cannot be after the "Required To" date.'),
+				title=_('Validation Error')
+			)
 
 
-    @frappe.whitelist()
-    def validate_posting_date(self):
-        if self.posting_date:
-            if self.posting_date > today():
-                frappe.throw(_("Posting Date cannot be set after today's date."))
+	@frappe.whitelist()
+	def validate_posting_date(self):
+		if self.posting_date:
+			if getdate(self.posting_date) > getdate(today()):
+				frappe.throw(_("Posting Date cannot be set after today's date."))


### PR DESCRIPTION
## Feature description
enforce rejection reason and align workflow state handling

## Solution description

- [x] TASK-2025-02068

**Reason for Rejection validation**

    Added server-side check in on_update_after_submit to ensure that when workflow state is set to Rejected,
    a Reason for   Rejection must be provided.
    Prevents accidental rejection without justification.

**Doctype JSON updates**

     Updated depends_on and read_only_depends_on to match the new workflow state "Pending Admin Approval" 
     instead of    the old "Pending Approval".

**Client-side script change**

     Modified the refresh condition to trigger logic when workflow state is "Initiate a Purchase Order" instead of "Approved".

**Other validations cleaned up**

     Retained validation for date ranges (required_from ≤ required_to).
     Ensured posting_date cannot be set in the future.

## Output screenshots (optional)

[Screencast from 28-08-25 02:15:01 PM IST.webm](https://github.com/user-attachments/assets/8a24d234-bc34-4674-8f05-6246c28bd5bd)

<img width="1494" height="967" alt="image" src="https://github.com/user-attachments/assets/4821b353-89f7-4506-b422-4bc331cb6dc6" />

<img width="1494" height="967" alt="image" src="https://github.com/user-attachments/assets/4cc814e2-7673-4c68-9d88-ce6a70e3db3c" />

## Areas affected and ensured
Equipment Acquiral Request


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - yes
  - Opera Mini
  - Safari
