### PR TITLE
TASK-2025-02242:Capture Reason for Rejection field

### DIFF
--- a/beams/beams/custom_scripts/purchase_order/purchase_order.js
+++ b/beams/beams/custom_scripts/purchase_order/purchase_order.js
@@ -1,7 +1,6 @@
 frappe.ui.form.on('Purchase Order', {
 	refresh(frm) {
 		workflow_actions(frm);
-		
 	}
 });
 

--- a/beams/beams/doctype/outward_pass/outward_pass.json
+++ b/beams/beams/doctype/outward_pass/outward_pass.json
@@ -23,6 +23,7 @@
   {
    "fieldname": "employee_in_charge",
    "fieldtype": "Link",
+   "ignore_user_permissions": 1,
    "in_list_view": 1,
    "label": "Employee in Charge",
    "options": "Employee",
@@ -102,7 +103,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-09-17 13:22:34.087810",
+ "modified": "2025-09-18 11:46:36.609567",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Outward Pass",

--- a/beams/beams/doctype/trip_sheet/trip_sheet.json
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.json
@@ -35,7 +35,8 @@
   "fuel_consumed",
   "amended_from",
   "section_break_kwfq",
-  "remarks"
+  "remarks",
+  "reason_for_rejection"
  ],
  "fields": [
   {
@@ -216,6 +217,14 @@
    "fieldname": "driver_name",
    "fieldtype": "Data",
    "label": "Driver Name"
+  },
+  {
+   "allow_on_submit": 1,
+   "depends_on": "eval: doc.workflow_state == \"Pending Verification\" || doc.workflow_state == \"Rejected\";\n",
+   "fieldname": "reason_for_rejection",
+   "fieldtype": "Small Text",
+   "label": "Reason for Rejection",
+   "read_only_depends_on": "eval: doc.workflow_state != \"Pending Verification\";"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -226,7 +235,7 @@
    "link_fieldname": "trip_sheet"
   }
  ],
- "modified": "2025-08-23 10:13:36.284763",
+ "modified": "2025-09-18 10:26:47.613941",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Trip Sheet",

--- a/beams/beams/doctype/trip_sheet/trip_sheet.py
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.py
@@ -13,7 +13,18 @@ class TripSheet(Document):
 		self.calculate_and_validate_fuel_data()
 		self.calculate_hours()
 		self.validate_trip_times()
+		self.validate_reason_for_rejection()
 
+	def validate_reason_for_rejection(self):
+		"""
+		Ensure that a Reason for Rejection is provided
+		whenever the workflow state is set to 'Rejected'.
+		"""
+		if self.workflow_state == "Rejected" and not self.reason_for_rejection:
+			frappe.throw(
+				msg="Please provide a Reason for Rejection before rejecting this request.",
+				title="Missing Reason for Rejection"
+			)
 
 	def before_save(self):
 		self.validate_posting_date()


### PR DESCRIPTION
## Feature description

Need to : 
- Add Reason for Rejection field in Trip sheet doctype
- Add `ignore_user_permissions`: 1 to the `employee_in_charge` field in the Outward Pass doctype 

## Solution description
- Added Reason for Rejection field in Trip sheet doctype
- Removed unwanted line break in purchase order client script
- Added `ignore_user_permissions`: 1 to the `employee_in_charge` field in the Outward Pass doctype 

## Output screenshots (optional)
[Screencast from 18-09-25 10:31:40 AM IST.webm](https://github.com/user-attachments/assets/04ef4013-dc6e-4876-8209-96eea6f6fcb2)

[Screencast from 18-09-25 12:00:22 PM IST.webm](https://github.com/user-attachments/assets/08f9588d-9531-4e6f-af40-e514007c21fb)


## Areas affected and ensured
Trip sheet doctype
Outward Pass doctype
## Is there any existing behavior change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?
  - Chrome
