### PR TITLE
fix: filter out appropriate data

### DIFF
--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.json
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.json
@@ -23,7 +23,6 @@
   "destination",
   "accommodation_required",
   "inside_kerala",
-  "room_criteria",
   "column_break_xmae",
   "start_date",
   "end_date",
@@ -38,9 +37,7 @@
   "attachments",
   "expense_claim_html",
   "journal_entry_expenses_table",
-  "reason_for_rejection",
-  "section_break_fdom",
-  "dynamic_link"
+  "reason_for_rejection"
  ],
  "fields": [
   {
@@ -167,13 +164,6 @@
    "label": "Accommodation Required "
   },
   {
-   "depends_on": "eval:doc.accommodation_required;",
-   "fieldname": "room_criteria",
-   "fieldtype": "Link",
-   "label": " Room Criteria",
-   "options": "Room Criteria"
-  },
-  {
    "default": "0",
    "description": "To mark Attendance for Travel Days",
    "fieldname": "mark_attendance",
@@ -216,18 +206,6 @@
    "label": "Attendance Request",
    "options": "Attendance Request",
    "read_only": 1
-  },
-  {
-   "fieldname": "dynamic_link",
-   "fieldtype": "Table",
-   "label": "Dynamic Link",
-   "options": "Dynamic Link"
-  },
-  {
-   "collapsible": 1,
-   "fieldname": "section_break_fdom",
-   "fieldtype": "Section Break",
-   "label": "Links"
   },
   {
    "fieldname": "number_of_travellers",
@@ -284,7 +262,7 @@
    "link_fieldname": "employee_travel_request"
   }
  ],
- "modified": "2025-09-22 11:21:22.931184",
+ "modified": "2025-10-02 11:38:14.876613",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Employee Travel Request",

--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.py
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.py
@@ -27,7 +27,6 @@ class EmployeeTravelRequest(Document):
 		self.validate_dates()
 		self.validate_expected_time()
 		self.total_days_calculate()
-		self.validate_vehicle_allocation()
 
 	def before_save(self):
 		self.validate_posting_date()

--- a/beams/beams/doctype/vehicle_safety_inspection/vehicle_safety_inspection.js
+++ b/beams/beams/doctype/vehicle_safety_inspection/vehicle_safety_inspection.js
@@ -1,8 +1,15 @@
 // Copyright (c) 2025, efeone and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Vehicle Safety Inspection", {
-// 	refresh(frm) {
+frappe.ui.form.on("Vehicle Safety Inspection", {
+    refresh(frm) {
+        frm.set_query("vehicle", () => {
+            return {
+                filters: {
+                    vehicle_safety_inspection: "",
+                }
+            };
+        });
+    }
+});
 
-// 	},
-// });

--- a/beams/beams/doctype/visit_request/visit_request.js
+++ b/beams/beams/doctype/visit_request/visit_request.js
@@ -1,8 +1,23 @@
 // Copyright (c) 2025, efeone and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Visit Request", {
-// 	refresh(frm) {
+frappe.ui.form.on("Visit Request", {
+    refresh(frm) {
+        create_inward_register(frm);
+    },
+});
 
-// 	},
-// });
+function create_inward_register(frm) {
+    if (frm.doc.workflow_state === "Security Informed") {
+        frm.add_custom_button("Inward Register", ()=> {
+            frappe.new_doc("Inward Register", {
+                visit_request       : frm.doc.name,
+                visitor_type        : frm.doc.visitor_type,
+                visitor_name        : frm.doc.visitor_name,
+                purpose_of_visit    :frm.doc.purpose_of_visit
+            });
+    },__("Create"));
+    }
+
+}
+

--- a/beams/beams/doctype/visit_request/visit_request.json
+++ b/beams/beams/doctype/visit_request/visit_request.json
@@ -36,13 +36,17 @@
   {
    "fieldname": "visitor_type",
    "fieldtype": "Link",
+   "in_list_view": 1,
    "label": "Visitor Type",
-   "options": "Visitor Type"
+   "options": "Visitor Type",
+   "reqd": 1
   },
   {
    "fieldname": "purpose_of_visit",
    "fieldtype": "Small Text",
-   "label": "Purpose of Visit"
+   "in_list_view": 1,
+   "label": "Purpose of Visit",
+   "reqd": 1
   },
   {
    "fieldname": "contact_number",
@@ -75,7 +79,9 @@
   {
    "fieldname": "visitor_name",
    "fieldtype": "Data",
-   "label": "Visitor Name"
+   "in_list_view": 1,
+   "label": "Visitor Name",
+   "reqd": 1
   },
   {
    "fieldname": "expected_date_and_time",
@@ -86,7 +92,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-09-19 10:02:04.968740",
+ "modified": "2025-10-02 14:12:01.602567",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Visit Request",

--- a/beams/beams/doctype/visitor_pass/visitor_pass.js
+++ b/beams/beams/doctype/visitor_pass/visitor_pass.js
@@ -12,5 +12,9 @@ frappe.ui.form.on("Visitor Pass", {
     },
     "returned_date": function (frm) {
         frm.call("validate_issued_date_and_returned_date");
+    },
+
+    refresh: (frm) => {
+        frm.toggle_display("returned_date", frm.doc.workflow_state !== "Draft");
     }
 });

--- a/beams/beams/doctype/visitor_pass/visitor_pass.json
+++ b/beams/beams/doctype/visitor_pass/visitor_pass.json
@@ -9,12 +9,11 @@
   "section_break_nrae",
   "inward_register",
   "issued_date",
-  "issued_time",
-  "issued_to",
+  "card_no",
   "column_break_eucm",
+  "issued_to",
   "expire_on",
   "returned_date",
-  "amended_from",
   "section_break_cofy",
   "purpose_of_visit"
  ],
@@ -22,16 +21,6 @@
   {
    "fieldname": "section_break_nrae",
    "fieldtype": "Section Break"
-  },
-  {
-   "fieldname": "amended_from",
-   "fieldtype": "Link",
-   "label": "Amended From",
-   "no_copy": 1,
-   "options": "Visitor Pass",
-   "print_hide": 1,
-   "read_only": 1,
-   "search_index": 1
   },
   {
    "fieldname": "inward_register",
@@ -44,17 +33,9 @@
   {
    "default": "Today",
    "fieldname": "issued_date",
-   "fieldtype": "Date",
+   "fieldtype": "Datetime",
    "in_list_view": 1,
-   "label": "Issued Date",
-   "reqd": 1
-  },
-  {
-   "default": "Now",
-   "fieldname": "issued_time",
-   "fieldtype": "Time",
-   "in_list_view": 1,
-   "label": "Issued Time",
+   "label": "Issued Date and Time",
    "reqd": 1
   },
   {
@@ -88,13 +69,18 @@
    "fieldname": "purpose_of_visit",
    "fieldtype": "Small Text",
    "label": "Purpose of visit"
+  },
+  {
+   "fieldname": "card_no",
+   "fieldtype": "Data",
+   "label": "Card No"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-08-06 06:27:13.317655",
+ "modified": "2025-10-02 13:59:51.892839",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Visitor Pass",

--- a/beams/beams/doctype/visitor_pass/visitor_pass.py
+++ b/beams/beams/doctype/visitor_pass/visitor_pass.py
@@ -61,8 +61,8 @@ class VisitorPass(Document):
 			)
 
 		if issued_date == returned_date:
-			if self.issued_time and self.returned_date:
-				issued_time = get_time(self.issued_time)
+			if self.issued_date and self.returned_date:
+				issued_time = get_time(self.issued_date)
 				returned_time = get_time(self.returned_date)
 
 				if issued_time >= returned_time:

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -4927,7 +4927,14 @@ def get_property_setters():
 			"field_name": "custodian",
 			"property": "allow_on_submit",
 			"value": 1
-		}
+		},
+		{
+			"doctype_or_field": "DocField",
+			"doc_type": "Vehicle",
+			"field_name": "vehicle_safety_inspection",
+			"property": "depends_on",
+			"value": "eval: !doc.__islocal"
+		},
 ]
 
 def get_material_request_custom_fields():


### PR DESCRIPTION
## Feature description
1. show only returned date and time in visitor pass when it is issued.
2. make issued date and time one field and card no. 
3. visit request -> enable creating inward register.


## Solution description
1. Applied fillters to fields to get appropriate data.
2. made necessary fields mandatory.
3. Inward register can be created when visit request is approved and informed security

## Output screenshots (optional)
<img width="1894" height="893" alt="image" src="https://github.com/user-attachments/assets/a3a666cb-5b6e-45ef-b2ac-86883cc1ebf4" />


## Was this feature tested on the browsers?
  - Chrome
