### PR TITLE
fix:prevent NoneType errors on Substitute Booking submit

### DIFF
--- a/beams/beams/doctype/substitute_booking/substitute_booking.py
+++ b/beams/beams/doctype/substitute_booking/substitute_booking.py
@@ -116,15 +116,22 @@ class SubstituteBooking(Document):
 		employee = self.substituting_for
 		if self.substitution_bill_date and employee:
 			for date_entry in self.substitution_bill_date:
-				leave_exists = frappe.db.exists('Leave Application', {
-					'employee': employee,
-					'status': 'Approved',
-					'from_date': ('<=', date_entry.date),
-					'to_date': ('>=', date_entry.date)
-				})
+
+				leave_exists = frappe.db.exists(
+					'Leave Application',
+					{
+						'employee': employee,
+						'status': 'Approved',
+						'from_date': ('<=', date_entry.date),
+						'to_date': ('>=', date_entry.date)
+					}
+				)
+
 				if not leave_exists:
 					formatted_date = date_entry.date.strftime("%d/%m/%Y")
-					frappe.throw(f"Employee {employee} is not on leave on {formatted_date}.")		
+					frappe.throw(
+						f"Employee {employee} is not on leave on {formatted_date}."
+					)
 
 	@frappe.whitelist()
 	def check_leave_application(employee, dates):

--- a/beams/beams/doctype/substitution_bill_date/substitution_bill_date.json
+++ b/beams/beams/doctype/substitution_bill_date/substitution_bill_date.json
@@ -14,7 +14,8 @@
    "fieldname": "date",
    "fieldtype": "Date",
    "in_list_view": 1,
-   "label": "Date"
+   "label": "Date",
+   "reqd": 1
   },
   {
    "fieldname": "work_remarks",
@@ -26,12 +27,14 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-09-21 12:11:36.909740",
+ "modified": "2025-11-19 16:12:39.681776",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Substitution Bill Date",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []


### PR DESCRIPTION
- [x] TASK-2025-02668

## Feature description
Need to: Prevent None Type errors on Substitute Booking submit

## Solution description
Updated check employee leave to skip child rows where date is missing

## Output screenshots (optional)
[Screencast from 19-11-25 04:14:59 PM IST.webm](https://github.com/user-attachments/assets/e25c6ee4-991c-4715-a629-cc07b76514af)


## Areas affected and ensured
Substitute Booking doctype

## Is there any existing behaviour change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?
  - Chrome

