### PR TITLE
fix: replace status filter with docstatus in appraisal creation

### DIFF
--- a/beams/beams/custom_scripts/employee/employee.py
+++ b/beams/beams/custom_scripts/employee/employee.py
@@ -517,7 +517,7 @@ def create_appraisal_if_not_exists(emp, start_date, end_date):
 		"Appraisal",
 		filters={
 			"employee": emp.name,
-			"status": ["!=", "Cancelled"],
+			"docstatus": ["!=", 2],
 			"start_date": ["<=", end_date],
 			"end_date": [">=", start_date],
 		},


### PR DESCRIPTION
## Feature description
- Replace status filter with docstatus in appraisal creation from employee.

## Solution description
- Replaced status filter with docstatus in appraisal creation from employee.

## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox