### PR TITLE
feat: add fields in Bureau doctype

### DIFF
--- a/beams/beams/doctype/bureau/bureau.json
+++ b/beams/beams/doctype/bureau/bureau.json
@@ -13,7 +13,10 @@
   "mode_of_payment",
   "column_break_xpwx",
   "company",
-  "location"
+  "location",
+  "is_parent_bureau",
+  "regional_bureau",
+  "parent_bureau_head"
  ],
  "fields": [
   {
@@ -65,11 +68,32 @@
   {
    "fieldname": "column_break_xpwx",
    "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "eval:!doc.is_parent_bureau",
+   "fieldname": "regional_bureau",
+   "fieldtype": "Link",
+   "label": "Parent Bureau",
+   "options": "Bureau"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_parent_bureau",
+   "fieldtype": "Check",
+   "label": "Is Parent Bureau"
+  },
+  {
+   "depends_on": "eval:!doc.is_parent_bureau",
+   "fieldname": "parent_bureau_head",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Parent Bureau Head",
+   "options": "Employee"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-11-19 09:58:28.027679",
+ "modified": "2025-11-26 12:16:52.601463",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Bureau",

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -5489,7 +5489,7 @@ def get_beams_roles():
         'Bureau User','Coordinating Editor','News Coordinator',
         'Security','Reporter','Salary Increment Approver',
         'Front Desk User', 'Asset Manager', 'Asset User',
-        'Management', 'Expense Approver'
+        'Management', 'Expense Approver','Bureau Head',
     ]
 
 def get_custom_translations():


### PR DESCRIPTION
## Feature description
Added the following fields to the Bureau DocType:
TASK-2025-02710

## Solution description

- Is Parent Bureau

      Type: Check
      Purpose: Identifies whether this Bureau stands at the top of its hierarchy

- Parent Bureau

      Type: Link (Bureau)
      Display When: Is Parent Bureau is unchecked

- Parent Bureau Head

      Type: Link (Employee)
      Display When: Is Parent Bureau is unchecked

-  Added a new Role "Bureau Head"

## Output screenshots (optional)

<img width="1431" height="942" alt="image" src="https://github.com/user-attachments/assets/b95f02dd-4d89-42fc-826d-90a41aea7963" />


[Screencast from 26-11-25 01:40:08 PM IST.webm](https://github.com/user-attachments/assets/da3650af-afc6-45b9-b082-85c61951afee)


## Areas affected and ensured

- Bureau

## Is there any existing behaviour change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on these browsers?
- [ ]   Chrome
- [x]   Mozilla Firefox
- [ ]   Opera Mini
- [ ]   Safari
