### PR TITLE
TASK-2025-02303 : standardize field labels in employee

### DIFF
--- a/beams/patches.txt
+++ b/beams/patches.txt
@@ -1,7 +1,7 @@
 [pre_model_sync]
 beams.patches.rename_hod_role #30-10-2024
 beams.patches.no_of_children_patch  #06-03-2025
-beams.patches.delete_custom_fields  #07-08-2025
+beams.patches.delete_custom_fields  #26-09-2025
 
 [post_model_sync]
 # Patches added in this section will be executed after doctypes are migrated

--- a/beams/patches/delete_custom_fields.py
+++ b/beams/patches/delete_custom_fields.py
@@ -176,6 +176,46 @@ fields_to_remove = [
 	{
 		'dt':'Job Applicant',
 		'fieldname': 'department'
+	},
+	{
+		'dt':'Employee',
+		'fieldname': 'emergency_contact_name'
+	},
+	{
+		'dt':'Employee',
+		'fieldname': 'emergency_phone'
+	},
+	{
+		'dt':'Employee',
+		'fieldname': 'relation_emergency'
+	},
+	{
+		'dt':'Employee',
+		'fieldname': 'physical_disabilities'
+	},
+	{
+		'dt':'Employee',
+		'fieldname': 'disabilities'
+	},
+	{
+		'dt':'Employee',
+		'fieldname': 'marital_indebtness'
+	},
+	{
+		'dt':'Employee',
+		'fieldname': 'court_proceedings'
+	},
+	{
+		'dt':'Employee',
+		'fieldname': 'are_you_willing_to_travel'
+	},
+	{
+		'dt':'Employee',
+		'fieldname': 'places_to_travel'
+	},
+	{
+		'dt':'Employee',
+		'fieldname': 'are_you_related_to_employee'
 	}
 ]
 

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -1863,7 +1863,7 @@ def get_employee_custom_fields():
 			{
 				"fieldname": "physical_disabilities",
 				"fieldtype": "Select",
-				"label": "Do you have a physical disability",
+				"label": "Do you have a Physical Disability",
 				"options":"Yes\nNo",
 				"default": "No",
 				"insert_after": "additional_information_section"
@@ -1871,7 +1871,7 @@ def get_employee_custom_fields():
 			{
 				"fieldname": "disabilities",
 				"fieldtype": "Data",
-				"label": "Please specify the disability",
+				"label": "Please specify the Disability",
 				"insert_after": "physical_disabilities",
 				"depends_on": "eval:doc.physical_disabilities == 'Yes'"
 			},
@@ -1880,7 +1880,7 @@ def get_employee_custom_fields():
 				"fieldtype": "Select",
 				"options":"Yes\nNo",
 				"default": "No",
-				"label": "Do you have marital indebtedness",
+				"label": "Do you have Marital Indebtedness",
 				"insert_after": "disabilities"
 			},
 			{
@@ -1895,7 +1895,7 @@ def get_employee_custom_fields():
 				"fieldtype": "Select",
 				"options":"Yes\nNo",
 				"default": "No",
-				"label": "Are there any ongoing court proceedings",
+				"label": "Are there any Ongoing Court Proceedings",
 				"insert_after": "marital_indebtness",
 			},
 			{
@@ -1912,7 +1912,7 @@ def get_employee_custom_fields():
 			},
 			{
 				"fieldname": "are_you_willing_to_travel",
-				"label": "Are you willing to travel",
+				"label": "Are you Willing to Travel",
 				"fieldtype": "Check",
 				"insert_after": "column_break_travel",
 			},
@@ -1943,13 +1943,13 @@ def get_employee_custom_fields():
 			},
 			{
 				"fieldname": "places_to_travel",
-				"label": "Places/Countries of your choice where you'd like to travel on job",
+				"label": "Places/Countries of your choice where you'd like to Travel on Job",
 				"fieldtype": "Data",
 				"insert_after": "state_restrictions_problems",
 			},
 			{
 				"fieldname": "are_you_related_to_employee",
-				"label": "Are you related to any of our employees",
+				"label": "Are you related to any of our Employees",
 				"fieldtype": "Check",
 				"insert_after": "places_to_travel"
 			},
@@ -2001,19 +2001,19 @@ def get_employee_custom_fields():
 			{
 				"fieldname": "emergency_contact_name",
 				"fieldtype": "Data",
-				"label": "Emergency Contact Name",
+				"label": "Emergency Contact Name 2",
 				"insert_after":"person_to_be_contacted"
 			},
 			{
 				"fieldname": "emergency_phone",
 				"fieldtype": "Data",
-				"label": "Emergency Phone",
+				"label": "Emergency Phone 2",
 				"insert_after":"emergency_phone_number"
 			},
 			{
 				"fieldname": "relation_emergency",
 				"fieldtype": "Data",
-				"label": "Relation",
+				"label": "Relation 2",
 				"insert_after":"relation"
 			},
 			{
@@ -4836,7 +4836,35 @@ def get_property_setters():
 			"field_name": "appraisal_cycle",
 			"property": "hidden",
 			"value": 1
-		}
+		},
+		{
+			"doctype_or_field": "DocField",
+			"doc_type": "Employee",
+			"field_name": "person_to_be_contacted",
+			"property": "label",
+			"value": "Emergency Contact Name 1"
+		},
+		{
+			"doctype_or_field": "DocField",
+			"doc_type": "Employee",
+			"field_name": "person_to_be_contacted",
+			"property": "label",
+			"value": "Emergency Contact Name 1"
+		},
+		{
+			"doctype_or_field": "DocField",
+			"doc_type": "Employee",
+			"field_name": "emergency_phone_number",
+			"property": "label",
+			"value": "Emergency Phone 1"
+		},
+		{
+			"doctype_or_field": "DocField",
+			"doc_type": "Employee",
+			"field_name": "relation",
+			"property": "label",
+			"value": "Relation 1"
+		},
 ]
 
 def get_material_request_custom_fields():


### PR DESCRIPTION
## Feature description
Standardize labels for emergency contact fields and related employee fields (disabilities, marital indebtedness, court proceedings, travel, and relation) in the Employee DocType to improve UI/user clarity and consistency.
## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description
- Updated property setters to rename existing fields in Employee DocType.
- Updated labels for disability, marital indebtedness, court proceedings, travel, and relation-related fields.
- Updated patch delete_custom_fields.py with new date to reflect changes.

## Output screenshots (optional)
Changed Emregency contact field labels for employee
<img width="1050" height="302" alt="image" src="https://github.com/user-attachments/assets/bf926e3a-8500-47da-81bc-30230fdab309" />
Updated Additional information field labels
<img width="1061" height="621" alt="image" src="https://github.com/user-attachments/assets/6dfa3c55-60dd-40bf-b514-3b34a8e276ee" />

## Areas affected and ensured
- Employee UI form displaying emergency contacts and related employee fields
- Patches for custom field cleanup

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
