### PR TITLE
TASK-2025-02466 : Set petty cash requested amount into received amount of Payment Entry.

### DIFF
--- a/beams/beams/doctype/petty_cash_request/petty_cash_request.js
+++ b/beams/beams/doctype/petty_cash_request/petty_cash_request.js
@@ -52,6 +52,7 @@ function open_payment_entry(frm) {
     frappe.new_doc("Payment Entry", {
         payment_type: "Internal Transfer",
         paid_amount: frm.doc.requested_amount,
+        received_amount : frm.doc.requested_amount,
         reference_date: frappe.datetime.nowdate(),
         paid_to: frm.doc.account
     });


### PR DESCRIPTION
## Feature description
- Set petty cash requested amount into received amount of Payment Entry.

## Solution description
- Set petty cash requested amount into received amount of Payment Entry.

## Output screenshots (optional)
<img width="1357" height="620" alt="image" src="https://github.com/user-attachments/assets/d24da3aa-1aa4-45ca-a807-0e9ec6af72c2" />

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox
