### PR TITLE
Task 2025 02353: blank option for reference field and remove default interview date

### DIFF
--- a/beams/setup.py
+++ b/beams/setup.py
@@ -2910,7 +2910,7 @@ def get_job_applicant_custom_fields():
 				"fieldname": "creference",
 				"fieldtype": "Select",
 				"label": "Can a Reference be Taken Now?",
-				"options": "Yes\nNo",
+				"options": "\nYes\nNo",
 				"insert_after": "column_break_6"
 			},
 			{

--- a/beams/www/job_application_upload/upload_doc.html
+++ b/beams/www/job_application_upload/upload_doc.html
@@ -399,6 +399,7 @@
 						<div class="column" >
 							<label for="reference_taken">Can a Reference be Taken Now?</label>
 							<select id="reference_taken" name="reference_taken">
+								<option value=""></option>
 								<option value="Yes">Yes</option>
 								<option value="No">No</option>
 							</select>
@@ -1110,7 +1111,6 @@
 		flatpickr("#interviewed_date", {
 			dateFormat: "d-m-Y",
 			maxDate: today,
-			defaultDate: today // optional: auto-fill with today's date
 		});
 
 		// Get the Aadhaar input and the error message div


### PR DESCRIPTION
## Feature description
Added a blank option to the “Can a Reference be Taken Now?” select field so no option is pre-selected by default.
Removed the default date(today) from the “Interviewed Date” field, keeping it empty
## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description
- Updated beams/setup.py to include a blank option (\n) in the reference select field.
- Modified upload_doc.html to render a blank <option> at the top of the reference dropdown.
- Removed the defaultDate option from the flatpickr initialization of the interview date field.

## Output screenshots (optional)
**Dropdown now shows a blank first option for the reference field.**
<img width="1155" height="602" alt="image" src="https://github.com/user-attachments/assets/62e1ec98-0a11-4745-bf8c-e25fa5f76bc2" />
**Interviewed date is now not set to 'Today'**
<img width="1424" height="653" alt="image" src="https://github.com/user-attachments/assets/918bf34c-a9f0-4377-8420-d98039296a62" />

**in Job Applicant**  
<img width="1424" height="653" alt="image" src="https://github.com/user-attachments/assets/918bf34c-a9f0-4377-8420-d98039296a62" />


## Areas affected and ensured
Job Application form: reference selection and interview date fields.
## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
