### PR TITLE
fix:default return datetime in manpower/vehicle/equipment return prompts

### DIFF
--- a/beams/beams/custom_scripts/project/project.js
+++ b/beams/beams/custom_scripts/project/project.js
@@ -228,73 +228,70 @@ frappe.ui.form.on('Project', {
     });
 
 
-    // Apply filter dynamically when Designation field changes in child table
-  frappe.ui.form.on('Allocated Manpower Detail', {
-      designation: function(frm, cdt, cdn) {
-          let row = locals[cdt][cdn];
-          frappe.model.set_value(cdt, cdn, 'employee', '');
-          if (row.designation) {
-              frm.fields_dict.allocated_manpower_details.grid.get_field("employee").get_query = function(doc, cdt, cdn) {
-                  let child_row = locals[cdt][cdn];
-                  return {
-                      filters: {
-                          designation: child_row.designation
-                      }
-                  };
-              };
-          }
-          frm.refresh_field("allocated_manpower_details");
-      },
+// Apply filter dynamically when Designation field changes in child table
+frappe.ui.form.on('Allocated Manpower Detail', {
+	designation: function(frm, cdt, cdn) {
+		let row = locals[cdt][cdn];
+		frappe.model.set_value(cdt, cdn, 'employee', '');
+		if (row.designation) {
+			frm.fields_dict.allocated_manpower_details.grid.get_field("employee").get_query = function(doc, cdt, cdn) {
+				let child_row = locals[cdt][cdn];
+				return {
+					filters: {
+						designation: child_row.designation
+					}
+				};
+			};
+		}
+		frm.refresh_field("allocated_manpower_details");
+	},
 
-      return: function(frm, cdt, cdn) {
-          let child = locals[cdt][cdn];
+	return: function(frm, cdt, cdn) {
+		let child = locals[cdt][cdn];
 
-          frappe.prompt([
-              {
-                  label: 'Returned Date',
-                  fieldname: 'returned_date',
-                  fieldtype: 'Datetime',
-                  reqd: 1
-              },
-              {
-                  label: 'Returned Reason',
-                  fieldname: 'returned_reason',
-                  fieldtype: 'Small Text',
-                  reqd: 1
-              }
-          ],
-          function(values) {
-              frappe.model.set_value(cdt, cdn, 'returned_date', values.returned_date);
-              frappe.model.set_value(cdt, cdn, 'returned_reason', values.returned_reason);
-              frappe.model.set_value(cdt, cdn, 'returned', 1);
+		frappe.prompt([
+			{
+				label: 'Returned Date',
+				fieldname: 'returned_date',
+				fieldtype: 'Datetime',
+				reqd: 1,
+				default: frappe.datetime.now_datetime()
+			},
+			{
+				label: 'Returned Reason',
+				fieldname: 'returned_reason',
+				fieldtype: 'Small Text',
+				reqd: 1
+			}
+		],
+		function(values) {
+			let args = {
+				project: frm.doc.name,
+				assigned_from: child.assigned_from,
+				returned_date: values.returned_date,
+				returned_reason: values.returned_reason
+			};
 
-              let args = {
-                  project: frm.doc.name,
-                  assigned_from: child.assigned_from,
-                  returned_date: values.returned_date,
-                  returned_reason: values.returned_reason
-              };
+			if (child.employee) {
+				args.employee = child.employee;
+			} else if (child.hired_personnel) {
+				args.hired_personnel = child.hired_personnel;
+			}
 
-              if (child.employee) {
-                  args.employee = child.employee;
-              } else if (child.hired_personnel) {
-                  args.hired_personnel = child.hired_personnel;
-              }
-
-              frappe.call({
-                  method: "beams.beams.custom_scripts.project.project.update_return_details_in_log",
-                  args: args,
-                  callback: function(r) {
-                      if (!r.exc) {
-                          frappe.msgprint("Manpower Transaction Log updated.");
-                      }
-                  }
-              });
-          },
-          'Return Manpower',
-          'Submit');
-      }
-  });
+			frappe.call({
+				method: "beams.beams.custom_scripts.project.project.update_return_details_in_log",
+				args: args,
+				callback: function(r) {
+					if (!r.exc) {
+						frappe.msgprint("Manpower Transaction Log updated.");
+					}
+				}
+			});
+		},
+		'Return Manpower',
+		'Submit');
+	}
+});
 
 frappe.ui.form.on('Required Manpower Details', {
 	required_to: function(frm, cdt, cdn) {
@@ -311,129 +308,126 @@ frappe.ui.form.on('Required Manpower Details', {
 	}
 });
 
-  function validate_dates(cdt, cdn) {
-      let row = locals[cdt][cdn];
-      if (row.required_from && row.required_to && row.required_from > row.required_to) {
-          frappe.msgprint(`Row ${row.idx || ''}: "Required From" must be before "Required To"`);
-      }
-  }
+function validate_dates(cdt, cdn) {
+	let row = locals[cdt][cdn];
+	if (row.required_from && row.required_to && row.required_from > row.required_to) {
+		frappe.msgprint(`Row ${row.idx || ''}: "Required From" must be before "Required To"`);
+	}
+}
 
+frappe.ui.form.on('Required Items Table', {
+required_item: function(frm, cdt, cdn) {
+	let row = locals[cdt][cdn];
+	if (row.required_item) {
+	frappe.call({
+		method: "beams.beams.custom_scripts.project.project.get_available_quantities",
+		args: {
+		items: JSON.stringify([row.required_item]),
+		source_name: frm.doc.name
+		},
+		callback: function(r) {
+		if (r.message) {
+			if (r.message._error) {
+			frappe.model.set_value(cdt, cdn, 'available_quantity', 0);
+			} else {
+			frappe.model.set_value(cdt, cdn, 'available_quantity', r.message[row.required_item] || 0);
+			}
+		}
+		}
+	});
+	}
+}
+});
 
-  frappe.ui.form.on('Required Items Table', {
-    required_item: function(frm, cdt, cdn) {
-      let row = locals[cdt][cdn];
-      if (row.required_item) {
-        frappe.call({
-          method: "beams.beams.custom_scripts.project.project.get_available_quantities",
-          args: {
-            items: JSON.stringify([row.required_item]),
-            source_name: frm.doc.name
-          },
-          callback: function(r) {
-            if (r.message) {
-              if (r.message._error) {
-                frappe.model.set_value(cdt, cdn, 'available_quantity', 0);
-              } else {
-                frappe.model.set_value(cdt, cdn, 'available_quantity', r.message[row.required_item] || 0);
-              }
-            }
-          }
-        });
-      }
-    }
-  });
+frappe.ui.form.on('Allocated Vehicle Details', {
+	return: function(frm, cdt, cdn) {
+		let row = locals[cdt][cdn];
+		frappe.prompt([
+			{
+				label: 'Return Date',
+				fieldname: 'return_date',
+				fieldtype: 'Datetime',
+				reqd: 1,
+				default: frappe.datetime.now_datetime()
+			},
+			{
+				label: 'Return Reason',
+				fieldname: 'return_reason',
+				fieldtype: 'Small Text',
+				reqd: 1
+			}
+		],
+		function(values) {
+			row.return_date = values.return_date;
+			row.return_reason = values.return_reason;
+			row.returned = 1;
+			frm.refresh_field('allocated_vehicle_details');
+			frappe.call({
+				method: "beams.beams.custom_scripts.project.project.update_vehicle_return_details_in_log",
+				args: {
+					project: frm.doc.name,
+					vehicle: row.vehicle,
+					return_date: values.return_date,
+					return_reason: values.return_reason
+				},
+				callback: function(r) {
+					if (!r.exc) {
+						frappe.msgprint("Vehicle Transaction Log updated.");
+						frm.save();
+					}
+				}
+			});
+		},
+		'Return Vehicle',
+		'Submit');
+	}
+});
 
-  frappe.ui.form.on('Allocated Vehicle Details', {
-      return: function(frm, cdt, cdn) {
-          let row = locals[cdt][cdn];
-          frappe.prompt([
-              {
-                  label: 'Return Date',
-                  fieldname: 'return_date',
-                  fieldtype: 'Datetime',
-                  reqd: 1
-              },
-              {
-                  label: 'Return Reason',
-                  fieldname: 'return_reason',
-                  fieldtype: 'Small Text',
-                  reqd: 1
-              }
-          ],
-          function(values) {
-              row.return_date = values.return_date;
-              row.return_reason = values.return_reason;
-              row.returned = 1;
-              frm.refresh_field('allocated_vehicle_details');
-              frappe.call({
-                  method: "beams.beams.custom_scripts.project.project.update_vehicle_return_details_in_log",
-                  args: {
-                      project: frm.doc.name,
-                      vehicle: row.vehicle,
-                      return_date: values.return_date,
-                      return_reason: values.return_reason
-                  },
-                  callback: function(r) {
-                      if (!r.exc) {
-                          frappe.msgprint("Vehicle Transaction Log updated.");
-                          frm.save();
-                      }
-                  }
-              });
-          },
-          'Return Vehicle',
-          'Submit');
-      }
-  });
+frappe.ui.form.on('Required Items Detail', {
+	return: function(frm, cdt, cdn) {
+		let child = locals[cdt][cdn];
 
-  frappe.ui.form.on('Required Items Detail', {
-      return: function(frm, cdt, cdn) {
-          let child = locals[cdt][cdn];
+		frappe.prompt([
+			{
+				label: 'Return Date',
+				fieldname: 'return_date',
+				fieldtype: 'Datetime',
+				reqd: 1,
+				default: frappe.datetime.now_datetime()
+			},
+			{
+				label: 'Returned Reason',
+				fieldname: 'returned_reason',
+				fieldtype: 'Small Text',
+				reqd: 1
+			},
+			{
+			label: 'Returned Count',
+			fieldname: 'returned_count',
+			fieldtype: 'Int',
+			reqd: 1
+		}
+		],
+		function(values) {
+			let args = {
+				project: frm.doc.name,
+				required_item: child.required_item,
+				return_date: values.return_date,
+				returned_reason: values.returned_reason,
+				returned_count: values.returned_count
+			};
 
-          frappe.prompt([
-              {
-                  label: 'Return Date',
-                  fieldname: 'return_date',
-                  fieldtype: 'Datetime',
-                  reqd: 1
-              },
-              {
-                  label: 'Returned Reason',
-                  fieldname: 'returned_reason',
-                  fieldtype: 'Small Text',
-                  reqd: 1
-              },
-              {
-                label: 'Returned Count',
-                fieldname: 'returned_count',
-                fieldtype: 'Int',
-                reqd: 1
-            }
-          ],
-          function(values) {
-              frappe.model.set_value(cdt, cdn, 'return_date', values.return_date);
-              frappe.model.set_value(cdt, cdn, 'returned_reason', values.returned_reason);
-              frappe.model.set_value(cdt, cdn, 'returned_count', values.returned_count);
-
-              let args = {
-                  project: frm.doc.name,
-                  required_item: child.required_item,
-                  return_date: values.return_date,
-                  returned_reason: values.returned_reason,
-                  returned_count: values.returned_count
-              };
-
-              frappe.call({
-                  method: "beams.beams.custom_scripts.project.project.update_return_details_in_equipment_log",
-                  args: args,
-                  callback: function(r) {
-                      if (!r.exc) {
-                          frappe.msgprint("Equipment Transaction Log updated successfully.");
-                      }
-                  }
-              });
-          },
-          'Return Equipment',
-          'Submit');
-      }
-  });
+			frappe.call({
+				method: "beams.beams.custom_scripts.project.project.update_return_details_in_equipment_log",
+				args: args,
+				callback: function(r) {
+					if (!r.exc) {
+						frappe.msgprint("Equipment Transaction Log updated successfully.");
+					}
+				}
+			});
+		},
+		'Return Equipment',
+		'Submit');
+	}
+});


### PR DESCRIPTION
## Feature description
default return datetime in manpower/vehicle/equipment return prompts

## Solution description

- [x] TASK-2025-02089

 Added default current datetime (`frappe.datetime.now_datetime()`) to all return prompts 
- issue fixed : project showing not saved atae
- Simplified and standardized return workflows across child tables:
  - Allocated Manpower Detail
  - Allocated Vehicle Details
  - Required Items Detail
- Removed redundant `frappe.model.set_value` calls where values are only used for backend updates
- Improved consistency in log update calls and success messages
## Output screenshots (optional)

[Screencast from 29-08-25 03:18:29 PM IST.webm](https://github.com/user-attachments/assets/789829d4-07f9-4a7d-bc5e-6d0dc8b9ab52)

<img width="1605" height="951" alt="image" src="https://github.com/user-attachments/assets/d88e30b9-3e5c-4b6b-92db-6b97ef757804" />

<img width="1605" height="951" alt="image" src="https://github.com/user-attachments/assets/3f67292b-9048-429d-80af-2e35b3e39373" />

<img width="1605" height="951" alt="image" src="https://github.com/user-attachments/assets/5ebbb1bf-899b-4cf9-bd5c-50cfd2755aef" />

## Areas affected and ensured

-  project
-  Equipment Transaction Log
-  Vehicle Transaction Log
- Manpower Transaction Log 

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
