### PR TITLE
TASK-2025-02424:Fix Attendance Request Validation Error & filter interview/LER statuses

### DIFF
--- a/beams/beams/custom_scripts/attendance_request/attendance_request.py
+++ b/beams/beams/custom_scripts/attendance_request/attendance_request.py
@@ -7,6 +7,9 @@ from frappe.utils import date_diff, today
 
 
 class AttendanceRequestOverride(AttendanceRequest):
+	def before_insert(self):
+		self.validate_attendance_request_submission()
+
 	def create_or_update_attendance(self, date: str):
 		'''
 			Method to Create or Update Attendance from Attendance Request
@@ -55,12 +58,12 @@ class AttendanceRequestOverride(AttendanceRequest):
 			doc.insert(ignore_permissions=True)
 			doc.submit()
 
-	def before_insert(self):
+	def validate_attendance_request_submission(self):
 		'''
 			Prevents the attendance request if the from date exceeds the limit configured in Beams HR Settings
 		'''
 		limit_days = frappe.db.get_single_value("Beams HR Settings", "attendance_request_submission_limit_days")
-		if self.from_date and date_diff(today(), self.from_date) > limit_days:
+		if limit_days and self.from_date and date_diff(today(), self.from_date) > limit_days:
 			frappe.throw(
 				_("You can only submit an Attendance Request within {0} days from the From Date.").format(limit_days)
 			)

--- a/beams/beams/doctype/employee_interview_tool/employee_interview_tool.json
+++ b/beams/beams/doctype/employee_interview_tool/employee_interview_tool.json
@@ -96,7 +96,7 @@
    "fieldname": "applicant_status",
    "fieldtype": "Select",
    "label": "Status",
-   "options": "\nOpen\nReplied\nRejected\nShortlisted from Interview\nLocal Enquiry Started\nLocal Enquiry Completed\nLocal Enquiry Rejected\nLocal Enquiry Approved\nSelected\nHold\nAccepted\nTraining Completed\nCompensation Proposal Created\nCompensation Proposal Accepted\nInterview Scheduled\nInterview Ongoing\nInterview Completed\nShortlisted\nPending Document Upload\nDocument Uploaded"
+   "options": "\nShortlisted from Interview\nLocal Enquiry Started\nInterview Scheduled\nInterview Ongoing\nDocument Uploaded"
   },
   {
    "fieldname": "section_break_ndqh",
@@ -130,7 +130,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-08-02 12:31:43.951250",
+ "modified": "2025-10-15 12:23:35.776429",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Employee Interview Tool",


### PR DESCRIPTION
## Feature description
Currently, users encounter an error when submitting an attendance request if the attendance_request_submission_limit_days is not configured (or set to 0).
In the Employee Interview Tool, statuses irrelevant to interview and Local Enquiry Report (LER) creation are currently displayed
## Analysis and design (optional)

## Solution description

- Added null check for attendance_request_submission_limit_days to prevent the "0 days" error.
- moved validation logic into validate_attendance_request_submission() and called it in before_insert.
- Updated the JSON of Employee Interview Tool to display only statuses relevant for interviews and Local Enquiry Reports (LER).
## Output screenshots (optional)
**Attendance request can be submitted if attendance_request_submission_limit_days is not set** 
<img width="1397" height="390" alt="image" src="https://github.com/user-attachments/assets/339fc22b-8cc2-44e9-8f08-40fb12584843" />
[Screencast from 10-15-2025 01:11:04 PM.webm](https://github.com/user-attachments/assets/7488f5b1-7846-4ce1-adb0-1f8a9d84259b)

**Employee Interview Tool status dropdown now shows:**
<img width="1367" height="846" alt="image" src="https://github.com/user-attachments/assets/d60df175-08cb-489b-a974-0105e2bdd3c5" />

## Areas affected and ensured
**Employee Interview Tool status dropdown now shows:**
- Shortlisted from Interview
- Local Enquiry Started
- Interview Scheduled
- Interview Ongoing

Document Uploaded
## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
