### PR TITLE
feat: restrict field visibility and editing to Operations Head

### DIFF
--- a/beams/beams/doctype/program_request/program_request.json
+++ b/beams/beams/doctype/program_request/program_request.json
@@ -152,14 +152,14 @@
   },
   {
    "allow_on_submit": 1,
-   "depends_on": "eval: doc.workflow_state == 'Request for Approval' || doc.workflow_state == 'Rejected';",
+   "depends_on": "eval:(doc.workflow_state == 'Request for Approval' || doc.workflow_state == 'Rejected') && frappe.user_roles.includes('Operations Head')\n",
    "fieldname": "reason_for_rejection",
    "fieldtype": "Small Text",
    "label": "Reason for Rejection",
    "read_only_depends_on": "eval: doc.workflow_state == 'Rejected';"
   },
   {
-   "depends_on": "eval:doc.workflow_state == 'Request for Approval' || \"doc.workflow_state == 'Draft'\"\n",
+   "depends_on": "eval:(doc.workflow_state == 'Request for Approval' || doc.workflow_state == 'Draft') && frappe.user_roles.includes('Operations Head')\n",
    "fieldname": "reason_for_revision",
    "fieldtype": "Small Text",
    "label": "Reason for Revision",
@@ -169,7 +169,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-08-27 12:55:29.768393",
+ "modified": "2025-09-01 16:55:32.459981",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Program Request",

--- a/beams/beams/doctype/technical_request_details/technical_request_details.json
+++ b/beams/beams/doctype/technical_request_details/technical_request_details.json
@@ -32,6 +32,7 @@
    "allow_on_submit": 1,
    "fieldname": "employee",
    "fieldtype": "Link",
+   "ignore_user_permissions": 1,
    "in_list_view": 1,
    "label": "Employee",
    "options": "Employee"
@@ -60,7 +61,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-08-26 11:24:06.330505",
+ "modified": "2025-09-01 15:11:57.197894",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Technical Request Details",


### PR DESCRIPTION
- [x] TASK-2025-02115
- [x] TASK-2025-02113

## Feature description
Need to:
- Update Program Request fields (reason for rejection, reason for revision) to show only when workflow state is Request for Approval or Rejected and user has Operations Head role
- Add ignore user permissions for Employee field in Technical Request Details

## Solution description
- Updated Program Request fields (reason for rejection, reason for revision) to show only when workflow state is Request for Approval or Rejected and user has Operations Head role
- Added ignore user permissions for Employee field in Technical Request Details

## Output screenshots (optional)
[Screencast from 01-09-25 05:27:41 PM IST.webm](https://github.com/user-attachments/assets/58a6a93b-c1d0-4a3c-a356-b61a588f0dd9)

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/1d567189-9797-4945-a0b6-b7e17c384ff2" />



## Areas affected and ensured
Program Request 

## Is there any existing behavior change of other features due to this code change?
No. 

## Was this feature tested on the browsers?
  - Chrome
