### PR TITLE
TASK-2025-02449:Update local enquiry report and Employee Interview Tool fields

### DIFF
--- a/beams/beams/doctype/employee_interview_tool/employee_interview_tool.js
+++ b/beams/beams/doctype/employee_interview_tool/employee_interview_tool.js
@@ -238,13 +238,13 @@ function toggle_create_interview_button(frm) {
 }
 
 /**
- * Adds 'Create Local Enquiry Report' button when applicant status matches - 'Shortlisted from Interview', 'Local Enquiry Started'
+ * Adds 'Create Local Enquiry Report' button when applicant status matches - 'Shortlisted from Interview'
  * Button triggers bulk LER creation for selected job applicants.
  */
 function toggle_local_enquiry_button(frm) {
 	frm.remove_custom_button('Create Local Enquiry Report');
 
-	const valid_statuses = ['Shortlisted from Interview', 'Local Enquiry Started'];
+	const valid_statuses = ['Shortlisted from Interview'];
 	const current_status = frm.doc.applicant_status;
 
 	if (valid_statuses.includes(current_status)) {

--- a/beams/beams/doctype/employee_interview_tool/employee_interview_tool.json
+++ b/beams/beams/doctype/employee_interview_tool/employee_interview_tool.json
@@ -96,7 +96,7 @@
    "fieldname": "applicant_status",
    "fieldtype": "Select",
    "label": "Status",
-   "options": "\nShortlisted from Interview\nLocal Enquiry Started\nInterview Scheduled\nInterview Ongoing\nDocument Uploaded"
+   "options": "\nShortlisted from Interview\nInterview Scheduled\nInterview Ongoing\nDocument Uploaded"
   },
   {
    "fieldname": "section_break_ndqh",
@@ -130,7 +130,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-10-15 12:23:35.776429",
+ "modified": "2025-10-16 16:29:40.898307",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Employee Interview Tool",

--- a/beams/beams/doctype/local_enquiry_report/local_enquiry_report.json
+++ b/beams/beams/doctype/local_enquiry_report/local_enquiry_report.json
@@ -12,6 +12,7 @@
   "designation",
   "department",
   "enquiry_officer",
+  "enquiry_officer_name",
   "column_break_xtgz",
   "status",
   "expected_completion_date",
@@ -24,8 +25,7 @@
   "information_collected_by_section",
   "information_given_by",
   "information_given_by_designation",
-  "column_break_unwc",
-  "information_collected_by"
+  "column_break_unwc"
  ],
  "fields": [
   {
@@ -90,12 +90,6 @@
    "label": "Designation"
   },
   {
-   "fieldname": "information_collected_by",
-   "fieldtype": "Data",
-   "label": "Information Collected By",
-   "read_only": 1
-  },
-  {
    "fieldname": "column_break_xtgz",
    "fieldtype": "Column Break"
   },
@@ -146,7 +140,7 @@
    "depends_on": "eval: !in_list([\"Draft\", \"Assigned to Admin\"], doc.workflow_state)",
    "fieldname": "information_collected_by_section",
    "fieldtype": "Section Break",
-   "label": "Information Collected By"
+   "label": "Information Given By"
   },
   {
    "fieldname": "column_break_unwc",
@@ -156,12 +150,20 @@
    "depends_on": "eval: !in_list([\"Draft\", \"Assigned to Admin\"], doc.workflow_state)",
    "fieldname": "enquiry_details",
    "fieldtype": "Section Break"
+  },
+  {
+   "depends_on": "eval: doc.workflow_state != 'Draft';",
+   "fetch_from": "enquiry_officer.employee_name",
+   "fieldname": "enquiry_officer_name",
+   "fieldtype": "Data",
+   "label": "Enquiry Officer Name",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-03-04 11:44:27.596407",
+ "modified": "2025-10-16 17:08:26.785153",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Local Enquiry Report",
@@ -181,6 +183,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/beams/beams/doctype/local_enquiry_report/local_enquiry_report.json
+++ b/beams/beams/doctype/local_enquiry_report/local_enquiry_report.json
@@ -140,7 +140,7 @@
    "depends_on": "eval: !in_list([\"Draft\", \"Assigned to Admin\"], doc.workflow_state)",
    "fieldname": "information_collected_by_section",
    "fieldtype": "Section Break",
-   "label": "Information Given By"
+   "label": "Information Collected From"
   },
   {
    "fieldname": "column_break_unwc",
@@ -163,7 +163,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-10-16 17:08:26.785153",
+ "modified": "2025-10-18 09:16:31.544974",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Local Enquiry Report",

--- a/beams/beams/doctype/local_enquiry_report/local_enquiry_report.py
+++ b/beams/beams/doctype/local_enquiry_report/local_enquiry_report.py
@@ -32,10 +32,6 @@ class LocalEnquiryReport(Document):
             Method to validate required fields before Pending Approval
         '''
         if self.workflow_state == 'Pending Approval':
-            if frappe.session.user:
-                # Setting Logged In user as information_collected_by
-                self.information_collected_by = frappe.session.user
-
             if not self.information_given_by:
                 frappe.throw('`Information Given By : Person Name` is required before Sending for Approval')
 

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -3161,7 +3161,7 @@ def get_job_applicant_custom_fields():
 			{
 				"fieldname": "specialised_training",
 				"fieldtype": "Small Text",
-				"label": "Have you attended any specialised training program?If yes, Please give detais :",
+				"label": "Have you attended any specialised training program?If yes, Please give details :",
 				"insert_after": "political_org"
 			},
 			{


### PR DESCRIPTION
## Feature description
This PR updates the Local Enquiry flow by changing applicant status logic, fixing UI labels, and cleaning up fields in the Local Enquiry Report.
## Analysis and design (optional)
Removed dependency on Local Enquiry Started status to simplify status handling.
Changed labels to follow consistent terminology (Information Collected From instead of Information Collected By).
Removed redundant fields and ensured correct auto-fetch behavior.
## Solution description
✅In employee_interview_tool.js
- Removed Local Enquiry Started from valid statuses for the Local Enquiry button.
✅ In employee_interview_tool.json
- Removed Local Enquiry Started from applicant status options.
- ✅ In local_enquiry_report.json
- Removed information_collected_by field
- Renamed the section label to Information Collected From.
- Added enquiry_officer_name (fetched from selected officer).
✅ In local_enquiry_report.py
- Removed auto-setting of information_collected_by.
 ## Output screenshots (optional)
<img width="1011" height="733" alt="image" src="https://github.com/user-attachments/assets/c5f7ebcd-7c1f-4199-872b-546d8978ba0d" />
<img width="1495" height="929" alt="image" src="https://github.com/user-attachments/assets/d5f7ad80-b6bf-4d4e-ae04-64fe500502a4" />
<img width="1458" height="565" alt="image" src="https://github.com/user-attachments/assets/34c76cd5-c0cd-4a44-932a-28bce7cfbfa4" />
## Areas affected and ensured
- Employee Interview Tool UI 
- Local Enquiry Report fields/UX

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
