### PR TITLE
fix:make vehicle allocation mandatory on travel request approval

### DIFF
--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.json
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.json
@@ -217,14 +217,16 @@
    "default": "0",
    "fieldname": "is_vehicle_required",
    "fieldtype": "Check",
-   "label": "Vehicle Required"
+   "label": "Vehicle Requried (Media One)"
   },
   {
    "allow_on_submit": 1,
    "fieldname": "travel_vehicle_allocation",
    "fieldtype": "Table",
    "label": "Travel Vehicle Allocation",
-   "options": "Vehicle Allocation"
+   "mandatory_depends_on": "eval:doc.workflow_state == 'Approved'",
+   "options": "Vehicle Allocation",
+   "reqd": 1
   },
   {
    "allow_on_submit": 1,
@@ -262,7 +264,7 @@
    "link_fieldname": "employee_travel_request"
   }
  ],
- "modified": "2025-10-02 11:38:14.876613",
+ "modified": "2025-10-16 09:53:04.933813",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Employee Travel Request",


### PR DESCRIPTION


## Feature description
make vehicle allocation mandatory on travel request approval

## Solution description

- [ ] TASK-2025-02435

changed label Vehicle Requried to Vehicle Requried(Media One)
Prevents submission of approved travel requests without vehicle allocation details

## Output screenshots (optional)

<img width="1481" height="966" alt="image" src="https://github.com/user-attachments/assets/f21b1c61-9983-443d-bfdf-3bd3fe295872" />

[Screencast from 16-10-25 10:42:57 AM IST.webm](https://github.com/user-attachments/assets/c8522e2a-fa64-42e5-bfc2-c60874dc462c)

## Areas affected and ensured
Employee Travel Request

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - yes
  - Opera Mini
  - Safari
