### PR TITLE
TASK-2025-02526: enable asset auditing particular to bureau related assets

### DIFF
--- a/beams/beams/doctype/asset_auditing/asset_auditing.js
+++ b/beams/beams/doctype/asset_auditing/asset_auditing.js
@@ -2,14 +2,14 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Asset Auditing', {
-    refresh: async function(frm) {
+    refresh: function(frm) {
         if (frm.doc.bureau) {
-            await set_asset_filter(frm);
+            set_asset_filter(frm);
         }
     },
 
-    bureau: async function(frm) {
-        await handle_bureau_change(frm);
+    bureau: function(frm) {
+        handle_bureau_change(frm);
     }
 });
 
@@ -17,10 +17,10 @@ frappe.ui.form.on('Asset Auditing', {
 /**
  * Handles logic when Bureau field value changes
  */
-async function handle_bureau_change(frm) {
+function handle_bureau_change(frm) {
     if (!frm.doc.bureau) return;
 
-    await set_asset_filter(frm);
+    set_asset_filter(frm);
 
     // Clear child table to avoid mismatched assets
     frm.clear_table('asset_auditing_detail');
@@ -31,13 +31,11 @@ async function handle_bureau_change(frm) {
 /**
  * Sets filter on Asset field in child table based on Bureau location
  */
-async function set_asset_filter(frm) {
-    const { message } = await frappe.db.get_value('Bureau', frm.doc.bureau, 'location');
-    if (!message?.location) return;
+function set_asset_filter(frm) {
 
     frm.fields_dict['asset_auditing_detail'].grid.get_field('asset').get_query = function() {
         return {
-            filters: { location: message.location }
+            filters: frm.doc.location
         };
     };
 }

--- a/beams/beams/doctype/asset_auditing/asset_auditing.js
+++ b/beams/beams/doctype/asset_auditing/asset_auditing.js
@@ -2,31 +2,43 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Asset Auditing', {
-    asset: function(frm) {
-        if (frm.doc.asset) {
-            frappe.db.get_value('Asset', frm.doc.asset, 'custodian', (r) => {
-                if (r && r.custodian) {
-                    frm.set_value('employee', r.custodian);
-                }
-            });
+    refresh: async function(frm) {
+        if (frm.doc.bureau) {
+            await set_asset_filter(frm);
         }
     },
-    posting_date:function (frm){
-      frm.call("validate_posting_date");
-    },
-    // Fetch asset by scanned QR code and set 'asset' field
-    scan_qr_code: function(frm) {
-        if (frm.doc.scan_qr_code) {
-            frappe.db.get_value('Asset', frm.doc.scan_qr_code, 'name')
-                .then(r => {
-                    if (r && r.message) {
-                        frm.set_value('asset', r.message.name);
-                    } else {
-                        frappe.msgprint(__('Asset not found for scanned QR code'));
-                        frm.set_value('asset', null);
-                    }
-                    frm.set_value('scan_qr_code', null);
-                });
-        }
+
+    bureau: async function(frm) {
+        await handle_bureau_change(frm);
     }
 });
+
+
+/**
+ * Handles logic when Bureau field value changes
+ */
+async function handle_bureau_change(frm) {
+    if (!frm.doc.bureau) return;
+
+    await set_asset_filter(frm);
+
+    // Clear child table to avoid mismatched assets
+    frm.clear_table('asset_auditing_detail');
+    frm.refresh_field('asset_auditing_detail');
+}
+
+
+/**
+ * Sets filter on Asset field in child table based on Bureau location
+ */
+async function set_asset_filter(frm) {
+    const { message } = await frappe.db.get_value('Bureau', frm.doc.bureau, 'location');
+    if (!message?.location) return;
+
+    frm.fields_dict['asset_auditing_detail'].grid.get_field('asset').get_query = function() {
+        return {
+            filters: { location: message.location }
+        };
+    };
+}
+

--- a/beams/beams/doctype/asset_auditing/asset_auditing.json
+++ b/beams/beams/doctype/asset_auditing/asset_auditing.json
@@ -6,16 +6,14 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
-  "scan_qr_code",
-  "asset",
   "employee",
+  "employee_name",
+  "bureau",
   "column_break_bgwn",
   "posting_date",
   "location",
-  "employee_name",
   "section_break_rev9",
-  "asset_photos",
-  "has_damage",
+  "asset_auditing_detail",
   "remarks",
   "amended_from"
  ],
@@ -25,38 +23,13 @@
    "fieldtype": "Section Break"
   },
   {
-   "fieldname": "amended_from",
-   "fieldtype": "Link",
-   "label": "Amended From",
-   "no_copy": 1,
-   "options": "Asset Auditing",
-   "print_hide": 1,
-   "read_only": 1,
-   "search_index": 1
-  },
-  {
-   "fieldname": "asset",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "label": "Asset",
-   "options": "Asset",
-   "reqd": 1
-  },
-  {
-   "description": "A minimum of 3 photos must be uploaded",
-   "fieldname": "asset_photos",
-   "fieldtype": "Table",
-   "label": "Asset Photos",
-   "options": "Attachments Detail",
-   "reqd": 1
-  },
-  {
-   "fetch_from": "asset.location",
+   "fetch_from": "bureau.location",
    "fieldname": "location",
    "fieldtype": "Link",
+   "in_list_view": 1,
    "label": "Location",
    "options": "Location",
-   "reqd": 1
+   "read_only": 1
   },
   {
    "fieldname": "remarks",
@@ -64,14 +37,9 @@
    "label": "Remarks"
   },
   {
-   "default": "0",
-   "fieldname": "has_damage",
-   "fieldtype": "Check",
-   "label": "Has Damage"
-  },
-  {
    "fieldname": "employee",
    "fieldtype": "Link",
+   "in_list_view": 1,
    "label": "Employee",
    "options": "Employee",
    "reqd": 1
@@ -87,22 +55,40 @@
    "fieldtype": "Column Break"
   },
   {
-   "fieldname": "scan_qr_code",
-   "fieldtype": "Data",
-   "label": "Scan QR Code",
-   "options": "Barcode"
-  },
-  {
    "fetch_from": "employee.employee_name",
    "fieldname": "employee_name",
    "fieldtype": "Data",
    "label": "Employee Name"
+  },
+  {
+   "fieldname": "bureau",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Bureau",
+   "options": "Bureau",
+   "reqd": 1
+  },
+  {
+   "fieldname": "asset_auditing_detail",
+   "fieldtype": "Table",
+   "label": "Asset Auditing Detail",
+   "options": "Asset Auditing Detail"
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "Asset Auditing",
+   "print_hide": 1,
+   "read_only": 1,
+   "search_index": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-05-23 13:12:53.697528",
+ "modified": "2025-10-29 11:12:10.998704",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Asset Auditing",
@@ -123,7 +109,8 @@
    "write": 1
   }
  ],
- "search_fields": "asset",
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": []

--- a/beams/beams/doctype/asset_auditing/asset_auditing.py
+++ b/beams/beams/doctype/asset_auditing/asset_auditing.py
@@ -7,11 +7,24 @@ from frappe.utils import today
 from frappe import _
 
 class AssetAuditing(Document):
+
     def before_save(self):
         self.validate_posting_date()
-        
+    
+    def before_submit(self):
+        self.validate_image_attached()
+    
+    def validate_image_attached(self):
+        """ 
+        Ensure each row in asset_auditing_detail has exactly 3 images attached.
+        """
+        for idx, row in enumerate(self.asset_auditing_detail, start=1):
+            images = [row.image, row.image_2, row.image_3]
+            attached_images = [img for img in images if img]
+            if len(attached_images) != 3:
+                frappe.throw(f"Row {idx} must have exactly 3 images attached.")
+    
     @frappe.whitelist()
     def validate_posting_date(self):
-        if self.posting_date:
-            if self.posting_date > today():
-                frappe.throw(_("Posting Date cannot be set after today's date."))
+        if self.posting_date and self.posting_date > today():
+            frappe.throw(_("Posting Date cannot be set after today's date."))

--- a/beams/beams/doctype/asset_auditing/asset_auditing.py
+++ b/beams/beams/doctype/asset_auditing/asset_auditing.py
@@ -15,12 +15,3 @@ class AssetAuditing(Document):
         if self.posting_date:
             if self.posting_date > today():
                 frappe.throw(_("Posting Date cannot be set after today's date."))
-
-    def before_submit(self):
-        if len(self.asset_photos) < 3:
-            frappe.msgprint(
-                msg="Please upload atleast 3 photos before submission.",
-                title="Message",
-                indicator="red"
-            )
-            raise frappe.ValidationError

--- a/beams/beams/doctype/asset_auditing_detail/asset_auditing_detail.json
+++ b/beams/beams/doctype/asset_auditing_detail/asset_auditing_detail.json
@@ -1,0 +1,88 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-10-06 15:34:39.514423",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "asset",
+  "asset_name",
+  "image",
+  "image_2",
+  "column_break_wanm",
+  "image_3",
+  "image_4",
+  "section_break_pmij",
+  "remarks"
+ ],
+ "fields": [
+  {
+   "fieldname": "asset",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Asset",
+   "options": "Asset",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "asset.asset_name",
+   "fieldname": "asset_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Asset Name"
+  },
+  {
+   "fieldname": "image",
+   "fieldtype": "Attach",
+   "in_list_view": 1,
+   "label": "Image 1",
+   "reqd": 1
+  },
+  {
+   "fieldname": "remarks",
+   "fieldtype": "Small Text",
+   "label": "Remarks"
+  },
+  {
+   "fieldname": "image_2",
+   "fieldtype": "Attach",
+   "in_list_view": 1,
+   "label": "Image 2"
+  },
+  {
+   "fieldname": "image_3",
+   "fieldtype": "Attach",
+   "in_list_view": 1,
+   "label": "Image 3"
+  },
+  {
+   "fieldname": "column_break_wanm",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_pmij",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "image_4",
+   "fieldtype": "Attach Image",
+   "label": "Image 4"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2025-10-28 09:46:12.091190",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "Asset Auditing Detail",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/beams/beams/doctype/asset_auditing_detail/asset_auditing_detail.json
+++ b/beams/beams/doctype/asset_auditing_detail/asset_auditing_detail.json
@@ -36,8 +36,7 @@
    "fieldname": "image",
    "fieldtype": "Attach",
    "in_list_view": 1,
-   "label": "Image 1",
-   "reqd": 1
+   "label": "Image 1"
   },
   {
    "fieldname": "remarks",
@@ -74,7 +73,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-10-28 09:46:12.091190",
+ "modified": "2025-10-29 14:23:31.126130",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Asset Auditing Detail",

--- a/beams/beams/doctype/asset_auditing_detail/asset_auditing_detail.py
+++ b/beams/beams/doctype/asset_auditing_detail/asset_auditing_detail.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class AssetAuditingDetail(Document):
+	pass


### PR DESCRIPTION
## Feature description
Enable all  bureau to do asset auditing
filter assets based on bureau location

## Solution description
enabled asset auditing to particular bureau related assets

## Output screenshots (optional)
<img width="1920" height="902" alt="image" src="https://github.com/user-attachments/assets/2b1c5114-f973-4aef-9c71-221751af87c0" />

## Was this feature tested on the browsers?
  - Chrome

