### PR TITLE
fix: prevent duplicate appraisals when next appraisal date is updated

### DIFF
--- a/beams/beams/custom_scripts/employee/employee.py
+++ b/beams/beams/custom_scripts/employee/employee.py
@@ -561,8 +561,17 @@ def employee_on_update(doc, method):
 		days = frappe.db.get_single_value("Beams HR Settings", "days_for_next_appraisal_creation") or 365
 		start_date = getdate(doc.next_appraisal_date)
 		end_date = add_days(start_date, days - 1)
-		create_appraisal_if_not_exists(
-			emp=doc,
-			start_date=start_date,
-			end_date=end_date
-		)	
+		existing_appraisal = frappe.get_all(
+			"Appraisal",
+			filters={
+				"employee": doc.name,
+				"start_date": ["<=", end_date],
+				"end_date": [">=", start_date],
+			},
+		)
+		if not existing_appraisal:
+			create_appraisal_if_not_exists(
+				emp=doc,
+				start_date=start_date,
+				end_date=end_date
+			)


### PR DESCRIPTION
## Feature description
Prevent creation of duplicate Appraisal records when an Employee's next_appraisal_date is manually updated or processed via the daily scheduler
## Analysis and design (optional)
Previously, saving an Employee triggered appraisal creation, and the daily scheduler also created appraisals. This caused the same employee to get duplicate appraisals for the same period.
## Solution description
Modified employee_on_update method to check for existing appraisals within the period before creating a new appraisal.
Ensured create_appraisal_if_not_exists function prevents duplicate or overlapping appraisals.
## Output screenshots (optional)
- Changed Next Appraisal Date in Employee 'Ryan'
<img width="1590" height="840" alt="image" src="https://github.com/user-attachments/assets/490800d8-c45e-4a0b-abbe-3fbdc929578a" />

- only one appraisal exists  in an appraisal period for employee 'Ryan'
<img width="1597" height="436" alt="image" src="https://github.com/user-attachments/assets/070d1d46-d77a-4191-96f6-d367bd9e9a29" />

## Areas affected and ensured
Employee DocType
Appraisal DocType
## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
