### PR TITLE
feat: Set default value of Material Request Purpose to Material Issue

### DIFF
--- a/beams/setup.py
+++ b/beams/setup.py
@@ -5135,10 +5135,9 @@ def get_property_setters():
 			"doc_type": "Material Request",
 			"field_name": "material_request_type",
 			"property": "default",
-			"property_type": "Select",
-			"value": "Material Issue"
-		}	
-
+			"property_type": "Data",
+			"value": "Material Issue",
+		}
 ]
 
 def get_material_request_custom_fields():

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -5137,7 +5137,7 @@ def get_property_setters():
 			"property": "default",
 			"property_type": "Data",
 			"value": "Material Issue",
-		}
+		},
 ]
 
 def get_material_request_custom_fields():

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -5130,6 +5130,14 @@ def get_property_setters():
 			"property": "reqd",
 			"value": 1
 		},
+		{
+			"doctype_or_field": "DocField",
+			"doc_type": "Material Request",
+			"field_name": "material_request_type",
+			"property": "default",
+			"property_type": "Select",
+			"value": "Material Issue"
+		}	
 
 ]
 


### PR DESCRIPTION
## Feature description
TASK-2025-02621
 1. Need to Make the Default value of Purpose as "Material Issue" Material Request Doctype



## Solution description
seted the Default Value of purpose field(Select) as Material Issue in Material request doctype via setup.py
## Output screenshots (optional)
<img width="1739" height="1008" alt="image" src="https://github.com/user-attachments/assets/8d690137-7147-416c-b759-7227f5e08fa0" />


## Areas affected and ensured
Material Request Doctype

## Is there any existing behavior change of other features due to this code change?
 No

## Was this feature tested on the browsers?

  - Mozilla Firefox

