### PR TITLE
    TASK-2025-02141 : implement sequential assessment officer notifications with primary officer logic.

### DIFF
--- a/beams/beams/custom_scripts/appraisal/appraisal.js
+++ b/beams/beams/custom_scripts/appraisal/appraisal.js
@@ -23,13 +23,17 @@ frappe.ui.form.on('Appraisal', {
 		frm.set_df_property('final_score', 'hidden', 1);
 
 		// Show "New Feedback" button only if the user is an assessment officer and not the appraised employee, before submission
+
 		if (!frm.is_new() && frm.doc.docstatus !== 1) {
 			let user = frappe.session.user;
-			frappe.db.get_value('Employee', { 'user_id': user }, ['name']).then(res => {
-				let logged_in_employee = res.message?.name;
-				frappe.db.get_value('Employee', frm.doc.employee, 'assessment_officer').then(emp_res => {
-					let appraisal_assessment_officer = emp_res.message?.assessment_officer;
-					if (appraisal_assessment_officer === logged_in_employee) {
+
+			frappe.call({
+				method: "beams.beams.custom_scripts.appraisal.appraisal.get_primary_assessment_officer",
+				args: { employee_id: frm.doc.employee },
+				callback: function(r) {
+					let primary_officer_user = r.message;
+
+					if (primary_officer_user === user) {
 						frappe.call({
 							method: 'beams.beams.custom_scripts.appraisal.appraisal.get_feedback_for_appraisal',
 							args: { appraisal_name: frm.doc.name },
@@ -40,19 +44,20 @@ frappe.ui.form.on('Appraisal', {
 										frm.events.show_feedback_dialog(frm);
 									});
 								} else {
-									frappe.db.get_value('Employee Performance Feedback', feedback_name, 'docstatus').then(val => {
-										const docstatus = val.message?.docstatus;
-										if (docstatus === 0) {
-											frm.add_custom_button(__('Edit Feedback'), () => {
-												frm.events.show_feedback_dialog(frm);
-											});
-										}
-									});
+									frappe.db.get_value('Employee Performance Feedback', feedback_name, 'docstatus')
+										.then(val => {
+											const docstatus = val.message?.docstatus;
+											if (docstatus === 0) {
+												frm.add_custom_button(__('Edit Feedback'), () => {
+													frm.events.show_feedback_dialog(frm);
+												});
+											}
+										});
 								}
 							}
 						});
 					}
-				});
+				}
 			});
 		}
 
@@ -521,31 +526,36 @@ frappe.ui.form.on('Appraisal', {
 
 		frappe.db.get_value("Employee", { user_id: current_user }, ["name"]).then(emp_res => {
 			const current_emp_id = emp_res.message?.name;
+			frappe.call({
+				method: "beams.beams.custom_scripts.appraisal.appraisal.get_primary_assessment_officer",
+				args: { employee_id: frm.doc.employee },
+				callback: function(r) {
+					const assigned_officer = r.message;
 
-			frappe.db.get_value("Employee", frm.doc.employee, ["assessment_officer"]).then(res => {
-				const assigned_officer = res.message?.assessment_officer;
-				if (current_emp_id === assigned_officer) {
-					frappe.call({
-						method: "beams.beams.custom_scripts.appraisal.appraisal.check_feedback_exists",
-						args: {
-							appraisal_name: frm.doc.name,
-							assessment_officer_user_id: current_user,
-							employee: frm.doc.employee
-						},
-						callback: function (res) {
-							console.log("Feedback Exists Response:", res.message);
-							if (res.message) {
-								frm.events.open_add_category_dialog(frm);
-							} else {
-								frappe.msgprint(__('You must add performance feedback before adding a category.'));
+					if (current_user === assigned_officer) {
+						// Only primary officer must add feedback before adding category
+						frappe.call({
+							method: "beams.beams.custom_scripts.appraisal.appraisal.check_feedback_exists",
+							args: {
+								appraisal_name: frm.doc.name,
+								assessment_officer_user_id: current_user,
+								employee: frm.doc.employee
+							},
+							callback: function(res) {
+								if (res.message) {
+									frm.events.open_add_category_dialog(frm);
+								} else {
+									frappe.msgprint(__('You must add performance feedback before adding a category.'));
+								}
 							}
-						}
-					});
-				} else {
-					frm.events.open_add_category_dialog(frm);
+						});
+					} else {
+						frm.events.open_add_category_dialog(frm);
+					}
 				}
 			});
 		});
+
 	},
 
 

--- a/beams/beams/custom_scripts/appraisal/appraisal.js
+++ b/beams/beams/custom_scripts/appraisal/appraisal.js
@@ -208,6 +208,23 @@ frappe.ui.form.on('Appraisal', {
 				}
 			});
 		});
+		const current_user = frappe.session.user;
+		frappe.db.get_value("Employee", { user_id: current_user }, "name").then(emp_res => {
+			const emp = emp_res.message?.name;
+
+			if (emp && emp === frm.doc.employee && frm.doc.appraisal_cycle) {
+				frappe.db.get_value("Appraisal Cycle", frm.doc.appraisal_cycle, "end_date").then(cycle_res => {
+					const end_date = cycle_res.message?.end_date;
+					if (end_date && frappe.datetime.get_today() > end_date) {
+						frm.disable_form();
+						frappe.show_alert({
+							message: __("This appraisal is read-only since the appraisal cycle has ended."),
+							indicator: "red"
+						});
+					}
+				});
+			}
+		});
 	},
 
 	validate: function (frm) {
@@ -685,4 +702,3 @@ function salary_amount_read_only(frm) {
 		frm.set_df_property("salary_increment_amount", "read_only", 0);
 	}
 }
-

--- a/beams/beams/custom_scripts/appraisal/appraisal.py
+++ b/beams/beams/custom_scripts/appraisal/appraisal.py
@@ -434,17 +434,28 @@ def notify_assestment_officer(doc):
 	Sends an email notification to the assessment officer to review the appraisal.
 	"""
 	appraisal = frappe.get_doc("Appraisal", doc)
-	assessment_officer_id = frappe.db.get_value("Employee", appraisal.employee, "assessment_officer")
+	assessment_officer_user = frappe.db.get_value(
+		"Assessment Officer", 
+		{"parent": appraisal.employee, "is_primary": 1},
+		"assessment_officer"
+	)
 
-	if not assessment_officer_id:
-		frappe.throw(f"Assessment Officer not set for employee {appraisal.employee}")
+	if not assessment_officer_user:
+		frappe.throw(f"Primary Assessment Officer not set for employee {appraisal.employee}")
 
-	user_id, officer_name = frappe.db.get_value("Employee", assessment_officer_id, ["user_id", "employee_name"])
+	officer = frappe.db.get_value(
+		"User",
+		assessment_officer_user,
+		["name as user_id", "full_name as officer_name", "email"],
+		as_dict=1
+	)
 
-	if not user_id:
-		frappe.throw(f"No User ID found for assessment officer {assessment_officer_id}")
+	if not officer:
+		frappe.throw(f"User record not found for Assessment Officer {assessment_officer_user}")
 
-	# Get email template
+	if not officer.email:
+		frappe.throw(f"No email found for Assessment Officer {officer.officer_name}")
+
 	template_name = frappe.db.get_single_value("Beams HR Settings", "assessment_reminder_template")
 	if not template_name:
 		frappe.throw("Please set 'Assessment Reminder Template' in Beams HR Settings.")
@@ -454,17 +465,17 @@ def notify_assestment_officer(doc):
 	context = {
 		"doc": appraisal,
 		"employee_name": appraisal.employee_name,
-		"officer_name": officer_name,
+		"officer_name": officer.officer_name,
 	}
 	subject = frappe.render_template(template.subject or '', context)
 	message = frappe.render_template(template.response or template.message or '', context)
 
-	frappe.sendmail(recipients=frappe.db.get_value("User", user_id, "email"), subject=subject, message=message)
+	frappe.sendmail(recipients=[officer.email], subject=subject, message=message)
 
 	frappe.get_doc({
 		"doctype": "Notification Log",
 		"subject": subject,
-		"for_user": user_id,
+		"for_user": officer.user_id,
 		"type": "Alert",
 		"document_type": "Appraisal",
 		"document_name": appraisal.name,
@@ -472,7 +483,7 @@ def notify_assestment_officer(doc):
 		"email_content": message
 	}).insert(ignore_permissions=True)
 
-	frappe.msgprint(f"Notification sent to {officer_name} for appraisal review.")
+	frappe.msgprint(f"Notification sent to {officer.officer_name} for appraisal review.")
 	return {"status": "ok"}
 
 @frappe.whitelist()
@@ -632,7 +643,7 @@ def send_next_officer_notification(appraisal_name):
 		return "No Appraisal Template"
 	officer_list = frappe.db.get_all(
 		"Assessment Officer",
-		filters={"parent": appraisal.appraisal_template},
+		filters={"parent": appraisal.employee, "is_primary": 0},
 		pluck="assessment_officer",
 		order_by="idx asc"
 	)
@@ -713,3 +724,16 @@ def notify_employee_on_appraisal_creation(doc, method):
 		"from_user": frappe.session.user,
 		"email_content": email_content
 	}).insert(ignore_permissions=True)
+
+@frappe.whitelist()
+def get_primary_assessment_officer(employee_id):
+	"""
+	Return primary assessment officer user for an employee
+	(ignores permissions so Assessment Officer can fetch it).
+	"""
+	officer_user = frappe.db.get_value(
+		"Assessment Officer",
+		{"parent": employee_id, "is_primary": 1},
+		"assessment_officer"
+	)
+	return officer_user

--- a/beams/beams/custom_scripts/employee/employee.py
+++ b/beams/beams/custom_scripts/employee/employee.py
@@ -465,3 +465,10 @@ def create_ceo_appraisal_alert_template():
 			)
 			unique_subject = f"[Escalation][{emp.name}] {subject}"
 			create_notification_log(unique_subject, ceo_emails, "Employee", emp.name, email_content)
+
+
+
+def validate(doc, method=None):
+    officers = doc.assessment_officers or []
+    if sum(1 for row in officers if row.is_primary) > 1:
+        frappe.throw("Only one Primary Assessment Officer can be selected.")

--- a/beams/beams/doctype/assessment_officer/assessment_officer.json
+++ b/beams/beams/doctype/assessment_officer/assessment_officer.json
@@ -7,7 +7,8 @@
  "engine": "InnoDB",
  "field_order": [
   "assessment_officer",
-  "assessment_days"
+  "assessment_days",
+  "is_primary"
  ],
  "fields": [
   {
@@ -22,12 +23,18 @@
    "fieldtype": "Int",
    "in_list_view": 1,
    "label": "Assessment Days"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_primary",
+   "fieldtype": "Check",
+   "label": "Primary Assessment Officer"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-08-30 15:55:34.947856",
+ "modified": "2025-09-06 14:49:18.299645",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Assessment Officer",

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -302,7 +302,8 @@ doc_events = {
 		"before_validate": "beams.beams.custom_scripts.employee.employee.manage_user_status",
 		"validate":  [
 			"beams.beams.custom_scripts.employee.employee.validate",
-			"beams.beams.custom_scripts.employee.employee.validate_offer_dates"
+			"beams.beams.custom_scripts.employee.employee.validate_offer_dates",
+			"beams.beams.custom_scripts.employee.employee.validate"
 		]
 	},
 	"Job Offer" : {

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -1996,13 +1996,6 @@ def get_employee_custom_fields():
 				"insert_after":"relation"
 			},
 			{
-				"fieldname": "assessment_officer",
-				"fieldtype": "Link",
-				"options": "Employee",
-				"label": "Assessment Officer",
-				"insert_after": "reports_to"
-			},
-			{
 				"fieldname": "appraisal_details",
 				"fieldtype": "Section Break",
 				"label": "Appraisal Details",


### PR DESCRIPTION
## Feature description
- Need to implement sequential assessment officer notifications with primary assessment officer logic.

## Solution description
 - Moved Assessment Officers to child table in Employee
- Added 'is_primary' checkbox to mark the Primary Assessment Officer (validation ensures only one)
- Notifications now sent only to Primary Officer when employee clicks "Notify Assessment Officers"
- Feedback button visible only to Primary Officer initially
- After Primary submits performance category, notifications sent sequentially to next officers
- Removed  'Assessment Officer' field from Employee
- make appraisal form read-only for employee after cycle end date

## Output screenshots (optional)
<img width="1154" height="598" alt="image" src="https://github.com/user-attachments/assets/e6bcb536-229f-4efa-9125-683545399604" />
<img width="1154" height="598" alt="image" src="https://github.com/user-attachments/assets/9757eade-2c31-4758-b75b-d0b15d5e5b98" />
<img width="1154" height="598" alt="image" src="https://github.com/user-attachments/assets/76843a83-86cb-4a63-b045-209948884a46" />
<img width="1154" height="598" alt="image" src="https://github.com/user-attachments/assets/0c300fba-cec2-4897-8859-9a8aaeea950f" />
<img width="1154" height="598" alt="image" src="https://github.com/user-attachments/assets/96b97009-f653-4f34-ab2c-2a30abb6cb0b" />

## Areas affected and ensured
- Appraisal

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox