### PR TITLE
TASK-2025-02597 : corrected escalation child table doctype name

### DIFF
--- a/beams/beams/custom_scripts/hd_ticket/hd_ticket.py
+++ b/beams/beams/custom_scripts/hd_ticket/hd_ticket.py
@@ -188,7 +188,7 @@ def send_escalation_notification(ticket_doc, template_name):
         return
 
     escalation_list = frappe.get_all(
-        "HD Team Escalation To",
+        "HD Ticket Escalation To",
         filters={"parent": hd_team},
         pluck="employee"
     )


### PR DESCRIPTION
## Feature description
Resolve TableMissingError by using correct doctype

## Solution description
doctype = "HD Team Escalation To"
 changed to : -
doctype = "HD Ticket Escalation To"


## Was this feature tested on the browsers?
  - Chrome

