### PR TITLE
 feat:fetch Only Items with Quantity and Rate from Supplier Quotation to purchase order

### DIFF
--- a/beams/beams/custom_scripts/supplier_quotation/supplier_quotation.py
+++ b/beams/beams/custom_scripts/supplier_quotation/supplier_quotation.py
@@ -1,0 +1,47 @@
+import frappe
+from frappe.model.mapper import get_mapped_doc
+
+
+
+@frappe.whitelist()
+def make_purchase_order_from_supplier_quotation(source_name, target_doc=None):
+    def postprocess(source_doc, target_doc,source_parent):
+        target_doc.items = []
+        for row in source_doc.get("items", []):
+            if row.qty and row.rate:
+                target_doc.append("items", {
+                    "item_code": row.item_code,
+                    "item_name": row.item_name,
+                    "qty": row.qty,
+                    "rate": row.rate,
+                    "uom": row.uom,
+                    "stock_uom": row.stock_uom,               
+                    "conversion_factor": row.conversion_factor
+                })
+        for row in source_doc.get("suggested_items_by_supplier", []):
+            if row.quantity and row.rate:
+                target_doc.append("items", {
+                    "item_code": row.item_code,
+                    "item_name": row.product_name,
+                    "qty": row.quantity,
+                    "rate": row.rate,
+                    "uom": row.uom,
+                    "stock_uom": row.uom,               
+                    "conversion_factor": 1
+                })
+    target_doc = get_mapped_doc(
+        "Supplier Quotation",
+        source_name,
+        {
+            "Supplier Quotation": {
+                "doctype": "Purchase Order",
+                "field_map": {
+                    "supplier": "supplier",
+                },
+                "postprocess": postprocess
+            }
+        },
+        target_doc
+    )
+
+    return target_doc

--- a/beams/beams/custom_scripts/supplier_quotation/supplier_quotation.py
+++ b/beams/beams/custom_scripts/supplier_quotation/supplier_quotation.py
@@ -5,45 +5,45 @@ from frappe.model.mapper import get_mapped_doc
 
 @frappe.whitelist()
 def make_purchase_order_from_supplier_quotation(source_name, target_doc=None):
-    '''Map Supplier Quotation to Purchase Order including both Items tables.
-        Filters out items without Qty and Rate.'''
-    def postprocess(source_doc, target_doc,source_parent):
-        target_doc.items = []
-        for row in source_doc.get("items", []):
-            if row.qty and row.rate:
-                target_doc.append("items", {
-                    "item_code": row.item_code,
-                    "item_name": row.item_name,
-                    "qty": row.qty,
-                    "rate": row.rate,
-                    "uom": row.uom,
-                    "stock_uom": row.stock_uom,               
-                    "conversion_factor": row.conversion_factor
-                })
-        for row in source_doc.get("suggested_items_by_supplier", []):
-            if row.quantity and row.rate:
-                target_doc.append("items", {
-                    "item_code": row.item_code,
-                    "item_name": row.product_name,
-                    "qty": row.quantity,
-                    "rate": row.rate,
-                    "uom": row.uom,
-                    "stock_uom": row.uom,               
-                    "conversion_factor": 1
-                })
-    target_doc = get_mapped_doc(
-        "Supplier Quotation",
-        source_name,
-        {
-            "Supplier Quotation": {
-                "doctype": "Purchase Order",
-                "field_map": {
-                    "supplier": "supplier",
-                },
-                "postprocess": postprocess
-            }
-        },
-        target_doc
-    )
+	'''Map Supplier Quotation to Purchase Order including both Items tables.
+		Filters out items without Qty and Rate.'''
+	def postprocess(source_doc, target_doc,source_parent):
+		target_doc.items = []
+		for row in source_doc.get("items", []):
+			if row.qty and row.rate:
+				target_doc.append("items", {
+					"item_code": row.item_code,
+					"item_name": row.item_name,
+					"qty": row.qty,
+					"rate": row.rate,
+					"uom": row.uom,
+					"stock_uom": row.stock_uom,               
+					"conversion_factor": row.conversion_factor
+				})
+		for row in source_doc.get("suggested_items_by_supplier", []):
+			if row.quantity and row.rate:
+				target_doc.append("items", {
+					"item_code": row.item_code,
+					"item_name": row.product_name,
+					"qty": row.quantity,
+					"rate": row.rate,
+					"uom": row.uom,
+					"stock_uom": row.uom,               
+					"conversion_factor": 1
+				})
+	target_doc = get_mapped_doc(
+		"Supplier Quotation",
+		source_name,
+		{
+			"Supplier Quotation": {
+				"doctype": "Purchase Order",
+				"field_map": {
+					"supplier": "supplier",
+				},
+				"postprocess": postprocess
+			}
+		},
+		target_doc
+	)
 
-    return target_doc
+	return target_doc

--- a/beams/beams/custom_scripts/supplier_quotation/supplier_quotation.py
+++ b/beams/beams/custom_scripts/supplier_quotation/supplier_quotation.py
@@ -5,6 +5,8 @@ from frappe.model.mapper import get_mapped_doc
 
 @frappe.whitelist()
 def make_purchase_order_from_supplier_quotation(source_name, target_doc=None):
+    '''Map Supplier Quotation to Purchase Order including both Items tables.
+        Filters out items without Qty and Rate.'''
     def postprocess(source_doc, target_doc,source_parent):
         target_doc.items = []
         for row in source_doc.get("items", []):

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -470,9 +470,9 @@ scheduler_events = {
 # Overriding Methods
 # ------------------------------
 #
-# override_whitelisted_methods = {
-# "frappe.desk.doctype.event.event.get_events": "beams.event.get_events"
-# }
+override_whitelisted_methods = {
+    "erpnext.buying.doctype.supplier_quotation.supplier_quotation.make_purchase_order":"beams.beams.custom_scripts.supplier_quotation.supplier_quotation.make_purchase_order_from_supplier_quotation",
+}
 #
 # each overriding function accepts a `data` argument;
 # generated from the base implementation of the doctype dashboard,


### PR DESCRIPTION

## Feature description
TASK-2025-02625
1. Fetch Only Items with Quantity and Rate from Supplier Quotation to purchase order
2. Map the Suggested Items by Supplier  child table item to the items in purcahse order

## Solution description
 fetched the correct items in on creation of Purchase Order  from Supplier Quotation, While Mapdoc, Pick Only Items with Qty, Rate is Filled. Items and Suggested Items by Supplier both the tables are considered creating Purchase Order.

## Output screenshots (optional)
[Screencast from 18-11-25 12:03:17 PM IST.webm](https://github.com/user-attachments/assets/9854bc03-38fd-43b0-a9e8-c96e1b9493e5)


## Areas affected and ensured
supplier quotation and purchase order doctype 

## Is there any existing behavior change of other features due to this code change?
 No
## Was this feature tested on the browsers?

  - Mozilla Firefox
 
