### PR TITLE
fix:ignore_user_permissions for  Received By field

### DIFF
--- a/beams/beams/doctype/guest_appointment/guest_appointment.json
+++ b/beams/beams/doctype/guest_appointment/guest_appointment.json
@@ -55,6 +55,7 @@
   {
    "fieldname": "received_by",
    "fieldtype": "Link",
+   "ignore_user_permissions": 1,
    "in_list_view": 1,
    "label": " Received By",
    "options": "Employee"
@@ -83,7 +84,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-08-07 17:19:52.507070",
+ "modified": "2025-09-20 10:20:06.027783",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Guest Appointment",

--- a/beams/beams/doctype/visit_request/visit_request.json
+++ b/beams/beams/doctype/visit_request/visit_request.json
@@ -16,8 +16,7 @@
   "column_break_gbkg",
   "request_date",
   "expected_date_and_time",
-  "approval_status",
-  "approver"
+  "approval_status"
  ],
  "fields": [
   {
@@ -70,12 +69,6 @@
    "options": "\nPending\nApproved\nRejected"
   },
   {
-   "fieldname": "approver",
-   "fieldtype": "Link",
-   "label": "Approver",
-   "options": "Employee"
-  },
-  {
    "fieldname": "column_break_gbkg",
    "fieldtype": "Column Break"
   },
@@ -93,7 +86,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-06-10 15:11:23.501215",
+ "modified": "2025-09-19 10:02:04.968740",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Visit Request",
@@ -114,6 +107,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []


### PR DESCRIPTION
## Feature description
Need to: 

- Remove Approver field in Visit Request doctype
- Add ignore_user_permissions: 1 to the Received By field in the  Guest Appointment doctype


## Solution description

- Removed Approver field in Visit Request doctype
- Added ignore_user_permissions: 1 to the Received By field in the  Guest Appointment doctype

## Output screenshots (optional)
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/fb362ba8-1841-454b-bb43-386beb2b2e4a" />


## Areas affected and ensured
 Guest Appointment doctype

## Is there any existing behavior change of other features due to this code change?
No. 

## Was this feature tested on the browsers?
  - Chrome

