### PR TITLE
feat:Sync allocated vehicles from Transportation Request to Project on submit

### DIFF
--- a/beams/beams/doctype/allocated_vehicle_details/allocated_vehicle_details.json
+++ b/beams/beams/doctype/allocated_vehicle_details/allocated_vehicle_details.json
@@ -12,6 +12,7 @@
   "no_of_travellers",
   "reference_doctype",
   "reference_name",
+  "hired_vehicle",
   "status",
   "return"
  ],
@@ -69,12 +70,17 @@
    "fieldname": "return",
    "fieldtype": "Button",
    "label": "Return"
+  },
+  {
+   "fieldname": "hired_vehicle",
+   "fieldtype": "Data",
+   "label": "Hired Vehicle"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-06-04 15:54:25.598053",
+ "modified": "2025-08-29 11:32:35.106425",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Allocated Vehicle Details",

--- a/beams/beams/doctype/transportation_request/transportation_request.js
+++ b/beams/beams/doctype/transportation_request/transportation_request.js
@@ -2,7 +2,7 @@
 // For license information, please see license.txt
 frappe.ui.form.on("Transportation Request", {
     refresh: function (frm) {
-        if (frm.doc.workflow_state === "Approved") {
+        if (frm.doc.workflow_state === "Pending Vehicle Allocation") {
             frm.add_custom_button(__('Vehicle Hire Request'), function () {
                 frappe.model.open_mapped_doc({
                     method: 'beams.beams.doctype.transportation_request.transportation_request.map_transportation_to_vehicle',
@@ -11,7 +11,7 @@ frappe.ui.form.on("Transportation Request", {
             }, __("Create"));
         }
 
-        if (frm.doc.workflow_state === "Pending Approval") {
+        if (frm.doc.workflow_state === "Pending Vehicle Allocation") {
             frm.set_df_property("vehicles", "read_only", false);
         } else {
             frm.set_df_property("vehicles", "read_only", true);

--- a/beams/beams/doctype/transportation_request/transportation_request.py
+++ b/beams/beams/doctype/transportation_request/transportation_request.py
@@ -13,14 +13,43 @@ class TransportationRequest(Document):
 	def validate(self):
 		if self.workflow_state == "Rejected" and not self.reason_for_rejection:
 			frappe.throw("Please provide a Reason for Rejection before rejecting this request.")
-		self.update_no_of_own_vehicles()
+		self.update_vehicle_counts()
+		if self.workflow_state == "Approved":
+			self.validate_vehicle_before_approvel()
+
+	def validate_vehicle_before_approvel(self):
+		"""Validate vehicle allocation before approving Transportation Request"""
+
+		if not self.vehicles:
+			frappe.throw(
+				_("Please add at least one vehicle in 'vehicles' before approving."),
+				title=_("Missing Vehicle")
+			)
+
+		for row in self.vehicles:
+			if not row.vehicle and not row.hired_vehicle:
+				frappe.throw(
+					_("Vehicle is missing in row {0} of 'Vehicles'. Please fill it before approving.")
+					.format(row.idx),
+					title=_("Missing Vehicle")
+				)
+
+		required_count = len(self.required_vehicle or [])
+		allocated_count = len(self.vehicles or [])
+
+		if required_count and allocated_count < required_count:
+			frappe.throw(
+				_("You need to allocate {0} vehicles, but only {1} are added.")
+				.format(required_count, allocated_count),
+				title=_("Insufficient Vehicles")
+			)
 
 	def before_update_after_submit(self):
-		self.update_no_of_own_vehicles()
+		self.update_vehicle_counts()
 
 	def on_submit(self):
-		# Always update own vehicles count on workflow update
-		self.update_no_of_own_vehicles()
+
+		self.update_vehicle_counts()
 
 		if self.workflow_state == "Approved" and self.reason_for_rejection:
 			frappe.throw("You cannot approve this request if 'Reason for Rejection' is filled.", title="Approval Error")
@@ -28,6 +57,9 @@ class TransportationRequest(Document):
 		if self.workflow_state == "Approved":
 			if not self.project:
 				frappe.throw("Project is required to update allocated vehicles.")
+			for vehicle in self.vehicles:
+				if not vehicle.status:
+					vehicle.status = "Allocated"
 
 			project_doc = frappe.get_doc("Project", self.project)
 
@@ -35,52 +67,65 @@ class TransportationRequest(Document):
 				return
 
 			existing_vehicles = project_doc.get("allocated_vehicle_details", [])
-			vehicles_to_update = {vehicle.vehicle: vehicle for vehicle in self.vehicles}
+
+			vehicles_to_update = {(v.vehicle or v.hired_vehicle): v for v in self.vehicles}
 
 			updated_vehicle_details = []
+
 			for existing_vehicle in existing_vehicles:
-				if existing_vehicle.reference_name != self.name:
-					updated_vehicle_details.append(existing_vehicle)
-				elif existing_vehicle.vehicle in vehicles_to_update:
-					vehicle = vehicles_to_update[existing_vehicle.vehicle]
+				vehicle_key = existing_vehicle.get("vehicle") or existing_vehicle.get("hired_vehicle")
+
+				if (existing_vehicle.get("reference_name") == self.name and
+					vehicle_key in vehicles_to_update):
+
+					vehicle = vehicles_to_update[vehicle_key]
+
 					updated_vehicle_details.append({
-						"vehicle": vehicle.vehicle,
+						"vehicle": vehicle.vehicle or "",
 						"hired_vehicle": vehicle.get("hired_vehicle", ""),
 						"reference_doctype": "Transportation Request",
 						"reference_name": self.name,
 						"from": vehicle.from_location,
 						"to": vehicle.to_location,
 						"no_of_travellers": vehicle.no_of_travellers,
-						"status": "Allocated"
+						"status": vehicle.status
 					})
-					del vehicles_to_update[existing_vehicle.vehicle]
 
-			for vehicle in vehicles_to_update.values():
+					del vehicles_to_update[vehicle_key]
+				else:
+					updated_vehicle_details.append(existing_vehicle)
+
+			for v in vehicles_to_update.values():
 				updated_vehicle_details.append({
-					"vehicle": vehicle.vehicle,
-					"hired_vehicle": vehicle.get("hired_vehicle", ""),
+					"vehicle": v.vehicle or "",
+					"hired_vehicle": v.get("hired_vehicle", ""),
 					"reference_doctype": "Transportation Request",
 					"reference_name": self.name,
-					"from": vehicle.from_location,
-					"to": vehicle.to_location,
-					"no_of_travellers": vehicle.no_of_travellers,
-					"status": "Allocated"
+					"from": v.from_location,
+					"to": v.to_location,
+					"no_of_travellers": v.no_of_travellers,
+					"status": v.status
 				})
 
 			project_doc.set("allocated_vehicle_details", updated_vehicle_details)
 
 			try:
 				project_doc.save(ignore_permissions=True)
+				frappe.msgprint(f"Vehicles are updated for Project {self.project}")
 			except Exception as e:
 				frappe.throw(f"Failed to update Project: {str(e)}")
 
-	def update_no_of_own_vehicles(self):
+	def update_vehicle_counts(self):
 		'''
-		Calculate the total number of rows in the "Vehicles" child table
-		and update the "No. of Own Vehicles" field.
+		Calculate:
+		- Total number of vehicles (rows in Vehicles table) → No. of Own Vehicles
+		- Total number of hired vehicles (rows where hired_vehicle is checked/Yes) → No. of Hired Vehicles
 		'''
 		total_vehicles = len(self.vehicles or [])
-		self.no_of_own_vehicles = total_vehicles
+		hired_vehicles = sum(1 for row in (self.vehicles or []) if row.hired_vehicle)
+
+		self.no_of_own_vehicles = total_vehicles - hired_vehicles
+		self.no_of_hired_vehicles = hired_vehicles
 
 	@frappe.whitelist()
 	def validate_posting_date(self):

--- a/beams/beams/doctype/vehicle_detail/vehicle_detail.json
+++ b/beams/beams/doctype/vehicle_detail/vehicle_detail.json
@@ -9,7 +9,9 @@
   "from_location",
   "to_location",
   "no_of_travellers",
-  "details"
+  "details",
+  "hired_vehicle",
+  "status"
  ],
  "fields": [
   {
@@ -44,17 +46,30 @@
    "in_list_view": 1,
    "label": "To",
    "options": "Location"
+  },
+  {
+   "fieldname": "hired_vehicle",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Hired Vehicle"
+  },
+  {
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "label": "Status",
+   "options": "\nAllocated\nHired"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-04-05 11:36:43.517503",
+ "modified": "2025-08-29 12:07:46.640766",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Vehicle Detail",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/beams/beams/doctype/vehicle_hire_request/vehicle_hire_request.py
+++ b/beams/beams/doctype/vehicle_hire_request/vehicle_hire_request.py
@@ -7,98 +7,91 @@ from frappe.utils import today
 from frappe import _
 
 class VehicleHireRequest(Document):
-    def on_submit(self):
-        self.generate_external_vehicle_details_from_hire_request()
-        if self.transportation_request:
-            frappe.db.set_value(
-            "Transportation Request",
-            self.transportation_request,
-            "vehicle_hire_request",
-            self.name
-            )
-        self.update_hired_vehicles_on_submit()
-        self.update_vehicle_details_on_project()
+	def on_submit(self):
+		self.generate_external_vehicle_details_from_hire_request()
+		if self.transportation_request:
+			frappe.db.set_value(
+			"Transportation Request",
+			self.transportation_request,
+			"vehicle_hire_request",
+			self.name
+			)
+		self.update_hired_vehicles_on_submit()
 
-    def on_cancel(self):
-        self.update_hired_vehicles_on_cancel()
+	def on_cancel(self):
+		self.update_hired_vehicles_on_cancel()
 
-    def before_save(self):
-        self.validate_posting_date()
+	def before_save(self):
+		self.validate_posting_date()
 
-    def update_hired_vehicles_on_submit(self):
-        '''
-        Calculate the total number of vehicles from the required_vehicles child table
-        and update the linked Transportation Request.
-        '''
-        if self.required_vehicles:
-            # Calculate the total number of vehicles
-            total_vehicles = len(self.required_vehicles)
+	def update_hired_vehicles_on_submit(self):
+		'''
+		On submission of Vehicle Hire Request update the hired vehicles in linked Transportation Request.
+		'''
+		if not self.transportation_request:
+			frappe.throw("Transportation Request is not linked.")
 
-            # Update the Transportation Request
-            if self.transportation_request:
-                frappe.db.set_value(
-                    "Transportation Request",
-                    self.transportation_request,
-                    "no_of_hired_vehicles",
-                    total_vehicles
-                )
+		tr = frappe.get_doc("Transportation Request", self.transportation_request)
 
-    def update_hired_vehicles_on_cancel(self):
-        '''
-        On cancellation of Transportation Request reset the number of hired vehicles.
-        '''
-        if self.transportation_request:
-            frappe.db.set_value(
-                "Transportation Request",
-                self.transportation_request,
-                "no_of_hired_vehicles",
-                0
-            )
+		for rv in self.required_vehicles:
 
-    def update_vehicle_details_on_project(self):
+			if rv.vehicle_number and not frappe.db.exists("Vehicle", rv.vehicle_number):
+				vehicle_doc = frappe.get_doc({
+					"doctype": "Vehicle",
+					"vehicle_number": rv.vehicle_number,
+					"license_plate": rv.vehicle_number,
+					"vehicle_type": rv.vehicle_type,
+				})
+				vehicle_doc.insert(ignore_permissions=True, ignore_mandatory=True)
 
-        if self.required_vehicles:
+			tr.append("vehicles", {
+				"hired_vehicle": rv.vehicle_number,
+				"from_location": rv.get("from"),
+				"to_location": rv.get("to"),
+				"no_of_travellers": rv.no_of_travellers,
+				"status": "Hired"
+			})
 
-            project_details = frappe.get_doc("Project", self.project)
+		tr.save(ignore_permissions=True)
+		frappe.msgprint(f"Vehicles updated in Transportation Request {tr.name}")
 
-            for vehicle in self.required_vehicles:
-                project_details.append("allocated_vehicle_details", {
-                    "vehicle": vehicle.vehicle_number,
-                    "hired_vehicle": vehicle.get("hired_vehicle", ""),
-                    "reference_doctype": "Vehicle Hire Request",
-                    "reference_name": self.name,
-                    "from":vehicle.get("from"),
-                    "to":vehicle.to,
-                    "no_of_travellers":vehicle.no_of_travellers,
-                    "status":"Hired"
-                })
-                project_details.save(ignore_permissions=True)
+	def update_hired_vehicles_on_cancel(self):
+		'''
+		On cancellation of Transportation Request reset the number of hired vehicles.
+		'''
+		if self.transportation_request:
+			frappe.db.set_value(
+				"Transportation Request",
+				self.transportation_request,
+				"no_of_hired_vehicles",
+				0
+			)
 
-    def generate_external_vehicle_details_from_hire_request(self):
-        """
-        Generate External Vehicle Details records from the Vehicle Hire Request child table
-        """
-        project = frappe.get_doc("Project", self.project)
+	def generate_external_vehicle_details_from_hire_request(self):
+		'''
+		Generate External Vehicle Details records from the Vehicle Hire Request child table
+		'''
+		project = frappe.get_doc("Project", self.project)
 
-        for vehicle in self.required_vehicles:
-            external_vehicle_detail = frappe.new_doc("External Vehicle Details")
+		for vehicle in self.required_vehicles:
+			external_vehicle_detail = frappe.new_doc("External Vehicle Details")
 
-            external_vehicle_detail.project = self.project
-            external_vehicle_detail.transportation_request = self.transportation_request
-            external_vehicle_detail.required_on = self.required_on
-            external_vehicle_detail.required_to = self.required_on
-            external_vehicle_detail.vehicle_no = vehicle.vehicle_number
-            external_vehicle_detail.returned = "No"
-            external_vehicle_detail.purpose = f"Vehicle Hire Request Against {self.project}"
-            external_vehicle_detail.vehicle_type = vehicle.vehicle_type
-            external_vehicle_detail.set("from", vehicle.get("from"))
-            external_vehicle_detail.to = vehicle.to
-            external_vehicle_detail.vehicle_number = vehicle.vehicle_number
+			external_vehicle_detail.project = self.project
+			external_vehicle_detail.transportation_request = self.transportation_request
+			external_vehicle_detail.required_on = self.required_on
+			external_vehicle_detail.required_to = self.required_on
+			external_vehicle_detail.vehicle_no = vehicle.vehicle_number
+			external_vehicle_detail.returned = "No"
+			external_vehicle_detail.purpose = f"Vehicle Hire Request Against {self.project}"
+			external_vehicle_detail.vehicle_type = vehicle.vehicle_type
+			external_vehicle_detail.set("from", vehicle.get("from"))
+			external_vehicle_detail.to = vehicle.to
+			external_vehicle_detail.vehicle_number = vehicle.vehicle_number
 
-            external_vehicle_detail.save()
+			external_vehicle_detail.save()
 
-    @frappe.whitelist()
-    def validate_posting_date(self):
-        if self.posting_date:
-            if self.posting_date > today():
-                frappe.throw(_("Posting Date cannot be set after today's date."))
+	@frappe.whitelist()
+	def validate_posting_date(self):
+		if self.posting_date:
+			if self.posting_date > today():
+				frappe.throw(_("Posting Date cannot be set after today's date."))


### PR DESCRIPTION
- [x] TASK-2025-02097
- [x] TASK-2025-02100

## Feature description
Need to: 

- Sync hired vehicle to vehicle table in linked Transportation Request
- Sync allocated vehicles from Transportation Request to Project on submit
- Set vehicle status to Allocated or Hired  when approved
- Allocate own and hired vehicles from Vehicles table to Allocated Vehicle Details in Project
- validate vehicle allocation before approving Transportation Request
- Update vehicle counts 
- Add Hired Vehicle field Allocated Vehicle Details Table in project
- Add Hired Vehicle field Status field in Vehicles table in Transportation Request


## Solution description
- Sync hired vehicle to vehicle table in linked Transportation Request
- Sync allocated vehicles from Transportation Request to Project on submit
- Set vehicle status to Allocated or Hired  when approved
- Allocated own and hired vehicles from Vehicles table to Allocated Vehicle Details in Project
- validated vehicle allocation before approving Transportation Request
- Updated vehicle counts 
- Added Hired Vehicle field Allocated Vehicle Details Table in project
- Added Hired Vehicle field Status field in Vehicles table in Transportation Request
- Converted codes into indentation tab space in Transportation Request

## Output screenshots (optional)
[Screencast from 30-08-25 11:56:32 AM IST.webm](https://github.com/user-attachments/assets/63572de6-bd9a-4f9f-af2e-778629e11138)


## Areas affected and ensured
Transportation Request doctype , Vehicle hire request doctype

## Is there any existing behavior change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?
  - Chrome

