### PR TITLE
chore: Pull emails on each minute

### DIFF
--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -458,7 +458,8 @@ scheduler_events = {
 	],
 	"cron": {
 		"* * * * *": [  # runs every minute
-			"beams.beams.custom_scripts.hd_ticket.hd_ticket.process_escalation_notifications"
+			"beams.beams.custom_scripts.hd_ticket.hd_ticket.process_escalation_notifications",
+			"frappe.email.doctype.email_account.email_account.pull",
 		]
 	}
   }


### PR DESCRIPTION
## Feature description
Pull emails on each minute

## Is there any existing behaviour change of other features due to this code change?
No

## Was this feature tested on the browsers?
- [x]   Chrome
- [ ]   Mozilla Firefox
- [ ]   Opera Mini
- [ ]   Safari