### PR TITLE
TASK-2025-02693:Restrict saving Bureau Trip Sheet if no Batta Policy exists

### DIFF
--- a/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.py
+++ b/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.py
@@ -19,6 +19,7 @@ class BureauTripSheet(Document):
 		self.calculate_total_batta()
 		self.calculate_total_daily_batta()
 		self.calculate_total_distance_based_on_odometer()
+		self.validate_batta_policy()
 
 	def calculate_batta(self):
 		'''
@@ -207,6 +208,28 @@ class BureauTripSheet(Document):
 			)
 			self.db_set("purchase_invoice", pi.name)
 
+	def validate_batta_policy(self):
+		'''
+		Validate that a Driver Batta Policy exists for the supplier's designation.
+		'''
+		if not self.supplier:
+			frappe.throw(title="Supplier Required", msg="Please select a Supplier before saving.")
+
+		designation = frappe.db.get_value("Supplier", self.supplier, "designation")
+
+		if not designation:
+			frappe.throw(title="Designation Missing", msg=f"Designation not set for Supplier: {self.supplier}.")
+
+		policy = frappe.db.exists(
+			"Batta Policy",
+			{"designation": designation}
+		)
+
+		if not policy:
+			frappe.throw(
+				title="Batta Policy Missing",
+				msg=f"No Driver Batta Policy found for designation {designation}. Please create before saving."
+			)
 
 @frappe.whitelist()
 def get_batta_for_food_allowance(designation, from_date_time, to_date_time, total_hrs):
@@ -264,7 +287,6 @@ def calculate_batta_allowance(designation=None, is_travelling_outside_kerala=0, 
 
 	batta_policy = frappe.get_all('Batta Policy', filters={'designation':'Driver'}, fields=['*'])
 	if not batta_policy:
-		frappe.throw(f"No Batta Policy found for the designation: Driver")
 		return {"batta": 0}
 
 	policy = batta_policy[0]


### PR DESCRIPTION
## Feature description
Need to :Restrict saving Bureau Trip Sheet if no Batta Policy exists

## Solution description

- Added validation in Bureau Trip Sheet to check for an existing Batta Policy based on supplier designation during save.

- If no policy exists, a clear error message is thrown instructing the user to set up a policy.

- Removed validation throws from helper calculation functions to avoid blocking intermediate field updates.

- When no policy exists, allowance fields default to 0.Calculations proceed normally when a policy is present.

## Output screenshots (optional)

[Screencast from 20-11-25 01:01:03 PM IST.webm](https://github.com/user-attachments/assets/cfbbc236-fb64-4ed2-9cc6-ca210b68eb57)

[Screencast from 20-11-25 01:02:24 PM IST.webm](https://github.com/user-attachments/assets/e926b5e3-f753-4559-bb06-6ffd4f82a435)

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/10efb9e8-26a4-4765-9b85-8911b6b0b89d" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/66ef4dfe-ca3a-4dd3-94eb-d5124153ddda" />



## Areas affected and ensured
Bureau Tripsheet doctype

## Is there any existing behavior change of other features due to this code change?
No. 

## Was this feature tested on the browsers?
  - Chrome
  