### PR TITLE
TASK-2025-02704: resolve migration failure

### DIFF
--- a/beams/patches.txt
+++ b/beams/patches.txt
@@ -1,7 +1,8 @@
 [pre_model_sync]
 beams.patches.rename_hod_role #30-10-2024
 beams.patches.no_of_children_patch  #06-03-2025
-beams.patches.delete_custom_fields  #26-09-2025
+beams.patches.delete_custom_fields  #21-11-2025
+beams.patches.delete_property_setter  #21-11-2025
 
 [post_model_sync]
 # Patches added in this section will be executed after doctypes are migrated

--- a/beams/patches/delete_custom_fields.py
+++ b/beams/patches/delete_custom_fields.py
@@ -216,7 +216,11 @@ fields_to_remove = [
 	{
 		'dt':'Employee',
 		'fieldname': 'are_you_related_to_employee'
-	}
+	},
+	{
+		'dt':'Employee Advance',
+		'fieldname': 'purpose'
+	},
 ]
 
 def execute():

--- a/beams/patches/delete_property_setter.py
+++ b/beams/patches/delete_property_setter.py
@@ -1,18 +1,27 @@
 import frappe
 
 def execute():
-    # Define the filter to find the Property Setter
-    filters = {
-        "doctype_or_field": "DocField",
-        "doc_type": "Employee Feedback Rating",
-        "field_name": "Rating",
-        "property": "read_only",
-        "property_type": "Check",
-        "value": "1"  
-    }
+	filters_list = [
+		{
+			"doctype_or_field": "DocField",
+			"doc_type": "Employee Feedback Rating",
+			"field_name": "Rating",
+			"property": "read_only",
+			"property_type": "Check",
+			"value": "1"
+		},
+		{
+			"doctype_or_field": "DocField",
+			"doc_type": "Employee Advance",
+			"field_name": "purpose",
+			"property": "hidden",
+			"property_type": "Small Text",
+			"value":1
+		},
+	]
 
-    # Find and delete the property setter if it exists
-    property_setter_name = frappe.db.exists("Property Setter", filters)
-    if property_setter_name:
-        frappe.db.delete("Property Setter", {"name": property_setter_name})
-        frappe.db.commit()
+	for filters in filters_list:
+		property_setter_name = frappe.db.exists("Property Setter", filters)
+		if property_setter_name:
+			frappe.db.delete("Property Setter", {"name": property_setter_name})
+	frappe.db.commit()

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -27,7 +27,6 @@ def after_install():
 	create_custom_fields(get_purchase_order_custom_fields(),ignore_validate=True)
 	create_custom_fields(get_material_request_custom_fields(), ignore_validate=True)
 	create_custom_fields(get_sales_order_custom_fields(), ignore_validate=True)
-	create_custom_fields(get_employee_advance_custom_fields(), ignore_validate=True)
 	create_custom_fields(get_journal_entry_custom_fields(), ignore_validate=True)
 	create_custom_fields(get_voucher_entry_custom_fields(), ignore_validate=True)
 	create_custom_fields(get_contract_custom_fields(),ignore_validate=True)
@@ -109,7 +108,6 @@ def before_uninstall():
 	delete_custom_fields(get_driver_custom_fields())
 	delete_custom_fields(get_material_request_custom_fields())
 	delete_custom_fields(get_sales_order_custom_fields())
-	delete_custom_fields(get_employee_advance_custom_fields())
 	delete_custom_fields(get_employee_custom_fields())
 	delete_custom_fields(get_journal_entry_custom_fields())
 	delete_custom_fields(get_voucher_entry_custom_fields())
@@ -4079,14 +4077,6 @@ def get_property_setters():
 		},
 		{
 			"doctype_or_field": "DocField",
-			"doc_type": "Employee Advance",
-			"field_name": "purpose",
-			"property": "hidden",
-			"property_type": "Small Text",
-			"value":1
-		},
-		{
-			"doctype_or_field": "DocField",
 			"doc_type": "Purchase Invoice",
 			"field_name": "update_stock",
 			"property": "hidden",
@@ -5308,31 +5298,6 @@ def get_sales_order_custom_fields():
 				"read_only":1,
 				"insert_after": "naming_series"
 			}
-		]
-	}
-
-def get_employee_advance_custom_fields():
-	'''
-	Custom fields that need to be added to the Employee Advance  Doctype
-	'''
-	return {
-		"Employee Advance": [
-			{
-				"fieldname": "purpose",
-				"fieldtype": "Link",
-				"label": "Purpose",
-				"options": "Employee Advance Purpose",
-				"insert_after":"currency"
-			},
-			{
-				"fieldname": "purpose",
-				"fieldtype": "Link",
-				"label": "Purpose",
-				"options": "Employee Advance Purpose",
-				"insert_after": "currency",
-				"reqd": 1
-			}
-
 		]
 	}
 


### PR DESCRIPTION
## Feature description
Fix migration failure caused by the duplicate "purpose" custom field defined for the Employee Advance DocType.
Since Employee Advance already contains a standard Purpose (Small Text) field, creating a custom field with the same name caused migration errors.
This feature removes the unnecessary custom field definition and adds a patch to delete any existing duplicate custom field from the database.
## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description
1.Removed Custom Field Creation
-   Deleted the entire get_employee_advance_custom_fields() function.
-   Removed function calls from:
    -   after_install()
    -   before_uninstall()
2. Updating delete_property_setter.py
 -  Added logic to remove property setters for:
      -  Employee Advance → purpose → hidden
3. Added Cleanup Patch
    - Updated delete_custom_fields.py to remove any existing custom field:
    - Updated delete_property_setter.py to remove property setter 
    - Updated patches.txt date to ensure the patch executes.
## Output screenshots (optional)
**Created an Employee Advance.standard 'purpose' field is visible there**
<img width="1333" height="927" alt="image" src="https://github.com/user-attachments/assets/5ecf222c-08d7-4fc2-949d-ed96a7dfa64e" />

## Areas affected and ensured
- Custom Field creation logic in setup.py
- Patches execution in delete_custom_fields for  delete_property_setter
- Employee Advance DocType field structure (ensured there is only one Purpose field)
## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
