### PR TITLE
TASK-2025-02499: add automated escalation notification process for overdue Helpdesk ticket SLAs

### DIFF
--- a/beams/beams/custom_scripts/hd_ticket/hd_ticket.js
+++ b/beams/beams/custom_scripts/hd_ticket/hd_ticket.js
@@ -1,6 +1,15 @@
 frappe.ui.form.on('HD Ticket', {
     // Called when form is loaded
     onload(frm) {
+        if (frm.is_new() && !frm.doc.requested_employee) {
+            frappe.db.get_value("Employee", { "user_id": frappe.session.user }, "name")
+                .then(r => {
+                    if (r.message && r.message.name) {
+                        frm.set_value('requested_employee', r.message.name);
+                    }
+                });
+        }
+
         if (frm.is_new() && !frm.doc.raised_by) {
             frm.set_value('raised_by', frappe.session.user);
         }
@@ -137,18 +146,6 @@ function resolved_button(frm) {
     if (!['Closed', 'Open'].includes(frm.doc.status)) {
         const btn = frm.add_custom_button(__('Resolved'), () => {
 
-            if (!frm.doc.resolution_details || frm.doc.resolution_details.trim() === "") {
-                frappe.msgprint({
-                    title: __('Missing Resolution Details'),
-                    message: __('Please fill in the <b>Resolution Details</b> before closing the ticket.'),
-                    indicator: 'red'
-                });
-
-                frm.scroll_to_field('resolution_details');
-                frm.fields_dict.resolution_details.set_focus();
-                return;
-            }
-
             frm.set_value('status', 'Closed');
             frm.save().then(() => {
                 frappe.show_alert({ message: __('Ticket marked as closed'), indicator: 'green' });
@@ -183,26 +180,19 @@ function add_request_buttons(frm) {
         },
         callback: function(r) {
             if (r.message && r.message.name) {
-                // Add Asset Request button
+                // Asset Request button
                 frm.add_custom_button(__('Asset Request'), () => {
-                    frappe.db.get_value("Employee", { "user_id": frm.doc.raised_by }, "name")
-                        .then(r => {
-                            frappe.new_doc('Asset Request', {
-                                'requested_by': r.message?.name
-                            });
-                        });
+                    frappe.new_doc('Asset Request', {
+                        'requested_by': frm.doc.requested_employee
+                    });
                 }, __('Create'));
 
-               // Add Material Request button
+                // Material Request button
                 frm.add_custom_button(__('Material Request'), () => {
-                    frappe.db.get_value("Employee", { "user_id": frm.doc.raised_by }, "name")
-                        .then(r => {
-                            frappe.new_doc('Material Request', {
-                                'requested_by': r.message?.name
-                            });
-                        });
+                    frappe.new_doc('Material Request', {
+                        'requested_by': frm.doc.requested_employee
+                    });
                 }, __('Create'));
-
             }
         }
     });

--- a/beams/beams/custom_scripts/hd_ticket/hd_ticket.py
+++ b/beams/beams/custom_scripts/hd_ticket/hd_ticket.py
@@ -148,23 +148,24 @@ def assign_to_current_user(docname, doctype):
     return {"message": f"Ticket {docname} assigned to {current_user}"}
 
 
-
-
 def process_escalation_notifications():
     """
-    	Check for overdue Helpdesk tickets and send escalation emails for response or resolution delays.
+    Check for overdue Helpdesk tickets and send escalation emails for response or resolution delays.
     """
-    hd_settings = frappe.get_single("HD Settings")
-    if not hd_settings.enable_escalation_notifications:
+    enable_escalation = frappe.db.get_single_value("HD Settings", "enable_escalation_notifications")
+    if not enable_escalation:
         return
+
+    response_template = frappe.db.get_single_value("HD Settings", "response_due_template")
+    resolution_template = frappe.db.get_single_value("HD Settings", "resolution_due_template")
 
     now = now_datetime()
     escalation_data = [
-        ("response_due_escalation_send", "first_responded_on", "response_by", hd_settings.response_due_template, "Response"),
-        ("resolution_due_escalation_send", "resolution_date", "resolution_by", hd_settings.resolution_due_template, "Resolution")
+        ("response_due_escalation_send", "first_responded_on", "response_by", response_template),
+        ("resolution_due_escalation_send", "resolution_date", "resolution_by", resolution_template)
     ]
 
-    for flag, date_field, due_field, template, notif_type in escalation_data:
+    for flag, date_field, due_field, template in escalation_data:
         if not template:
             continue
         tickets = frappe.get_all(
@@ -186,11 +187,11 @@ def send_escalation_notification(ticket_doc, template_name):
     if not hd_team:
         return
 
-    hd_team_doc = frappe.get_doc("HD Team", hd_team)
-    if not hd_team_doc.escalation_to:
+    escalation_to = frappe.get_value("HD Team", hd_team, "escalation_to")
+    if not escalation_to:
         return
 
-    user_email = frappe.db.get_value("Employee", hd_team_doc.escalation_to, "user_id")
+    user_email = frappe.db.get_value("Employee", escalation_to, "user_id")
     if not user_email:
         return
 

--- a/beams/beams/custom_scripts/hd_ticket/hd_ticket.py
+++ b/beams/beams/custom_scripts/hd_ticket/hd_ticket.py
@@ -1,6 +1,10 @@
-import frappe
-from frappe.desk.form.assign_to import add as assign_to_user, clear as clear_all_assignments
+from frappe.desk.form.assign_to import add as assign_to_user
+from frappe.desk.form.assign_to import clear as clear_all_assignments
+from frappe.utils import now_datetime
 from helpdesk.helpdesk.doctype.hd_ticket.hd_ticket import HDTicket
+
+import frappe
+
 
 class HDTicketOverride(HDTicket):
 
@@ -142,3 +146,62 @@ def assign_to_current_user(docname, doctype):
     })
 
     return {"message": f"Ticket {docname} assigned to {current_user}"}
+
+
+
+
+def process_escalation_notifications():
+    """
+    	Check for overdue Helpdesk tickets and send escalation emails for response or resolution delays.
+    """
+    hd_settings = frappe.get_single("HD Settings")
+    if not hd_settings.enable_escalation_notifications:
+        return
+
+    now = now_datetime()
+    escalation_data = [
+        ("response_due_escalation_send", "first_responded_on", "response_by", hd_settings.response_due_template, "Response"),
+        ("resolution_due_escalation_send", "resolution_date", "resolution_by", hd_settings.resolution_due_template, "Resolution")
+    ]
+
+    for flag, date_field, due_field, template, notif_type in escalation_data:
+        if not template:
+            continue
+        tickets = frappe.get_all(
+            "HD Ticket",
+            filters={flag: 0, date_field: ["is", "not set"], due_field: ["<", now]},
+            fields=["name", "agent_group"]
+        )
+        for ticket in tickets:
+            ticket_doc = frappe.get_doc("HD Ticket", ticket.name)
+            send_escalation_notification(ticket_doc, template, notif_type)
+            frappe.db.set_value("HD Ticket", ticket.name, flag, 1)
+
+
+def send_escalation_notification(ticket_doc, template_name):
+    """
+    	Send an escalation email notification to the designated escalation contact for a Helpdesk ticket.
+    """
+    hd_team = ticket_doc.agent_group
+    if not hd_team:
+        return
+
+    hd_team_doc = frappe.get_doc("HD Team", hd_team)
+    if not hd_team_doc.escalation_to:
+        return
+
+    user_email = frappe.db.get_value("Employee", hd_team_doc.escalation_to, "user_id")
+    if not user_email:
+        return
+
+    email_template = frappe.get_doc("Email Template", template_name)
+    subject = frappe.render_template(email_template.subject or "", {"doc": ticket_doc})
+    message = frappe.render_template(email_template.response, {"doc": ticket_doc})
+
+    frappe.sendmail(
+        recipients=[user_email],
+        subject=subject,
+        message=message,
+        reference_doctype="HD Ticket",
+        reference_name=ticket_doc.name
+    )

--- a/beams/beams/custom_scripts/hd_ticket/hd_ticket.py
+++ b/beams/beams/custom_scripts/hd_ticket/hd_ticket.py
@@ -174,7 +174,7 @@ def process_escalation_notifications():
         )
         for ticket in tickets:
             ticket_doc = frappe.get_doc("HD Ticket", ticket.name)
-            send_escalation_notification(ticket_doc, template, notif_type)
+            send_escalation_notification(ticket_doc, template)
             frappe.db.set_value("HD Ticket", ticket.name, flag, 1)
 
 

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -452,6 +452,11 @@ scheduler_events = {
 	"monthly": [
 		"beams.beams.custom_scripts.asset.asset.asset_notifications"
 	],
+	"cron": {
+		"* * * * *": [  # runs every minute
+			"beams.beams.custom_scripts.hd_ticket.hd_ticket.process_escalation_notifications"
+		]
+	}
   }
 
 # Testing

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -1,8 +1,8 @@
-import frappe
-from frappe import _
 from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 from frappe.desk.page.setup_wizard.setup_wizard import make_records
 
+import frappe
+from frappe import _
 
 hod_leave_approval_response = '''<div class="ql-editor read-mode">
 	<p>Dear {{ hod_name }},</p>
@@ -76,6 +76,7 @@ def after_install():
 	create_custom_fields(get_supplier_quotation_item_custom_fields(), ignore_validate=True)
 	create_custom_fields(get_purchase_receipt_item_custom_fields(), ignore_validate=True)
 	create_custom_fields(get_hd_team_custom_fields(), ignore_validate=True)
+	create_custom_fields(get_hd_settings_custom_fields(), ignore_validate=True)
 	
 	setup_notifications()
 
@@ -231,8 +232,30 @@ def get_hd_ticket_custom_fields():
 				"fieldname": "employee_name",
 				"fieldtype": "Data",
 				"label": "Employee Name",
-				"insert_after": "raised_by",
+				"insert_after": "requested_employee",
 				"read_only": 1,
+				"fetch_from": "requested_employee.employee_name"
+			},
+			{
+				"fieldname": "requested_employee",
+				"fieldtype": "Link",
+				"label": "Requested Employee",
+				"options":"Employee",
+				"insert_after": "raised_by",
+			},
+			{
+				"fieldname": "response_due_escalation_send",
+				"fieldtype": "Check",
+				"label": "Response Due Escalation Send",
+				"read_only": 1,
+				"insert_after": "avg_response_time"
+			},
+			{
+				"fieldname": "resolution_due_escalation_send",
+				"fieldtype": "Check",
+				"label": "Resolution Due Escalation Send",
+				"read_only": 1,
+				"insert_after": "user_resolution_time"
 			}
 
 		]
@@ -5011,7 +5034,7 @@ def get_property_setters():
 			"doctype_or_field": "DocField",
 			"doc_type": "HD Ticket",
 			"field_name": "description",
-			"property": "reqd",
+			"property": "allow_in_quick_entry",
 			"value": 1
 		},
 		{
@@ -5034,7 +5057,15 @@ def get_property_setters():
 			"property": "field_order",
 			"value": '["basic_details_tab", "basic_information", "employee", "naming_series", "first_name", "middle_name", "last_name", "bureau", "employee_name", "column_break_9", "gender", "date_of_birth", "name_of_father", "name_of_spouse", "salutation", "column_break1", "date_of_joining", "date_of_appointment", "image", "status", "training_status", "erpnext_user", "user_id", "create_user", "create_user_permission", "company_details_section", "company", "department", "employment_type", "employee_number", "column_break_25", "designation", "reports_to", "assessment_officer", "column_break_18", "branch", "grade", "employment_details", "job_applicant", "joining_details", "scheduled_confirmation_date", "column_break_32", "final_confirmation_date", "contract_end_date", "col_break_22", "notice_number_of_days", "date_of_retirement", "appraisal_details", "appraisal_template", "next_appraisal_col", "next_appraisal_date", "assessment_officers_sec", "assessment_officers", "contact_details", "cell_number", "company_number", "column_break_40", "personal_email", "company_email", "column_break4", "prefered_contact_email", "prefered_email", "unsubscribed", "address_section", "current_address_column", "pincode", "current_address", "landmark", "current_accommodation_type", "column_break_46", "permanent_pin_code", "permanent_address", "landmark_per", "permanent_accommodation_type", "emergency_contact_details", "person_to_be_contacted", "emergency_contact_name", "column_break_55", "emergency_phone_number", "emergency_phone", "column_break_19", "relation", "relation_emergency", "attendance_and_leave_details", "attendance_device_id", "leave_policy", "leave_policy_name", "column_break_44", "holiday_list", "default_shift", "approvers_section", "expense_approver", "leave_approver", "column_break_45", "shift_request_approver", "salary_information", "ctc", "salary_currency", "salary_mode", "salary_cb", "payroll_cost_center", "pan_number", "provident_fund_account", "salary_structure", "bank_details_section", "bank_name", "column_break_heye", "bank_ac_no", "bank_cb", "ifsc_code", "micr_code", "iban", "nominee_details_section", "nominee_details", "personal_details", "marital_status", "aadhar_id", "no_of_children", "family_background", "column_break6", "blood_group", "health_details", "health_insurance_section", "health_insurance_provider", "health_insurance_no", "passport_details_section", "passport_number", "valid_upto", "column_break_73", "date_of_issue", "place_of_issue", "additional_information_section", "physical_disabilities", "disabilities", "marital_indebtness", "court_proceedings", "court_proceedings_details", "column_break_travel", "are_you_willing_to_travel", "in_india", "abroad", "state_restrictions_problems", "places_to_travel", "are_you_related_to_employee", "related_employee_name", "profile_tab", "bio", "educational_qualification", "education_qualification", "education", "previous_work_experience", "previous_employment_history", "external_work_history", "history_in_company", "internal_work_history", "documents_tab", "employee_documents", "exit", "resignation_letter_date", "relieving_date", "exit_interview_details", "held_on", "new_workplace", "column_break_99", "leave_encashed", "encashment_date", "feedback_section", "reason_for_leaving", "column_break_104", "feedback", "lft", "rgt", "old_parent", "connections_tab", "stringer_type"]',
 		},
-	]
+		{
+			"doctype_or_field": "DocField",
+			"doc_type": "HD Ticket",
+			"field_name": "raised_by",
+			"property": "hidden",
+			"value": 1
+		}
+
+]
 
 def get_material_request_custom_fields():
 	'''
@@ -5721,6 +5752,49 @@ def get_hd_team_custom_fields():
 				"label": "Agents",
 				"options": "Ticket Agents",
 				"insert_after": "team_name"
+			},
+			{
+				"fieldname": "escalation_to",
+				"fieldtype": "Link",
+				"label": "Escalation To",
+				"options": "Employee",
+				"insert_after": "agents"
+			}
+		]
+	}
+
+
+def get_hd_settings_custom_fields():
+	'''
+		Custom fields that need to be added to the HD Settings DocType
+	'''
+	return {
+		"HD Settings": [
+			{
+				"fieldname": "escalation_notifications_templates",
+				"fieldtype": "Tab Break",
+				"label": "Escalation Notifications Templates",
+				"insert_after": "reply_via_agent_email_content"
+			},
+			{
+				"fieldname": "enable_escalation_notifications",
+				"fieldtype": "Check",
+				"label": "Enable Escalation Notifications",
+				"insert_after": "escalation_notifications_templates"
+			},
+			{
+				"fieldname": "response_due_template",
+				"fieldtype": "Link",
+				"label": "Response Due Template",
+				"options": "Email Template",
+				"insert_after": "enable_escalation_notifications"
+			},
+			{
+				"fieldname": "resolution_due_template",
+				"fieldtype": "Link",
+				"label": "Resolution Due Template",
+				"options": "Email Template",
+				"insert_after": "response_due_template"
 			}
 		]
 	}


### PR DESCRIPTION
## Feature description
This feature automates the escalation notification process for overdue Helpdesk (HD) tickets. It ensures that when a ticket's response or resolution SLA is breached, an escalation email is automatically sent to the designated escalation contact defined in the corresponding HD Team.

## Solution description
1. Added a scheduled function process_escalation_notifications() that checks for HD Tickets with overdue response or resolution times.
2. Configured the function to respect the “Enable Escalation Notifications” setting in HD Settings.
3. Integrated escalation templates (response_due_template and resolution_due_template) to send context-specific email alerts.
4. Implemented send_escalation_notification() to handle fetching escalation contact details, rendering the email subject and body using the selected Email Template, and sending the email via frappe.sendmail.
5. Updated escalation flags (response_due_escalation_send, resolution_due_escalation_send) in the ticket to prevent duplicate notifications.

## Output screenshots (optional)
<img width="1912" height="899" alt="image" src="https://github.com/user-attachments/assets/8c29ad84-aca7-4d7b-a25f-bb03e82dc834" />
<img width="1912" height="899" alt="image" src="https://github.com/user-attachments/assets/66f795b9-e3b1-4170-a0db-37ff9b20879c" />


## Was this feature tested on the browsers?
  - Chrome
