### PR TITLE
feat:Show key fields in list view in Key Log doctype

### DIFF
--- a/beams/beams/doctype/inward_register/inward_register.js
+++ b/beams/beams/doctype/inward_register/inward_register.js
@@ -9,13 +9,14 @@ frappe.ui.form.on('Inward Register', {
 				});
 			}, __("Create"));
 
-			if (!frappe.user.has_role('Security') || frappe.user.has_role('Administrator')) {
+			if (!frappe.user.has_role('Security')) {
 				frm.add_custom_button(__(' Visitor Pass'), function () {
 					frappe.new_doc("Visitor Pass", {
 						inward_register: frm.doc.name,
 						issued_date: frappe.datetime.now_date(),
 						issued_time: frappe.datetime.now_time(),
-						issued_to: frm.doc.visitor_name
+						issued_to: frm.doc.visitor_name,
+						purpose_of_visit: frm.doc.purpose_of_visit
 					});
 				}, __("Create"));
 				if (frm.doc.visitor_type === 'Courier') {

--- a/beams/beams/doctype/key_log/key_log.json
+++ b/beams/beams/doctype/key_log/key_log.json
@@ -16,7 +16,8 @@
   "column_break_bb13",
   "assigned_date",
   "returned_date",
-  "status"
+  "status",
+  "amended_from"
  ],
  "fields": [
   {
@@ -41,6 +42,7 @@
   {
    "fieldname": "status",
    "fieldtype": "Select",
+   "in_list_view": 1,
    "label": "Status",
    "options": "In Custody\nReturned"
   },
@@ -51,6 +53,7 @@
   {
    "fieldname": "key_holder",
    "fieldtype": "Link",
+   "in_list_view": 1,
    "label": "Key Holder",
    "options": "Employee"
   },
@@ -58,6 +61,7 @@
    "depends_on": "eval:doc.is_vehicle",
    "fieldname": "vehicle",
    "fieldtype": "Link",
+   "in_list_view": 1,
    "label": "Vehicle ",
    "options": "Vehicle"
   },
@@ -77,15 +81,26 @@
    "depends_on": "eval: doc.is_service_unit",
    "fieldname": "service_unit",
    "fieldtype": "Link",
+   "in_list_view": 1,
    "label": "Service Unit",
    "options": "Service Unit"
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "Key Log",
+   "print_hide": 1,
+   "read_only": 1,
+   "search_index": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-08-11 09:35:43.183752",
+ "modified": "2025-09-15 11:01:30.482008",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Key Log",


### PR DESCRIPTION
## Feature description
Need to: 
-  Add status,Key Holder,Vehicle and Service Unit fields in Key Log doctype in list view 
-  Remove the role Administrator from Visitor Pass button

## Solution description
- Added status,Key Holder,Vehicle and Service Unit fields in Key Log doctype in list view 
-  Updated visibility logic for the Visitor Pass custom button that is removed Administrator  role  from Visitor Pass button


## Output screenshots (optional)

[Screencast from 15-09-25 11:58:25 AM IST.webm](https://github.com/user-attachments/assets/3c6feded-4159-441d-98ed-e69cba0ab874)

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/8ed34cb9-f723-4059-aff7-1f9ef21072c6" />

## Areas affected and ensured
visitor pass 
key log doctype

## Is there any existing behaviour change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome

