### PR TITLE
feat: render Terms & Conditions from Beams HR Settings with improved UI

### DIFF
--- a/beams/beams/custom_scripts/appraisal/appraisal.js
+++ b/beams/beams/custom_scripts/appraisal/appraisal.js
@@ -1,6 +1,6 @@
 frappe.ui.form.on('Appraisal', {
 	refresh: function (frm) {
-        frm.toggle_reqd('appraisal_cycle', 0);
+		frm.toggle_reqd('appraisal_cycle', 0);
 		if (!frm.doc) return;
 		salary_amount_read_only(frm);
 		frm.trigger('update_self_kra_rating_list_view');
@@ -234,25 +234,25 @@ frappe.ui.form.on('Appraisal', {
 					show_final_assessment_progress(frm, emp);
 				}
 			});
-        if (!frm.is_new()) {
-            if (!frm.doc.consent_received) {
-                frm.disable_form();
-                frm.dashboard.set_headline_alert(
-                    __("Waiting for Employee Appraisal Consent Submission"), "orange"
-                );
-            } else {
-                frm.enable_form();
-            }
-        }
-        if (frm.doc.employee) {
-            frappe.db.get_value("Employee", frm.doc.employee, "employment_type")
-                .then(r => {
-                    if (r && r.message && r.message.employment_type === "Contract") {
-                        // Set indicator on page header
-                        frm.page.set_indicator(__('Contract Employee'), 'red');
-                    }
-                });
-        }
+		if (!frm.is_new()) {
+			if (!frm.doc.consent_received) {
+				frm.disable_form();
+				frm.dashboard.set_headline_alert(
+					__("Waiting for Employee Appraisal Consent Submission"), "orange"
+				);
+			} else {
+				frm.enable_form();
+			}
+		}
+		if (frm.doc.employee) {
+			frappe.db.get_value("Employee", frm.doc.employee, "employment_type")
+				.then(r => {
+					if (r && r.message && r.message.employment_type === "Contract") {
+						// Set indicator on page header
+						frm.page.set_indicator(__('Contract Employee'), 'red');
+					}
+				});
+		}
 	},
 	employee: function (frm) {
 		if (frm.doc.employee) {

--- a/beams/beams/custom_scripts/appraisal/appraisal.js
+++ b/beams/beams/custom_scripts/appraisal/appraisal.js
@@ -243,7 +243,16 @@ frappe.ui.form.on('Appraisal', {
             } else {
                 frm.enable_form();
             }
-        }    
+        }
+        if (frm.doc.employee) {
+            frappe.db.get_value("Employee", frm.doc.employee, "employment_type")
+                .then(r => {
+                    if (r && r.message && r.message.employment_type === "Contract") {
+                        // Set indicator on page header
+                        frm.page.set_indicator(__('Contract Employee'), 'red');
+                    }
+                });
+        }
 	},
 	employee: function (frm) {
 		if (frm.doc.employee) {

--- a/beams/beams/doctype/employee_appraisal_consent/employee_appraisal_consent.js
+++ b/beams/beams/doctype/employee_appraisal_consent/employee_appraisal_consent.js
@@ -15,8 +15,6 @@ frappe.ui.form.on("Employee Appraisal Consent", {
  * - Reads linked Terms & Conditions from HR Settings (singleton).
  * - Fetches its `terms` content and displays it in a styled box.
  * - Toggles the "consent_given" checkbox based on availability.
- *
- * @param {frappe.ui.Form} frm - Current Employee Appraisal Consent form.
  */
 function render_appraisal_consent_terms(frm) {
 	// Always clear before re-render
@@ -56,9 +54,6 @@ function render_appraisal_consent_terms(frm) {
 
 /**
  * Enable or disable the "consent_given" checkbox dynamically.
- *
- * @param {frappe.ui.Form} frm - Current form.
- * @param {boolean} readonly - If true, disable the checkbox.
  */
 function toggle_consent_checkbox_readonly(frm, readonly) {
 	const fieldname = "consent_given";
@@ -73,8 +68,6 @@ function toggle_consent_checkbox_readonly(frm, readonly) {
 
 /**
  * Add a "View Appraisal" button to navigate to the linked Appraisal document.
- *
- * @param {frappe.ui.Form} frm - The current form.
  */
 function add_view_appraisal_button(frm) {
 	if (frm.doc.appraisal) {

--- a/beams/beams/doctype/employee_appraisal_consent/employee_appraisal_consent.js
+++ b/beams/beams/doctype/employee_appraisal_consent/employee_appraisal_consent.js
@@ -3,84 +3,82 @@
 
 frappe.ui.form.on("Employee Appraisal Consent", {
 	refresh(frm) {
-		if (frm.is_new()) {
-	        fetch_terms_from_settings(frm);
-	    }
-	    render_appraisal_terms(frm);
-        if (!frm.is_new() && frm.doc.docstatus === 1) {
-                add_view_appraisal_button(frm);
-        }
-  },
-  terms_and_conditions(frm) {
-	render_appraisal_terms(frm);
-  }
+		render_appraisal_consent_terms(frm);
+		if (!frm.is_new() && frm.doc.docstatus === 1) {
+			add_view_appraisal_button(frm);
+		}
+	}
 });
+
 /**
- * Fetch default Appraisal Terms from Beams HR Settings
+ * Render appraisal consent Terms & Conditions in the form.
+ * - Reads linked Terms & Conditions from HR Settings (singleton).
+ * - Fetches its `terms` content and displays it in a styled box.
+ * - Toggles the "consent_given" checkbox based on availability.
+ *
+ * @param {frappe.ui.Form} frm - Current Employee Appraisal Consent form.
  */
-function fetch_terms_from_settings(frm) {
-  frappe.db.get_value("Beams HR Settings", {}, "appraisal_consent_terms")
-	.then(r => {
-	  if (r.message && r.message.appraisal_consent_terms) {
-		frappe.db.get_value("Terms and Conditions", r.message.appraisal_consent_terms, "terms")
-		  .then(res => {
-			if (res.message && res.message.terms) {
-			  frm.set_value("terms_and_conditions", res.message.terms);
-			  render_appraisal_terms(frm);
+function render_appraisal_consent_terms(frm) {
+	// Always clear before re-render
+	$(frm.fields_dict['terms_and_conditions'].wrapper).empty();
+	frappe.db.get_single_value("Beams HR Settings", "appraisal_consent_terms")
+		.then(terms_name => {
+			if (terms_name) {
+				frappe.db.get_value("Terms and Conditions", terms_name, "terms")
+					.then(res => {
+						let terms_text = res?.message?.terms;
+						if (terms_text) {
+							// Render formatted Terms text inside styled scrollable box
+							$(frm.fields_dict['terms_and_conditions'].wrapper).html(`
+								<div class="alert alert-info"
+									 style="max-height: 250px; overflow-y: auto; padding: 10px; border-radius: 6px;">
+									${terms_text}
+								</div>
+							`);
+							toggle_consent_checkbox_readonly(frm, false);
+						} else {
+							// No terms text found → clear + disable checkbox
+							$(frm.fields_dict['terms_and_conditions'].wrapper).empty();
+							toggle_consent_checkbox_readonly(frm, true);
+						}
+					});
+			} else {
+				// No Terms & Conditions linked in HR Settings → clear + disable checkbox
+				$(frm.fields_dict['terms_and_conditions'].wrapper).empty();
+				toggle_consent_checkbox_readonly(frm, true);
 			}
-		  });
-	  }
-	});
-}
-/**
- * Show appraisal terms in a scrollable box
- * and enable consent checkbox after reading.
- */
-function render_appraisal_terms(frm) {
-  $("#appraisal-terms-container").remove();
-
-  if (frm.doc.terms_and_conditions) {
-	const terms_content = frm.doc.terms_and_conditions || "No Terms available.";
-
-	const container = $("<div>")
-	  .attr("id", "appraisal-terms-container")
-	  .css({
-		maxHeight: "300px",       
-		overflowY: "auto",        
-		border: "1px solid #ccc",
-		padding: "10px",
-		marginBottom: "20px",
-		backgroundColor: "#fafafa",
-		whiteSpace: "pre-wrap"
-	  })
-	  .html(terms_content);
-	frm.set_df_property("terms_and_conditions", "hidden", 1);
-	$(frm.fields_dict.consent_given.wrapper).before(container);
-	frm.set_df_property("consent_given", "read_only", 1);
-	setTimeout(() => {
-	  if (container[0].scrollHeight > container.innerHeight()) {
-		container.on("scroll", function () {
-		  if (
-			container.scrollTop() + container.innerHeight() >=
-			container[0].scrollHeight
-		  ) {
-			frm.set_df_property("consent_given", "read_only", 0);
-		  }
+		})
+		.catch(err => {
+			console.error("Error fetching appraisal consent terms:", err);
+			toggle_consent_checkbox_readonly(frm, true);
 		});
-	  } else {
-		frm.set_df_property("consent_given", "read_only", 0);
-	  }
-	}, 300);
-  } else {
-	frm.set_df_property("consent_given", "read_only", 1);
-  }
 }
+
 /**
- * Adds a "View Appraisal" button to the Employee Appraisal Consent form. 
+ * Enable or disable the "consent_given" checkbox dynamically.
+ *
+ * @param {frappe.ui.Form} frm - Current form.
+ * @param {boolean} readonly - If true, disable the checkbox.
+ */
+function toggle_consent_checkbox_readonly(frm, readonly) {
+	const fieldname = "consent_given";
+
+	if (!frm.fields_dict[fieldname]) return;
+	frm.set_df_property(fieldname, "read_only", readonly);
+	const input = frm.fields_dict[fieldname].$wrapper.find("input[type=checkbox]");
+	if (input.length) {
+		input.prop("disabled", readonly);
+	}
+}
+
+/**
+ * Add a "View Appraisal" button to navigate to the linked Appraisal document.
+ *
+ * @param {frappe.ui.Form} frm - The current form.
  */
 function add_view_appraisal_button(frm) {
 	if (frm.doc.appraisal) {
-		frm.add_custom_button(__('View Appraisal'), () => {
+		frm.add_custom_button(__("View Appraisal"), () => {
 			frappe.set_route("Form", "Appraisal", frm.doc.appraisal);
 		});
 	}


### PR DESCRIPTION
## Feature description
- Update the Employee Appraisal Consent form to show the full Terms & Conditions from  Beams HR Settings. The terms are displayed in a scrollable box, the consent checkbox is enabled only if terms exist, and a View Appraisal button is added for submitted records.
- Indicate contract employees on the Appraisal form
## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description
- Use frappe.db.get_single_value to fetch the linked Terms & Conditions document.
- Fetch terms field from the linked Terms and Conditions DocType.
- Render HTML content directly into a scrollable, styled container inside the form.
- Dynamically enable or disable the consent_given checkbox depending on whether terms exist.
- Add a View Appraisal button if the appraisal is submitted.
## Output screenshots (optional)
set appraisal consent terms in Beams HR Settings.
<img width="1474" height="791" alt="image" src="https://github.com/user-attachments/assets/678dfd4d-4c8d-4892-b38f-ad575f5e8aa2" />

fetched terms and conditions from Beams HR Settings to Employee Appraisal Consent
<img width="1501" height="867" alt="image" src="https://github.com/user-attachments/assets/f4616ea4-21c7-4af9-a5d7-4eea1d371f1b" />

If the employee is on contract basis,it is indicated as follows
<img width="1513" height="699" alt="image" src="https://github.com/user-attachments/assets/f589f8be-8b18-4e6e-ac59-1fc06d76aad8" />

## Areas affected and ensured
Employee Appraisal Consent form (terms_and_conditions field, consent_given checkbox, action buttons).
Beams HR Settings
## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
