### PR TITLE
refactor: change name [recharge] to [refill]

### DIFF
--- a/beams/beams/doctype/fuel_card_log/fuel_card_log.js
+++ b/beams/beams/doctype/fuel_card_log/fuel_card_log.js
@@ -76,7 +76,7 @@ frappe.ui.form.on("Fuel Card Log", {
 	  }, 'Add');
 
 	  // Button: Set Recharge History
-	  frm.add_custom_button('Recharge', () => {
+	  frm.add_custom_button('Refill', () => {
 		frappe.prompt([
 		  {
 			label: 'Refilling Amount',
@@ -85,7 +85,7 @@ frappe.ui.form.on("Fuel Card Log", {
 			reqd: 1
 		  },
 		  {
-			label: 'Recharged Date',
+			label: 'Refilling Date',
 			fieldname: 'recharged_date',
 			fieldtype: 'Date',
 			default: frappe.datetime.get_today(),


### PR DESCRIPTION
## Feature description
change recharge name to refill

## Solution description
Updated all UI labels where “Recharge” appeared to “Refill”.

Modified custom button label in Fuel Card form script:

## Output screenshots (optional)
<img width="662" height="481" alt="image" src="https://github.com/user-attachments/assets/e6fa1380-76e8-48d3-a628-0d39786841d9" />



## Was this feature tested on the browsers?
  - Chrome
