### PR TITLE
fix: prevent overlapping bookings for meeting rooms

### DIFF
--- a/beams/beams/custom_scripts/event/event.js
+++ b/beams/beams/custom_scripts/event/event.js
@@ -1,100 +1,76 @@
 frappe.ui.form.on('Event', {
-    /**
-     * Adds a custom button 'Training Request' for users with 'HOD' role
-     * This button creates a new 'Training Request' document.
-     */
-    refresh: function (frm) {
-        // Add filter for 'meeting_room' field
-        frm.set_query('meeting_room', function () {
-            if (frm.doc.assign_service_unit) {
-                return {
-                    filters: {
-                        allow_appointment: 1
-                    }
-                };
-            }
-        });
+	/**
+	 * Adds a custom button 'Training Request' for users with 'HOD' role
+	 * This button creates a new 'Training Request' document.
+	 */
+	refresh: function (frm) {
+		// Add filter for 'meeting_room' field
+		frm.set_query('meeting_room', function () {
+			if (frm.doc.assign_service_unit) {
+				return {
+					filters: {
+						allow_appointment: 1
+					}
+				};
+			}
+		});
 
-        if (!frm.is_new() && frappe.user.has_role('HOD')) {
-            // Adds the custom button 'Training Request' in the 'Create' section
-            frm.add_custom_button('Training Request', function () {
-                // Call the server-side function to fetch the employee ID for the current user
-                frappe.call({
-                    method: "beams.beams.custom_scripts.employee.employee.get_employee_name_for_user",
-                    args: {
-                        user_id: frappe.session.user
-                    },
-                    callback: function (response) {
-                        if (response.message) {
-                            const session_employee = response.message;
+		if (!frm.is_new() && frappe.user.has_role('HOD')) {
+			// Adds the custom button 'Training Request' in the 'Create' section
+			frm.add_custom_button('Training Request', function () {
+				// Call the server-side function to fetch the employee ID for the current user
+				frappe.call({
+					method: "beams.beams.custom_scripts.employee.employee.get_employee_name_for_user",
+					args: {
+						user_id: frappe.session.user
+					},
+					callback: function (response) {
+						if (response.message) {
+							const session_employee = response.message;
 
-                            if (frm.doc.event_participants && frm.doc.event_participants.length > 0) {
-                                const other_employees = frm.doc.event_participants.filter(participant => {
-                                    const participant_employee = participant.reference_docname;
-                                    return participant_employee !== session_employee;
-                                });
+							if (frm.doc.event_participants && frm.doc.event_participants.length > 0) {
+								const other_employees = frm.doc.event_participants.filter(participant => {
+									const participant_employee = participant.reference_docname;
+									return participant_employee !== session_employee;
+								});
 
-                                if (other_employees.length > 0) {
-                                    const next_employee = other_employees[0].reference_docname;
+								if (other_employees.length > 0) {
+									const next_employee = other_employees[0].reference_docname;
 
-                                    // Create a new Training Request with the next employee
-                                    frappe.new_doc('Training Request', {
-                                        employee: next_employee,
-                                        training_requested_by: session_employee
-                                    });
-                                } else {
-                                    frappe.msgprint(__('No other employees found in the event participants.'));
-                                }
-                            } else {
-                                frappe.msgprint(__('No participants found in this Event.'));
-                            }
-                        } else {
-                            // Show a message if no employee record is found for the user
-                            frappe.msgprint(__('No employee record found for the current user.'));
-                        }
-                    }
-                });
-            }, 'Create');
-        }
+									// Create a new Training Request with the next employee
+									frappe.new_doc('Training Request', {
+										employee: next_employee,
+										training_requested_by: session_employee
+									});
+								} else {
+									frappe.msgprint(__('No other employees found in the event participants.'));
+								}
+							} else {
+								frappe.msgprint(__('No participants found in this Event.'));
+							}
+						} else {
+							// Show a message if no employee record is found for the user
+							frappe.msgprint(__('No employee record found for the current user.'));
+						}
+					}
+				});
+			}, 'Create');
+		}
 
-        // Add button to create Guest Appointment in the 'Create' group
-        frm.add_custom_button(__('Guest Appointment'), () => {
-            if (!frm.doc.external_participants || frm.doc.external_participants.length === 0) {
-                frappe.msgprint(__('No external participants found to create appointments.'));
-                return;
-            }
+		// Add button to create Guest Appointment in the 'Create' group
+		frm.add_custom_button(__('Guest Appointment'), () => {
+			if (!frm.doc.external_participants || frm.doc.external_participants.length === 0) {
+				frappe.msgprint(__('No external participants found to create appointments.'));
+				return;
+			}
 
-            // Map external participants and open the Guest Appointment DocType
-            frappe.new_doc('Guest Appointment', {
-                event: frm.doc.name, // Map the current Event to the Guest Appointment
-                participants: frm.doc.external_participants.map(participant => ({
-                    participant_name: participant.participant_name
-                }))
-            });
-        }, 'Create'); // Add the button under the 'Create' group
-
-        if (frm.doc.meeting_room && frm.doc.starts_on && frm.doc.ends_on) {
-            // Check for conflicting events with the selected meeting room and date range
-            frappe.call({
-                method: "frappe.client.get_list",
-                args: {
-                    doctype: "Event",
-                    filters: {
-                        meeting_room: frm.doc.meeting_room,
-                        // Check if any existing event starts before this event ends and ends after this event starts
-                        starts_on: ["<=", frm.doc.ends_on],
-                        ends_on: [">=", frm.doc.starts_on],
-                        name: ["!=", frm.doc.name] // Exclude the current event
-                    },
-                    fields: ["name", "starts_on", "ends_on"]
-                },
-                callback: function (response) {
-                    if (response.message && response.message.length > 0) {
-                        frm.dashboard.clear_headline()
-                        frm.dashboard.set_headline(`The selected Meeting Room <b>${frm.doc.meeting_room}</b> is already assigned to another Event during this time.`, 'red')
-                    }
-                }
-            });
-        }
-    }
+			// Map external participants and open the Guest Appointment DocType
+			frappe.new_doc('Guest Appointment', {
+				event: frm.doc.name, // Map the current Event to the Guest Appointment
+				participants: frm.doc.external_participants.map(participant => ({
+					participant_name: participant.participant_name
+				}))
+			});
+		}, 'Create'); // Add the button under the 'Create' group
+	}
 });

--- a/beams/beams/custom_scripts/event/event.py
+++ b/beams/beams/custom_scripts/event/event.py
@@ -2,52 +2,40 @@ import frappe
 from frappe.model.document import Document
 from frappe import _
 
-
 @frappe.whitelist()
-def validate_event_conflict(doc, method):
-    '''
-    checks for conflicting events in the same meeting room
-    by comparing the event's start and end times. If another event exists
-    in the same room during the selected time, it displays a warning message.
-    '''
-    if doc.meeting_room and doc.starts_on and doc.ends_on and doc.workflow_state == "Draft":
-        conflicting_events = frappe.get_all("Event", filters={
-            "meeting_room": doc.meeting_room,
-            "starts_on": ["<=", doc.ends_on],
-            "ends_on": [">=", doc.starts_on],
-            "name": ["!=", doc.name]
-        }, fields=["name", "starts_on", "ends_on"])
-        if conflicting_events:
-            frappe.msgprint(_(f"The selected Service Unit <b>{doc.meeting_room}</b> is already assigned to another Event during this time. Send to Admin for Approval."), title="Warning", indicator="red")
+def validate_event_conflict(doc, method=None):
+	"""
+	Prevent saving if another event exists
+	for the same meeting room in the overlapping time.
+	"""
 
+	doc = frappe.parse_json(doc)
 
-@frappe.whitelist()
-def validate_event_before_approval(doc, method):
-    '''
-    Ensure that before approving an event, no other 'Open' events exist
-    with the same service unit (meeting room) at the same time.
-    '''
-    if doc.workflow_state == "Approved" and doc.status == "Open":
-        conflicting_events = frappe.get_all(
-            "Event",
-            filters={
-                "meeting_room": doc.meeting_room,
-                "starts_on": ["<=", doc.ends_on],
-                "ends_on": [">=", doc.starts_on],
-                "status": "Open",
-                "name": ["!=", doc.name],
-            },
-            fields=["name", "starts_on", "ends_on"]
-        )
-        if conflicting_events:
-            frappe.throw(_("Cannot approve this event because another 'Open' event exists in the same Service Unit at the same time."))
+	if not doc.get("meeting_room") or not doc.get("starts_on") or not doc.get("ends_on"):
+		return
+
+	conflict = frappe.db.exists(
+		"Event",
+		{
+			"meeting_room": doc.get("meeting_room"),
+			"starts_on": ["<=", doc.get("ends_on")],
+			"ends_on": [">=", doc.get("starts_on")],
+			"name": ["!=", doc.get("name")],
+		}
+	)
+
+	if conflict:
+		frappe.throw(
+			_(f"The selected Meeting Room <b>{doc.get('meeting_room')}</b> is already booked during this time."),
+			title=_("Meeting Room Conflict")
+		)
 
 @frappe.whitelist()
 def validate_reason_for_rejection(doc, method):
-    '''
-    checks if the workflow state of the document is "Rejected"
-    and if a reason for rejection has not been provided. If no reason is provided,
-    it raises an error with a message to prompt the user to provide one.
-    '''
-    if doc.workflow_state == "Rejected" and not doc.reason_for_rejection:
-        frappe.throw(_("Provide a Reason for Rejection before Rejecting this Event."))
+	'''
+	checks if the workflow state of the document is "Rejected"
+	and if a reason for rejection has not been provided. If no reason is provided,
+	it raises an error with a message to prompt the user to provide one.
+	'''
+	if doc.workflow_state == "Rejected" and not doc.reason_for_rejection:
+		frappe.throw(_("Provide a Reason for Rejection before Rejecting this Event."))

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -343,8 +343,7 @@ doc_events = {
 					"beams.beams.custom_scripts.event.event.validate_reason_for_rejection"
 		],
 		"validate":[
-					"beams.beams.custom_scripts.event.event.validate_event_conflict",
-					"beams.beams.custom_scripts.event.event.validate_event_before_approval"
+					"beams.beams.custom_scripts.event.event.validate_event_conflict"
 		],
 	},
 	"Salary Slip": {


### PR DESCRIPTION
## Feature description

- prevent overlapping bookings for meeting rooms

## Solution description

- [x] TASK-2025-02249

- Previously, the meeting room conflict check ran only in JS (frappe.call inside refresh), which displayed warnings but still allowed saving the Event.
- This caused a risk of multiple events being booked for the same meeting room at the same time.
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------    
- Moved validation to Python (event.py)
- Added validate_event_conflict with frappe.throw, which blocks saving when a conflict exists.
- Added a proper title to the error message (Meeting Room Conflict).
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------    

- Cleaned up JS (event.js)
- Removed inline conflict-checking code.

----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------    
- Updated hooks (hooks.py)
- Added validate_event_conflict to Event’s validate hook.
- Removed duplicate/unused validators that were doing partial checks.

## Output screenshots (optional)

[Screencast from 19-09-25 12:53:23 PM IST.webm](https://github.com/user-attachments/assets/a1bc6510-d810-432e-8a31-d07e1e46276b)

[Screencast from 19-09-25 12:54:15 PM IST.webm](https://github.com/user-attachments/assets/71eafe9b-e128-4bfd-af89-32fc23bd8bf6)

## Areas affected and ensured
event

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - yes
  - Opera Mini
  - Safari
