### PR TITLE
TASK-2025-02388 : Asset return from asset request 

### DIFF
--- a/beams/beams/custom_scripts/asset_movement/asset_movement.py
+++ b/beams/beams/custom_scripts/asset_movement/asset_movement.py
@@ -104,30 +104,40 @@ def update_asset_location_from_movement(doc, method=None):
 
 
 def update_allocated_asset_details(doc, method=None):
-    """Update Asset Request with Asset Movement Item details when Asset Movement is submitted."""
+	"""Update Asset Request with Asset Movement Item details when Asset Movement is submitted."""
 
-    if doc.reference_doctype != "Asset Request" or not doc.reference_name:
-        return
+	if doc.reference_doctype != "Asset Request" or not doc.reference_name:
+		return
 
-    asset_request = frappe.get_doc("Asset Request", doc.reference_name)
+	asset_request = frappe.get_doc("Asset Request", doc.reference_name)
 
-    asset_request.asset_movement_items = []
+	asset_request.asset_movement_items = []
 
-    for asset_row in doc.assets:
-        new_row = asset_request.append("allocated_assets", {})
+	for asset_row in doc.assets:
+		new_row = asset_request.append("allocated_assets", {})
 
-        new_row.company = asset_row.company
-        new_row.asset = asset_row.asset
-        new_row.asset_name = asset_row.asset_name
-        new_row.source_location = asset_row.source_location
-        new_row.target_location = asset_row.target_location
-        new_row.from_employee = asset_row.from_employee
-        new_row.to_employee = asset_row.to_employee
-        new_row.department = asset_row.department
-        new_row.room = asset_row.room
-        new_row.row = asset_row.row
-        new_row.shelf = asset_row.shelf
-        new_row.bin = asset_row.bin
+		new_row.company = asset_row.company
+		new_row.asset = asset_row.asset
+		new_row.asset_name = asset_row.asset_name
+		new_row.source_location = asset_row.source_location
+		new_row.target_location = asset_row.target_location
+		new_row.from_employee = asset_row.from_employee
+		new_row.to_employee = asset_row.to_employee
+		new_row.department = asset_row.department
+		new_row.room = asset_row.room
+		new_row.row = asset_row.row
+		new_row.shelf = asset_row.shelf
+		new_row.bin = asset_row.bin
 
-    asset_request.save(ignore_permissions=True)
+	asset_request.save(ignore_permissions=True)
 
+
+
+def update_asset_custodian_on_receipt(doc, method=None):
+
+	"""Clears the Asset custodian when an Asset Movement with purpose 'Receipt' is submitted and no new employee is assigned."""
+
+	if doc.purpose == "Receipt" and doc.reference_doctype == "Asset Request":
+		for asset_row in doc.assets:
+			if asset_row.asset and not asset_row.to_employee:
+				frappe.db.set_value("Asset", asset_row.asset, "custodian", None)

--- a/beams/beams/custom_scripts/asset_movement/asset_movement.py
+++ b/beams/beams/custom_scripts/asset_movement/asset_movement.py
@@ -109,27 +109,29 @@ def update_allocated_asset_details(doc, method=None):
 	if doc.reference_doctype != "Asset Request" or not doc.reference_name:
 		return
 
-	asset_request = frappe.get_doc("Asset Request", doc.reference_name)
+	if doc.purpose == "Issue":
 
-	asset_request.asset_movement_items = []
+		asset_request = frappe.get_doc("Asset Request", doc.reference_name)
 
-	for asset_row in doc.assets:
-		new_row = asset_request.append("allocated_assets", {})
+		asset_request.asset_movement_items = []
 
-		new_row.company = asset_row.company
-		new_row.asset = asset_row.asset
-		new_row.asset_name = asset_row.asset_name
-		new_row.source_location = asset_row.source_location
-		new_row.target_location = asset_row.target_location
-		new_row.from_employee = asset_row.from_employee
-		new_row.to_employee = asset_row.to_employee
-		new_row.department = asset_row.department
-		new_row.room = asset_row.room
-		new_row.row = asset_row.row
-		new_row.shelf = asset_row.shelf
-		new_row.bin = asset_row.bin
+		for asset_row in doc.assets:
+			new_row = asset_request.append("allocated_assets", {})
 
-	asset_request.save(ignore_permissions=True)
+			new_row.company = asset_row.company
+			new_row.asset = asset_row.asset
+			new_row.asset_name = asset_row.asset_name
+			new_row.source_location = asset_row.source_location
+			new_row.target_location = asset_row.target_location
+			new_row.from_employee = asset_row.from_employee
+			new_row.to_employee = asset_row.to_employee
+			new_row.department = asset_row.department
+			new_row.room = asset_row.room
+			new_row.row = asset_row.row
+			new_row.shelf = asset_row.shelf
+			new_row.bin = asset_row.bin
+
+		asset_request.save(ignore_permissions=True)
 
 
 

--- a/beams/beams/doctype/asset_request/asset_request.js
+++ b/beams/beams/doctype/asset_request/asset_request.js
@@ -296,7 +296,6 @@ function open_return_assets_popup(frm) {
                                 purpose: values.purpose,
                                 transaction_date: frappe.datetime.now_datetime(),
                                 company: frm.doc.company || (items[0].company || ""),
-                                // to_employee: values.assigned_to,
                                 reference_doctype: "Asset Request",
                                 reference_name: frm.doc.name,
                                 assets: items.map(row => ({

--- a/beams/beams/doctype/asset_request/asset_request.js
+++ b/beams/beams/doctype/asset_request/asset_request.js
@@ -16,6 +16,7 @@ frappe.ui.form.on('Asset Request', {
 
         make_child_table_read_only(frm);
         asset_recevied_acknowledgement(frm);
+        return_allocated_assets(frm);
     }
 });
 
@@ -77,10 +78,11 @@ function open_assign_assets_popup(frm) {
                     { label: 'Item', fieldname: 'item', fieldtype: 'Link', options: 'Item', in_list_view: 1 },
                     { label: 'Asset Type', fieldname: 'asset_type', fieldtype: 'Select', options: '\nSingle Asset\nBundle', in_list_view: 1 },
                     { label: 'Asset', fieldname: 'asset', fieldtype: 'Link', options: 'Asset', in_list_view: 1 },
-                    { label: 'Bundle', fieldname: 'bundle', fieldtype: 'Link', options: 'Asset Bundle', in_list_view: 1 }
+                    { label: 'Bundle', fieldname: 'bundle', fieldtype: 'Link', options: 'Asset Bundle', in_list_view: 1 },
                 ]
             }
         ],
+        size: 'large',
         primary_action_label: __('Assign'),
         primary_action(values) {
             frappe.call({
@@ -200,3 +202,154 @@ function set_requested_by_if_empty(frm) {
             });
     }
 }
+
+/**
+ * Adds a custom button to return allocated assets if any are unreturned
+ */
+function return_allocated_assets(frm) {
+    if (frm.doc.allocated_assets && !frm.doc.allocated_assets.some(row => !row.returned)) return;
+    const btn = frm.add_custom_button(__('Return Allocated Assets'), () => {
+        open_return_assets_popup(frm);
+    });
+    btn.css({
+                backgroundColor: '#1878d2ff',
+                color: 'white',
+                border: 'none',
+                fontWeight: '500'
+            });
+}
+
+
+/**
+ * Opens a dialog to process the return of selected allocated assets and create an Asset Movement
+ */
+
+function open_return_assets_popup(frm) {
+
+    const asset_ids = (frm.doc.allocated_assets || [])
+    .filter(row => !row.returned && row.asset)
+    .map(row => row.asset);
+
+
+    console.log(asset_ids, "asset_ids");
+    
+    // Fetch asset details
+    frappe.call({
+        method: "frappe.client.get_list",
+        args: {
+            doctype: "Asset",
+            filters: [["name", "in", asset_ids]],
+            fields: ["name", "location", "custodian", "company"]
+        },
+        callback: function (res) {
+            const assets = res.message || [];
+
+            const rows = assets.map(asset => ({
+                asset: asset.name,
+                source_location: asset.location || "",
+                from_employee: asset.custodian || "",
+                target_location: "",
+                to_employee: "",
+                company: asset.company || ""
+            }));
+
+            let d = new frappe.ui.Dialog({
+                title: __('Return Allocated Assets'),
+                fields: [
+                    {
+                        label: 'Returning From',
+                        fieldname: 'from_employee',
+                        fieldtype: 'Link',
+                        options: 'Employee',
+                        reqd: 1,
+                        default: frm.doc.requested_by
+                    },
+                    {
+                        label: __("Purpose"),
+                        fieldname: "purpose",
+                        fieldtype: "Data",
+                        default: "Receipt",
+                        reqd: 1,
+                        read_only: 1
+                    },
+                    { 
+                        label: 'Target Location', 
+                        fieldname: 'target_location', 
+                        fieldtype: 'Link', 
+                        options: 'Location', 
+                        reqd: 1 
+                    },
+                    {
+                        label: 'Items',
+                        fieldname: 'items_table',
+                        fieldtype: 'Table',
+                        cannot_add_rows: 0,
+                        in_place_edit: true,
+                        data: rows,
+                        fields: [
+                            { label: 'Asset', fieldname: 'asset', fieldtype: 'Link', options: 'Asset', in_list_view: 1, reqd: 1 },
+                            { label: 'Source Location', fieldname: 'source_location', fieldtype: 'Data', in_list_view: 1, read_only: 1 },
+                            { label: 'From Employee', fieldname: 'from_employee', fieldtype: 'Link', options: 'Employee', in_list_view: 1, read_only: 1 },
+                        ]
+                    }
+                ],
+                size: 'large',
+                primary_action_label: __('Return'),
+                primary_action: function (values) {
+                    const items = values.items_table || [];
+
+
+                    frappe.confirm(
+                        __('Are you sure you want to return assets?'),
+                        function () {
+                            const movement_doc = {
+                                doctype: "Asset Movement",
+                                purpose: values.purpose,
+                                transaction_date: frappe.datetime.now_date(),
+                                company: frm.doc.company || (items[0].company || ""),
+                                to_employee: values.assigned_to,
+                                reference_doctype: "Asset Request",
+                                reference_name: frm.doc.name,
+                                assets: items.map(row => ({
+                                    asset: row.asset,
+                                    source_location: row.source_location,
+                                    target_location: values.target_location,
+                                    from_employee: values.from_employee,
+                                }))
+                            };
+
+                            frappe.call({
+                                method: "frappe.client.insert",
+                                args: { doc: movement_doc },
+                                callback: function (r) {
+                                    if (r.message) {
+                                        frappe.msgprint(__('Asset Movement created in Draft.'));
+
+                                        frappe.call({
+                                            method: "beams.beams.doctype.asset_request.asset_request.mark_assets_returned",
+                                            args: {
+                                                docname: frm.doc.name,
+                                                assets: items.map(item => item.asset)
+                                            },
+                                            callback: function (res) {
+                                                if (!res.exc) {
+                                                    frappe.msgprint(__('Marked assets as returned.'));
+                                                    frm.reload_doc();
+                                                    d.hide();
+                                                }
+                                            }
+                                        });
+
+                                    }
+                                }
+                            });
+                        }
+                    );
+                }
+            });
+
+            d.show();
+        }
+    });
+}
+

--- a/beams/beams/doctype/asset_request/asset_request.js
+++ b/beams/beams/doctype/asset_request/asset_request.js
@@ -230,8 +230,6 @@ function open_return_assets_popup(frm) {
     .filter(row => !row.returned && row.asset)
     .map(row => row.asset);
 
-
-    console.log(asset_ids, "asset_ids");
     
     // Fetch asset details
     frappe.call({
@@ -257,14 +255,6 @@ function open_return_assets_popup(frm) {
                 title: __('Return Allocated Assets'),
                 fields: [
                     {
-                        label: 'Returning From',
-                        fieldname: 'from_employee',
-                        fieldtype: 'Link',
-                        options: 'Employee',
-                        reqd: 1,
-                        default: frm.doc.requested_by
-                    },
-                    {
                         label: __("Purpose"),
                         fieldname: "purpose",
                         fieldtype: "Data",
@@ -289,7 +279,6 @@ function open_return_assets_popup(frm) {
                         fields: [
                             { label: 'Asset', fieldname: 'asset', fieldtype: 'Link', options: 'Asset', in_list_view: 1, reqd: 1 },
                             { label: 'Source Location', fieldname: 'source_location', fieldtype: 'Data', in_list_view: 1, read_only: 1 },
-                            { label: 'From Employee', fieldname: 'from_employee', fieldtype: 'Link', options: 'Employee', in_list_view: 1, read_only: 1 },
                         ]
                     }
                 ],
@@ -305,16 +294,16 @@ function open_return_assets_popup(frm) {
                             const movement_doc = {
                                 doctype: "Asset Movement",
                                 purpose: values.purpose,
-                                transaction_date: frappe.datetime.now_date(),
+                                transaction_date: frappe.datetime.now_datetime(),
                                 company: frm.doc.company || (items[0].company || ""),
-                                to_employee: values.assigned_to,
+                                // to_employee: values.assigned_to,
                                 reference_doctype: "Asset Request",
                                 reference_name: frm.doc.name,
                                 assets: items.map(row => ({
                                     asset: row.asset,
                                     source_location: row.source_location,
                                     target_location: values.target_location,
-                                    from_employee: values.from_employee,
+                                    from_employee: frm.doc.requested_by
                                 }))
                             };
 
@@ -352,4 +341,3 @@ function open_return_assets_popup(frm) {
         }
     });
 }
-

--- a/beams/beams/doctype/asset_request/asset_request.json
+++ b/beams/beams/doctype/asset_request/asset_request.json
@@ -9,6 +9,7 @@
   "section_break_acln",
   "requested_by",
   "employee_name",
+  "bureau",
   "column_break_amir",
   "item_type",
   "required_by",
@@ -89,6 +90,12 @@
    "fieldtype": "Data",
    "label": "Employee Name",
    "read_only": 1
+  },
+  {
+   "fieldname": "bureau",
+   "fieldtype": "Link",
+   "label": "Bureau",
+   "options": "Bureau"
   }
  ],
  "grid_page_length": 50,
@@ -100,7 +107,7 @@
    "link_fieldname": "reference_name"
   }
  ],
- "modified": "2025-10-08 10:47:30.632688",
+ "modified": "2025-10-09 11:21:58.030833",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Asset Request",

--- a/beams/beams/doctype/asset_request/asset_request.py
+++ b/beams/beams/doctype/asset_request/asset_request.py
@@ -57,7 +57,8 @@ def create_asset_movement(assigned_to, purpose, items, reference_name=None):
 	for row in items:
 		# Single Asset
 		if row.get("asset"):
-			movement.append("assets", {"asset": row["asset"], "to_employee": assigned_to})
+			source_location = frappe.db.get_value("Asset", row["asset"], "location")
+			movement.append("assets", {"asset": row["asset"], "to_employee": assigned_to, "source_location": source_location})
 
 		# Bundle
 		elif row.get("bundle"):
@@ -65,7 +66,8 @@ def create_asset_movement(assigned_to, purpose, items, reference_name=None):
 
 			# Add assets from bundle
 			for asset in getattr(bundle_doc, "assets", []):
-				movement.append("assets", {"asset": asset.asset, "to_employee": assigned_to})
+				source_location = frappe.db.get_value("Asset", asset.asset, "location")
+				movement.append("assets", {"asset": asset.asset, "to_employee": assigned_to, "source_location": source_location})
 
 			# Create Stock Entry if stock_items exist
 			stock_items = getattr(bundle_doc, "stock_items", [])
@@ -132,7 +134,7 @@ def update_issued_quantity(doc, method=None):
 
 	request.save(ignore_permissions=True)
 
-
+@frappe.whitelist()
 def acknowledge_assets(asset_request_name):
     """Mark all unacknowledged assets in an Asset Request as acknowledged and notify if technical item."""
     
@@ -177,3 +179,25 @@ def send_mail_to_asset_manager(asset_request, item_type):
         subject=f"Assets Acknowledged: {asset_request.name}",
         message=f"The assets in Asset Request {asset_request.name} have been acknowledged."
     )
+
+
+
+@frappe.whitelist()
+def mark_assets_returned(docname, assets):
+    """Mark selected allocated assets as returned in Asset Request."""
+
+    if isinstance(assets, str):
+        assets = json.loads(assets)
+
+    doc = frappe.get_doc("Asset Request", docname)
+
+    updated = 0
+    for row in doc.allocated_assets:
+        if row.asset in assets:
+            row.returned = 1
+            updated += 1
+
+    if updated:
+        doc.save(ignore_permissions=True)
+
+    return {"updated": updated}

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -382,7 +382,8 @@ doc_events = {
 			"beams.beams.custom_scripts.asset_movement.asset_movement.update_issued_quantity",
 			"beams.beams.custom_scripts.asset_movement.asset_movement.update_asset_location_from_movement",
 			"beams.beams.doctype.asset_request.asset_request.update_issued_quantity",
-			"beams.beams.custom_scripts.asset_movement.asset_movement.update_allocated_asset_details"
+			"beams.beams.custom_scripts.asset_movement.asset_movement.update_allocated_asset_details",
+			"beams.beams.custom_scripts.asset_movement.asset_movement.update_asset_custodian_on_receipt"
 			],
 		"before_save": "beams.beams.custom_scripts.asset_movement.asset_movement.before_save",
 	},

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -5458,9 +5458,17 @@ def get_asset_movement_custom_fields():
 				"fieldtype": "Check",		
 				"label": "Acknowledged",
 				"insert_after": "bin",
-				"hidden": 1,
+				"read_only": 1,
 				"allow_on_submit": 1
-			}
+			},
+			{
+				"fieldname": "returned",
+				"fieldtype": "Check",		
+				"label": "Returned",
+				"insert_after": "acknowledged",
+				"read_only": 1,
+				"allow_on_submit": 1
+			},
 		]
 	}
 def get_asset_category_custom_fields():


### PR DESCRIPTION
## Feature description
Ability to return allocated assets.

## Solution description
1. Allocated assets can be returned from asset request if there is a allocation using return allocated asset button to a specified location.
2. Asset movement (purpose :- receipt) will be created in draft

## Output screenshots (optional)
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/1b9fc827-1b4a-4809-b2da-4c5efdd95a85" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b19f5ce1-b750-45a2-8c63-9b13596b619f" />


## Was this feature tested on the browsers?
  - Chrome
