### PR TITLE
TASK-2025-02536: support multiple escalation recipients in HD Team

### DIFF
--- a/beams/beams/custom_scripts/hd_ticket/hd_ticket.py
+++ b/beams/beams/custom_scripts/hd_ticket/hd_ticket.py
@@ -187,9 +187,12 @@ def send_escalation_notification(ticket_doc, template_name):
     if not hd_team:
         return
 
-    hd_team_doc = frappe.get_doc("HD Team", hd_team)
-    if hasattr(hd_team_doc, "escalation_to"):
-            escalation_list = [row.employee for row in hd_team_doc.escalation_to]
+    escalation_list = frappe.get_all(
+        "HD Team Escalation To",
+        filters={"parent": hd_team},
+        pluck="employee"
+    )
+
 
     if not escalation_list:
         return

--- a/beams/beams/custom_scripts/hd_ticket/hd_ticket.py
+++ b/beams/beams/custom_scripts/hd_ticket/hd_ticket.py
@@ -187,12 +187,21 @@ def send_escalation_notification(ticket_doc, template_name):
     if not hd_team:
         return
 
-    escalation_to = frappe.get_value("HD Team", hd_team, "escalation_to")
-    if not escalation_to:
+    hd_team_doc = frappe.get_doc("HD Team", hd_team)
+    if hasattr(hd_team_doc, "escalation_to"):
+            escalation_list = [row.employee for row in hd_team_doc.escalation_to]
+
+    if not escalation_list:
         return
 
-    user_email = frappe.db.get_value("Employee", escalation_to, "user_id")
-    if not user_email:
+    user_emails = frappe.db.get_list(
+        "Employee",
+        filters={"name": ["in", escalation_list]},
+        pluck="user_id"
+    )
+
+    user_emails = [email for email in user_emails if email]
+    if not user_emails:
         return
 
     email_template = frappe.get_doc("Email Template", template_name)
@@ -200,7 +209,7 @@ def send_escalation_notification(ticket_doc, template_name):
     message = frappe.render_template(email_template.response, {"doc": ticket_doc})
 
     frappe.sendmail(
-        recipients=[user_email],
+        recipients= user_emails,
         subject=subject,
         message=message,
         reference_doctype="HD Ticket",

--- a/beams/beams/doctype/hd_ticket_escalation_to/hd_ticket_escalation_to.json
+++ b/beams/beams/doctype/hd_ticket_escalation_to/hd_ticket_escalation_to.json
@@ -1,0 +1,34 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-10-30 16:24:25.556061",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "employee"
+ ],
+ "fields": [
+  {
+   "fieldname": "employee",
+   "fieldtype": "Link",
+   "label": "Employee",
+   "options": "Employee"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2025-10-30 16:24:48.544442",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "HD Ticket Escalation To",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/beams/beams/doctype/hd_ticket_escalation_to/hd_ticket_escalation_to.py
+++ b/beams/beams/doctype/hd_ticket_escalation_to/hd_ticket_escalation_to.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class HDTicketEscalationTo(Document):
+	pass

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -5063,7 +5063,35 @@ def get_property_setters():
 			"field_name": "raised_by",
 			"property": "hidden",
 			"value": 1
-		}
+		},
+		{
+			"doctype_or_field": "DocField",
+			"doc_type": "HD Ticket",
+			"field_name": "status_category",
+			"property": "hidden",
+			"value": 1
+		},
+		{
+			"doctype_or_field": "DocField",
+			"doc_type": "HD Ticket",
+			"field_name": "status",
+			"property": "hidden",
+			"value": 1
+		},
+		{
+			"doctype_or_field": "DocField",
+			"doc_type": "HD Ticket",
+			"field_name": "template",
+			"property": "hidden",
+			"value": 1
+		},
+		{
+			"doctype_or_field": "DocField",
+			"doc_type": "HD Ticket",
+			"field_name": "key",
+			"property": "hidden",
+			"value": 1
+		},
 
 ]
 
@@ -5755,9 +5783,9 @@ def get_hd_team_custom_fields():
 			},
 			{
 				"fieldname": "escalation_to",
-				"fieldtype": "Link",
+				"fieldtype": "Table MultiSelect",
 				"label": "Escalation To",
-				"options": "Employee",
+				"options": "HD Ticket Escalation To",
 				"insert_after": "agents"
 			}
 		]


### PR DESCRIPTION
## Feature description
change the single user escalation_to to multiple user escalation_to (Helpdesk).
hide status , status category field in HD Ticket.

## Solution description
1. changed single field into multiselect table and escalation mail is being send to selected employee's
2. using property setter fields are been made to hide 

## Output screenshots (optional)
<img width="1908" height="826" alt="image" src="https://github.com/user-attachments/assets/a153be61-40d1-4837-bf69-bbe3271841a9" />



## Was this feature tested on the browsers?
  - Chrome
