### PR TITLE
TASK-2025-02481: leave policy assignment not created during employee creation

### DIFF
--- a/beams/beams/custom_scripts/employee/employee.py
+++ b/beams/beams/custom_scripts/employee/employee.py
@@ -610,3 +610,5 @@ def populate_employee_details_from_applicant(doc, method):
 		if employment_type:
 			doc.employment_type = employment_type
 	doc.save()
+
+	assign_leave_policy_on_joining(doc, method)

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -300,10 +300,9 @@ doc_events = {
 	"Employee" : {
 		"autoname": "beams.beams.custom_scripts.employee.employee.autoname",
 		"after_insert": [
-			"beams.beams.custom_scripts.employee.employee.assign_leave_policy_on_joining",
 			"beams.beams.custom_scripts.employee.employee.send_joining_based_appraisal_notification",
-			"beams.beams.custom_scripts.employee.employee.populate_employee_details_from_applicant"
-		],	
+			"beams.beams.custom_scripts.employee.employee.populate_employee_details_from_applicant",
+		],
 		"before_validate": "beams.beams.custom_scripts.employee.employee.manage_user_status",
 		"validate":  [
 			"beams.beams.custom_scripts.employee.employee.validate",


### PR DESCRIPTION
## Fix description
Leave Policy Assignment was not created for an employee during Employee creation.
## Analysis and design (optional)
The issue was caused by the order of after_insert hooks in the Employee DocType: assign_leave_policy_on_joining ran before populate_employee_details_from_applicant, leaving employment_type and leave_policy unset.
## Solution description

- Updated the Employee creation flow to call assign_leave_policy_on_joining at the end of populate_employee_details_from_applicant.
- This ensures employment_type is populated first, allowing the leave_policy to be fetched and assigned correctly.

## Output screenshots (optional)
**Created employee 'Rani Ram' via job applicant(Job Applicant->Job Offer->Employee).Leave Policy Assignment is created along with employee creation**
<img width="1803" height="1009" alt="image" src="https://github.com/user-attachments/assets/c5e47dde-8069-48cf-8f23-23d79a675b32" />
<img width="1803" height="1009" alt="image" src="https://github.com/user-attachments/assets/671756a4-bc09-46e9-b16f-89743602ef45" />
<img width="1803" height="1009" alt="image" src="https://github.com/user-attachments/assets/735bed3c-86cb-4817-95f0-49c8c91f35c1" />
<img width="1803" height="1009" alt="image" src="https://github.com/user-attachments/assets/82deaf2e-2eb2-457e-9f64-894d2cb5455f" />
<img width="1803" height="1009" alt="image" src="https://github.com/user-attachments/assets/4ace5065-9e1e-44cd-b6c2-598fa8c4d2e0" />

## Areas affected and ensured
Employee DocType
Leave Policy Assignment creation on Employee insertion
## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
