### PR TITLE
TASK-2025-02234:Apply restrictions to workflow buttons

### DIFF
--- a/beams/beams/custom_scripts/purchase_order/purchase_order.js
+++ b/beams/beams/custom_scripts/purchase_order/purchase_order.js
@@ -1,0 +1,39 @@
+frappe.ui.form.on('Purchase Order', {
+	refresh(frm) {
+		workflow_actions(frm);
+		
+	}
+});
+
+/**
+ * Shows workflow buttons to the Purchase Order form based on the total amount.
+ */
+function workflow_actions(frm) {
+	if (frm.doc.workflow_state === "Pending Accounts Approval"){;
+		const add_workflow_button = (label, action) => {
+			frm.page.add_action_item(__(label), () => {
+				frappe.xcall('frappe.model.workflow.apply_workflow', {
+					doc: frm.doc,
+					action: action
+				})
+			});
+		};
+
+		frappe.db.get_single_value('Beams Accounts Settings', 'purchase_threshold')
+			.then(threshold => {
+				if (!threshold) {
+					return;
+				}
+
+				frm.page.clear_actions_menu();
+				const grand_total = frm.doc.grand_total;
+				let actions = ['Forward to CEO'];
+				if (grand_total < threshold) {
+					actions.unshift('Approve', 'Reject');
+				}
+
+				actions.forEach(action => add_workflow_button(action, action));
+			});
+		}
+
+}

--- a/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.json
+++ b/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.json
@@ -10,6 +10,7 @@
   "column_break_eqou",
   "equalize_purchase_and_quotation_amounts",
   "single_sales_order",
+  "purchase_threshold",
   "tab_break_4hid",
   "default_working_hours",
   "batta_claim_service_item",
@@ -124,12 +125,18 @@
   {
    "fieldname": "column_break_jaqb",
    "fieldtype": "Column Break"
+  },
+  {
+   "description": "Amount limit used to control Purchase Order approvals",
+   "fieldname": "purchase_threshold",
+   "fieldtype": "Float",
+   "label": "Purchase Threshold "
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-10-16 14:57:42.229657",
+ "modified": "2025-09-17 10:09:26.560768",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Beams Accounts Settings",
@@ -146,6 +153,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -71,7 +71,8 @@ doctype_js = {
 	"Payroll Entry":"beams/custom_scripts/payroll_entry/payroll_entry.js",
 	"Employee Separation": "beams/custom_scripts/employee_separation/employee_separation.js",
 	"Job Opening": "beams/custom_scripts/job_opening/job_opening.js",
-	"HD Ticket":"beams/custom_scripts/hd_ticket/hd_ticket.js" 
+	"HD Ticket":"beams/custom_scripts/hd_ticket/hd_ticket.js",
+	"Purchase Order":"beams/custom_scripts/purchase_order/purchase_order.js"
 }
 doctype_list_js = {
 	"Sales Invoice" : "beams/custom_scripts/sales_invoice/sales_invoice_list.js",


### PR DESCRIPTION
## Feature description
Need to:

- Add Purchase Threshold field in Beams Account Settings
- Apply restrictions to workflow buttons in Purchase Order

## Solution description
- Added Purchase Threshold field in Beams Account Settings
- Applied restrictions to workflow buttons in Purchase Order that is  Shows "Approve", "Reject", and "Forward to CEO" if the total is below the threshold and Shows only "Forward to CEO" if the total is above or equal to the threshold.

## Output screenshots (optional)
[Screencast from 17-09-25 05:10:17 PM IST.webm](https://github.com/user-attachments/assets/c3fb859a-905a-4a1e-b211-3b12fff668de)


## Areas affected and ensured
Purchase Order doctype

## Is there any existing behavior change of other features due to this code change?
 No.

## Was this feature tested on the browsers?
  - Chrome

