### PR TITLE
TASK-2025-02629: set mode of payment from bureau

### DIFF
--- a/beams/beams/doctype/bureau/bureau.json
+++ b/beams/beams/doctype/bureau/bureau.json
@@ -10,6 +10,8 @@
   "bureau_name",
   "cost_center",
   "amended_from",
+  "mode_of_payment",
+  "column_break_xpwx",
   "company",
   "location"
  ],
@@ -53,11 +55,21 @@
    "fieldtype": "Link",
    "label": "Location ",
    "options": "Location"
+  },
+  {
+   "fieldname": "mode_of_payment",
+   "fieldtype": "Link",
+   "label": "Mode of Payment ",
+   "options": "Mode of Payment"
+  },
+  {
+   "fieldname": "column_break_xpwx",
+   "fieldtype": "Column Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-01-18 11:38:59.252359",
+ "modified": "2025-11-19 09:58:28.027679",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Bureau",
@@ -77,6 +89,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -2249,7 +2249,7 @@ def get_voucher_entry_custom_fields():
 				"fieldtype": "Link",
 				"options": "Bureau",
 				"label": "Bureau",
-				"insert_after": "balance"
+				"insert_after": "naming_series"
 			}
 		]
 	}

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -5138,6 +5138,20 @@ def get_property_setters():
 			"property_type": "Data",
 			"value": "Material Issue",
 		},
+		{
+			"doc_type": "Voucher Entry",
+			"field_name": "mode_of_payment",
+			"property": "fetch_from",
+			"value": "bureau.mode_of_payment"
+		},
+		{
+			"doctype_or_field": "DocField",
+			"doc_type": "Voucher Entry",
+			"field_name": "mode_of_payment",
+			"property": "fetch_if_empty",
+			"value": 1
+		},
+
 ]
 
 def get_material_request_custom_fields():

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -5151,7 +5151,6 @@ def get_property_setters():
 			"property": "fetch_if_empty",
 			"value": 1
 		},
-
 ]
 
 def get_material_request_custom_fields():


### PR DESCRIPTION
## Feature description

- This feature introduces the Mode of Payment field to the Bureau DocType and ensures that the selected value is  fetched into the Voucher Entry DocType.
- Adjusted placement of Bureau field in Voucher Entry form

## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description

- Included a new mode_of_payment Link field in the Bureau DocType.
- Added a Column Break to maintain form layout consistency.
- Updated JSON metadata (field position, modified timestamp, row format).
- Implemented Property Setters to:
   -   Set fetch_from = bureau.mode_of_payment for Voucher Entry.
  -   Enable fetch_if_empty = 1 to auto-populate the field when blank.
-  Changed insert_after for bureau field from 'balance' to 'naming_series' to ensure 
proper field ordering.
## Output screenshots (optional)
**Created Mode of Payment field in Voucher Entry**
<img width="1614" height="932" alt="image" src="https://github.com/user-attachments/assets/165b1b5d-7302-4683-bacb-d947907e06a9" />

**In Voucher Entry,mode of payment updated according to on changing of bureau**
[Screencast from 11-19-2025 10:26:15 AM.webm](https://github.com/user-attachments/assets/14081261-2b91-4607-8be7-c97ae9fcd499)

**Changed bureau field position in Voucher Entry**
<img width="1471" height="601" alt="image" src="https://github.com/user-attachments/assets/0d45d21e-0b2a-4b73-ada1-344c57396964" />

## Areas affected and ensured

- Bureau DocType UI.
- Voucher Entry DocType (Mode of Payment field behavior).
- Property Setters configuration.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
