### PR TITLE
TASK-2025-02407: button to view job offer for accepted compensation proposals

### DIFF
--- a/beams/beams/doctype/compensation_proposal/compensation_proposal.js
+++ b/beams/beams/doctype/compensation_proposal/compensation_proposal.js
@@ -10,8 +10,23 @@ frappe.ui.form.on('Compensation Proposal', {
                 }
             };
         });
+        handle_custom_buttons (frm);
+    },
+    job_offer: function (frm) {
+        handle_custom_buttons (frm);
     },
     proposed_ctc: function (frm) {
         frm.call("validate_proposed_ctc");
     }
 });
+
+/**
+ * Adds custom buttons to the Compensation Proposal form based on the document state.
+ */
+function handle_custom_buttons (frm) {
+    if (frm.doc.workflow_state === 'Applicant Accepted' && frm.doc.job_offer) {
+        frm.add_custom_button(__('Job Offer'), function () {
+            frappe.set_route('Form', 'Job Offer', frm.doc.job_offer);
+        }, __('View'));
+    }
+}

--- a/beams/beams/doctype/compensation_proposal/compensation_proposal.js
+++ b/beams/beams/doctype/compensation_proposal/compensation_proposal.js
@@ -2,31 +2,31 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Compensation Proposal', {
-    refresh: function(frm) {
-        frm.set_query('job_applicant', function() {
-            return {
-                filters: {
-                    status: 'Selected'
-                }
-            };
-        });
-        handle_custom_buttons (frm);
-    },
-    job_offer: function (frm) {
-        handle_custom_buttons (frm);
-    },
-    proposed_ctc: function (frm) {
-        frm.call("validate_proposed_ctc");
-    }
+	refresh: function(frm) {
+		frm.set_query('job_applicant', function() {
+			return {
+				filters: {
+					status: 'Selected'
+				}
+			};
+		});
+		handle_custom_buttons (frm);
+	},
+	job_offer: function (frm) {
+		handle_custom_buttons (frm);
+	},
+	proposed_ctc: function (frm) {
+		frm.call("validate_proposed_ctc");
+	}
 });
 
 /**
  * Adds custom buttons to the Compensation Proposal form based on the document state.
  */
 function handle_custom_buttons (frm) {
-    if (frm.doc.workflow_state === 'Applicant Accepted' && frm.doc.job_offer) {
-        frm.add_custom_button(__('Job Offer'), function () {
-            frappe.set_route('Form', 'Job Offer', frm.doc.job_offer);
-        }, __('View'));
-    }
+	if (frm.doc.workflow_state === 'Applicant Accepted' && frm.doc.job_offer) {
+		frm.add_custom_button(__('Job Offer'), function () {
+			frappe.set_route('Form', 'Job Offer', frm.doc.job_offer);
+		}, __('View'));
+	}
 }

--- a/beams/beams/doctype/compensation_proposal/compensation_proposal.json
+++ b/beams/beams/doctype/compensation_proposal/compensation_proposal.json
@@ -16,6 +16,7 @@
   "amended_from",
   "section_break_jt",
   "job_offer_term_template",
+  "job_offer",
   "column_break_ogbe",
   "terms_and_conditions",
   "section_break_vcik",
@@ -140,13 +141,20 @@
    "fieldtype": "Attach",
    "label": "Payslip - Month 3",
    "read_only": 1
+  },
+  {
+   "fieldname": "job_offer",
+   "fieldtype": "Link",
+   "label": "Job Offer",
+   "options": "Job Offer",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-07-24 17:24:49.165221",
+ "modified": "2025-10-16 09:52:47.742311",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Compensation Proposal",

--- a/beams/beams/doctype/compensation_proposal/compensation_proposal.py
+++ b/beams/beams/doctype/compensation_proposal/compensation_proposal.py
@@ -48,7 +48,7 @@ class CompensationProposal(Document):
 			job_offer.flags.ignore_validate = True
 			job_offer.insert()
 			job_offer.submit()
-
+			frappe.db.set_value("Compensation Proposal", self.name, "job_offer", job_offer.name)
 			frappe.msgprint(
 				'Job Offer Created: <a href="{0}">{1}</a>'.format(
 					get_url_to_form(job_offer.doctype, job_offer.name),


### PR DESCRIPTION
## Feature description
When a Compensation Proposal is marked “Applicant Accepted”, a Job Offer is created for the job applicant.
Currently, there is no way to view the Job Offer from the Compensation Proposal.

Added a Job Offer link and a “View Job Offer” button in the Compensation Proposal form.
The button appears when the workflow state is “Applicant Accepted” and a Job Offer exists, allowing users to go directly to the linked Job Offer.
## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description
- The job_offer field was added to the Compensation Proposal as a read-only link to the Job Offer.
- The client-script JavaScript code makes the “View Job Offer” button appear automatically when the workflow state changes or the field is updated
- The backend python code sets the job_offer field safely using frappe.db.set_value to avoid errors when the document is submitted.

## Output screenshots (optional)
**Button appears in the Compensation Proposal form when the workflow state is “Applicant Accepted” and a Job Offer is linked.Clicking the button navigates to the corresponding Job Offer form.**

<img width="1641" height="523" alt="image" src="https://github.com/user-attachments/assets/285d5920-e344-482f-9b0f-c8f073f620d7" />

**The flow from Compensation Proposal to Job Offer creation was tested by the responsible users while logged in.**
## Areas affected and ensured
Compensation Proposal form UI-job offer view button
Job Offer creation workflow.
## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
