### PR TITLE
fix: create Material Request from HD Ticket

### DIFF
--- a/beams/beams/custom_scripts/hd_ticket/hd_ticket.js
+++ b/beams/beams/custom_scripts/hd_ticket/hd_ticket.js
@@ -34,14 +34,22 @@ frappe.ui.form.on('HD Ticket', {
   On click, it creates a new "Material Request" document.
   Populates items from the 'material_request_items' child table of HD Ticket.
 */
+
 function add_material_request_button(frm) {
     frm.add_custom_button(__('Material Request'), () => {
-        frappe.new_doc('Material Request', {
-            items: (frm.doc.material_request_items || []).map(row => ({
-                item_code: row.item,
-                qty: row.quantity,
-                schedule_date: row.required_by
-            }))
+        frappe.call({
+            method: "beams.beams.custom_scripts.hd_ticket.hd_ticket.create_material_request_from_ticket",
+            args: {
+                ticket_name: frm.doc.name
+            },
+            callback: function (r) {
+                if (!r.exc && r.message) {
+                    frappe.new_doc('Material Request', r.message);
+                }
+            }
         });
     }, __('Create'));
 }
+
+
+

--- a/beams/beams/custom_scripts/hd_ticket/hd_ticket.py
+++ b/beams/beams/custom_scripts/hd_ticket/hd_ticket.py
@@ -84,3 +84,26 @@ class HDTicketOverride(HDTicket):
             self.agent_group = default_team
         else:
             self.agent_group = ''
+            
+            
+            
+
+@frappe.whitelist()
+def create_material_request_from_ticket(ticket_name):
+    ticket = frappe.get_doc("HD Ticket", ticket_name)
+    mr = frappe.new_doc("Material Request")
+    mr.material_request_type = "Purchase"
+    mr.transaction_date = frappe.utils.today()
+
+    for row in ticket.material_request_items:
+        mr.append("items", {
+            "item_code": row.item,
+            "qty": row.quantity,
+            "uom": frappe.db.get_value("Item", row.item, "stock_uom"),
+            "schedule_date": row.required_by or frappe.utils.today()
+        })
+
+    return mr.as_dict()
+
+
+


### PR DESCRIPTION
## Feature description
Create material request from HD Ticket

## Solution description
passed all the neccessary data related to item before creating material request

## Output screenshots (optional)
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/c5318917-27e8-4281-868a-71398a4a9858" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/db0842cf-ab42-409e-a31c-8c2bfa917296" />


## Was this feature tested on the browsers?
  - Chrome

