### PR TITLE
feat: acknowledge, transfer and resolve tickets and ability to create…

### DIFF
--- a/beams/beams/custom_scripts/hd_settings/hd_settings.py
+++ b/beams/beams/custom_scripts/hd_settings/hd_settings.py
@@ -1,0 +1,30 @@
+import frappe
+
+def update_ticket_type(doc, method):
+    """Create or update HD Ticket ticket_type Property Setter from HD Settings."""
+
+    default_ticket_type = doc.default_ticket_type
+
+    if default_ticket_type:
+        ps = frappe.db.exists("Property Setter", {
+            "doctype_or_field": "DocField",
+            "doc_type": "HD Ticket",
+            "field_name": "ticket_type",
+            "property": "default"
+        })
+
+        if ps:
+            prop_setter = frappe.get_doc("Property Setter", ps)
+            prop_setter.value = default_ticket_type
+            prop_setter.save()
+        else:
+            prop_setter = frappe.get_doc({
+                "doctype": "Property Setter",
+                "doctype_or_field": "DocField",
+                "doc_type": "HD Ticket",
+                "field_name": "ticket_type",
+                "property": "default",
+                "property_type": "Data",
+                "value": default_ticket_type
+            })
+            prop_setter.insert()

--- a/beams/beams/custom_scripts/hd_team/hd_team.py
+++ b/beams/beams/custom_scripts/hd_team/hd_team.py
@@ -1,0 +1,28 @@
+import frappe
+from helpdesk.helpdesk.doctype.hd_team.hd_team import HDTeam
+
+
+class HDTeamOverride(HDTeam):
+    def before_save(self):
+        self.set_users_from_agent()
+
+    def set_users_from_agent(self):
+        """
+        Set users from HD Agent MultiSelect.
+        Only active agents are considered.
+        """
+        self.users = []
+
+        if not self.agents:
+            return
+
+        agent_names = [agent.agent for agent in self.agents]
+
+        active_users = frappe.get_all(
+            "HD Agent",
+            filters={"name": ["in", agent_names]},
+            pluck="user"
+        )
+
+        for user in active_users:
+            self.append("users", {"user": user})

--- a/beams/beams/custom_scripts/hd_ticket/hd_ticket.js
+++ b/beams/beams/custom_scripts/hd_ticket/hd_ticket.js
@@ -7,10 +7,12 @@ frappe.ui.form.on('HD Ticket', {
     },
 
     refresh(frm) {
-        frm.clear_custom_buttons();
-        if (frm.doc.material_request_needed) {
-            add_material_request_button(frm);
-        }
+        working_button(frm);
+        transfer_ticket(frm);
+        resolved_button(frm);
+        hide_assignment_btn(frm);
+        add_request_buttons(frm)
+        
     },
 
     ticket_type(frm) {
@@ -21,33 +23,165 @@ frappe.ui.form.on('HD Ticket', {
             .catch(() => frm.set_value('agent_group', ''));
     },
     
-    material_request_needed(frm) {
-        frm.clear_custom_buttons();
-        if (frm.doc.material_request_needed) {
-            add_material_request_button(frm);
-        }
-    }
 });
 
-/*
-  Adds a "Material Request" button under the "Create" group in the form.
-  On click, it creates a new "Material Request" document.
-  Populates items from the 'material_request_items' child table of HD Ticket.
-*/
 
-
-function add_material_request_button(frm) {
-    frm.add_custom_button(__('Material Request'), () => {
-        frappe.call({
-            method: "beams.beams.custom_scripts.hd_ticket.hd_ticket.create_material_request_from_ticket",
-            args: {
-                ticket_name: frm.doc.name
-            },
-            callback: function (r) {
-                if (!r.exc && r.message) {
-                    frappe.set_route("Form", "Material Request", r.message);
+/**
+ * Assign ticket to current user if status is Open or Transferred
+ */
+function working_button(frm) {
+    if (['Open', 'Transferred'].includes(frm.doc.status)) {
+        const btn = frm.add_custom_button(__('Working'), () => {
+            frappe.call({
+                method: "beams.beams.custom_scripts.hd_ticket.hd_ticket.assign_to_current_user",
+                args: {
+                    docname: frm.doc.name,
+                    doctype: frm.doc.doctype
+                },
+                callback: function(r) {
+                    if (!r.exc) {
+                        frappe.show_alert({ message: __('Ticket assigned to you'), indicator: 'green' });
+                        frm.set_value('status', 'Working');
+                        frm.save().then(() => frm.reload_doc());
+                    }
                 }
-            }
+            });
         });
-    }, __('Create'));
+
+        btn.css({
+            backgroundColor: '#007bff',
+            color: 'white',
+            border: 'none',
+            fontWeight: '500'
+        });
+    }
+}
+
+
+/**
+ * Open dialog to transfer ticket to another active agent
+ */
+function transfer_ticket(frm) {
+    if (!['Closed', 'Open'].includes(frm.doc.status)) {
+        const btn = frm.add_custom_button(__('Transfer'), () => {
+            let d = new frappe.ui.Dialog({
+                title: 'Transfer Ticket',
+                fields: [
+                    {
+                        label: 'Agent',
+                        fieldname: 'agent',
+                        fieldtype: 'Link',
+                        options: 'HD Agent',
+                        get_query: function() {
+                            return { filters: { 'is_active': 1 } };
+                        }
+                    }
+                ],
+                size: 'small',
+                primary_action_label: 'Assign',
+                primary_action(values) {
+                    frappe.call({
+                        method: 'beams.beams.custom_scripts.hd_ticket.hd_ticket.assign_ticket_to_agent',
+                        args: {
+                            ticket_name: frm.doc.name,
+                            agent: values.agent
+                        },
+                        callback: function(r) {
+                            if (!r.exc) {
+                                frappe.show_alert({ message: __('Ticket transferred successfully'), indicator: 'orange' });
+                                frm.set_value('status', 'Transferred');
+                                frm.save().then(() => frm.reload_doc());
+                            }
+                        }
+                    });
+                    d.hide();
+                }
+            });
+
+            d.show();
+        });
+
+        btn.css({
+            backgroundColor: '#fd7e14',
+            color: 'white',
+            border: 'none',
+            fontWeight: '500'
+        });
+    }
+}
+
+
+/**
+ * Set ticket status to Closed
+ */
+function resolved_button(frm) {
+    if (!['Closed', 'Open', 'Transferred'].includes(frm.doc.status)) {
+        const btn = frm.add_custom_button(__('Resolved'), () => {
+
+            if (!frm.doc.resolution_details || frm.doc.resolution_details.trim() === "") {
+                frappe.msgprint({
+                    title: __('Missing Resolution Details'),
+                    message: __('Please fill in the <b>Resolution Details</b> before closing the ticket.'),
+                    indicator: 'red'
+                });
+
+                frm.scroll_to_field('resolution_details');
+                frm.fields_dict.resolution_details.set_focus();
+                return;
+            }
+
+            frm.set_value('status', 'Closed');
+            frm.save().then(() => {
+                frappe.show_alert({ message: __('Ticket marked as closed'), indicator: 'green' });
+                frm.reload_doc();
+            });
+        });
+
+        btn.css({
+            backgroundColor: '#1c9a68ff',
+            color: 'white',
+            border: 'none',
+            fontWeight: '500'
+        });
+    }
+}
+
+
+
+/**
+ * Add Asset Request and Material Request buttons if user is an active HD Agent
+ */
+function add_request_buttons(frm) {
+    frappe.call({
+        method: 'frappe.client.get_value',
+        args: {
+            doctype: 'HD Agent',
+            fieldname: 'name',
+            filters: {
+                user: frappe.session.user,
+                is_active: 1
+            }
+        },
+        callback: function(r) {
+            if (r.message && r.message.name) {
+                // Add Asset Request button
+                frm.add_custom_button(__('Asset Request'), () => {
+                    frappe.new_doc('Asset Request', { 'employee': frm.doc.raised_by });
+                }, __('Create'));
+
+                // Add Material Request button
+                frm.add_custom_button(__('Material Request'), () => {
+                    frappe.new_doc('Material Request', { 'requested_by': frm.doc.raised_by });
+                }, __('Create'));
+            }
+        }
+    });
+}
+
+
+/**
+ * hide assignment button
+ */
+function hide_assignment_btn(frm) {
+    $(".add-assignment-btn").hide();
 }

--- a/beams/beams/custom_scripts/hd_ticket/hd_ticket.js
+++ b/beams/beams/custom_scripts/hd_ticket/hd_ticket.js
@@ -7,12 +7,27 @@ frappe.ui.form.on('HD Ticket', {
     },
 
     refresh(frm) {
-        working_button(frm);
-        transfer_ticket(frm);
-        resolved_button(frm);
-        hide_assignment_btn(frm);
-        add_request_buttons(frm)
-        
+        frappe.call({
+            method: 'frappe.client.get_value',
+            args: {
+                doctype: 'HD Agent',
+                fieldname: 'name',
+                filters: {
+                    user: frappe.session.user,
+                    is_active: 1
+                }
+            },
+            callback: function(r) {
+                if (r.message && r.message.name) {
+                    // User is an active HD Agent, show all buttons
+                    working_button(frm);
+                    transfer_ticket(frm);
+                    resolved_button(frm);
+                    add_request_buttons(frm);
+                }
+                hide_assignment_btn(frm);
+            }
+        });
     },
 
     ticket_type(frm) {
@@ -40,9 +55,12 @@ function working_button(frm) {
                 },
                 callback: function(r) {
                     if (!r.exc) {
-                        frappe.show_alert({ message: __('Ticket assigned to you'), indicator: 'green' });
-                        frm.set_value('status', 'Working');
-                        frm.save().then(() => frm.reload_doc());
+                        frappe.show_alert({
+                            message: __('Ticket assigned to you'),
+                            indicator: 'green'
+                        });
+
+                        frm.reload_doc();
                     }
                 }
             });
@@ -56,6 +74,7 @@ function working_button(frm) {
         });
     }
 }
+
 
 
 /**
@@ -115,7 +134,7 @@ function transfer_ticket(frm) {
  * Set ticket status to Closed
  */
 function resolved_button(frm) {
-    if (!['Closed', 'Open', 'Transferred'].includes(frm.doc.status)) {
+    if (!['Closed', 'Open'].includes(frm.doc.status)) {
         const btn = frm.add_custom_button(__('Resolved'), () => {
 
             if (!frm.doc.resolution_details || frm.doc.resolution_details.trim() === "") {
@@ -166,13 +185,24 @@ function add_request_buttons(frm) {
             if (r.message && r.message.name) {
                 // Add Asset Request button
                 frm.add_custom_button(__('Asset Request'), () => {
-                    frappe.new_doc('Asset Request', { 'employee': frm.doc.raised_by });
+                    frappe.db.get_value("Employee", { "user_id": frm.doc.raised_by }, "name")
+                        .then(r => {
+                            frappe.new_doc('Asset Request', {
+                                'requested_by': r.message?.name
+                            });
+                        });
                 }, __('Create'));
 
-                // Add Material Request button
+               // Add Material Request button
                 frm.add_custom_button(__('Material Request'), () => {
-                    frappe.new_doc('Material Request', { 'requested_by': frm.doc.raised_by });
+                    frappe.db.get_value("Employee", { "user_id": frm.doc.raised_by }, "name")
+                        .then(r => {
+                            frappe.new_doc('Material Request', {
+                                'requested_by': r.message?.name
+                            });
+                        });
                 }, __('Create'));
+
             }
         }
     });

--- a/beams/beams/custom_scripts/hd_ticket/hd_ticket.py
+++ b/beams/beams/custom_scripts/hd_ticket/hd_ticket.py
@@ -1,5 +1,5 @@
 import frappe
-from frappe.desk.form.assign_to import add as assign_to_user
+from frappe.desk.form.assign_to import add as assign_to_user, clear as clear_all_assignments
 from helpdesk.helpdesk.doctype.hd_ticket.hd_ticket import HDTicket
 
 class HDTicketOverride(HDTicket):
@@ -86,24 +86,54 @@ class HDTicketOverride(HDTicket):
 			self.agent_group = ''
 
 
+
 @frappe.whitelist()
-def create_material_request_from_ticket(ticket_name):
-	"""
-		Create Material Request from HD Ticket
-	"""
-	ticket = frappe.get_doc("HD Ticket", ticket_name)
-	mr = frappe.new_doc("Material Request")
-	mr.material_request_type = "Purchase"
-	mr.transaction_date = frappe.utils.today()
+def assign_ticket_to_agent(ticket_name, agent):
+    """
+    Assign ticket to a specific agent
+    """
 
-	for row in ticket.material_request_items:
-		mr.append("items", {
-			"item_code": row.item,
-			"qty": row.quantity,
-			"uom": frappe.db.get_value("Item", row.item, "stock_uom"),
-			"schedule_date": row.required_by or frappe.utils.today()
-		})
-		mr.insert(ignore_permissions=True)
+    if not frappe.db.exists('HD Agent', {'user': agent, 'is_active': 1}):
+        frappe.throw(f'User {agent} is not an active HD Agent.')
 
-	return mr.name
+    if not frappe.db.exists('HD Ticket', ticket_name):
+        frappe.throw(f'Ticket {ticket_name} does not exist.')
 
+    todo_exists = frappe.db.exists('ToDo', {
+        'reference_type': 'HD Ticket',
+        'reference_name': ticket_name,
+        'owner': agent,
+        'status': ['!=', 'Cancelled'],
+    })
+
+    if todo_exists:
+        frappe.msgprint(f'Ticket {ticket_name} is already assigned to {agent}.')
+        return
+
+    assign_to_user({
+        'doctype': 'HD Ticket',
+        'name': ticket_name,
+        'assign_to': [agent],
+        'description': 'Ticket assigned to you.',
+    })
+
+    frappe.msgprint(f'Ticket {ticket_name} has been assigned to {agent}.')
+
+
+
+@frappe.whitelist()
+def assign_to_current_user(docname, doctype):
+    current_user = frappe.session.user
+
+    status = frappe.db.get_value(doctype, docname, ["status", "status_category"], as_dict=True)
+
+    if status.status == 'Open' and status.status_category == 'Open':
+        clear_all_assignments(doctype, docname, ignore_permissions=True)
+        frappe.db.set_value(doctype, docname, "status", "Replied")
+
+    assign_to_user({
+        "assign_to": frappe.as_json([current_user]),
+        "doctype": doctype,
+        "name": docname,
+        "notify": 0
+    })

--- a/beams/beams/custom_scripts/hd_ticket/hd_ticket.py
+++ b/beams/beams/custom_scripts/hd_ticket/hd_ticket.py
@@ -123,17 +123,22 @@ def assign_ticket_to_agent(ticket_name, agent):
 
 @frappe.whitelist()
 def assign_to_current_user(docname, doctype):
+    """Assign ticket to current user if it's Open or Transferred using Document API"""
     current_user = frappe.session.user
 
-    status = frappe.db.get_value(doctype, docname, ["status", "status_category"], as_dict=True)
+    doc = frappe.get_doc(doctype, docname)
 
-    if status.status == 'Open' and status.status_category == 'Open':
+    if doc.status in ['Open', 'Transferred'] and doc.status_category == 'Open':
         clear_all_assignments(doctype, docname, ignore_permissions=True)
-        frappe.db.set_value(doctype, docname, "status", "Replied")
+
+        doc.status = 'Replied'
+        doc.save(ignore_permissions=True)
 
     assign_to_user({
-        "assign_to": frappe.as_json([current_user]),
+        "assign_to": [current_user],
         "doctype": doctype,
         "name": docname,
         "notify": 0
     })
+
+    return {"message": f"Ticket {docname} assigned to {current_user}"}

--- a/beams/beams/doctype/recipients/recipients.json
+++ b/beams/beams/doctype/recipients/recipients.json
@@ -32,7 +32,6 @@
   {
    "fieldname": "remarks",
    "fieldtype": "Small Text",
-   "in_list_view": 1,
    "label": "Remarks"
   },
   {
@@ -67,7 +66,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-10-15 17:22:41.166081",
+ "modified": "2025-10-17 17:06:46.696652",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Recipients",

--- a/beams/beams/doctype/ticket_agents/ticket_agents.json
+++ b/beams/beams/doctype/ticket_agents/ticket_agents.json
@@ -1,0 +1,35 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-10-10 12:22:21.009304",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "agent"
+ ],
+ "fields": [
+  {
+   "fieldname": "agent",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Agent",
+   "options": "HD Agent",
+   "reqd": 1
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2025-10-10 15:29:44.146169",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "Ticket Agents",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/beams/beams/doctype/ticket_agents/ticket_agents.py
+++ b/beams/beams/doctype/ticket_agents/ticket_agents.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class TicketAgents(Document):
+	pass

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -170,7 +170,7 @@ override_doctype_class = {
 	"Attendance Request": "beams.beams.custom_scripts.attendance_request.attendance_request.AttendanceRequestOverride",
 	"Shift Type": "beams.beams.custom_scripts.shift_type.shift_type.ShiftTypeOverride",
 	"Interview": "beams.beams.custom_scripts.interview.interview.InterviewOverride",
-	# "HD Ticket" :"beams.beams.custom_scripts.hd_ticket.hd_ticket.HDTicketOverride",
+	"HD Ticket" :"beams.beams.custom_scripts.hd_ticket.hd_ticket.HDTicketOverride",
 	"Appraisal": "beams.beams.custom_scripts.appraisal.appraisal.CustomAppraisal",
 	"HD Team": "beams.beams.custom_scripts.hd_team.hd_team.HDTeamOverride"
 }

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -170,8 +170,9 @@ override_doctype_class = {
 	"Attendance Request": "beams.beams.custom_scripts.attendance_request.attendance_request.AttendanceRequestOverride",
 	"Shift Type": "beams.beams.custom_scripts.shift_type.shift_type.ShiftTypeOverride",
 	"Interview": "beams.beams.custom_scripts.interview.interview.InterviewOverride",
-	"HD Ticket" :"beams.beams.custom_scripts.hd_ticket.hd_ticket.HDTicketOverride",
-	"Appraisal": "beams.beams.custom_scripts.appraisal.appraisal.CustomAppraisal"
+	# "HD Ticket" :"beams.beams.custom_scripts.hd_ticket.hd_ticket.HDTicketOverride",
+	"Appraisal": "beams.beams.custom_scripts.appraisal.appraisal.CustomAppraisal",
+	"HD Team": "beams.beams.custom_scripts.hd_team.hd_team.HDTeamOverride"
 }
 
 # Document Events

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -413,6 +413,9 @@ doc_events = {
 	},
 	"Job Opening": {
 		"after_insert": "beams.beams.custom_scripts.job_opening.job_opening.generate_qr_for_job"
+	},
+	"HD Settings": {
+		"validate": "beams.beams.custom_scripts.hd_settings.hd_settings.update_ticket_type"
 	}
 }
 

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -75,6 +75,7 @@ def after_install():
 	create_custom_fields(get_asset_maintenance_task_custom_fields(), ignore_validate=True)
 	create_custom_fields(get_supplier_quotation_item_custom_fields(), ignore_validate=True)
 	create_custom_fields(get_purchase_receipt_item_custom_fields(), ignore_validate=True)
+	create_custom_fields(get_hd_team_custom_fields(), ignore_validate=True)
 	
 	setup_notifications()
 
@@ -214,14 +215,6 @@ def get_hd_ticket_custom_fields():
 	'''
 	return {
 		"HD Ticket": [
-
-			{
-				"fieldname": "raised_for",
-				"fieldtype": "Link",
-				"options": "User",
-				"label": "Raised For (Email)",
-				"insert_after": "raised_by"
-			},
 			{
 				"fieldname": "attach",
 				"fieldtype": "Attach",
@@ -235,19 +228,13 @@ def get_hd_ticket_custom_fields():
 				"insert_after": "attach"
 			},
 			{
-				"fieldname": "material_request_needed",
-				"fieldtype": "Check",
-				"label": "Material Request Needed",
-				"insert_after": "ticket_section_break"
-			},
-			{
-				"fieldname": "material_request_items",
-				"fieldtype": "Table",
-				"label": "Material Request Items",
-				"insert_after": "material_request_needed",
-				"options": "Material Request Items",
-				"depends_on": "eval:doc.material_request_needed == 1"
+				"fieldname": "employee_name",
+				"fieldtype": "Data",
+				"label": "Employee Name",
+				"insert_after": "raised_by",
+				"read_only": 1,
 			}
+
 		]
 	}
 
@@ -4993,6 +4980,33 @@ def get_property_setters():
 			"property": "hidden",
 			"value": 1
 		}
+		,{
+			"doc_type": "HD Ticket",
+			"field_name": "ticket_type",
+			"property": "allow_in_quick_entry",
+			"value": 1
+		},
+		{   
+			"doctype_or_field": "DocField",
+			"doc_type": "HD Ticket",
+			"field_name": "agent_group",
+			"property": "fetch_from",
+			"value": "ticket_type.team_name"
+		},
+		{
+			"doctype_or_field": "DocField",
+			"doc_type": "HD Ticket",
+			"field_name": "summary",
+			"property": "hidden",
+			"value": 1
+		},
+		{
+			"doctype_or_field": "DocField",
+			"doc_type": "HD Ticket",
+			"field_name": "description",
+			"property": "reqd",
+			"value": 1
+		}
 
 ]
 
@@ -5035,6 +5049,14 @@ def get_material_request_custom_fields():
 				"allow_on_submit": 1,
 				"read_only_depends_on": "eval:doc.workflow_state == 'Rejected'"
 			},
+			{
+				"fieldname": "employee_name",
+				"fieldtype": "Data",	
+				"label": "Employee Name",
+				"insert_after": "requested_by",
+				"read_only": 1,
+				"fetch_from": "requested_by.employee_name"
+			}
 		]
 	}
 
@@ -5656,6 +5678,23 @@ def get_purchase_receipt_item_custom_fields():
 				"fieldtype": "Data",
 				"label": "Model",
 				"insert_after": "make"
+			}
+		]
+	}
+
+
+def get_hd_team_custom_fields():
+	'''
+		Custom fields that need to be added to the HD Team DocType
+	'''
+	return {
+		"HD Team": [
+			{
+				"fieldname": "agents",
+				"fieldtype": "Table MultiSelect",
+				"label": "Agents",
+				"options": "Ticket Agents",
+				"insert_after": "team_name"
 			}
 		]
 	}

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -5006,6 +5006,13 @@ def get_property_setters():
 			"field_name": "description",
 			"property": "reqd",
 			"value": 1
+		},
+		{
+			"doctype_or_field": "DocField",
+			"doc_type": "HD Ticket",
+			"field_name": "first_response_time",
+			"property": "in_list_view",
+			"value": 1
 		}
 
 ]


### PR DESCRIPTION
## Feature description

Task ID :- TASK-2025-02459

customize the helpdesk ticket for accepting , transfering, resolving and create asset and material request.

Add three buttons (Working, Transfer, Resolved)
In status open and transfter show working button , change the status accordingly to working .
show transfer and resolved button on status working .
resolved button clicked , close the ticket and mark sla resolved.

create asset and material request button , clicked redirect to that page.

## Solution description

Added a Working button (visible only when status is Open or Transferred) to assign the ticket to the current user.
Added a Transfer button to reassign the ticket to another active HD Agent through a dialog.
Added a Resolved button (hidden for Closed/Open/Transferred) that validates resolution details before marking the ticket Closed.
Added Asset Request and Material Request creation buttons, visible only to active agents.
Hid the default “Assign” button (.add-assignment-btn) for better control and UI consistency.
Set ticket type default as default ticket type in hd settings

## Output screenshots (optional)
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/1e1d0dc4-9917-4718-b1cb-5b72fddc76cd" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/937906fc-f038-4f0e-a0a0-17309b486fa2" />

## Was this feature tested on the browsers?
  - Chrome

