### PR TITLE
TASK-2025-02562: set default Batta Type to Internal and make field read-only

### DIFF
--- a/beams/beams/doctype/batta_claim/batta_claim.json
+++ b/beams/beams/doctype/batta_claim/batta_claim.json
@@ -61,10 +61,12 @@
    "search_index": 1
   },
   {
+   "default": "Internal",
    "fieldname": "batta_type",
    "fieldtype": "Select",
    "label": "Batta Type",
-   "options": "Internal\nExternal"
+   "options": "Internal\nExternal",
+   "read_only": 1
   },
   {
    "depends_on": "eval:doc.batta_type == \"Internal\"\n",
@@ -291,7 +293,7 @@
    "link_fieldname": "batta_claim_reference"
   }
  ],
- "modified": "2025-10-02 13:44:09.312155",
+ "modified": "2025-11-18 09:25:07.845171",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Batta Claim",
@@ -312,6 +314,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []


### PR DESCRIPTION
## Feature description
Ensure that in the Batta Claim form, the Batta Type field is always set to Internal by default and cannot be modified by users
## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description
The following changes were made to the batta_claim.json DocType definition:
- Set default value
  - Added "default": "Internal" to the batta_type field configuration.
- Enforced read-only behavior
  - Added "read_only": 1 to ensure users cannot change the Batta Type.
 ## Output screenshots (optional)
**An Employee created batta claim and it is approved by accounts manager as shown in figure**
<img width="1336" height="902" alt="image" src="https://github.com/user-attachments/assets/995712bb-4f37-4982-9fd6-17d9085e96ea" />
<img width="1225" height="837" alt="image" src="https://github.com/user-attachments/assets/e768903b-9fc0-460d-b736-1e6b134b28f9" />
<img width="1225" height="837" alt="image" src="https://github.com/user-attachments/assets/ceb0310d-4af1-4a62-b050-2d23bba58cc3" />


## Areas affected and ensured
Batta Claim Form UI
Batta Claim DocType JSON
## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
