### PR TITLE
feat: Calculate salary increment from  Final Appraisal Category in Appraisal doctype

### DIFF
--- a/beams/beams/custom_scripts/appraisal/appraisal.py
+++ b/beams/beams/custom_scripts/appraisal/appraisal.py
@@ -319,7 +319,6 @@ def add_to_category_details(parent_docname, category, remarks):
 	try:
 		# Get current user
 		current_user = frappe.session.user
-
 		# Get Employee document linked to current user
 		employee_doc = frappe.get_all(
 			"Employee",
@@ -327,13 +326,11 @@ def add_to_category_details(parent_docname, category, remarks):
 			fields=["name", "designation"],
 			limit=1
 		)
-
 		if not employee_doc:
 			frappe.throw(f"No Employee linked to user {current_user}")
 
 		employee_name = employee_doc[0].name
 		designation = employee_doc[0].designation
-
 		# Get Appraisal document
 		parent_doc = frappe.get_doc("Appraisal", parent_docname)
 		for row in parent_doc.category_details:
@@ -347,13 +344,26 @@ def add_to_category_details(parent_docname, category, remarks):
 			"employee": employee_name,
 			"designation": designation
 		})
-
+		parent_doc.final_performance_category = category
+		if frappe.db.exists("Appraisal Category", category):
+			category_doc = frappe.get_doc("Appraisal Category", category)
+			employee_ctc = parent_doc.employee_ctc or 0
+			increment_percentage = 0
+			for ps in category_doc.payscale_details:
+				if (ps.minimum_ctc <= employee_ctc <= ps.maximum_ctc):
+					increment_percentage = ps.percentage
+					break
+			if increment_percentage:
+				parent_doc.salary_increment_percentage = increment_percentage
+				parent_doc.salary_increment_amount = (employee_ctc * increment_percentage) / 100
+			else:
+				parent_doc.salary_increment_percentage = 0
+				parent_doc.salary_increment_amount = 0
 		parent_doc.save(ignore_permissions=True)
 		return "Success"
 	except Exception:
 		frappe.log_error(frappe.get_traceback(), "Add to Category Details Error")
 		return "Failed"
-
 
 
 @frappe.whitelist()

--- a/beams/beams/doctype/appraisal_category/appraisal_category.js
+++ b/beams/beams/doctype/appraisal_category/appraisal_category.js
@@ -3,11 +3,52 @@
 
 frappe.ui.form.on("Appraisal Category", {
   validate: function(frm) {
-      if (frm.doc.appraisal_threshold < 0 || frm.doc.appraisal_threshold > 5) {
-        frappe.throw({
-              title: __('Invalid Appraisal Threshold'),
-              message: __('Appraisal Threshold must be between 0 and 5.')
-          });
-      }
+	  if (frm.doc.appraisal_threshold < 0 || frm.doc.appraisal_threshold > 5) {
+		frappe.throw({
+			  title: __('Invalid Appraisal Threshold'),
+			  message: __('Appraisal Threshold must be between 0 and 5.')
+		  });
+	  }
   }
 });
+
+frappe.ui.form.on("Payscale Details", {
+	maximum_ctc: function(frm, cdt, cdn) {
+		update_min_ctc(frm);
+	},
+	payscale_details_add: function(frm, cdt, cdn) {
+		update_min_ctc(frm);
+	},
+	payscale_details_remove: function(frm, cdt, cdn) {
+        update_min_ctc(frm);
+    }
+});
+
+
+/**
+* Updates the minimum CTC for a row in the payscale_details table.
+* Sets minimum CTC to 0 for the first row.
+* Sets minimum CTC of the current row to the previous row's maximum CTC + 1.
+* If current row's maximum CTC is 0, clears min and max CTC for subsequent rows.
+*/
+function update_min_ctc(frm) {
+    let grid = frm.doc.payscale_details || [];
+    for (let i = 0; i < grid.length; i++) {
+        if (i === 0) {
+            grid[i].minimum_ctc = 0;
+        } else {
+            let prev_row = grid[i - 1];
+            if (prev_row.maximum_ctc != null) {
+                grid[i].minimum_ctc = prev_row.maximum_ctc + 1;
+            }
+        }
+        if (grid[i].maximum_ctc === 0) {
+            for (let j = i + 1; j < grid.length; j++) {
+                grid[j].minimum_ctc = null;
+                grid[j].maximum_ctc = null;
+            }
+            break; 
+        }
+    }
+    frm.refresh_field("payscale_details");
+}

--- a/beams/beams/doctype/appraisal_category/appraisal_category.json
+++ b/beams/beams/doctype/appraisal_category/appraisal_category.json
@@ -8,7 +8,9 @@
  "field_order": [
   "category",
   "appraisal_threshold",
-  "category_description"
+  "category_description",
+  "payscale_details_section",
+  "payscale_details"
  ],
  "fields": [
   {
@@ -26,11 +28,22 @@
    "fieldname": "appraisal_threshold",
    "fieldtype": "Float",
    "label": "Appraisal Threshold"
+  },
+  {
+   "fieldname": "payscale_details_section",
+   "fieldtype": "Section Break",
+   "label": "Payscale Details"
+  },
+  {
+   "fieldname": "payscale_details",
+   "fieldtype": "Table",
+   "label": "Payscale Details",
+   "options": "Payscale Details"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-01-08 13:30:50.693446",
+ "modified": "2025-09-02 13:07:44.132881",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Appraisal Category",
@@ -50,6 +63,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/beams/beams/doctype/payscale_details/payscale_details.json
+++ b/beams/beams/doctype/payscale_details/payscale_details.json
@@ -1,0 +1,48 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-09-02 13:03:41.916320",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "minimum_ctc",
+  "maximum_ctc",
+  "percentage"
+ ],
+ "fields": [
+  {
+   "fieldname": "maximum_ctc",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Maximum CTC"
+  },
+  {
+   "fieldname": "percentage",
+   "fieldtype": "Percent",
+   "in_list_view": 1,
+   "label": "Percentage"
+  },
+  {
+   "fieldname": "minimum_ctc",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Minimum CTC",
+   "read_only": 1
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2025-09-03 10:12:49.628652",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "Payscale Details",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/beams/beams/doctype/payscale_details/payscale_details.py
+++ b/beams/beams/doctype/payscale_details/payscale_details.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class PayscaleDetails(Document):
+	pass

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -3550,21 +3550,84 @@ def get_appraisal_custom_fields():
 				"insert_after": "final_assesment_tab_break"
 			},
 			{
+				"fieldname": "appraisal_section_break",
+				"fieldtype": "Section Break",
+				"label": "",
+				"insert_after": "category_html"
+			},
+			{
 				"fieldname": "category_based_on_marks",
 				"fieldtype": "Link",
 				"options": "Appraisal Category",
 				"label": "Category based on marks",
-				"insert_after": "category_html",
+				"insert_after": "appraisal_section_break",
 				"read_only": 1
+			},
+			{
+				"fieldname": "appraisal_ctc_break",
+				"fieldtype": "Column Break",
+				"label": "",
+				"insert_after": "category_based_on_marks"
+			},
+			{
+				"fieldname": "employee_ctc",
+				"fieldtype": "Currency",
+				"label": "Employee CTC",
+				"fetch_from": "employee.ctc",
+				"insert_after": "appraisal_ctc_break",
+				"read_only": 1
+			},
+			{
+				"fieldname": "ctc_section_break",
+				"fieldtype": "Section Break",
+				"label": "",
+				"insert_after": "employee_ctc"
 			},
 			{
 				"fieldname": "category_details",
 				"fieldtype": "Table",
 				"label": "Category Details",
 				"options": "Category Details",
-				"insert_after": "category_based_on_marks",
+				"insert_after": "ctc_section_break",
 				"allow_on_submit": 1,
 				"read_only": 1
+			},
+			{
+				"fieldname": "final_section_break",
+				"fieldtype": "Section Break",
+				"label": "",
+				"insert_after": "category_details"
+			},
+			{
+				"fieldname": "final_performance_category",
+				"fieldtype": "Link",
+				"label": "Final Performance Category",
+				"options": "Appraisal Category",
+				"insert_after": "final_section_break"
+			},
+			{
+				"fieldname": "final_column_break",
+				"fieldtype": "Column Break",
+				"label": "",
+				"insert_after": "final_performance_category"
+			},
+			{
+				"fieldname": "salary_increment_percentage",
+				"fieldtype": "Percent",
+				"label": "Salary Increment  Percentage",
+				"insert_after": "final_column_break"
+			},
+			{
+				"fieldname": "salary_increment_break",
+				"fieldtype": "Column Break",
+				"label": "",
+				"insert_after": "salary_increment_percentage"
+			},
+			{
+				"fieldname": "salary_increment_amount",
+				"fieldtype": "Currency",
+				"label": "Salary Increment Amount",
+				"insert_after": "salary_increment_break"
 			},
 			{
 				"fieldname": "employee_self_kra_rating",


### PR DESCRIPTION
## Feature description
1. Need to customize the Appraisal Doctype
2. Need to set the employee ctc from the employee
3. Implement  Final Performance Category based on the category added in category details child table
4. Modify the Appraisal Category Doctype
5. set the salary increment percentage and salary increment Amount based on the Final  Appraisal category in appraisal

## Solution description
1. customized the Appraisal doctype
- Added the field employee ctc , final appraisal category , salary increment percentage and salary increment Amount
2.set the employee ctc from the employee
- set the employee ctc based on the cost to company (ctc) in employee
3. Implement  Final Performance Category based on the category added in category details child table 
4.   Modified the Appraisal Category Doctype
- created the child table Payscale details in added Appraisal Category doctype
- Automatically sets the first row minimum CTC  zero as default and next row’s minimum CTC as the previous row’s maximum CTC + 1 
5.set the salary increment percentage and salary increment Amount based on the Final  Appraisal category in appraisal
- based  on the final appraisal category in appraisal  compute salary increment  amount from CTC range in Appraisal Category doctype
## Output screenshots (optional)
<img width="1661" height="895" alt="image" src="https://github.com/user-attachments/assets/3334cae1-8155-4577-9f03-107962126701" />
[Screencast from 03-09-25 02:21:34 PM IST.webm](https://github.com/user-attachments/assets/01d388f5-2aca-43eb-8452-c5b880bd47d4)
[Screencast from 03-09-25 02:21:34 PM IST.webm](https://github.com/user-attachments/assets/23149cb9-c7ac-427b-8fd6-d1d4dbe30d3a)

## Areas affected and ensured
Appraisal and Appraisal Category Doctype

## Is there any existing behavior change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?
  
  - Mozilla Firefox
 
