### PR TITLE
Add Ignore user permission in the tripsheet and bureau trip sheet doctype

### DIFF
--- a/beams/beams/doctype/bureau_trip_details/bureau_trip_details.json
+++ b/beams/beams/doctype/bureau_trip_details/bureau_trip_details.json
@@ -140,7 +140,6 @@
    "fieldtype": "Section Break"
   },
   {
-   "description": "Daily Batta Without Food Allowance",
    "fieldname": "daily_batta",
    "fieldtype": "Currency",
    "in_list_view": 1,
@@ -198,7 +197,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-10-02 11:25:52.888802",
+ "modified": "2025-11-19 15:20:43.780054",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Bureau Trip Details",

--- a/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.json
+++ b/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.json
@@ -244,6 +244,7 @@
   {
    "fieldname": "employees",
    "fieldtype": "Table MultiSelect",
+   "ignore_user_permissions": 1,
    "label": "Employees",
    "options": "Employees"
   },
@@ -258,7 +259,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-11-11 13:59:02.866885",
+ "modified": "2025-11-19 14:46:18.341478",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Bureau Trip Sheet",

--- a/beams/beams/doctype/trip_sheet/trip_sheet.json
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.json
@@ -234,6 +234,7 @@
   {
    "fieldname": "employees",
    "fieldtype": "Table MultiSelect",
+   "ignore_user_permissions": 1,
    "label": "Employees",
    "options": "Employees"
   }
@@ -246,7 +247,7 @@
    "link_fieldname": "trip_sheet"
   }
  ],
- "modified": "2025-11-07 11:25:27.747808",
+ "modified": "2025-11-19 14:46:36.960867",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Trip Sheet",

--- a/beams/beams/doctype/work_detail/work_detail.json
+++ b/beams/beams/doctype/work_detail/work_detail.json
@@ -55,7 +55,6 @@
    "read_only": 1
   },
   {
-   "description": "Daily Batta Without Food Allowance",
    "fieldname": "daily_batta",
    "fieldtype": "Currency",
    "in_list_view": 1,
@@ -183,7 +182,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-11-06 17:01:03.359336",
+ "modified": "2025-11-19 14:40:30.451617",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Work Detail",


### PR DESCRIPTION
## Feature description
Task 2025 02683 and TASK-2025-02669 
- Need to remove the description field in batta in child tables work detail and  Bureau  trip sheet details child  doctype
- need to add ignore user permission in fields employee in trip sheet and bureau trip sheet doctype 

## Solution description
-  Removed the description field in batta in child tables work detail and  Bureau  trip sheet details doctype
- Added ignore user permission in fields employee in trip sheet and bureau trip sheet doctype 

## Output screenshots (optional)
<img width="1807" height="928" alt="image" src="https://github.com/user-attachments/assets/1a40ddba-b097-46eb-a9e5-648d137b6061" />
<img width="1807" height="928" alt="image" src="https://github.com/user-attachments/assets/d0aac962-39e3-4f6a-9b4c-cebd16802d96" />


## Areas affected and ensured
bureau trip sheet ,trip sheet ,work detail and  Bureau  trip sheet details child  doctype
## Is there any existing behavior change of other features due to this code change?
No.
## Was this feature tested on the browsers?
 
  - Mozilla Firefox
