### PR TITLE
feat: Include Event in workspace shortcuts and links

### DIFF
--- a/beams/beams/workspace/front_office/front_office.json
+++ b/beams/beams/workspace/front_office/front_office.json
@@ -1,6 +1,6 @@
 {
  "charts": [],
- "content": "[{\"id\":\"ocu1vThYY8\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h2\\\">Front Office</span>\",\"col\":12}},{\"id\":\"CB70ZQ1GaM\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"aWrt1Hj7as\",\"type\":\"paragraph\",\"data\":{\"text\":\"<span class=\\\"h4\\\">Shortcuts</span>\",\"col\":12}},{\"id\":\"HWiZevrw8P\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Inward Register\",\"col\":3}},{\"id\":\"jq0X7agFP-\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Outward Register\",\"col\":3}},{\"id\":\"RZh447rnSA\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Visitor Pass\",\"col\":3}},{\"id\":\"s7OfgszFoL\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Guest Appointment\",\"col\":3}},{\"id\":\"RQdsVRqxNH\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Visit Request\",\"col\":3}},{\"id\":\"HOouBBycLa\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Courier Log\",\"col\":3}},{\"id\":\"-ynj7QSjER\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Service Unit\",\"col\":3}},{\"id\":\"7klUbg0J-q\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"rAvoQwu_YV\",\"type\":\"paragraph\",\"data\":{\"text\":\"<span class=\\\"h4\\\">Quick List</span>\",\"col\":12}},{\"id\":\"gxMXXi_iJ3\",\"type\":\"quick_list\",\"data\":{\"quick_list_name\":\"Inward Register\",\"col\":4}},{\"id\":\"8LCudFhvWl\",\"type\":\"quick_list\",\"data\":{\"quick_list_name\":\"Visitor Pass\",\"col\":4}},{\"id\":\"81I_Nq6fB5\",\"type\":\"quick_list\",\"data\":{\"quick_list_name\":\"Outward Register\",\"col\":4}}]",
+ "content": "[{\"id\":\"ocu1vThYY8\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h2\\\">Front Office</span>\",\"col\":12}},{\"id\":\"CB70ZQ1GaM\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"aWrt1Hj7as\",\"type\":\"paragraph\",\"data\":{\"text\":\"<span class=\\\"h4\\\">Shortcuts</span>\",\"col\":12}},{\"id\":\"HWiZevrw8P\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Inward Register\",\"col\":3}},{\"id\":\"jq0X7agFP-\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Outward Register\",\"col\":3}},{\"id\":\"RZh447rnSA\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Visitor Pass\",\"col\":3}},{\"id\":\"s7OfgszFoL\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Guest Appointment\",\"col\":3}},{\"id\":\"RQdsVRqxNH\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Visit Request\",\"col\":3}},{\"id\":\"HOouBBycLa\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Courier Log\",\"col\":3}},{\"id\":\"-ynj7QSjER\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Service Unit\",\"col\":3}},{\"id\":\"LDu8SEIGcq\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Event\",\"col\":3}},{\"id\":\"7klUbg0J-q\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"rAvoQwu_YV\",\"type\":\"paragraph\",\"data\":{\"text\":\"<span class=\\\"h4\\\">Quick List</span>\",\"col\":12}},{\"id\":\"gxMXXi_iJ3\",\"type\":\"quick_list\",\"data\":{\"quick_list_name\":\"Inward Register\",\"col\":4}},{\"id\":\"8LCudFhvWl\",\"type\":\"quick_list\",\"data\":{\"quick_list_name\":\"Visitor Pass\",\"col\":4}},{\"id\":\"81I_Nq6fB5\",\"type\":\"quick_list\",\"data\":{\"quick_list_name\":\"Outward Register\",\"col\":4}}]",
  "creation": "2025-05-14 10:54:36.053067",
  "custom_blocks": [],
  "docstatus": 0,
@@ -13,7 +13,7 @@
  "is_hidden": 0,
  "label": "Front Office",
  "links": [],
- "modified": "2025-08-06 17:07:27.985945",
+ "modified": "2025-09-19 16:27:42.970307",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Front Office",
@@ -46,6 +46,14 @@
    "doc_view": "List",
    "label": "Service Unit",
    "link_to": "Service Unit",
+   "stats_filter": "[]",
+   "type": "DocType"
+  },
+  {
+   "color": "Orange",
+   "doc_view": "List",
+   "label": "Event",
+   "link_to": "Event",
    "stats_filter": "[]",
    "type": "DocType"
   },


### PR DESCRIPTION
## Feature description
Add Event shortcut and link to Front Office workspace

## Solution description
Previously, the Front Office workspace did not provide quick access to the Event DocType, requiring users to manually search for it.

Added an "Event" shortcut in the workspace content section for quick navigation.
Added an "Event" DocType link under workspace links with list view as the default.

## Output screenshots (optional)
<img width="1659" height="970" alt="image" src="https://github.com/user-attachments/assets/f516f123-758d-47f8-b393-75a4026828f0" />


## Areas affected and ensured

Front Office workspace
 

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - yes
  - Opera Mini
  - Safari
