### PR TITLE
feat:Set Default Rate as 0 on Items in RFQ

### DIFF
--- a/beams/templates/pages/request_for_quotation.html
+++ b/beams/templates/pages/request_for_quotation.html
@@ -52,7 +52,7 @@
             <label class="block text-sm font-medium text-gray-700 mb-1">Rate <span class="text-red-500">*</span></label>
             <div class="flex">
               <span class="inline-flex items-center px-3 text-sm text-gray-500 bg-gray-50 border border-r-0 rounded-l-md">{{ doc.currency_symbol or "₹" }}</span>
-              <input type="number" class="rate-input flex-1 px-3 py-2 border rounded-r-md focus:ring-2 focus:ring-blue-500" placeholder="0.00" step="0.01" onchange="calculateAmount(this)" />
+              <input type="number" value="0.00" class="rate-input flex-1 px-3 py-2 border rounded-r-md focus:ring-2 focus:ring-blue-500" placeholder="0.00" step="0.01" onchange="calculateAmount(this)" />
             </div>
             <small class="text-xs text-gray-500 mt-1 block">Required to include item</small>
           </div>
@@ -227,11 +227,6 @@
   // --- Data Collection - Separate original and suggested items ---
   function getOriginalItemData(card) {
     const rate = parseFloat(card.querySelector(".rate-input")?.value) || 0;
-    
-    // Only return data if rate is present
-    if (rate <= 0) {
-      return null;
-    }
 
     return {
       item_code: card.dataset.itemCode || null,
@@ -250,12 +245,6 @@
 
   function getSuggestedItemData(card) {
     const rate = parseFloat(card.querySelector(".rate-input")?.value) || 0;
-    
-    // Only return data if rate is present
-    if (rate <= 0) {
-      return null;
-    }
-
     const qty = parseFloat(card.querySelector(".qty-input")?.value) || 1;
     const amount = qty * rate;
 
@@ -347,11 +336,6 @@
     console.log("Validation data:", data);
     const totalItems = data.items.length + data.suggested_items.length;
     console.log("Total items for validation:", totalItems);
-    
-    if (totalItems === 0) {
-      alert("Please enter a rate for at least one item to submit the quotation.");
-      return false;
-    }
     return true;
   }
 


### PR DESCRIPTION
## Feature description
Set Default Rate as 0 on Items in RQF (Request for Quotation) on Supplier Portal

- [ ] TASK-2025-02623

## Solution description
- Set Default Rate as 0 on Items in RQF (Request for Quotation) on Supplier Portal
- Removed rate > 0 restriction from item data collection
- Updated getOriginalItemData() and getSuggestedItemData() to include items even when rate = 0
- Removed validation blocking quotation submission when all rates are zero
- Ensured default rate value = 0.00 is accepted without errors
- Submission now includes original and suggested items regardless of rate value

## Output screenshots (optional)

[Screencast from 18-11-25 12:45:49 PM IST.webm](https://github.com/user-attachments/assets/cae74ae1-e2a4-4f8c-9f4c-f657204dce67)

<img width="1845" height="973" alt="image" src="https://github.com/user-attachments/assets/7939381e-23b1-4326-a055-ec469f70bc64" />

<img width="1845" height="973" alt="image" src="https://github.com/user-attachments/assets/b001d39a-4928-48ff-8ea8-5a5386bbb1ab" />


## Areas affected and ensured
Supplier Portal

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - yes
  - Opera Mini
  - Safari
