### PR TITLE
refactor: hide fields based on workflow

### DIFF
--- a/beams/beams/doctype/asset_request/asset_request.js
+++ b/beams/beams/doctype/asset_request/asset_request.js
@@ -2,6 +2,9 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Asset Request', {
+    onload_post_render: function(frm) {
+        make_child_table_read_only(frm);
+    },
     refresh: function(frm) {
         if (frm.doc.workflow_state === "Approved by Asset Manager") {
             frm.add_custom_button(__('Assign Assets'), function() {
@@ -9,25 +12,17 @@ frappe.ui.form.on('Asset Request', {
             }, __("Create"));
         }
 
-        if (frm.doc.workflow_state === "Draft") {
-            make_child_table_read_only(frm);
-        }
+        make_child_table_read_only(frm);
     }
 });
 
 function make_child_table_read_only(frm) {
-    frm.doc.items.forEach((row) => {
+
+    if (frm.doc.workflow_state == "Draft") {
         ['asset_type', 'item_code', 'issued_quantity', 'acquired_quantity'].forEach(field => {
-            frm.set_df_property(
-                "items",
-                "read_only",
-                1,
-                frm.doc.name,
-                field,
-                row.name
-            );
+            frm.fields_dict.items.grid.update_docfield_property(field, "read_only", 1);
         });
-    });
+    }
 
     frm.fields_dict['items'].grid.refresh();
 }

--- a/beams/beams/doctype/gate_pass/gate_pass.json
+++ b/beams/beams/doctype/gate_pass/gate_pass.json
@@ -7,9 +7,9 @@
  "engine": "InnoDB",
  "field_order": [
   "employee_in_charge",
+  "transaction_type",
   "assets",
   "scan_asset",
-  "transaction_type",
   "column_break_cgmc",
   "posting_date_and_time",
   "bundles",
@@ -105,13 +105,14 @@
    "fieldname": "transaction_type",
    "fieldtype": "Select",
    "label": "Transaction Type",
-   "options": "\nInward\nOutward"
+   "options": "\nInward\nOutward",
+   "reqd": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-09-24 13:14:54.311238",
+ "modified": "2025-09-30 17:05:18.581139",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Gate Pass",


### PR DESCRIPTION
## Feature description
1. Make transaction type field mandatory.
2. Hide fields based on workflow.

## Solution description
1. Added mandatory to the field transaction type.
2. made fields hidden on  onload_post_render event based on workflow state.

## Output screenshots (optional)
<img width="1530" height="596" alt="image" src="https://github.com/user-attachments/assets/29680038-8b05-473f-be55-ba8cb527c926" />


## Was this feature tested on the browsers?
  - Chrome
