### PR TITLE
feat: created employee appraisal consent

### DIFF
--- a/beams/beams/custom_scripts/appraisal/appraisal.js
+++ b/beams/beams/custom_scripts/appraisal/appraisal.js
@@ -1,5 +1,6 @@
 frappe.ui.form.on('Appraisal', {
 	refresh: function (frm) {
+        frm.toggle_reqd('appraisal_cycle', 0);
 		if (!frm.doc) return;
 		salary_amount_read_only(frm);
 		frm.trigger('update_self_kra_rating_list_view');
@@ -233,6 +234,16 @@ frappe.ui.form.on('Appraisal', {
 					show_final_assessment_progress(frm, emp);
 				}
 			});
+        if (!frm.is_new()) {
+            if (!frm.doc.consent_received) {
+                frm.disable_form();
+                frm.dashboard.set_headline_alert(
+                    __("Waiting for Employee Appraisal Consent Submission"), "orange"
+                );
+            } else {
+                frm.enable_form();
+            }
+        }    
 	},
 	employee: function (frm) {
 		if (frm.doc.employee) {

--- a/beams/beams/custom_scripts/appraisal/appraisal.py
+++ b/beams/beams/custom_scripts/appraisal/appraisal.py
@@ -13,13 +13,10 @@ from frappe.utils import getdate, add_months
 
 class CustomAppraisal(HRMSAppraisal):
 	def validate(self):
-		if not self.status:
-			self.status = "Draft"
-
+		super().validate()
 		self.set_kra_evaluation_method()
-
 		validate_active_employee(self.employee)
-		# Skip cycle validation if not set
+
 		if self.appraisal_cycle:
 			from hrms.hr.doctype.appraisal_cycle.appraisal_cycle import validate_active_appraisal_cycle
 			validate_active_appraisal_cycle(self.appraisal_cycle)
@@ -27,7 +24,6 @@ class CustomAppraisal(HRMSAppraisal):
 		self.validate_duplicate()
 		self.validate_total_weightage("appraisal_kra", "KRAs")
 		self.validate_total_weightage("self_ratings", "Self Ratings")
-
 		self.set_goal_score()
 		self.calculate_self_appraisal_score()
 		self.calculate_avg_feedback_score()
@@ -37,7 +33,6 @@ class CustomAppraisal(HRMSAppraisal):
 		"""Skip duplicate check if no appraisal cycle and no dates."""
 		if not (self.appraisal_cycle or (self.start_date and self.end_date)):
 			return
-
 		super().validate_duplicate()
 
 	def set_kra_evaluation_method(self):
@@ -48,16 +43,16 @@ class CustomAppraisal(HRMSAppraisal):
 				self.rate_goals_manually = 1
 
 	def calculate_final_score(self):
-		"""Skip fetching appraisal cycle if not set."""
+		"""Calculate final score using formula if available, else fallback to average."""
 		final_score = 0
+		formula = None
+		based_on_formula = False
+		appraisal_cycle_doc = None
 
 		if self.appraisal_cycle:
 			appraisal_cycle_doc = frappe.get_cached_doc("Appraisal Cycle", self.appraisal_cycle)
 			formula = appraisal_cycle_doc.final_score_formula
 			based_on_formula = appraisal_cycle_doc.calculate_final_score_based_on_formula
-		else:
-			formula = None
-			based_on_formula = False
 
 		if based_on_formula and formula:
 			employee_doc = frappe.get_cached_doc("Employee", self.employee)
@@ -66,7 +61,10 @@ class CustomAppraisal(HRMSAppraisal):
 				"average_feedback_score": flt(self.avg_feedback_score),
 				"self_appraisal_score": flt(self.self_score),
 			}
-			data.update(appraisal_cycle_doc.as_dict())
+
+			# Update with appraisal cycle & employee data
+			if appraisal_cycle_doc:
+				data.update(appraisal_cycle_doc.as_dict())
 			data.update(employee_doc.as_dict())
 			data.update(self.as_dict())
 
@@ -74,8 +72,11 @@ class CustomAppraisal(HRMSAppraisal):
 			sanitized_formula = sanitize_expression(formula)
 			final_score = frappe.safe_eval(sanitized_formula, data)
 		else:
-			# Fallback simple average calculation
-			final_score = (flt(self.total_score) + flt(self.avg_feedback_score) + flt(self.self_score)) / 3
+			# Fallback average - only include scores that exist
+			scores = [flt(self.total_score), flt(self.avg_feedback_score), flt(self.self_score)]
+			valid_scores = [s for s in scores if s > 0]
+			if valid_scores:
+				final_score = sum(valid_scores) / len(valid_scores)
 
 		self.final_score = flt(final_score, self.precision("final_score"))
 
@@ -838,3 +839,31 @@ def set_salary_assignment_from_date(doc, method):
 		first_next_month = add_months(today.replace(day=1), 1)
 		doc.salary_assignment_from_date = first_next_month
 
+def after_insert_create_consent(doc, method):
+    """
+    Create Employee Appraisal Consent automatically
+    whenever an Appraisal is created.
+    Fetches consent terms from Beams HR Settings.
+    """
+    existing_consent = frappe.get_all(
+        "Employee Appraisal Consent",
+        filters={"appraisal": doc.name},
+        limit=1
+    )
+
+    if existing_consent:
+        return 
+    terms_name = frappe.db.get_single_value("Beams HR Settings", "appraisal_consent_terms")
+    terms_text = ""
+    if terms_name:
+        terms_text = frappe.db.get_value("Terms and Conditions", terms_name, "terms") or ""
+
+    consent_doc = frappe.get_doc({
+        "doctype": "Employee Appraisal Consent",
+        "employee": doc.employee,
+        "appraisal": doc.name,
+        "terms_and_conditions": terms_text,
+        "consent_given": 0
+    })
+
+    consent_doc.insert(ignore_permissions=True)

--- a/beams/beams/custom_scripts/employee/employee.py
+++ b/beams/beams/custom_scripts/employee/employee.py
@@ -539,7 +539,7 @@ def create_appraisal_if_not_exists(emp, start_date, end_date):
 		"appraisal_template": emp.appraisal_template,
 		"start_date": start_date,
 		"end_date": end_date,
-		"status": "Draft"
+		"consent_received": 0 
 	})
 
 	for goal in template_goals:
@@ -565,4 +565,4 @@ def employee_on_update(doc, method):
 			emp=doc,
 			start_date=start_date,
 			end_date=end_date
-		)
+		)	

--- a/beams/beams/doctype/beams_hr_settings/beams_hr_settings.json
+++ b/beams/beams/doctype/beams_hr_settings/beams_hr_settings.json
@@ -48,6 +48,7 @@
   "appraisal_reminder_template",
   "column_break_dwmr",
   "assessment_reminder_template",
+  "appraisal_consent_terms",
   "section_break_egls",
   "appraisal_initiative_days",
   "hr_notification_days_before_deadline",
@@ -371,13 +372,19 @@
    "fieldtype": "Link",
    "label": "CEO Appraisal Alert Template",
    "options": "Email Template"
+  },
+  {
+   "fieldname": "appraisal_consent_terms",
+   "fieldtype": "Link",
+   "label": "Appraisal Consent Terms",
+   "options": "Terms and Conditions"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-09-01 12:03:18.874306",
+ "modified": "2025-09-15 15:51:29.758758",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Beams HR Settings",

--- a/beams/beams/doctype/employee_appraisal_consent/employee_appraisal_consent.js
+++ b/beams/beams/doctype/employee_appraisal_consent/employee_appraisal_consent.js
@@ -1,0 +1,78 @@
+// Copyright (c) 2025, efeone and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on("Employee Appraisal Consent", {
+	refresh(frm) {
+		if (frm.is_new()) {
+	  fetch_terms_from_settings(frm);
+	}
+	render_appraisal_terms(frm);
+  },
+  terms_and_conditions(frm) {
+	render_appraisal_terms(frm);
+  }
+});
+
+
+/**
+ * Fetch default Appraisal Terms from Beams HR Settings
+ */
+function fetch_terms_from_settings(frm) {
+  frappe.db.get_value("Beams HR Settings", {}, "appraisal_consent_terms")
+	.then(r => {
+	  if (r.message && r.message.appraisal_consent_terms) {
+		frappe.db.get_value("Terms and Conditions", r.message.appraisal_consent_terms, "terms")
+		  .then(res => {
+			if (res.message && res.message.terms) {
+			  frm.set_value("terms_and_conditions", res.message.terms);
+			  render_appraisal_terms(frm);
+			}
+		  });
+	  }
+	});
+}
+
+
+/**
+ * Show appraisal terms in a scrollable box
+ * and enable consent checkbox after reading.
+ */
+function render_appraisal_terms(frm) {
+  $("#appraisal-terms-container").remove();
+
+  if (frm.doc.terms_and_conditions) {
+	const terms_content = frm.doc.terms_and_conditions || "No Terms available.";
+
+	const container = $("<div>")
+	  .attr("id", "appraisal-terms-container")
+	  .css({
+		maxHeight: "300px",       
+		overflowY: "auto",        
+		border: "1px solid #ccc",
+		padding: "10px",
+		marginBottom: "20px",
+		backgroundColor: "#fafafa",
+		whiteSpace: "pre-wrap"
+	  })
+	  .html(terms_content);
+	frm.set_df_property("terms_and_conditions", "hidden", 1);
+	$(frm.fields_dict.consent_given.wrapper).before(container);
+	frm.set_df_property("consent_given", "read_only", 1);
+	setTimeout(() => {
+	  if (container[0].scrollHeight > container.innerHeight()) {
+		container.on("scroll", function () {
+		  if (
+			container.scrollTop() + container.innerHeight() >=
+			container[0].scrollHeight
+		  ) {
+			frm.set_df_property("consent_given", "read_only", 0);
+		  }
+		});
+	  } else {
+		frm.set_df_property("consent_given", "read_only", 0);
+	  }
+	}, 300);
+  } else {
+	frm.set_df_property("consent_given", "read_only", 1);
+  }
+}

--- a/beams/beams/doctype/employee_appraisal_consent/employee_appraisal_consent.js
+++ b/beams/beams/doctype/employee_appraisal_consent/employee_appraisal_consent.js
@@ -4,16 +4,17 @@
 frappe.ui.form.on("Employee Appraisal Consent", {
 	refresh(frm) {
 		if (frm.is_new()) {
-	  fetch_terms_from_settings(frm);
-	}
-	render_appraisal_terms(frm);
+	        fetch_terms_from_settings(frm);
+	    }
+	    render_appraisal_terms(frm);
+        if (!frm.is_new() && frm.doc.docstatus === 1) {
+                add_view_appraisal_button(frm);
+        }
   },
   terms_and_conditions(frm) {
 	render_appraisal_terms(frm);
   }
 });
-
-
 /**
  * Fetch default Appraisal Terms from Beams HR Settings
  */
@@ -31,8 +32,6 @@ function fetch_terms_from_settings(frm) {
 	  }
 	});
 }
-
-
 /**
  * Show appraisal terms in a scrollable box
  * and enable consent checkbox after reading.
@@ -75,4 +74,14 @@ function render_appraisal_terms(frm) {
   } else {
 	frm.set_df_property("consent_given", "read_only", 1);
   }
+}
+/**
+ * Adds a "View Appraisal" button to the Employee Appraisal Consent form. 
+ */
+function add_view_appraisal_button(frm) {
+	if (frm.doc.appraisal) {
+		frm.add_custom_button(__('View Appraisal'), () => {
+			frappe.set_route("Form", "Appraisal", frm.doc.appraisal);
+		});
+	}
 }

--- a/beams/beams/doctype/employee_appraisal_consent/employee_appraisal_consent.json
+++ b/beams/beams/doctype/employee_appraisal_consent/employee_appraisal_consent.json
@@ -1,0 +1,127 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "format:{EMP}-{YY}-{####}",
+ "creation": "2025-09-15 10:22:51.797696",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "section_break_kukn",
+  "employee",
+  "employee_name",
+  "amended_from",
+  "appraisal",
+  "column_break_voru",
+  "posting_date",
+  "company",
+  "section_break_afmk",
+  "terms_and_conditions",
+  "consent_given",
+  "employee_signature"
+ ],
+ "fields": [
+  {
+   "fieldname": "section_break_kukn",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "employee",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Employee",
+   "options": "Employee"
+  },
+  {
+   "fetch_from": "employee.employee_name",
+   "fieldname": "employee_name",
+   "fieldtype": "Data",
+   "label": "Employee Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "Employee Appraisal Consent",
+   "print_hide": 1,
+   "read_only": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "column_break_voru",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "posting_date",
+   "fieldtype": "Data",
+   "label": "Posting Date",
+   "read_only": 1
+  },
+  {
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "label": "Company",
+   "options": "Company"
+  },
+  {
+   "fieldname": "section_break_afmk",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "terms_and_conditions",
+   "fieldtype": "Text Editor",
+   "label": "Terms and Conditions",
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "consent_given",
+   "fieldtype": "Check",
+   "label": "I acknowledge and accept the appraisal terms provided by company and agree to comply with its guidelines"
+  },
+  {
+   "depends_on": "eval: doc.consent_given",
+   "fieldname": "employee_signature",
+   "fieldtype": "Signature",
+   "label": "Employee Signature",
+   "mandatory_depends_on": "eval: doc.consent_given"
+  },
+  {
+   "fieldname": "appraisal",
+   "fieldtype": "Link",
+   "label": "Appraisal",
+   "options": "Appraisal",
+   "read_only": 1
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "is_submittable": 1,
+ "links": [],
+ "modified": "2025-09-15 11:32:59.220357",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "Employee Appraisal Consent",
+ "naming_rule": "Expression",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/beams/beams/doctype/employee_appraisal_consent/employee_appraisal_consent.py
+++ b/beams/beams/doctype/employee_appraisal_consent/employee_appraisal_consent.py
@@ -1,16 +1,11 @@
 # Copyright (c) 2025, efeone and contributors
 # For license information, please see license.txt
 
-# import frappe
 import frappe
 from frappe import _
 from frappe.model.document import Document
 
-
 class EmployeeAppraisalConsent(Document):
-	
-
-
 	def before_submit(self):
 		"""
 		Validate conditions before submitting the document:
@@ -23,3 +18,12 @@ class EmployeeAppraisalConsent(Document):
 		employee_user_id = frappe.db.get_value("Employee", self.employee, "user_id")
 		if frappe.session.user != employee_user_id:
 			frappe.throw(_("Only the selected employee can submit this document."))
+
+	def on_submit(self):
+		"""
+		When employee submits the consent form,
+		mark consent_received = 1 in the linked Appraisal.
+		"""
+		if self.appraisal:
+			frappe.db.set_value("Appraisal", self.appraisal, "consent_received", 1)
+			frappe.db.commit()		

--- a/beams/beams/doctype/employee_appraisal_consent/employee_appraisal_consent.py
+++ b/beams/beams/doctype/employee_appraisal_consent/employee_appraisal_consent.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2025, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+import frappe
+from frappe import _
+from frappe.model.document import Document
+
+
+class EmployeeAppraisalConsent(Document):
+	
+
+
+	def before_submit(self):
+		"""
+		Validate conditions before submitting the document:
+		1. Ensure 'Consent Given' checkbox is checked.
+		2. Ensure 'Employee Signature' field is filled.
+		3. Ensure that only the selected employee can submit this document.
+		"""
+		if not self.consent_given:
+			frappe.throw(_("You must check 'Consent Given' before submitting."))
+		employee_user_id = frappe.db.get_value("Employee", self.employee, "user_id")
+		if frappe.session.user != employee_user_id:
+			frappe.throw(_("Only the selected employee can submit this document."))

--- a/beams/beams/doctype/employee_appraisal_consent/employee_appraisal_consent.py
+++ b/beams/beams/doctype/employee_appraisal_consent/employee_appraisal_consent.py
@@ -7,6 +7,12 @@ from frappe.model.document import Document
 
 class EmployeeAppraisalConsent(Document):
 	def before_submit(self):
+		self.validate_consent_conditions()
+
+	def on_submit(self):
+		self.update_appraisal_consent_status()	
+		
+	def validate_consent_conditions(self):
 		"""
 		Validate conditions before submitting the document:
 		1. Ensure 'Consent Given' checkbox is checked.
@@ -19,7 +25,7 @@ class EmployeeAppraisalConsent(Document):
 		if frappe.session.user != employee_user_id:
 			frappe.throw(_("Only the selected employee can submit this document."))
 
-	def on_submit(self):
+	def update_appraisal_consent_status(self):
 		"""
 		When employee submits the consent form,
 		mark consent_received = 1 in the linked Appraisal.

--- a/beams/beams/doctype/employee_appraisal_consent/test_employee_appraisal_consent.py
+++ b/beams/beams/doctype/employee_appraisal_consent/test_employee_appraisal_consent.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, efeone and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestEmployeeAppraisalConsent(FrappeTestCase):
+	pass

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -337,7 +337,11 @@ doc_events = {
 		"before_insert": [
 			"beams.beams.custom_scripts.appraisal.appraisal.set_self_appraisal",
 		],
-		"on_submit": "beams.beams.custom_scripts.appraisal.appraisal.create_salary_structure_assignment"
+		"on_submit": "beams.beams.custom_scripts.appraisal.appraisal.create_salary_structure_assignment",
+		"after_insert":  [
+			"beams.beams.custom_scripts.appraisal.appraisal.notify_employee_on_appraisal_creation",
+			"beams.beams.custom_scripts.appraisal.appraisal.after_insert_create_consent"
+		]
 	},
 	"Event" :{
 		"on_update":[

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -3793,7 +3793,14 @@ def get_appraisal_custom_fields():
 				"insert_after": "employee_image",
 				"precision": 3,
 				"read_only": 1
-			}
+			},
+			{
+				"fieldname": "consent_received",
+				"fieldtype": "Check",
+				"label": "Consent Received",
+				"insert_after": "final_average_score",
+				"read_only": 1
+			},
 		]
 	}
 


### PR DESCRIPTION
## Feature description
- Customize Beams HR Settings and the Appraisal doctype.
- Create an Employee Appraisal Consent doctype.
- Remove the mandatory requirement for Appraisal Cycle in the Appraisal doctype.
- Set the Appraisal form to editable once the Employee Appraisal Consent is submitted.
- Automatically create an Employee Appraisal Consent record when an Appraisal is created.
- Add a "View Appraisal" button in the Employee Appraisal Consent form.
- Add validation in the Employee Appraisal Consent doctype.
- Automatically check the Consent Received checkbox when the employee submits the consent form.

## Solution description
- Added consent terms in beams hr settings and consent received checkbox in appraisal.
- Created an Employee Appraisal Consent doctype.
- Removed the mandatory requirement for Appraisal Cycle in the Appraisal doctype.
- Set the Appraisal form to editable once the Employee Appraisal Consent is submitted.
- Automatically create an Employee Appraisal Consent record when an Appraisal is created.
- Added a "View Appraisal" button in the Employee Appraisal Consent form.
- Added validation in the Employee Appraisal Consent doctype.
- Automatically check the Consent Received checkbox when the employee submits the consent form.

## Output screenshots (optional)
<img width="1319" height="636" alt="image" src="https://github.com/user-attachments/assets/c3fdc6cb-0bda-479c-b50c-576c629ca178" />
<img width="1319" height="636" alt="image" src="https://github.com/user-attachments/assets/0259f9c9-3bf9-4ad8-bc7e-a86009859e11" />
<img width="1319" height="636" alt="image" src="https://github.com/user-attachments/assets/dfafe659-8b73-4a95-beb4-1be2e931abbd" />

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox