### PR TITLE
fix: typo in salary_structure fieldname in appraisal

### DIFF
--- a/beams/beams/custom_scripts/appraisal/appraisal.js
+++ b/beams/beams/custom_scripts/appraisal/appraisal.js
@@ -241,7 +241,7 @@ frappe.ui.form.on('Appraisal', {
 					frm.set_value("salary_structure", r.salary_structure);
 				}
 				else {
-					frm.set_value("salary_strcuture", '')
+					frm.set_value("salary_structure", '')
 				}
 			});
 		}


### PR DESCRIPTION
## Feature description
Fixed a typo where `salary_strcuture` was being set instead of `salary_structure`
in the Appraisal custom script. This caused the field value to not clear properly
when no salary structure was returned.
## Analysis and design (optional)
- Identified that the wrong field name (salary_structure) was being set when the salary structure was not returned from the backend call.
- Corrected the field reference to salary_structure to match the actual DocType field.

## Solution description
- Updated appraisal.js to replace the incorrect salary_strcuture field reference with the correct salary_structure.
- Ensures that the salary_structure field is properly cleared when no value is found.

## Output screenshots (optional)
when try to create appraisal for an employee,following error occurred
![Uploading image.png…]()

## Areas affected and ensured
Appraisal form-salary structure field
## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
