### PR TITLE
TASK-2025-02581:multi select link field to select multiple active employees for trip

### DIFF
--- a/beams/beams/doctype/trip_sheet/trip_sheet.js
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.js
@@ -25,30 +25,12 @@ frappe.ui.form.on('Trip Sheet', {
 	},
 
 	refresh: function (frm) {
-		if (!frm.is_new()){
-			frm.add_custom_button(__('Vehicle Incident Record'), function () {
-				frappe.call({
-					method: "beams.beams.doctype.trip_sheet.trip_sheet.create_vehicle_incident_record",
-					args: {
-						trip_sheet: frm.doc.name
-					},
-					callback: function (r) {
-						if (r.message) {
-							frappe.new_doc("Vehicle Incident Record", r.message);
-						}
-					}
-				});
-			}, __("Create"));
+		if (!frm.is_new()) {
+			add_vehicle_incident_button(frm);
 		}
 
-		frm.set_query('travel_requests', function () {
-			return {
-				query: 'beams.beams.doctype.trip_sheet.trip_sheet.get_filtered_travel_requests',
-				filters: {
-					driver: frm.doc.driver
-				}
-			};
-		});
+		set_travel_request_filter(frm);
+		filter_employee_field(frm);
 
 	},
 
@@ -183,6 +165,53 @@ frappe.ui.form.on('Trip Sheet', {
 		frm.set_value('safety_inspection_completed', all_fit_for_use ? 1 : 0);
 	}
 });
+
+/*
+Add custom button for Vehicle Incident Record
+*/
+
+function add_vehicle_incident_button(frm) {
+	frm.add_custom_button(__('Vehicle Incident Record'), function () {
+		frappe.call({
+			method: "beams.beams.doctype.trip_sheet.trip_sheet.create_vehicle_incident_record",
+			args: {
+				trip_sheet: frm.doc.name
+			},
+			callback: function (r) {
+				if (r.message) {
+					frappe.new_doc("Vehicle Incident Record", r.message);
+				}
+			}
+		});
+	}, __("Create"));
+}
+
+/*
+Set query filter for Travel Requests
+*/
+function set_travel_request_filter(frm) {
+	frm.set_query('travel_requests', function () {
+		return {
+			query: 'beams.beams.doctype.trip_sheet.trip_sheet.get_filtered_travel_requests',
+			filters: {
+				driver: frm.doc.driver
+			}
+		};
+	});
+}
+
+/*
+Function to filter active employees
+*/
+function filter_employee_field(frm) {
+	frm.set_query("employees", () => {
+		return {
+			filters: {
+				status: "Active"
+			}
+		};
+	});
+}
 
 frappe.ui.form.on('Trip Details', {
 	from_time: function (frm, cdt, cdn) {

--- a/beams/beams/doctype/trip_sheet/trip_sheet.json
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.json
@@ -16,8 +16,10 @@
   "ending_date_and_time",
   "section_break_ziua",
   "references_column",
-  "travel_requests",
+  "employees",
   "column_break_zgya",
+  "travel_requests",
+  "column_break_cjoq",
   "transportation_requests",
   "pre_trip_checklist_section",
   "clean_vehicle",
@@ -75,8 +77,7 @@
   },
   {
    "fieldname": "references_column",
-   "fieldtype": "Column Break",
-   "label": "References"
+   "fieldtype": "Column Break"
   },
   {
    "fieldname": "travel_requests",
@@ -225,6 +226,16 @@
    "fieldtype": "Small Text",
    "label": "Reason for Rejection",
    "read_only_depends_on": "eval: doc.workflow_state != \"Pending Verification\";"
+  },
+  {
+   "fieldname": "column_break_cjoq",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "employees",
+   "fieldtype": "Table MultiSelect",
+   "label": "Employees",
+   "options": "Employees"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -235,7 +246,7 @@
    "link_fieldname": "trip_sheet"
   }
  ],
- "modified": "2025-09-18 10:26:47.613941",
+ "modified": "2025-11-07 11:25:27.747808",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Trip Sheet",
@@ -257,6 +268,7 @@
   }
  ],
  "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
  "search_fields": "driver,vehicle,starting_date_and_time",
  "sort_field": "modified",
  "sort_order": "DESC",


### PR DESCRIPTION
## Feature description
Need to: Add a new Multi-Select Link field in  Trip Sheet DocType to allow selecting multiple active employees for the trip

## Solution description

- Added a new Multi-Select Link field in Trip Sheet DocType to allow selecting multiple active employees for the trip

- Change the functions in refresh() in to  helper functions, keeping it clean.
     add_vehicle_incident_button(frm) → adds the “Vehicle Incident Record” button.

     set_travel_request_filter(frm) → applies the filter to the travel_requests field.

## Output screenshots (optional)

[Screencast from 07-11-25 11:50:14 AM IST.webm](https://github.com/user-attachments/assets/509d3331-caed-4385-9bbc-c5135d656f52)


## Areas affected and ensured
Trip Sheet doctype

## Is there any existing behavior change of other features due to this code change?
No. 

## Was this feature tested on the browsers?
  - Chrome

