### PR TITLE
fix:Clear Auto Setting of Party Type and Party in Payment Entry

### DIFF
--- a/beams/beams/custom_scripts/payment_entry/payment_entry.js
+++ b/beams/beams/custom_scripts/payment_entry/payment_entry.js
@@ -1,26 +1,26 @@
-frappe.ui.form.on('Payment Entry', {
-    payment_type(frm) {
-        if (frm.doc.payment_type === 'Pay') {
-            frm.set_value('party_type', 'Employee');
-        }
-    },
-    onload_post_render(frm) {
-        if (frm.is_new() && frm.doc.payment_type === 'Pay') {
-            frm.set_value('party_type', 'Employee');
-        }
-    },
-    party_type(frm) {
-        if (frm.doc.party_type === "Employee") {
-            frappe.db.get_list('Employee', {
-                filters: { user_id: frappe.session.user },
-                fields: ['name']
-            }).then(records => {
-                if (records.length > 0) {
-                    frm.set_value("party", records[0].name);
-                } else {
-                    frappe.msgprint(__("No Employee record found for the current user."));
-                }
-            });
-        }
-    }
-});
+// frappe.ui.form.on('Payment Entry', {
+//     payment_type(frm) {
+//         if (frm.doc.payment_type === 'Pay') {
+//             frm.set_value('party_type', 'Employee');
+//         }
+//     },
+//     onload_post_render(frm) {
+//         if (frm.is_new() && frm.doc.payment_type === 'Pay') {
+//             frm.set_value('party_type', 'Employee');
+//         }
+//     },
+//     party_type(frm) {
+//         if (frm.doc.party_type === "Employee") {
+//             frappe.db.get_list('Employee', {
+//                 filters: { user_id: frappe.session.user },
+//                 fields: ['name']
+//             }).then(records => {
+//                 if (records.length > 0) {
+//                     frm.set_value("party", records[0].name);
+//                 } else {
+//                     frappe.msgprint(__("No Employee record found for the current user."));
+//                 }
+//             });
+//         }
+//     }
+// });


### PR DESCRIPTION
## Feature description
Clear Auto Setting of Party Type and Party in Payment Entry

## Solution description

- [ ] TASK-2025-02423

## Output screenshots (optional)

[Screencast from 15-10-25 10:28:17 AM IST.webm](https://github.com/user-attachments/assets/5b0e98e3-32de-4524-b44e-6e5177c84463)

[Screencast from 15-10-25 10:30:21 AM IST.webm](https://github.com/user-attachments/assets/0dbfc418-0254-489c-9fdf-63d4625a20f1)

[Screencast from 15-10-25 10:31:08 AM IST.webm](https://github.com/user-attachments/assets/3ec4efd0-4df2-4e77-9ff5-ea9696e19bac)

[Screencast from 15-10-25 10:31:49 AM IST.webm](https://github.com/user-attachments/assets/6d78a0ca-1fc2-4292-a9ef-e74ba09bae61)

## Areas affected and ensured
payment entry

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - yes
  - Opera Mini
  - Safari
