### PR TITLE
TASK-2025-02655: change HD Ticket access control and button visibility logic

### DIFF
--- a/beams/beams/custom_scripts/hd_ticket/hd_ticket.js
+++ b/beams/beams/custom_scripts/hd_ticket/hd_ticket.js
@@ -15,29 +15,41 @@ frappe.ui.form.on('HD Ticket', {
         }
     },
 
-    refresh(frm) {
+    refresh: async function(frm) {
+        const current_user = frappe.session.user;
+        const user_roles = frappe.user_roles;
+        const is_admin = current_user === "Administrator" || user_roles.includes("System Manager");
 
-        frappe.call({
-            method: 'frappe.client.get_value',
-            args: {
-                doctype: 'HD Agent',
-                fieldname: 'name',
+        hide_assignment_btn(frm);
+
+        if (frm.doc.status === "Open" || is_admin) {
+            working_button(frm);
+        }
+
+        // Show Transfer/Resolved buttons only if status is Replied or Administrator/System Manager
+        if (frm.doc.status === "Replied" || is_admin) {
+
+            // Fetch all active ToDos for this ticket
+            const todos = await frappe.db.get_list("ToDo", {
+                fields: ["allocated_to"],
                 filters: {
-                    user: frappe.session.user
+                    reference_type: "HD Ticket",
+                    reference_name: frm.doc.name,
+                    status: ["!=", "Cancelled"]
                 }
-            },
-            callback: function(r) {
-                if (r.message && r.message.name) {
-                    working_button(frm);
-                    transfer_ticket(frm);
-                    resolved_button(frm);
-                    add_request_buttons(frm);
-                }
-                hide_assignment_btn(frm);
-            }
-        });
-    },
+            });
 
+            const assigned_users = todos.map(todo => todo.allocated_to);
+            const is_assigned = assigned_users.includes(current_user);
+            if (is_assigned || is_admin) {
+                transfer_ticket(frm);
+                resolved_button(frm);
+                add_request_buttons(frm);
+            } else {
+                frm.disable_form();
+            }
+        }
+    },
     ticket_type(frm) {
         if (!frm.doc.ticket_type) return frm.set_value('agent_group', '');
 


### PR DESCRIPTION
## Feature description
Tickets assigned to a team allow all active agents to mark them as Working. Once a ticket is in this state, team members cannot edit, transfer, or resolve the ticket—they can only perform this single action
## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description
- Converted refresh function to async/await for proper fetching of ToDos.
- Implemented checks to:
  - Allow any team agent to mark the ticket as Working.
  - Restrict other team members to comment-only once ticket is in progress.
  - Grant L2 users full access regardless of ticket status.
- Updated button visibility and form enable/disable logic accordingly.
 ## Output screenshots (optional)
**A ticket was created and assigned to three agents. When one agent logged in, they updated the ticket status to "Replied" via the Working button.**
<img width="1378" height="937" alt="image" src="https://github.com/user-attachments/assets/5fe98219-2434-444f-b7b4-2961e9135924" />
**The remaining agents can't edit the form and existing buttons are not visiblt to them**
<img width="1378" height="937" alt="image" src="https://github.com/user-attachments/assets/c479c66f-b407-47e6-acd9-0d384ec688e1" />
<img width="1378" height="937" alt="image" src="https://github.com/user-attachments/assets/506a37c5-22af-4ac8-9b1b-eb4f64619189" />

## Areas affected and ensured

- HD Ticket form (refresh event)
- Button actions: Working, Transfer, Resolved, Add Request
- Form enable/disable behavior based on role and ticket status

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
