### PR TITLE
fix: calculate batta and food allowance in buearo trip sheet

### DIFF
--- a/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.py
+++ b/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.py
@@ -288,7 +288,7 @@ def get_batta_for_food_allowance(designation, from_date_time, to_date_time, tota
 	to_date_time = get_datetime(to_date_time)
 	required_hours = 6
 
-	if batta_policy and float(total_hrs) > required_hours:
+	if batta_policy and float(total_hrs) >= required_hours:
 		break_fast, lunch, dinner = frappe.db.get_value('Batta Policy', batta_policy, ['break_fast', 'lunch', 'dinner'])
 		same_date = getdate(from_date_time) == getdate(to_date_time)
 
@@ -355,7 +355,7 @@ def calculate_batta_allowance(designation=None, is_travelling_outside_kerala=0, 
 
 	if not is_actual_daily_batta_without_overnight:
 		if not is_overnight_stay:
-			if total_distance_travelled_km > 100 and total_hours >= 8:
+			if total_distance_travelled_km >= 100 and total_hours >= 8:
 				if is_travelling_outside_kerala:
 					daily_batta_without_overnight_stay = float(policy.get('outside_kerala', 0))
 				else:


### PR DESCRIPTION
## Issue  description
TASK-2025-02737
-  need to fix the distance travelled is 100 km and total hours  equal  to 8 hours no batta is calculated in daily batta
- need to fix the disatnce travelled is 50 km and above the total hour equal to 6 hour is no food allowance is calculated 


## Solution description
- Fixed the batta calculation when the disatance travelled is equal to 100 km and total hours is greater than and equal to 8  hour 
- fixed the food allowance when the distance travelled is greater than equal to 50km and total hours is greater than equal to 6 hours 


## Output screenshots (optional)
[Screencast from 26-11-25 03:16:21 PM IST.webm](https://github.com/user-attachments/assets/f83e8bd5-3e96-4b65-a065-1deb54650165)


## Areas affected and ensured
Bureau trip sheet
## Is there any existing behaviour change of other features due to this code change?
No. 
## Was this feature tested on these browsers?

  Mozilla Firefox

