### PR TITLE
fix:allow Asset Movement without Employee user permission check

### DIFF
--- a/beams/beams/doctype/allocated_manpower_detail/allocated_manpower_detail.json
+++ b/beams/beams/doctype/allocated_manpower_detail/allocated_manpower_detail.json
@@ -98,6 +98,7 @@
    "options": "\nAllocated\nHired"
   },
   {
+   "depends_on": "eval: doc.parenttype !== \"Manpower Transaction Log\"",
    "fieldname": "return",
    "fieldtype": "Button",
    "label": "Return"
@@ -106,12 +107,13 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-04-19 14:17:19.313917",
+ "modified": "2025-09-15 15:24:13.501350",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Allocated Manpower Detail",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -5086,7 +5086,8 @@ def get_asset_movement_custom_fields():
 				"label": "New Custodian",
 				"options": "Employee",
 				"insert_after": "assets",
-				"read_only": 1
+				"read_only": 1,
+				"ignore_user_permissions":1
 			},
 			{
 				"fieldname": "user_id",


### PR DESCRIPTION
## Feature description
allow Asset Movement without Employee user permission check

## Solution description

- [x] TASK-2025-02109
- [x] TASK-2025-02108

- The `new_custodian` custom field on Asset Movement was previously restricted by  User Permissions on Employee, causing errors when users without access to the  linked Employee tried to submit Asset Movement documents.

- Added `"ignore_user_permissions": 1` to the New Custodian field  

- This ensures that users with proper Asset Movement permissions can still create and update records regardless of their Employee access level.

- Added client-side script for Manpower Transaction Log to hide the 'return' button  in the allocated manpower detail child table grid.

## Output screenshots (optional)

[Screencast from 01-09-25 10:23:13 AM IST.webm](https://github.com/user-attachments/assets/ee31e9ec-11a4-4070-974e-7b9079dfe36d)

<img width="1407" height="969" alt="image" src="https://github.com/user-attachments/assets/f84cf492-fab2-4aa0-830c-7c5a2aa0e017" />

## Areas affected and ensured
Asset movement
equipment request

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - yes
  - Opera Mini
  - Safari
