### PR TITLE
TASK-2025-02357: prevent HTML encoding of form fields

### DIFF
--- a/beams/www/job_application_upload/upload_doc.js
+++ b/beams/www/job_application_upload/upload_doc.js
@@ -29,8 +29,7 @@ $(document).ready(function () {
 	}
 
   // Safely sanitize values
-	const safeValue = (value) =>
-	value ? frappe.utils.xss_sanitise(String(value)) : "";
+	const safeValue = (value) => (value ? String(value).trim() : "");
 	const date_of_birth = safeValue($("#date_of_birth").val());
 	const interviewed_date = safeValue($("#interviewed_date").val());
 


### PR DESCRIPTION
## Feature description
Prevent HTML entity encoding of form fields (like House No./Name) in the Job Applicant submission form so that special characters (e.g., /, &) are saved correctly.
## Analysis and design (optional)
The issue occurred because frappe.utils.xss_sanitise was encoding special characters unnecessarily. The solution is to replace it with a simple trim() and string conversion to preserve user input while keeping it safe for submission.
## Solution description
- Updated safeValue() function to remove xss_sanitise and use simple sanitization:
      const safeValue = (value) => (value ? String(value).trim() : "");
- Applied this change to all form field values before submission.
- Ensures fields like House No./Name, addresses, and other text inputs retain original characters.

## Output screenshots (optional)
**Form submission now correctly saves HS-11/678 instead of HS-11&#x2F;678 in Job Applicant**
<img width="1502" height="568" alt="image" src="https://github.com/user-attachments/assets/4adaf221-4ce3-49ec-8d43-a3009f0f514e" />

## Areas affected and ensured
Job Applicant UI--> Now string containing special characters are saved correctly
## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
