### PR TITLE
TASK-2025-02585:multi select link field to select multiple active employees for trip

### DIFF
--- a/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.js
+++ b/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.js
@@ -156,35 +156,9 @@ frappe.ui.form.on("Bureau Trip Sheet", {
 		frm.call("calculate_total_distance_based_on_odometer");
 	},
 	refresh: function(frm) {
-		// Fetch Batta Policy values and set read-only properties
-		frappe.call({
-			method: "beams.beams.doctype.bureau_trip_sheet.bureau_trip_sheet.get_batta_policy_values",
-			callback: function(response) {
-				if (response.message) {
-					let is_actual_daily_batta_without_overnight_stay = response.message.is_actual__;
-					let is_actual_daily_batta_with_overnight_stay = response.message.is_actual_;
-					let is_actual_food_allowance = response.message.is_actual___;
-
-					// Set read-only properties
-					frm.set_df_property('daily_batta_without_overnight_stay', 'read_only', is_actual_daily_batta_without_overnight_stay == 0);
-					frm.set_df_property('daily_batta_with_overnight_stay', 'read_only', is_actual_daily_batta_with_overnight_stay == 0);
-
-					// Refresh fields
-					frm.refresh_field('daily_batta_without_overnight_stay');
-					frm.refresh_field('daily_batta_with_overnight_stay');
-
-					frm.fields_dict['work_details'].grid.update_docfield_property('breakfast', 'read_only', is_actual_food_allowance == 0);
-					frm.fields_dict['work_details'].grid.update_docfield_property('lunch', 'read_only', is_actual_food_allowance == 0);
-					frm.fields_dict['work_details'].grid.update_docfield_property('dinner', 'read_only', is_actual_food_allowance == 0);
-
-					// Refresh child table
-					frm.refresh_field('work_details');
-				}
-			}
-		});
-
-		// Call the supplier filter function
 		filter_supplier_field(frm);
+		set_batta_policy_properties(frm);
+		filter_employee_field(frm);
 	},
 
 	onload: function(frm) {
@@ -201,6 +175,47 @@ function filter_supplier_field(frm) {
 				is_transporter: 1
 			}
 		};
+	});
+}
+
+/* Function to filter active employees */
+function filter_employee_field(frm) {
+	frm.set_query("employees", () => {
+		return {
+			filters: {
+				status: "Active"
+			}
+		};
+	});
+}
+
+/* Function to set Batta Policy properties */
+function set_batta_policy_properties(frm) {
+	frappe.call({
+		method: "beams.beams.doctype.bureau_trip_sheet.bureau_trip_sheet.get_batta_policy_values",
+		callback: function(response) {
+			if (response.message) {
+				let is_actual_daily_batta_without_overnight_stay = response.message.is_actual__;
+				let is_actual_daily_batta_with_overnight_stay = response.message.is_actual_;
+				let is_actual_food_allowance = response.message.is_actual___;
+
+				// Set read-only properties for parent fields
+				frm.set_df_property('daily_batta_without_overnight_stay', 'read_only', is_actual_daily_batta_without_overnight_stay == 0);
+				frm.set_df_property('daily_batta_with_overnight_stay', 'read_only', is_actual_daily_batta_with_overnight_stay == 0);
+
+				// Refresh parent fields
+				frm.refresh_field('daily_batta_without_overnight_stay');
+				frm.refresh_field('daily_batta_with_overnight_stay');
+
+				// Set read-only properties for child table fields
+				frm.fields_dict['work_details'].grid.update_docfield_property('breakfast', 'read_only', is_actual_food_allowance == 0);
+				frm.fields_dict['work_details'].grid.update_docfield_property('lunch', 'read_only', is_actual_food_allowance == 0);
+				frm.fields_dict['work_details'].grid.update_docfield_property('dinner', 'read_only', is_actual_food_allowance == 0);
+
+				// Refresh child table
+				frm.refresh_field('work_details');
+			}
+		}
 	});
 }
 

--- a/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.json
+++ b/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.json
@@ -8,8 +8,9 @@
  "field_order": [
   "section_break_qq5d",
   "supplier",
-  "bureau",
+  "employees",
   "column_break_psaw",
+  "bureau",
   "company",
   "section_break_qavf",
   "is_overnight_stay",
@@ -238,12 +239,18 @@
    "fieldtype": "Float",
    "label": "Total Distance (KM)",
    "read_only": 1
+  },
+  {
+   "fieldname": "employees",
+   "fieldtype": "Table MultiSelect",
+   "label": "Employees",
+   "options": "Employees"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-11-06 12:53:07.360302",
+ "modified": "2025-11-07 10:28:03.398951",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Bureau Trip Sheet",

--- a/beams/beams/doctype/employees/employees.json
+++ b/beams/beams/doctype/employees/employees.json
@@ -1,0 +1,36 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-11-07 10:25:49.024492",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "employee"
+ ],
+ "fields": [
+  {
+   "fieldname": "employee",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Employee",
+   "options": "Employee",
+   "reqd": 1
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2025-11-07 10:26:29.343875",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "Employees",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/beams/beams/doctype/employees/employees.py
+++ b/beams/beams/doctype/employees/employees.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class Employees(Document):
+	pass


### PR DESCRIPTION
## Feature description
Need to: Add a new Multi-Select Link field in Bureau Trip Sheet DocType to allow selecting multiple active employees for the trip

## Solution description

- Added a new Multi-Select Link field in Bureau Trip Sheet DocType to allow selecting multiple active employees for the trip in
- use helper function set_batta_policy_properties(frm) to Handles fetching and applying Batta Policy read-only settings for parent and child fields.

## Output screenshots (optional)
[Screencast from 07-11-25 10:59:30 AM IST.webm](https://github.com/user-attachments/assets/c20884a5-6e5c-49dc-a068-41025d7fab01)

## Areas affected and ensured

Bureau Trip Sheet doctype

## Is there any existing behaviour change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Chrome
