### PR TITLE
feat:Calculate OT batta based on Supplier working hours

### DIFF
--- a/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.js
+++ b/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.js
@@ -228,23 +228,38 @@ function calculate_hours_and_days(frm, cdt, cdn) {
 		let to_date = new Date(row.to_date_and_time);
 
 		let total_hours = (to_date - from_date) / (1000 * 60 * 60);
+		total_hours = Math.round(total_hours);
 		let number_of_days = Math.ceil(total_hours / 24);
 
-		frappe.db.get_single_value('Beams Accounts Settings', 'default_working_hours')
-			.then(default_hours => {
-				default_hours = parseFloat(default_hours) || 0;
-				let ot_hours = Math.max(0, total_hours - default_hours);
+		if (!frm.doc.supplier) {
+			frappe.msgprint(__('Please select a Supplier to calculate OT hours.'));
+			return;
+		}
+		frappe.call({
+			method: "beams.beams.doctype.bureau_trip_sheet.bureau_trip_sheet.get_ot_working_hours",
+			args: {
+				supplier: frm.doc.supplier
+			},
+			callback: function (r) {
+				if (r.message != null) {
+					let ot_working_hours = parseFloat(r.message) || 0;
+					let ot_hours = 0;
+					if (total_hours > ot_working_hours) {
+						ot_hours = total_hours - ot_working_hours;
+					}
+					frappe.model.set_value(cdt, cdn, 'total_hours', total_hours.toFixed(2));
+					frappe.model.set_value(cdt, cdn, 'ot_hours', ot_hours.toFixed(2));
+					frappe.model.set_value(cdt, cdn, 'number_of_days', number_of_days);
 
-				frappe.model.set_value(cdt, cdn, 'total_hours', total_hours.toFixed(2));
-				frappe.model.set_value(cdt, cdn, 'ot_hours', ot_hours.toFixed(2));
-				frappe.model.set_value(cdt, cdn, 'number_of_days', number_of_days);
+					frm.refresh_field("work_details");
 
-				frm.refresh_field("work_details");
-				setTimeout(() => {
-					calculate_daily_batta(frm, cdt, cdn);
-					calculate_ot_batta(frm, cdt, cdn);
-				}, 200);
-			});
+					setTimeout(() => {
+						calculate_daily_batta(frm, cdt, cdn);
+						calculate_ot_batta(frm, cdt, cdn);
+					}, 200);
+				}
+			}
+		});
 	}
 }
 
@@ -285,7 +300,6 @@ function update_all_daily_batta(frm) {
 
 	}
 }
-
 
 /* Update OT batta for all work details rows */
 function update_all_ot_batta(frm) {

--- a/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.py
+++ b/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.py
@@ -187,3 +187,19 @@ def get_batta_policy_values():
 	'''
 	result = frappe.db.get_value('Batta Policy', {}, ['is_actual', 'is_actual_', 'is_actual__', 'is_actual___'], as_dict=True)
 	return result
+
+@frappe.whitelist()
+def get_ot_working_hours(supplier):
+    """
+    Returns OT working hours based on Supplier or Beams Account Settings.
+    If the supplier has a valid 'ot_working_hours', use that.
+    Otherwise, fall back to 'default_working_hours' from Beams Accounts Settings.
+    """
+    ot_hours = frappe.db.get_value("Supplier", supplier, "ot_working_hours")
+
+    # Check for None, 0, or empty string
+    if not ot_hours:
+        ot_hours = frappe.db.get_single_value("Beams Accounts Settings", "default_working_hours")
+
+    # Return a numeric value (float for better accuracy)
+    return float(ot_hours or 0)

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -1735,6 +1735,13 @@ def get_supplier_custom_fields():
 				"insert_after": "is_transporter",
 				"depends_on": "eval:doc.is_transporter == 1"
 
+			},
+			{
+				"fieldname": "ot_working_hours",
+				"fieldtype": "Float",
+				"label": "OT Working Hours",
+				"insert_after": "ot_batta",
+				"depends_on": "eval:doc.is_transporter == 1"
 			}
 		]
 	}


### PR DESCRIPTION
- [x] TASK-2025-02582
- [x] TASK-2025-02583

## Feature description
Need to:

- Add  field “ Working Hours” in Supplier DocType.
- In Bureau Trip Sheet, when calculating OT (Over-Time):
If the selected Supplier has a value in OT Working Hours
 →  Use that value for OT calculation
Else
 →  Use the default OT Working Hour value from Beams Account Settings

## Solution description

- Added  field “ Working Hours” in Supplier DocType.

- In Bureau Trip Sheet, calculated OT (Over-Time) If the selected Supplier has a value in OT Working Hours Use that value for OT calculation else use the default OT Working Hour value from Beams Account Settings

## Output screenshots (optional)
[Screencast from 11-11-25 10:29:52 AM IST.webm](https://github.com/user-attachments/assets/e7513853-c7f3-489a-8edf-a4f4ce07efea)

## Areas affected and ensured
 Bureau Trip Sheet 

## Is there any existing behavior change of other features due to this code change? No. 

## Was this feature tested on the browsers?
  - Chrome

