### PR TITLE
fix:Corrected batta calculation issue for both food and batta

### DIFF
--- a/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.js
+++ b/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.js
@@ -5,8 +5,7 @@ frappe.ui.form.on('Bureau Trip Details', {
 	from_date_and_time: function (frm, cdt, cdn) {
 		calculate_hours_and_days(frm, cdt, cdn);
 		setTimeout(() => {
-			set_batta_for_food_allowance(frm, cdt, cdn);
-			calculate_batta(frm, cdt, cdn);
+			calculate_row_allowances(frm, cdt, cdn);
 		}, 200);
 	},
 	to_date_and_time: function (frm, cdt, cdn) {
@@ -22,35 +21,23 @@ frappe.ui.form.on('Bureau Trip Details', {
 				return;
 			}
 			setTimeout(() => {
-				set_batta_for_food_allowance(frm, cdt, cdn);
-				calculate_batta(frm, cdt, cdn);
-		}, 200);
+				calculate_row_allowances(frm, cdt, cdn);
+			}, 200);
 		}
 
 		calculate_hours_and_days(frm, cdt, cdn);
 	},
 	total_hours: function (frm, cdt, cdn) {
-		calculate_daily_batta(frm, cdt, cdn);
 		calculate_ot_batta(frm, cdt, cdn);
-		set_batta_for_food_allowance(frm, cdt, cdn);
+		calculate_row_allowances(frm, cdt, cdn);
 	},
 	ot_hours: function (frm, cdt, cdn) {
 		calculate_ot_batta(frm, cdt, cdn);
 	},
-	breakfast: function (frm, cdt, cdn) {
-	   calculate_total_food_allowance(frm, cdt, cdn);
-	},
-	lunch: function (frm, cdt, cdn) {
-	   calculate_total_food_allowance(frm, cdt, cdn);
-	},
-	dinner: function (frm, cdt, cdn) {
-	   calculate_total_food_allowance(frm, cdt, cdn);
-	},
 	distance_travelled_km: function(frm, cdt, cdn) {
 		calculate_total_distance_travelled(frm, cdt, cdn);
 		setTimeout(() => {
-			set_batta_for_food_allowance(frm, cdt, cdn);
-			calculate_batta(frm, cdt, cdn);
+			calculate_row_allowances(frm, cdt, cdn);
 		}, 30);
 	},
 	work_details_add:  function(frm, cdt, cdn) {
@@ -64,8 +51,7 @@ frappe.ui.form.on('Bureau Trip Details', {
 		calculate_total_ot_batta(frm, cdt, cdn);
 
 		setTimeout(() => {
-			set_batta_for_food_allowance(frm, cdt, cdn);
-			calculate_batta(frm, cdt, cdn);
+			calculate_row_allowances(frm, cdt, cdn);
 		}, 30);
 	},
 	work_details_remove: function(frm, cdt, cdn) {
@@ -74,46 +60,30 @@ frappe.ui.form.on('Bureau Trip Details', {
 		calculate_total_daily_batta(frm, cdt, cdn);
 		calculate_total_ot_batta(frm, cdt, cdn);
 		setTimeout(() => {
-			set_batta_for_food_allowance(frm, cdt, cdn);
-			calculate_batta(frm, cdt, cdn);
+			calculate_row_allowances(frm, cdt, cdn);
 		}, 30);
-	},
-	total_hours: function(frm, cdt, cdn) {
-		calculate_hours(frm, cdt, cdn);
-		set_batta_for_food_allowance(frm, cdt, cdn);
-	},
-	daily_batta: function(frm, cdt, cdn) {
-		calculate_total_food_allowance(frm, cdt, cdn);
-	},
-	total_batta: function(frm, cdt, cdn) {
-		calculate_total_daily_batta(frm, cdt, cdn);
-	},
-	ot_batta: function(frm, cdt, cdn) {
-		calculate_total_ot_batta(frm, cdt, cdn);
 	}
 });
 
 frappe.ui.form.on("Bureau Trip Sheet", {
 	refresh: function (frm) {
 		filter_supplier_field(frm);
-		update_all_daily_batta(frm);
-		update_all_ot_batta(frm);
 		calculate_allowance(frm);
+		frm.doc.work_details.forEach(row => calculate_row_allowances(frm, row.doctype, row.name));
 	},
 	validate: function (frm) {
-		update_all_daily_batta(frm);
-		update_all_ot_batta(frm);
 		calculate_batta(frm);
 		calculate_total_distance_travelled(frm);
 		calculate_hours(frm);
 		calculate_total_daily_batta(frm);
 		calculate_total_ot_batta(frm);
+		frm.doc.work_details.forEach(row => calculate_row_allowances(frm, row.doctype, row.name));
 	},
 	batta: function (frm) {
-		update_all_daily_batta(frm);
+		frm.doc.work_details.forEach(row => calculate_ot_batta(frm, row.doctype, row.name));
 	},
 	ot_batta: function (frm) {
-		update_all_ot_batta(frm);
+		frm.doc.work_details.forEach(row => calculate_ot_batta(frm, row.doctype, row.name));
 	},
 	daily_batta_with_overnight_stay: function (frm) {
 		calculate_batta(frm);
@@ -129,25 +99,21 @@ frappe.ui.form.on("Bureau Trip Sheet", {
 	},
 	is_overnight_stay: function (frm) {
 		calculate_allowance(frm);
-		calculate_daily_batta(frm);
+		frm.doc.work_details.forEach(row => {
+			calculate_row_allowances(frm, row.doctype, row.name);
+		});
 	},
 	is_travelling_outside_kerala: function (frm) {
 		calculate_allowance(frm);
-		calculate_daily_batta(frm);
+		frm.doc.work_details.forEach(row => {
+			calculate_row_allowances(frm, row.doctype, row.name);
+		});
 	},
 	total_distance_travelled_km: function (frm) {
 		calculate_allowance(frm);
 	},
 	total_hours: function(frm) {
 		calculate_allowance(frm);
-	},
-	is_overnight_stay: function(frm) {
-		calculate_allowance(frm);
-		frm.doc.work_details.forEach(row => {
-		  set_batta_for_food_allowance(frm, row["doctype"], row["name"]);
-		  set_batta_for_food_allowance(frm, row["doctype"], row["name"]);
-		})
-
 	},
 	initial_odometer_reading: function (frm) {
 		frm.call("calculate_total_distance_based_on_odometer");
@@ -228,7 +194,7 @@ function calculate_hours_and_days(frm, cdt, cdn) {
 		let to_date = new Date(row.to_date_and_time);
 
 		let total_hours = (to_date - from_date) / (1000 * 60 * 60);
-		total_hours = Math.round(total_hours);
+		total_hours = Math.round(total_hours * 100) / 100;
 		let number_of_days = Math.ceil(total_hours / 24);
 
 		if (!frm.doc.supplier) {
@@ -254,25 +220,13 @@ function calculate_hours_and_days(frm, cdt, cdn) {
 					frm.refresh_field("work_details");
 
 					setTimeout(() => {
-						calculate_daily_batta(frm, cdt, cdn);
 						calculate_ot_batta(frm, cdt, cdn);
+						calculate_row_allowances(frm, cdt, cdn);
 					}, 200);
 				}
 			}
 		});
 	}
-}
-
-/* Calculate daily batta based on number of days and batta rate */
-function calculate_daily_batta(frm, cdt, cdn) {
-	let row = locals[cdt][cdn];
-
-	let total_hours = row.total_hours || 0;
-	let number_of_days = Math.ceil(total_hours / 24);
-	let daily_batta = number_of_days * (frm.doc.batta || 0);
-
-	frappe.model.set_value(cdt, cdn, 'daily_batta', daily_batta);
-	frm.refresh_field('work_details');
 }
 
 /* Calculate overtime batta based on OT hours and OT batta rate */
@@ -284,21 +238,6 @@ function calculate_ot_batta(frm, cdt, cdn) {
 
 	frappe.model.set_value(cdt, cdn, 'ot_batta', ot_batta);
 	frm.refresh_field('work_details');
-}
-
-/* Update daily batta for all work details rows */
-function update_all_daily_batta(frm) {
-	if (frm.doc.work_details) {
-		frm.doc.work_details.forEach(row => {
-			calculate_daily_batta(frm, row.doctype, row.name);
-		});
-		setTimeout(() => {
-			frm.refresh_field('work_details');
-			calculate_daily_batta(frm, cdt, cdn);
-			calculate_ot_batta(frm, cdt, cdn);
-		}, 200);
-
-	}
 }
 
 /* Update OT batta for all work details rows */
@@ -315,22 +254,25 @@ function update_all_ot_batta(frm) {
 
 /* Calculate total batta by summing daily batta values */
 function calculate_batta(frm) {
-	let total_batta = (frm.doc.daily_batta_with_overnight_stay || 0) +
-					  (frm.doc.daily_batta_without_overnight_stay || 0);
+	let batta = 0;
 
-	frappe.model.set_value(frm.doctype, frm.docname, 'batta', total_batta);
+	if (frm.doc.is_overnight_stay) {
+		batta = frm.doc.daily_batta_with_overnight_stay || 0;
+	} else {
+		batta = frm.doc.daily_batta_without_overnight_stay || 0;
+	}
+
+	frm.set_value("batta", batta);
 }
 
-/* Calculate total food allowance and total batta for a row */
-function calculate_total_food_allowance(frm, cdt, cdn) {
+/* Calculate total_batta = daily_batta + total_food_allowance for a row and update totals */
+function calculate_total_batta_for_row(frm, cdt, cdn) {
 	let row = locals[cdt][cdn];
-	row.total_food_allowance = (row.breakfast || 0) + (row.lunch || 0) + (row.dinner || 0);
-	row.total_batta = row.total_food_allowance + (row.daily_batta || 0);
-
+	let total = (row.daily_batta || 0) + (row.total_food_allowance || 0);
+	frappe.model.set_value(cdt, cdn, "total_batta", total);
 	frm.refresh_field("work_details");
-
-	let total_batta_sum = frm.doc.work_details.reduce((sum, r) => sum + (r.total_batta || 0), 0);
-	frm.set_value("total_daily_batta", total_batta_sum);
+	calculate_total_daily_batta(frm);
+	calculate_total_driver_batta(frm);
 }
 
 /* Calculate total distance travelled across all work details rows */
@@ -382,49 +324,97 @@ function calculate_total_driver_batta(frm) {
 	frm.refresh_field("total_driver_batta");
 }
 
-
-/* Determines eligibility for food allowance and updates fields accordingly.*/
-function set_batta_for_food_allowance(frm, cdt, cdn) {
+/* Determines eligibility for batta/food allowance per row and updates fields accordingly. */
+function calculate_row_allowances(frm, cdt, cdn) {
 	let child = locals[cdt][cdn];
+	let designation = frm.doc.designation || "Driver";
+	let is_overnight_stay = frm.doc.is_overnight_stay || 0;
+	let is_travelling_outside_kerala = frm.doc.is_travelling_outside_kerala || 0;
+	let distance = child.distance_travelled_km || 0;
+	let total_hrs = child.total_hours || 0;
+	let num_days = Math.max(1, Math.ceil(total_hrs / 24));
 
-	let designation = "Driver";
-	let is_overnight_stay = frm.doc.is_overnight_stay;
+	// Reset
+	frappe.model.set_value(child.doctype, child.name, "daily_batta", 0);
+	frappe.model.set_value(child.doctype, child.name, "breakfast", 0);
+	frappe.model.set_value(child.doctype, child.name, "lunch", 0);
+	frappe.model.set_value(child.doctype, child.name, "dinner", 0);
+	frappe.model.set_value(child.doctype, child.name, "total_food_allowance", 0);
 
-	let is_eligible = false;
-	if (child.distance_travelled_km >= 50 && child.distance_travelled_km <= 100 && child.total_hours > 6) {
-		is_eligible = true;
+	if (!frm.doc.supplier) {
+		frappe.msgprint(__("Please select a supplier."));
+		return;
 	}
 
 	if (is_overnight_stay) {
-		  frappe.model.set_value(child.doctype, child.name, "breakfast", 0);
-		  frappe.model.set_value(child.doctype, child.name, "lunch", 0);
-		  frappe.model.set_value(child.doctype, child.name, "dinner", 0);
-		  frappe.model.set_value(child.doctype, child.name, "total_food_allowance", 0);
-		  return;
-	  }
+		frappe.call({
+			method: "beams.beams.doctype.bureau_trip_sheet.bureau_trip_sheet.calculate_batta_allowance",
+			args: {
+				designation: designation,
+				is_travelling_outside_kerala: is_travelling_outside_kerala,
+				is_overnight_stay: 1,
+				total_distance_travelled_km: distance,
+				total_hours: total_hrs
+			},
+			callback: function (r) {
+				if (r.message) {
+					let rate = r.message.daily_batta_with_overnight_stay || 0;
+					let daily = num_days * rate;
+					frappe.model.set_value(child.doctype, child.name, "daily_batta", daily);
+					frm.set_value("daily_batta_with_overnight_stay", rate);
+					calculate_total_batta_for_row(frm, child.doctype, child.name);
+				}
+			}
+		});
+		return;
+	}
 
-	else if (is_eligible && !is_overnight_stay) {
+	if (distance >= 100 && total_hrs >= 8) {
+		frappe.call({
+			method: "beams.beams.doctype.bureau_trip_sheet.bureau_trip_sheet.calculate_batta_allowance",
+			args: {
+				designation: designation,
+				is_travelling_outside_kerala: is_travelling_outside_kerala,
+				is_overnight_stay: 0,
+				total_distance_travelled_km: distance,
+				total_hours: total_hrs
+			},
+			callback: function (r) {
+				if (r.message) {
+					let rate = r.message.daily_batta_without_overnight_stay || 0;
+					let daily = num_days * rate;
+					frappe.model.set_value(child.doctype, child.name, "daily_batta", daily);
+					frm.set_value("daily_batta_without_overnight_stay", rate);
+					calculate_total_batta_for_row(frm, child.doctype, child.name);
+				}
+			}
+		});
+		return;
+	} else if ((distance >= 50 && distance < 100 && total_hrs >= 6) || (distance >= 100 && total_hrs >= 6 && total_hrs < 8)) {
 		frappe.call({
 			method: "beams.beams.doctype.bureau_trip_sheet.bureau_trip_sheet.get_batta_for_food_allowance",
 			args: {
 				designation: designation,
 				from_date_time: child.from_date_and_time,
 				to_date_time: child.to_date_and_time,
-				total_hrs: child.total_hours,
+				total_hrs: total_hrs
 			},
 			callback: function (r) {
 				if (r && r.message) {
-				  let response = r.message;
-				  frappe.model.set_value(child.doctype, child.name, "breakfast", response.break_fast);
-				  frappe.model.set_value(child.doctype, child.name, "lunch", response.lunch);
-				  frappe.model.set_value(child.doctype, child.name, "dinner", response.dinner);
-				  frappe.model.set_value(child.doctype, child.name, "total_food_allowance", response.break_fast + response.lunch + response.dinner);
+					let response = r.message;
+					frappe.model.set_value(child.doctype, child.name, "breakfast", response.break_fast);
+					frappe.model.set_value(child.doctype, child.name, "lunch", response.lunch);
+					frappe.model.set_value(child.doctype, child.name, "dinner", response.dinner);
+					let food_total = response.break_fast + response.lunch + response.dinner;
+					frappe.model.set_value(child.doctype, child.name, "total_food_allowance", food_total);
+					calculate_total_batta_for_row(frm, child.doctype, child.name);
 				}
 			}
 		});
+		return;
 	}
 }
-
+/* Calculates daily batta allowances based on the selected policy*/
 function calculate_allowance(frm) {
 	if (!frm.doc.supplier.length) {
 		frappe.msgprint(__("Please select a supplier."));
@@ -434,7 +424,7 @@ function calculate_allowance(frm) {
 	frappe.call({
 		method: "beams.beams.doctype.bureau_trip_sheet.bureau_trip_sheet.calculate_batta_allowance",
 		args: {
-			designation: frm.doc.designation,
+			designation: frm.doc.designation || "Driver",
 			is_travelling_outside_kerala: frm.doc.is_travelling_outside_kerala || 0,
 			is_overnight_stay: frm.doc.is_overnight_stay || 0,
 			total_distance_travelled_km: frm.doc.total_distance_travelled_km || 0,
@@ -444,7 +434,7 @@ function calculate_allowance(frm) {
 			if (r.message) {
 				frm.set_value("daily_batta_with_overnight_stay", r.message.daily_batta_with_overnight_stay);
 				frm.set_value("daily_batta_without_overnight_stay", r.message.daily_batta_without_overnight_stay);
-				frm.set_value("batta", r.message.batta);
+				frm.set_value("batta", (r.message.daily_batta_with_overnight_stay || 0) + (r.message.daily_batta_without_overnight_stay || 0));
 			}
 		}
 	});

--- a/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.py
+++ b/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.py
@@ -2,19 +2,22 @@
 # For license information, please see license.txt
 
 import frappe
+import math
 from frappe.model.document import Document
-from frappe.utils import get_datetime, getdate
+from frappe.utils import get_datetime, getdate, flt
 from frappe import _
 from frappe.utils import nowdate
 
 
 class BureauTripSheet(Document):
 	def validate(self):
-		self.calculate_batta()
 		self.calculate_total_distance_travelled()
 		self.calculate_hours()
-		self.calculate_total_daily_batta()
+		self.calculate_daily_batta()
+		self.calculate_batta()
 		self.calculate_total_ot_batta()
+		self.calculate_total_batta()
+		self.calculate_total_daily_batta()
 		self.calculate_total_distance_based_on_odometer()
 
 	def calculate_batta(self):
@@ -80,9 +83,9 @@ class BureauTripSheet(Document):
 		self.total_daily_batta = total_batta
 
 	def calculate_total_ot_batta(self):
-		"""
+		'''
 		Calculate the total OT batta by summing up the 'ot_batta' values from work details.
-		"""
+		'''
 		total_ot_batta = 0
 
 		if self.work_details:
@@ -91,6 +94,82 @@ class BureauTripSheet(Document):
 					total_ot_batta += row.ot_batta
 
 		self.total_ot_batta = total_ot_batta
+
+	def calculate_daily_batta(self):
+		'''
+		Auto creation logic:
+		✔ For Overnight Stay: BATTA (no food allowance) - always applies based on policy
+		✔ For Normal (non-overnight):
+		  - 100+ KM AND >= 8 Hours → BATTA (no food allowance)
+		  - 50 to 100 KM AND >= 6 Hours → Food Allowance
+		  - 100+ KM AND 6 to 8 Hours → Food Allowance
+		  - Else → No Allowance
+		'''
+		self.daily_batta_without_overnight_stay = 0
+		self.daily_batta_with_overnight_stay = 0
+		if not self.get("work_details"):
+			return
+		for row in self.work_details:
+			total_hours = flt(row.total_hours or 0)
+			distance = flt(row.distance_travelled_km or 0)
+			row.number_of_days = max(1, math.ceil(total_hours / 24))
+			row.daily_batta = 0
+			row.breakfast = 0
+			row.lunch = 0
+			row.dinner = 0
+			row.total_food_allowance = 0
+			if self.is_overnight_stay:
+				batta_data = calculate_batta_allowance(
+					designation="Driver",
+					is_travelling_outside_kerala=self.is_travelling_outside_kerala or 0,
+					is_overnight_stay=1,
+					total_distance_travelled_km=distance,
+					total_hours=total_hours
+				)
+				parent_daily_batta_value = flt(batta_data.get("daily_batta_with_overnight_stay", 0))
+				if parent_daily_batta_value > 0:
+					self.daily_batta_with_overnight_stay = parent_daily_batta_value
+					row.daily_batta = row.number_of_days * parent_daily_batta_value
+				continue
+			if distance >= 100 and total_hours >= 8:
+				batta_data = calculate_batta_allowance(
+					designation="Driver",
+					is_travelling_outside_kerala=self.is_travelling_outside_kerala or 0,
+					is_overnight_stay=0,
+					total_distance_travelled_km=distance,
+					total_hours=total_hours
+				)
+				parent_daily_batta_value = flt(batta_data.get("daily_batta_without_overnight_stay", 0))
+				if parent_daily_batta_value > 0:
+					self.daily_batta_without_overnight_stay = parent_daily_batta_value
+					row.daily_batta = row.number_of_days * parent_daily_batta_value
+				continue
+			elif ((50 <= distance < 100 and total_hours >= 6) or
+				  (distance >= 100 and 6 <= total_hours < 8)):
+				values = get_batta_for_food_allowance(
+					designation="Driver",
+					from_date_time=row.from_date_and_time,
+					to_date_time=row.to_date_and_time,
+					total_hrs=total_hours
+				)
+				row.breakfast = values.get("break_fast", 0)
+				row.lunch = values.get("lunch", 0)
+				row.dinner = values.get("dinner", 0)
+				row.total_food_allowance = flt(row.breakfast) + flt(row.lunch) + flt(row.dinner)
+				continue
+
+	def calculate_total_batta(self):
+		'''
+		Server-side equivalent of JS calculate_total_batta.
+		Calculates total_batta = daily_batta + total_food_allowance for each row.
+		'''
+		if not self.get('work_details'):
+			return
+
+		for row in self.work_details:
+			daily_batta = row.daily_batta or 0
+			food_allowance = row.total_food_allowance or 0
+			row.total_batta = daily_batta + food_allowance
 
 	def on_submit(self):
 		'''
@@ -183,9 +262,9 @@ def calculate_batta_allowance(designation=None, is_travelling_outside_kerala=0, 
 	total_distance_travelled_km = sanitize_number(total_distance_travelled_km)
 	total_hours = sanitize_number(total_hours)
 
-	batta_policy = frappe.get_all('Batta Policy', filters={'designation': 'Driver'}, fields=['*'])
+	batta_policy = frappe.get_all('Batta Policy', filters={'designation':'Driver'}, fields=['*'])
 	if not batta_policy:
-		frappe.throw(f"No Batta Policy found for the designation: {designation}")
+		frappe.throw(f"No Batta Policy found for the designation: Driver")
 		return {"batta": 0}
 
 	policy = batta_policy[0]
@@ -229,16 +308,14 @@ def get_batta_policy_values():
 
 @frappe.whitelist()
 def get_ot_working_hours(supplier):
-    """
-    Returns OT working hours based on Supplier or Beams Account Settings.
-    If the supplier has a valid 'ot_working_hours', use that.
-    Otherwise, fall back to 'default_working_hours' from Beams Accounts Settings.
-    """
-    ot_hours = frappe.db.get_value("Supplier", supplier, "ot_working_hours")
+	"""
+	Returns OT working hours based on Supplier or Beams Account Settings.
+	If the supplier has a valid 'ot_working_hours', use that.
+	Otherwise, fall back to 'default_working_hours' from Beams Accounts Settings.
+	"""
+	ot_hours = frappe.db.get_value("Supplier", supplier, "ot_working_hours")
 
-    # Check for None, 0, or empty string
-    if not ot_hours:
-        ot_hours = frappe.db.get_single_value("Beams Accounts Settings", "default_working_hours")
+	if not ot_hours:
+		ot_hours = frappe.db.get_single_value("Beams Accounts Settings", "default_working_hours")
 
-    # Return a numeric value (float for better accuracy)
-    return float(ot_hours or 0)
+	return float(ot_hours or 0)


### PR DESCRIPTION
- [x] TASK-2025-02560

## Feature description
Need to: Correct batta calculation issue in the Bureau Trip Sheet doctype, where both Food Batta and Travel Batta were being applied under certain conditions. Only one type of batta should be applied per trip based on distance and work hours.

## Solution description
To address the issue of both Food Batta and Travel Batta being applied simultaneously, the batta calculation logic has been updated in the Bureau Trip Sheet doctype to strictly enforce mutual exclusivity:

Single batta rule enforced: Only one type of batta—Travel Batta or Food Batta—will be applied per trip entry based on the conditions.

Logic changes:

If distance is ≥ 100 km and working hours ≥ 8, Travel Batta applies. Food Batta is cleared.

If distance is between 50–100 km or ≥ 100 km but < 8 hours, and working hours are ≥ 6, then Food Batta applies. Travel Batta is cleared.

Other distances/hours result in no batta applied.

Recalculation runs automatically when the relevant fields (distance_travelled_km, total_hours, is_overnight_stay) are updated.

Parent fields (like total_daily_batta, batta) are updated to reflect the correct values based on calculated totals from all rows.

 Test Cases
Test Case 1: Food Batta applies, then changed to Travel Batta

Enter distance_travelled_km = 60 and total_hours = 6 → Food Batta applies.

Change distance to 120, and hours to 8 → Food Batta must be cleared and Travel Batta should apply.

Expected Result: Only Travel Batta should be applied in the final result.

Test Case 2: Travel Batta applies first, then changed to Food Batta

Enter distance_travelled_km = 150 and total_hours = 8 → Travel Batta applies.

Change distance to 70 and hours to 6 → Travel Batta must be cleared and Food Batta should apply.

Expected Result: Only Food Batta should be applied after the change.

Test Case 3: Rapid field changes

Change distance_travelled_km and total_hours back and forth between conditions.

Ensure that only the correct batta is applied each time.

Expected Result: No scenario should apply both batta types simultaneously at any point.

## Output screenshots (optional)
[Screencast from 17-11-25 09:30:24 AM IST.webm](https://github.com/user-attachments/assets/09da71b3-877f-406e-8efa-85c4935bdbd4)

[Screencast from 17-11-25 09:37:57 AM IST.webm](https://github.com/user-attachments/assets/117e2358-c891-4379-95cf-026189a2e09c)

[Screencast from 17-11-25 09:39:29 AM IST.webm](https://github.com/user-attachments/assets/679a2222-1d1f-4b19-84c8-4e1e267083cf)


[Screencast from 17-11-25 09:41:50 AM IST.webm](https://github.com/user-attachments/assets/d6ab1e54-be01-48e3-9264-3e459e8c6277)

[Screencast from 17-11-25 10:07:22 AM IST.webm](https://github.com/user-attachments/assets/5dafcfe2-ce80-42ce-8430-1660e1fc0ed8)


## Areas affected and ensured
Bureau trip sheet doctype


## Is there any existing behavior change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?
  - Chrome
 
