### PR TITLE
feat: Customize  the supplier quotation doctype

### DIFF
--- a/beams/beams/doctype/suggested_items_by_supplier/suggested_items_by_supplier.json
+++ b/beams/beams/doctype/suggested_items_by_supplier/suggested_items_by_supplier.json
@@ -8,6 +8,7 @@
  "field_order": [
   "product_name",
   "quantity",
+  "item_code",
   "column_break_bnog",
   "rate",
   "uom",
@@ -65,19 +66,28 @@
   {
    "fieldname": "section_break_myob",
    "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "item_code",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Item Code",
+   "options": "Item",
+   "reqd": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-09-01 09:41:31.945187",
+ "modified": "2025-11-17 16:58:44.236800",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Suggested Items By Supplier",
  "owner": "Administrator",
  "permissions": [],
  "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -5724,7 +5724,17 @@ def get_supplier_quotation_custom_fields():
 				"label": "Suggested Items by Supplier",	
 				"options": "Suggested Items By Supplier",
 				"insert_after": "items"
-   			}
+   			},
+			{
+				"fieldname": "priority",
+				"fieldtype": "Select",
+				"label": "Priority",	
+				"options": "Low\nMedium\nHigh\nUrgent",
+				"default":"Medium",
+				"insert_after": "company",
+				"in_list_view": 1
+   			},
+			   
 		]
 	}
 


### PR DESCRIPTION
## Feature description
TASK-2025-02624 and TASK-2025-02626
1. need to  customize  the supplier quotation doctype 
2. need to add field in the Suggested Items by Supplier doctype

## Solution description
1. customize  the supplier quotation doctype  
-  added field in the supplier quottaion  
- added  field in the Suggested Items by Supplier child doctype
## Output screenshots (optional)
[Screencast from 18-11-25 09:42:57 AM IST.webm](https://github.com/user-attachments/assets/9bc1c8ff-9d33-4b8b-b6b1-89c883b0b9c6)

## Areas affected and ensured
suppler quotation doctype and uggested Items by Supplie child doctype

## Is there any existing behavior change of other features due to this code change?
 No.

## Was this feature tested on the browsers?
  
  - Mozilla Firefox
  
