### PR TITLE
TASK-2025-02683: show ticket subcategory after ticket creation

### DIFF
--- a/beams/beams/custom_scripts/hd_ticket/hd_ticket.js
+++ b/beams/beams/custom_scripts/hd_ticket/hd_ticket.js
@@ -49,6 +49,12 @@ frappe.ui.form.on('HD Ticket', {
                 }
             }
         });
+
+        if (frm.is_new()) {
+		    frm.set_df_property("ticket_subcategory", "hidden", 1)
+		} else {
+		    frm.set_df_property("ticket_subcategory", "hidden", 0)
+		}
     },
 
     ticket_type(frm) {

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -263,8 +263,7 @@ def get_hd_ticket_custom_fields():
 				"fieldtype": "Link",
 				"label": "Ticket Subcategory",
 				"options":"HD Ticket SubCategory",
-				"insert_after": "ticket_type",
-				"allow_in_quick_entry": 1
+				"insert_after": "ticket_type"
 			},
 			{
 				"fieldname": "assigned_agent",


### PR DESCRIPTION
## Feature description
show ticket subcategory after ticket creation

## Solution description
Ticket subcategory field is removed from quick entry and shown after ticket creation 

## Output screenshots (optional)
<img width="1801" height="851" alt="image" src="https://github.com/user-attachments/assets/add26f3c-18e7-4af9-810b-8d3f6c72848c" />
<img width="1806" height="786" alt="image" src="https://github.com/user-attachments/assets/2547a2fc-9805-454c-9306-b64e605793db" />

## Was this feature tested on the browsers?
  - Chrome
