### PR TITLE
feat: allow Salary Increment Approver to edit salary increment amount in Appraisal

### DIFF
--- a/beams/beams/custom_scripts/appraisal/appraisal.js
+++ b/beams/beams/custom_scripts/appraisal/appraisal.js
@@ -1,5 +1,6 @@
 frappe.ui.form.on('Appraisal', {
 	refresh: function (frm) {
+		salary_amount_read_only(frm);
 		frm.trigger('update_self_kra_rating_list_view');
 		frm.remove_custom_button(__('View Goals'));
 		set_table_properties(frm, 'employee_self_kra_rating');
@@ -611,6 +612,12 @@ frappe.ui.form.on('Appraisal', {
 				frm.refresh_field(child_table);
 			}
 		});
+	},
+	salary_increment_amount: function(frm) {
+		if (frm.doc.employee_ctc && frm.doc.salary_increment_amount) {
+			let percentage = (frm.doc.salary_increment_amount / frm.doc.employee_ctc) * 100;
+			frm.set_value("salary_increment_percentage", percentage.toFixed(2));
+		}
 	}
 });
 
@@ -657,5 +664,15 @@ function set_marks_read_only(frm, table_name,field_name) {
 	});
 }
 
-
+/**
+* Sets the "salary_increment_amount" field as read-only
+* if the logged-in user does not have the "Salary Increment Approver" role.
+*/
+function salary_amount_read_only(frm) {
+	if (!frappe.user_roles.includes("Salary Increment Approver")) {
+		frm.set_df_property("salary_increment_amount", "read_only", 1);
+	} else {
+		frm.set_df_property("salary_increment_amount", "read_only", 0);
+	}
+}
 

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -3603,7 +3603,8 @@ def get_appraisal_custom_fields():
 				"fieldtype": "Link",
 				"label": "Final Performance Category",
 				"options": "Appraisal Category",
-				"insert_after": "final_section_break"
+				"insert_after": "final_section_break",
+				"read_only": 1
 			},
 			{
 				"fieldname": "final_column_break",
@@ -3615,7 +3616,8 @@ def get_appraisal_custom_fields():
 				"fieldname": "salary_increment_percentage",
 				"fieldtype": "Percent",
 				"label": "Salary Increment  Percentage",
-				"insert_after": "final_column_break"
+				"insert_after": "final_column_break",
+				"read_only": 1
 			},
 			{
 				"fieldname": "salary_increment_break",
@@ -3627,7 +3629,8 @@ def get_appraisal_custom_fields():
 				"fieldname": "salary_increment_amount",
 				"fieldtype": "Currency",
 				"label": "Salary Increment Amount",
-				"insert_after": "salary_increment_break"
+				"insert_after": "salary_increment_break",
+				"read_only": 1
 			},
 			{
 				"fieldname": "employee_self_kra_rating",
@@ -5026,7 +5029,7 @@ def get_beams_roles():
 	'''
 		Method to get BEAMS specific roles
 	'''
-	return ['Production Manager', 'CEO', 'Company Secretary', 'HOD','Enquiry Officer','Enquiry Manager','Shift Publisher','Program Producer','Operations Head','Operations User','Admin','Driver','Budget User','Technical Store Head','Budget Verifier','Budget Verifier Finance','Budget Approver','Admin User','Bureau User','Coordinating Editor','News Coordinator','Security','Reporter']
+	return ['Production Manager', 'CEO', 'Company Secretary', 'HOD','Enquiry Officer','Enquiry Manager','Shift Publisher','Program Producer','Operations Head','Operations User','Admin','Driver','Budget User','Technical Store Head','Budget Verifier','Budget Verifier Finance','Budget Approver','Admin User','Bureau User','Coordinating Editor','News Coordinator','Security','Reporter','Salary Increment Approver']
 
 def get_custom_translations():
 	'''


### PR DESCRIPTION
## Feature description
1.Need to create the role salary increment approver 
2. make read only Final Performance Category , Salary Increment Percentage  and Salary Increment Amount
3. implement the Salary Increment Amount is edit by salary increment approver users only
4. implement to set the Salary Increment Percentage  of the and Employee CTC and on change of the Salary Increment Amount 

## Solution description
1. created new role salary increment approver  via setup.py
2. added read only to fields  Final Performance Category , Salary Increment Percentage  and Salary Increment Amount via setup.py
3. implemented salary increment approver  users can be only edit the Salary Increment Amount via appraisal.js
4. calculated the Salary Increment Percentage based on Employee CTC and on change of the Salary Increment Amount via appraisal.js 

## Output screenshots (optional)
[Screencast from 03-09-25 02:21:34 PM IST.webm](https://github.com/user-attachments/assets/e49b30b5-aa0d-4907-8b3b-8e5b0f96080e)


## Areas affected and ensured
Appraisal doctype

## Is there any existing behavior change of other features due to this code change?
 No.

## Was this feature tested on the browsers?
 
  - Mozilla Firefox
  
