### PR TITLE
TASK-2025-02619: diable assignment rule if enabled related to HD Team

### DIFF
--- a/beams/beams/custom_scripts/hd_team/hd_team.py
+++ b/beams/beams/custom_scripts/hd_team/hd_team.py
@@ -69,3 +69,20 @@ class HDTeamOverride(HDTeam):
 			if total_users_in_assignment_rule == 0:
 				assignment_rule_doc.disabled = True
 				assignment_rule_doc.save()
+
+
+def disable_hd_team_assignment_rule_if_enabled(doc, method):
+    """
+		Disable the assignment rule linked to the HD Team if it is enabled.
+    """
+    assignment_rule = frappe.get_value(
+        "HD Team",
+        doc.name,
+        "assignment_rule"
+    )
+    if not assignment_rule:
+        return
+
+    is_disabled = frappe.get_value("Assignment Rule", assignment_rule, "disabled")
+    if not is_disabled:
+        frappe.db.set_value("Assignment Rule", assignment_rule, "disabled", 1)

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -415,6 +415,9 @@ doc_events = {
 	},
 	"HD Settings": {
 		"validate": "beams.beams.custom_scripts.hd_settings.hd_settings.update_ticket_type"
+	},
+	"HD Team": {
+		"on_update":"beams.beams.custom_scripts.hd_team.hd_team.disable_hd_team_assignment_rule_if_enabled"
 	}
 }
 


### PR DESCRIPTION
## Feature description
1. Disable Assignment Rule if it is enabled .
2. When Agents are added in HD Team , if there exists Assignment Rule related to that Team and it is enabled just disable it .

## Solution description
on updation of HD Team if the Assignment Rule is enabled , Disabled it .

## Output screenshots (optional)
<img width="1818" height="838" alt="image" src="https://github.com/user-attachments/assets/54fa24f4-c938-4452-a2a7-7a13c53a7570" />



## Was this feature tested on the browsers?
  - Chrome

