### PR TITLE
feat:Validate reason for rejection field in Purchase Order

### DIFF
--- a/beams/beams/custom_scripts/purchase_order/purchase_order.py
+++ b/beams/beams/custom_scripts/purchase_order/purchase_order.py
@@ -4,6 +4,14 @@ from frappe import _
 from frappe.desk.form.assign_to import add as add_assign
 from frappe.utils.user import get_users_with_role
 
+
+def validate_reason_for_rejection(doc,method):
+		'''
+			Validate that "Reason for Rejection" is filled if the status is "Rejected"
+		'''
+		if doc.workflow_state == "Rejected" and not doc.reason_for_rejection:
+			frappe.throw("Please provide a Reason for Rejection before rejecting this request.")
+
 @frappe.whitelist()
 def create_todo_on_finance_verification(doc, method):
 	"""
@@ -33,20 +41,6 @@ def create_todo_on_finance_verification(doc, method):
 			"description": description
 		})
 
-def create_todo_on_purchase_order_creation(doc, method):
-	"""
-		Create a ToDo for  Accounts User when a new Purchase Order is created.
-	"""
-	users = get_users_with_role("Accounts User")
-
-	if users:
-		description = f"New Purchase Order Created: {doc.supplier}.<br>Please review and update details or take necessary actions."
-		add_assign({
-			"assign_to": users,
-			"doctype": "Purchase Order",
-			"name": doc.name,
-			"description": description
-		})
 
 def validate(self):
 	'''

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -209,9 +209,8 @@ doc_events = {
 	},
 	"Purchase Order": {
 		"on_update": "beams.beams.custom_scripts.purchase_order.purchase_order.create_todo_on_finance_verification",
-		"after_insert": "beams.beams.custom_scripts.purchase_order.purchase_order.create_todo_on_purchase_order_creation",
 		"before_save": "beams.beams.custom_scripts.purchase_order.purchase_order.validate_budget",
-		# "validate": "beams.beams.custom_scripts.purchase_order.purchase_order.fetch_department_from_cost_center",
+		"validate": "beams.beams.custom_scripts.purchase_order.purchase_order.validate_reason_for_rejection",
 		"on_change":"beams.beams.custom_scripts.purchase_order.purchase_order.update_equipment_quantities"
 	},
 	"Material Request":{

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -894,6 +894,20 @@ def get_purchase_order_custom_fields():
 				"fieldtype": "Attach",
 				"label": "Attachments",
 				"insert_after": "base_net_total"
+			},
+			{
+				"fieldname": "rejection_section",
+				"fieldtype": "Section Break",
+				"label": "Rejection Details",
+				"insert_after": "section_gst_breakup"
+			},
+			{
+				"fieldname": "reason_for_rejection",
+				"fieldtype": "Small Text",
+				"label": "Reason for Rejection",
+				"insert_after": "rejection_section",
+				"depends_on": "eval:doc.workflow_state == 'Rejected' || doc.workflow_state == 'Pending Accounts Approval'  || doc.workflow_state == 'Pending CEO Approval'",
+				"read_only_depends_on": "eval:!(doc.workflow_state == 'Pending Accounts Approval' || doc.workflow_state == 'Pending CEO Approval')"
 			}
 		],
 		"Purchase Order Item": [


### PR DESCRIPTION
## Feature description
Need to: Add reason for rejection field  and Validate it before rejection Purchase Order

## Solution description

-  Added reason for rejection field  and Validated it before rejection Purchase Order
- Removed  ToDo creation code for  Accounts User when a new Purchase Order is created.

## Output screenshots (optional)
[Screencast from 08-09-25 04:04:12 PM IST.webm](https://github.com/user-attachments/assets/84751838-0f87-49ae-ac6c-a980b55bdb63)

## Areas affected and ensured
Purchase Order

## Is there any existing behavior change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?
  - Chrome

