### PR TITLE
TASK-2025-02262:Ignore_user_permissions for Requested By field

### DIFF
--- a/beams/beams/doctype/digital_library_request/digital_library_request.json
+++ b/beams/beams/doctype/digital_library_request/digital_library_request.json
@@ -32,6 +32,7 @@
   {
    "fieldname": "requested_by",
    "fieldtype": "Link",
+   "ignore_user_permissions": 1,
    "in_list_view": 1,
    "label": "Requested By ",
    "options": "Employee",
@@ -63,7 +64,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-01-31 10:26:57.030843",
+ "modified": "2025-09-22 10:06:53.951315",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Digital Library Request",
@@ -84,6 +85,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.json
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.json
@@ -60,6 +60,7 @@
   {
    "fieldname": "requested_by",
    "fieldtype": "Link",
+   "ignore_user_permissions": 1,
    "label": "Requested By",
    "options": "Employee",
    "reqd": 1
@@ -283,7 +284,7 @@
    "link_fieldname": "employee_travel_request"
   }
  ],
- "modified": "2025-08-19 10:14:47.244103",
+ "modified": "2025-09-22 11:21:22.931184",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Employee Travel Request",


### PR DESCRIPTION
## Feature description
Need to: Add ignore_permission _true is 1 in Requested by  field in Employee Travel Request doctype and Digital Library Request doctype

## Solution description
 Added ignore_permission _true is 1 in Requested by  field in Employee Travel Request doctype and Digital Library Request doctype

## Output screenshots (optional)
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/51ce990f-1b5b-4bd2-b6ab-37efb346da05" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/86c53cb7-27bb-4db3-b296-b9a0830c777d" />

## Areas affected and ensured
Employee Travel Request doctype 
Digital Library Request doctype


## Is there any existing behavior change of other features due to this code change?
No. 

## Was this feature tested on the browsers?
  - Chrome
