### PR TITLE
TASK-2025-02235 : schedule-based appraisal creation from employee

### DIFF
--- a/beams/beams/custom_scripts/appraisal/appraisal.js
+++ b/beams/beams/custom_scripts/appraisal/appraisal.js
@@ -210,20 +210,19 @@ frappe.ui.form.on('Appraisal', {
 			});
 		});
 		const current_user = frappe.session.user;
-		frappe.db.get_value("Employee", { user_id: current_user }, "name").then(emp_res => {
+		frappe.db.get_value("Employee", { user_id: current_user }, ["name"]).then(emp_res => {
 			const emp = emp_res.message?.name;
 
-			if (emp && emp === frm.doc.employee && frm.doc.appraisal_cycle) {
-				frappe.db.get_value("Appraisal Cycle", frm.doc.appraisal_cycle, "end_date").then(cycle_res => {
-					const end_date = cycle_res.message?.end_date;
-					if (end_date && frappe.datetime.get_today() > end_date) {
-						frm.disable_form();
-						frappe.show_alert({
-							message: __("This appraisal is read-only since the appraisal cycle has ended."),
-							indicator: "red"
-						});
-					}
-				});
+			if (emp && emp === frm.doc.employee && frm.doc.end_date) {
+				const today = frappe.datetime.str_to_obj(frappe.datetime.get_today());
+				const end_date = frappe.datetime.str_to_obj(frm.doc.end_date);
+				if (today > end_date) {
+					frm.disable_form();
+					frappe.show_alert({
+						message: __("This appraisal is read-only since the appraisal period has ended."),
+						indicator: "red"
+					});
+				}
 			}
 		});
 		frappe.db.get_value("Employee", { user_id: frappe.session.user }, "name")

--- a/beams/beams/custom_scripts/appraisal/appraisal.py
+++ b/beams/beams/custom_scripts/appraisal/appraisal.py
@@ -7,6 +7,78 @@ from frappe.utils import get_link_to_form
 from six import string_types
 from frappe.utils import get_fullname
 
+from hrms.hr.doctype.appraisal.appraisal import Appraisal as HRMSAppraisal
+from hrms.hr.utils import validate_active_employee
+from frappe.utils import flt
+
+class CustomAppraisal(HRMSAppraisal):
+	def validate(self):
+		if not self.status:
+			self.status = "Draft"
+
+		self.set_kra_evaluation_method()
+
+		validate_active_employee(self.employee)
+		# Skip cycle validation if not set
+		if self.appraisal_cycle:
+			from hrms.hr.doctype.appraisal_cycle.appraisal_cycle import validate_active_appraisal_cycle
+			validate_active_appraisal_cycle(self.appraisal_cycle)
+
+		self.validate_duplicate()
+		self.validate_total_weightage("appraisal_kra", "KRAs")
+		self.validate_total_weightage("self_ratings", "Self Ratings")
+
+		self.set_goal_score()
+		self.calculate_self_appraisal_score()
+		self.calculate_avg_feedback_score()
+		self.calculate_final_score()
+
+	def validate_duplicate(self):
+		"""Skip duplicate check if no appraisal cycle and no dates."""
+		if not (self.appraisal_cycle or (self.start_date and self.end_date)):
+			return
+
+		super().validate_duplicate()
+
+	def set_kra_evaluation_method(self):
+		"""Only check KRA evaluation method if cycle is set."""
+		if self.is_new() and self.appraisal_cycle:
+			kra_method = frappe.db.get_value("Appraisal Cycle", self.appraisal_cycle, "kra_evaluation_method")
+			if kra_method == "Manual Rating":
+				self.rate_goals_manually = 1
+
+	def calculate_final_score(self):
+		"""Skip fetching appraisal cycle if not set."""
+		final_score = 0
+
+		if self.appraisal_cycle:
+			appraisal_cycle_doc = frappe.get_cached_doc("Appraisal Cycle", self.appraisal_cycle)
+			formula = appraisal_cycle_doc.final_score_formula
+			based_on_formula = appraisal_cycle_doc.calculate_final_score_based_on_formula
+		else:
+			formula = None
+			based_on_formula = False
+
+		if based_on_formula and formula:
+			employee_doc = frappe.get_cached_doc("Employee", self.employee)
+			data = {
+				"goal_score": flt(self.total_score),
+				"average_feedback_score": flt(self.avg_feedback_score),
+				"self_appraisal_score": flt(self.self_score),
+			}
+			data.update(appraisal_cycle_doc.as_dict())
+			data.update(employee_doc.as_dict())
+			data.update(self.as_dict())
+
+			from hrms.payroll.utils import sanitize_expression
+			sanitized_formula = sanitize_expression(formula)
+			final_score = frappe.safe_eval(sanitized_formula, data)
+		else:
+			# Fallback simple average calculation
+			final_score = (flt(self.total_score) + flt(self.avg_feedback_score) + flt(self.self_score)) / 3
+
+		self.final_score = flt(final_score, self.precision("final_score"))
+
 
 def validate_kra_marks(doc, method):
 	fields = ['employee_self_kra_rating', 'dept_self_kra_rating', 'company_self_kra_rating']

--- a/beams/beams/custom_scripts/employee/employee.py
+++ b/beams/beams/custom_scripts/employee/employee.py
@@ -466,9 +466,103 @@ def create_ceo_appraisal_alert_template():
 			unique_subject = f"[Escalation][{emp.name}] {subject}"
 			create_notification_log(unique_subject, ceo_emails, "Employee", emp.name, email_content)
 
+def validate_assessment_officer(doc, method=None):
+	officers = doc.assessment_officers or []
+	if sum(1 for row in officers if row.is_primary) > 1:
+		frappe.throw("Only one Primary Assessment Officer can be selected.")
 
+@frappe.whitelist()
+def update_next_appraisal_dates_and_create_appraisal():
+	"""
+	Daily Scheduler:
+	- For each active employee, check if next_appraisal_date + days <= today.
+	- If overdue, update next_appraisal_date and create appraisal in Draft.
+	"""
+	days = frappe.db.get_single_value("Beams HR Settings", "days_for_next_appraisal_creation")
+	today_date = getdate(today())
 
-def validate(doc, method=None):
-    officers = doc.assessment_officers or []
-    if sum(1 for row in officers if row.is_primary) > 1:
-        frappe.throw("Only one Primary Assessment Officer can be selected.")
+	employees = frappe.get_all(
+		"Employee",
+		filters={"status": "Active"},
+		fields=["name", "next_appraisal_date", "employee_name", "appraisal_template"]
+	)
+
+	for emp in employees:
+		if not emp.next_appraisal_date:
+			continue
+
+		next_appraisal_date = getdate(emp.next_appraisal_date)
+		next_cycle_date = add_days(next_appraisal_date, days)
+
+		if next_cycle_date <= today_date:
+			frappe.db.set_value("Employee", emp.name, "next_appraisal_date", next_cycle_date)
+			frappe.db.commit()
+
+			create_appraisal_if_not_exists(
+				emp=frappe._dict(emp),
+				start_date=next_cycle_date,
+				end_date=add_days(next_cycle_date, days - 1)
+			)
+
+def create_appraisal_if_not_exists(emp, start_date, end_date):
+	"""
+	Create a Draft appraisal if template exists and no overlapping appraisal exists.
+	Maps goals from Appraisal Template into appraisal_kra table.
+	Returns True if appraisal was created, False otherwise.
+	"""
+	if not emp.appraisal_template:
+		return False
+
+	existing = frappe.get_all(
+		"Appraisal",
+		filters={
+			"employee": emp.name,
+			"status": ["!=", "Cancelled"],
+			"start_date": ["<=", end_date],
+			"end_date": [">=", start_date],
+		},
+		limit=1
+	)
+
+	if existing:
+		return False
+
+	template_goals = frappe.get_all(
+		"Appraisal Template Goal",
+		filters={"parent": emp.appraisal_template},
+		fields=["key_result_area", "per_weightage"]
+	)
+
+	appraisal_doc = frappe.get_doc({
+		"doctype": "Appraisal",
+		"employee": emp.name,
+		"appraisal_template": emp.appraisal_template,
+		"start_date": start_date,
+		"end_date": end_date,
+		"status": "Draft"
+	})
+
+	for goal in template_goals:
+		appraisal_doc.append("appraisal_kra", {
+			"kra": goal.key_result_area,
+			"per_weightage": goal.per_weightage
+		})
+
+	appraisal_doc.insert(ignore_permissions=True)
+	return True
+
+def employee_on_update(doc, method):
+	"""
+	Triggered when Employee is saved.
+	- If next_appraisal_date and appraisal_template are set,
+	  create appraisal instantly if it doesn't exist already.
+	"""
+	if doc.next_appraisal_date and doc.appraisal_template:
+		days = frappe.db.get_single_value("Beams HR Settings", "days_for_next_appraisal_creation") or 365
+		start_date = getdate(doc.next_appraisal_date)
+		end_date = add_days(start_date, days - 1)
+		create_appraisal_if_not_exists(
+			emp=doc,
+			start_date=start_date,
+			end_date=end_date
+		)

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -169,7 +169,8 @@ override_doctype_class = {
 	"Attendance Request": "beams.beams.custom_scripts.attendance_request.attendance_request.AttendanceRequestOverride",
 	"Shift Type": "beams.beams.custom_scripts.shift_type.shift_type.ShiftTypeOverride",
 	"Interview": "beams.beams.custom_scripts.interview.interview.InterviewOverride",
-	"HD Ticket" :"beams.beams.custom_scripts.hd_ticket.hd_ticket.HDTicketOverride"
+	"HD Ticket" :"beams.beams.custom_scripts.hd_ticket.hd_ticket.HDTicketOverride",
+	"Appraisal": "beams.beams.custom_scripts.appraisal.appraisal.CustomAppraisal"
 }
 
 # Document Events
@@ -304,8 +305,9 @@ doc_events = {
 		"validate":  [
 			"beams.beams.custom_scripts.employee.employee.validate",
 			"beams.beams.custom_scripts.employee.employee.validate_offer_dates",
-			"beams.beams.custom_scripts.employee.employee.validate"
-		]
+			"beams.beams.custom_scripts.employee.employee.validate_assessment_officer"
+		],
+		"on_update": "beams.beams.custom_scripts.employee.employee.employee_on_update"
 	},
 	"Job Offer" : {
 		"on_submit":"beams.beams.custom_scripts.job_offer.job_offer.make_employee",
@@ -329,7 +331,7 @@ doc_events = {
 		"validate": [
 			"beams.beams.custom_scripts.appraisal.appraisal.validate_appraisal",
 			"beams.beams.custom_scripts.appraisal.appraisal.set_category_based_on_marks",
-			"beams.beams.custom_scripts.appraisal.appraisal.validate_kra_marks",
+			"beams.beams.custom_scripts.appraisal.appraisal.validate_kra_marks"
 		],
 		"before_insert": [
 			"beams.beams.custom_scripts.appraisal.appraisal.set_self_appraisal",
@@ -419,7 +421,8 @@ scheduler_events = {
 		"beams.beams.doctype.beams_admin_settings.beams_admin_settings.send_asset_reservation_notifications",
 		"beams.beams.custom_scripts.employee.employee.send_pre_deadline_appraisal_reminder",
 		"beams.beams.custom_scripts.employee.employee.send_appraisal_escalation",
-		"beams.beams.custom_scripts.employee.employee.create_ceo_appraisal_alert_template"
+		"beams.beams.custom_scripts.employee.employee.create_ceo_appraisal_alert_template",
+		"beams.beams.custom_scripts.employee.employee.update_next_appraisal_dates_and_create_appraisal"
 	],
 # "all": [
 # "beams.tasks.all"

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -2047,6 +2047,12 @@ def get_employee_custom_fields():
 				"insert_after": "next_appraisal_date"
 			},
 			{
+				"fieldname": "joining_details",
+				"fieldtype": "Section Break",
+				"label": "Joining Details",
+				"insert_after": "employment_details"
+			},
+			{
 				"fieldname": "assessment_officers",
 				"fieldtype": "Table",
 				"options": "Assessment Officer",
@@ -4776,6 +4782,20 @@ def get_property_setters():
 			"property": "hidden",
 			"property_type": "Check",
 			"value": "1"
+		},	
+		{
+			"doctype_or_field": "DocField",
+			"doc_type": "Appraisal",
+			"field_name": "appraisal_cycle",
+			"property": "reqd",
+			"value": 0
+		},
+		{
+			"doctype_or_field": "DocField",
+			"doc_type": "Appraisal",
+			"field_name": "appraisal_cycle",
+			"property": "hidden",
+			"value": 1
 		}
 ]
 


### PR DESCRIPTION
## Feature description
- Customize employee doctype
- Set the next appraisal date according to the number of days specified in Beams HR Settings.
- Create appraisal from employee when the next appraisal date sets.
- When an employee user logs in and opens an appraisal form, the form should be disabled once the appraisal end date has passed.

## Solution description
- Customized employee and appraisal doctype.
- Set the next appraisal date according to the number of days specified in Beams HR Settings.
- Created appraisal from employee when the next appraisal date sets.
- When an employee user logs in and opens an appraisal form, the form should be disabled once the appraisal end date has passed.

## Output screenshots (optional)
<img width="1323" height="633" alt="image" src="https://github.com/user-attachments/assets/0426a140-2d04-4fbe-8d58-73fb01a36523" />
<img width="1323" height="633" alt="image" src="https://github.com/user-attachments/assets/8668d132-86ac-428e-b930-bf70d4b37004" />

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox