### PR TITLE
Task 2025 02468: Update Appraisal,Employee Appraisal Consent and Employee

### DIFF
--- a/beams/beams/custom_scripts/appraisal/appraisal.js
+++ b/beams/beams/custom_scripts/appraisal/appraisal.js
@@ -235,12 +235,24 @@ frappe.ui.form.on('Appraisal', {
 				}
 			});
 		if (!frm.is_new()) {
+			const today = frappe.datetime.get_today();
+			const start_date = frm.doc.start_date;
+			const appraisal_period_started = start_date && today >= start_date;
 			if (!frm.doc.consent_received) {
 				frm.disable_form();
 				frm.dashboard.set_headline_alert(
 					__("Waiting for Employee Appraisal Consent Submission"), "orange"
 				);
-			} else {
+			} else if (!appraisal_period_started) {
+				frm.disable_form();
+				frm.dashboard.set_headline_alert(
+				__("Appraisal period will begin on {0}. Form will be editable after this date.",
+					[frappe.datetime.str_to_user(start_date)]
+				),
+				"green"
+			);
+			}
+			else {
 				frm.enable_form();
 			}
 		}

--- a/beams/beams/custom_scripts/employee/employee.py
+++ b/beams/beams/custom_scripts/employee/employee.py
@@ -604,4 +604,9 @@ def populate_employee_details_from_applicant(doc, method):
 			"reason_for_leaving": row.reason_for_leaving,
 			"attachments": row.attachments
 		})
+
+	if job_applicant.job_title:
+		employment_type = frappe.db.get_value("Job Opening", job_applicant.job_title, "employment_type")
+		if employment_type:
+			doc.employment_type = employment_type
 	doc.save()

--- a/beams/beams/doctype/assessment_officer/assessment_officer.json
+++ b/beams/beams/doctype/assessment_officer/assessment_officer.json
@@ -28,13 +28,14 @@
    "default": "0",
    "fieldname": "is_primary",
    "fieldtype": "Check",
+   "in_list_view": 1,
    "label": "Primary Assessment Officer"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-09-06 14:49:18.299645",
+ "modified": "2025-10-21 09:41:26.744718",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Assessment Officer",

--- a/beams/beams/doctype/employee_appraisal_consent/employee_appraisal_consent.json
+++ b/beams/beams/doctype/employee_appraisal_consent/employee_appraisal_consent.json
@@ -11,6 +11,7 @@
   "employee_name",
   "amended_from",
   "appraisal",
+  "user",
   "column_break_voru",
   "posting_date",
   "company",
@@ -93,13 +94,21 @@
    "label": "Appraisal",
    "options": "Appraisal",
    "read_only": 1
+  },
+  {
+   "fetch_from": "employee.user_id",
+   "fieldname": "user",
+   "fieldtype": "Link",
+   "hidden": 1,
+   "label": "User",
+   "options": "User"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-09-15 11:32:59.220357",
+ "modified": "2025-10-21 09:39:35.784377",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Employee Appraisal Consent",

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -2136,8 +2136,13 @@ def get_employee_custom_fields():
 				"options": "Previous Employment History",
 				"label": "External Work History",
 				"insert_after": "previous_work_experience"
-			}
-
+			},
+			{
+				"fieldname": "custom_current_address",
+				"fieldtype": "Column Break",
+				"label": "Current Address",
+				"insert_after": "address_section"
+			},
 		],
 
 		"Employee External Work History":[
@@ -4979,8 +4984,9 @@ def get_property_setters():
 			"field_name": "external_work_history",
 			"property": "hidden",
 			"value": 1
-		}
-		,{
+		},
+		{
+			"doctype_or_field": "DocField",
 			"doc_type": "HD Ticket",
 			"field_name": "ticket_type",
 			"property": "allow_in_quick_entry",
@@ -5013,9 +5019,21 @@ def get_property_setters():
 			"field_name": "first_response_time",
 			"property": "in_list_view",
 			"value": 1
-		}
-
-]
+		},
+		{
+			"doctype_or_field": "DocField",
+			"doc_type": "Employee",
+			"field_name": "column_break_46",
+			"property": "label",
+			"value": "Permanent Address"
+		},
+		{
+			"doctype_or_field": "DocType",
+			"doc_type": "Employee",
+			"property": "field_order",
+			"value": '["basic_details_tab", "basic_information", "employee", "naming_series", "first_name", "middle_name", "last_name", "bureau", "employee_name", "column_break_9", "gender", "date_of_birth", "name_of_father", "name_of_spouse", "salutation", "column_break1", "date_of_joining", "date_of_appointment", "image", "status", "training_status", "erpnext_user", "user_id", "create_user", "create_user_permission", "company_details_section", "company", "department", "employment_type", "employee_number", "column_break_25", "designation", "reports_to", "assessment_officer", "column_break_18", "branch", "grade", "employment_details", "job_applicant", "joining_details", "scheduled_confirmation_date", "column_break_32", "final_confirmation_date", "contract_end_date", "col_break_22", "notice_number_of_days", "date_of_retirement", "appraisal_details", "appraisal_template", "next_appraisal_col", "next_appraisal_date", "assessment_officers_sec", "assessment_officers", "contact_details", "cell_number", "company_number", "column_break_40", "personal_email", "company_email", "column_break4", "prefered_contact_email", "prefered_email", "unsubscribed", "address_section", "current_address_column", "pincode", "current_address", "landmark", "current_accommodation_type", "column_break_46", "permanent_pin_code", "permanent_address", "landmark_per", "permanent_accommodation_type", "emergency_contact_details", "person_to_be_contacted", "emergency_contact_name", "column_break_55", "emergency_phone_number", "emergency_phone", "column_break_19", "relation", "relation_emergency", "attendance_and_leave_details", "attendance_device_id", "leave_policy", "leave_policy_name", "column_break_44", "holiday_list", "default_shift", "approvers_section", "expense_approver", "leave_approver", "column_break_45", "shift_request_approver", "salary_information", "ctc", "salary_currency", "salary_mode", "salary_cb", "payroll_cost_center", "pan_number", "provident_fund_account", "salary_structure", "bank_details_section", "bank_name", "column_break_heye", "bank_ac_no", "bank_cb", "ifsc_code", "micr_code", "iban", "nominee_details_section", "nominee_details", "personal_details", "marital_status", "aadhar_id", "no_of_children", "family_background", "column_break6", "blood_group", "health_details", "health_insurance_section", "health_insurance_provider", "health_insurance_no", "passport_details_section", "passport_number", "valid_upto", "column_break_73", "date_of_issue", "place_of_issue", "additional_information_section", "physical_disabilities", "disabilities", "marital_indebtness", "court_proceedings", "court_proceedings_details", "column_break_travel", "are_you_willing_to_travel", "in_india", "abroad", "state_restrictions_problems", "places_to_travel", "are_you_related_to_employee", "related_employee_name", "profile_tab", "bio", "educational_qualification", "education_qualification", "education", "previous_work_experience", "previous_employment_history", "external_work_history", "history_in_company", "internal_work_history", "documents_tab", "employee_documents", "exit", "resignation_letter_date", "relieving_date", "exit_interview_details", "held_on", "new_workplace", "column_break_99", "leave_encashed", "encashment_date", "feedback_section", "reason_for_leaving", "column_break_104", "feedback", "lft", "rgt", "old_parent", "connections_tab", "stringer_type"]',
+		},
+	]
 
 def get_material_request_custom_fields():
 	'''


### PR DESCRIPTION
## Feature description
Currently, employees can edit the appraisal even before the appraisal period start date, which is invalid.
Employment type was not set in Employee during creation based on the Job Applicant.
When an Employee Appraisal Consent is created, a notification(using frappe notification) should be sent to the respective employee. Therefore, a field for User was added in Employee Appraisal Consent.
Restructured the Address section with separate column breaks for "Current Address" and "Permanent Address
## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description
- Appraisal form (appraisal.js): Disabled the form for employees if consent is not received or the appraisal period hasn’t started. Added a dashboard alert indicating when the form will become editable.
- Employee creation (employee.py): Populates employment_type in Employee from the corresponding Job Opening of the Job Applicant.
- Employee Appraisal Consent (employee_appraisal_consent.json): Added a hidden user field to identify the employee for sending notifications.
- Assessment Officer (assessment_officer.json): Made the Primary Assessment Officer field visible in list view.
- Employee Address Section (setup.py): Added separate column breaks for Current and Permanent addresses and updated the field order accordingly.

## Output screenshots (optional)
**Created an appraisal for employee 'Hani'** 
<img width="1654" height="913" alt="image" src="https://github.com/user-attachments/assets/bf4a4f95-525f-4540-b2a2-80364d934382" />
**Even though the employee has submitted the appraisal consent, the appraisal form will be editable only after the appraisal period has started.** 
<img width="1654" height="913" alt="image" src="https://github.com/user-attachments/assets/ee35ddd0-817f-4023-998b-2bcad2414a93" />

Employment type is populated from the Job Applicant to the Employee during creation based on the Job Opening.<img width="1650" height="879" alt="image" src="https://github.com/user-attachments/assets/e7e74f94-39b8-4fd4-a8e3-e1c6e36e3549" />
<img width="1674" height="930" alt="image" src="https://github.com/user-attachments/assets/1661bc3d-ed65-455a-84db-59cda78d26e9" />
<img width="1674" height="930" alt="image" src="https://github.com/user-attachments/assets/c3a5d0c7-db1d-4799-bbc2-f79c2d3bf46d" />

The Address section will be now displayed as two separate columns labeled 'Current Address' and 'Permanent Address'
<img width="1674" height="930" alt="image" src="https://github.com/user-attachments/assets/172f5faf-fe4f-4e96-9fbd-914aa6090932" />

Now primary officer field is visible in listview
<img width="1399" height="592" alt="image" src="https://github.com/user-attachments/assets/63b1adf0-fcda-4208-82b6-82698798bf0e" />


## Areas affected and ensured
Employee Appraisal form.
Employee creation process.
Employee Appraisal Consent DocType.
Assessment Officer table.

Employee Address section in Employee form.
## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
