### PR TITLE
feat: create ticket type subcategory

### DIFF
--- a/beams/beams/doctype/hd_ticket_subcategory/hd_ticket_subcategory.js
+++ b/beams/beams/doctype/hd_ticket_subcategory/hd_ticket_subcategory.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, efeone and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("HD Ticket SubCategory", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/beams/beams/doctype/hd_ticket_subcategory/hd_ticket_subcategory.json
+++ b/beams/beams/doctype/hd_ticket_subcategory/hd_ticket_subcategory.json
@@ -6,7 +6,7 @@
  "engine": "InnoDB",
  "field_order": [
   "ticket_subcategory",
-  "ticket_team"
+  "ticket_type"
  ],
  "fields": [
   {
@@ -17,17 +17,17 @@
    "unique": 1
   },
   {
-   "fieldname": "ticket_team",
+   "fieldname": "ticket_type",
    "fieldtype": "Link",
    "in_list_view": 1,
-   "label": "Ticket Team",
-   "options": "HD Team"
+   "label": "Ticket Type",
+   "options": "HD Ticket Type"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-11-13 10:20:14.053893",
+ "modified": "2025-11-13 14:27:44.597546",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "HD Ticket SubCategory",

--- a/beams/beams/doctype/hd_ticket_subcategory/hd_ticket_subcategory.json
+++ b/beams/beams/doctype/hd_ticket_subcategory/hd_ticket_subcategory.json
@@ -1,0 +1,56 @@
+{
+ "actions": [],
+ "autoname": "field:ticket_subcategory",
+ "creation": "2025-11-13 10:11:06.372311",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "ticket_subcategory",
+  "ticket_team"
+ ],
+ "fields": [
+  {
+   "fieldname": "ticket_subcategory",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Ticket SubCategory",
+   "unique": 1
+  },
+  {
+   "fieldname": "ticket_team",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Ticket Team",
+   "options": "HD Team"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2025-11-13 10:20:14.053893",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "HD Ticket SubCategory",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "title_field": "ticket_subcategory"
+}

--- a/beams/beams/doctype/hd_ticket_subcategory/hd_ticket_subcategory.py
+++ b/beams/beams/doctype/hd_ticket_subcategory/hd_ticket_subcategory.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class HDTicketSubCategory(Document):
+	pass

--- a/beams/beams/doctype/hd_ticket_subcategory/test_hd_ticket_subcategory.py
+++ b/beams/beams/doctype/hd_ticket_subcategory/test_hd_ticket_subcategory.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, efeone and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestHDTicketSubCategory(FrappeTestCase):
+	pass

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -256,6 +256,14 @@ def get_hd_ticket_custom_fields():
 				"label": "Resolution Due Escalation Send",
 				"read_only": 1,
 				"insert_after": "user_resolution_time"
+			},
+			{
+				"fieldname": "ticket_subcategory",
+				"fieldtype": "Link",
+				"label": "Ticket Subcategory",
+				"options":"HD Ticket SubCategory",
+				"insert_after": "ticket_type",
+				"allow_in_quick_entry": 1
 			}
 
 		]


### PR DESCRIPTION
## Feature description
create a doctype for storing details of ticket subcategory and link it with ticket .
when creating ticket  subcategory under team should be able to select

## Solution description
Create "HD Ticket Subcategory" doctype with name and ticket type( link to it )

## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.
<img width="1748" height="656" alt="image" src="https://github.com/user-attachments/assets/d9ab49ef-a1be-4a8d-aef1-02519fcf046c" />
<img width="1024" height="384" alt="image" src="https://github.com/user-attachments/assets/280467f4-1274-474f-91de-4df128168eaf" />


## Was this feature tested on the browsers?
  - Chrome
