### PR TITLE
TASK-2025-02250: Double increment calculation based on appraisal

### DIFF
--- a/beams/beams/custom_scripts/appraisal/appraisal.js
+++ b/beams/beams/custom_scripts/appraisal/appraisal.js
@@ -720,11 +720,13 @@ function salary_amount_read_only(frm) {
 		frm.set_df_property("salary_structure", "read_only", 1);
 		frm.set_df_property("salary_assignment_from_date", "read_only", 1);
 		frm.set_df_property("create_salary_assignment", "read_only", 1);
+		frm.set_df_property("allow_double_increment", "read_only", 1)
 	} else {
 		frm.set_df_property("salary_increment_amount", "read_only", 0);
 		frm.set_df_property("salary_structure", "read_only", 0);
 		frm.set_df_property("salary_assignment_from_date", "read_only", 0);
 		frm.set_df_property("create_salary_assignment", "read_only", 0);
+		frm.set_df_property("allow_double_increment", "read_only", 0)
 	}
 }
 /**

--- a/beams/beams/custom_scripts/appraisal/appraisal.py
+++ b/beams/beams/custom_scripts/appraisal/appraisal.py
@@ -418,15 +418,25 @@ def add_to_category_details(parent_docname, category, remarks):
 		parent_doc.final_performance_category = category
 		if frappe.db.exists("Appraisal Category", category):
 			category_doc = frappe.get_doc("Appraisal Category", category)
+			parent_doc.allow_double_increment = category_doc.allow_double_increment
 			employee_ctc = parent_doc.employee_ctc or 0
 			increment_percentage = 0
 			for ps in category_doc.payscale_details:
-				if (ps.minimum_ctc <= employee_ctc <= ps.maximum_ctc):
-					increment_percentage = ps.percentage
-					break
+				if not ps.maximum_ctc or ps.maximum_ctc == 0:
+					if employee_ctc >= ps.minimum_ctc:
+							increment_percentage = ps.percentage
+							break
+				else:
+					if ps.minimum_ctc <= employee_ctc <= ps.maximum_ctc:
+						increment_percentage = ps.percentage
+						break
 			if increment_percentage:
 				parent_doc.salary_increment_percentage = increment_percentage
-				parent_doc.salary_increment_amount = (employee_ctc * increment_percentage) / 100
+				base_increment = (employee_ctc * increment_percentage) / 100
+				if category_doc.allow_double_increment:
+					parent_doc.salary_increment_amount = base_increment + increment_percentage
+				else:
+					parent_doc.salary_increment_amount = base_increment
 			else:
 				parent_doc.salary_increment_percentage = 0
 				parent_doc.salary_increment_amount = 0
@@ -435,7 +445,6 @@ def add_to_category_details(parent_docname, category, remarks):
 	except Exception:
 		frappe.log_error(frappe.get_traceback(), "Add to Category Details Error")
 		return "Failed"
-
 
 @frappe.whitelist()
 def map_appraisal_to_event(source_name):

--- a/beams/beams/doctype/appraisal_category/appraisal_category.json
+++ b/beams/beams/doctype/appraisal_category/appraisal_category.json
@@ -8,6 +8,9 @@
  "field_order": [
   "category",
   "appraisal_threshold",
+  "column_break_auin",
+  "allow_double_increment",
+  "section_break_dnxg",
   "category_description",
   "payscale_details_section",
   "payscale_details"
@@ -39,11 +42,25 @@
    "fieldtype": "Table",
    "label": "Payscale Details",
    "options": "Payscale Details"
+  },
+  {
+   "fieldname": "column_break_auin",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "allow_double_increment",
+   "fieldtype": "Check",
+   "label": "Allow Double Increment"
+  },
+  {
+   "fieldname": "section_break_dnxg",
+   "fieldtype": "Section Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-09-02 13:07:44.132881",
+ "modified": "2025-09-20 12:54:43.406230",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Appraisal Category",

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -3718,6 +3718,12 @@ def get_appraisal_custom_fields():
 				"description": "The date from which the salary structure assignment will be effective"
 			},
 			{
+				"fieldname": "allow_double_increment",
+				"fieldtype": "Check",
+				"label": "Allow Double Increment",
+				"insert_after": "create_salary_assignment"
+			},
+			{
 				"fieldname": "create_salary_assignment",
 				"fieldtype": "Check",
 				"label": "Create Salary Structure Assignment",


### PR DESCRIPTION
## Feature description

- This feature implements double increment calculation based on appraisal. Added the “Allow Double Increment” feature to Appraisal and Appraisal Category. When enabled, this allows the salary increment to include both the calculated increment and the salary increment percentage.
- Initially, the salary increment percentage was not calculated for CTC values that were not defined in the appraisal category.

## Analysis and design (optional)
- Introduced a new Check field allow_double_increment in both Appraisal Category and Appraisal.
- Modified the increment calculation logic to handle the double increment scenario.
- Updated the frontend to make allow_double_increment read-only based on conditions (similar to other salary fields).
## Solution description
Backend:
    - In appraisal.py, during add_to_category_details(), fetch allow_double_increment from the category.
    - Modify increment calculation:
      - If double increment is allowed: salary_increment_amount = base_increment + increment_percentage
      - Otherwise: salary_increment_amount = base_increment
Frontend (JavaScript):
    - Updated salary_amount_read_only(frm) to include allow_double_increment in read-only toggling logic.
Setup file:
    - Added allow_double_increment field in:
    - Appraisal Category DocType
    - Appraisal custom fields via setup.py
## Output screenshots (optional)
An Appraisal was created for the employee 'Jake'. When a user with the 'Salary Increment Approver' role logged in and added the performance category 'Category C', the increment was calculated as follows:

<img width="1539" height="745" alt="image" src="https://github.com/user-attachments/assets/a33257fb-43d7-4d34-8ccb-6d6f3e8a2d78" />
<img width="1449" height="897" alt="image" src="https://github.com/user-attachments/assets/352c7453-111e-4ec1-a7f9-70d263ee4ec9" />
Here, Category C is eligible for a double increment, so the double increment was calculated based on the employee's CTC and the salary hike percentage.

## Areas affected and ensured
- Appraisal Category DocType
- Appraisal DocType
- Salary increment calculation logic

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
