### PR TITLE
TASK-2025-02743: resolved validation issue for Driver and  Vehicle fields in Trip Sheet

### DIFF
--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.json
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.json
@@ -226,9 +226,8 @@
    "fieldname": "travel_vehicle_allocation",
    "fieldtype": "Table",
    "label": "Travel Vehicle Allocation",
-   "mandatory_depends_on": "eval:doc.workflow_state == 'Approved'",
-   "options": "Vehicle Allocation",
-   "reqd": 1
+   "mandatory_depends_on": "eval:doc.workflow_state == 'Approved by HOD' && doc.is_vehicle_required == 1\n",
+   "options": "Vehicle Allocation"
   },
   {
    "allow_on_submit": 1,
@@ -278,7 +277,7 @@
    "link_fieldname": "employee_travel_request"
   }
  ],
- "modified": "2025-11-04 15:27:48.573167",
+ "modified": "2025-11-27 13:32:29.099720",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Employee Travel Request",


### PR DESCRIPTION
## Feature description
Need to: 
Need to fix the validation behaviuor for Driver and Vehicle fields in the Trip Sheet doctype.

Currently, these fields remain mandatory at all times.
They must become mandatory only when: workflow_state == "Approved by HOD " and "doc.is_vehicle_required == 1"

## Solution description
Removed static Mandatory = Yes from the Driver and Vehicle fields.

Added dynamic mandatory logic using Mandatory Depends On:

eval:doc.workflow_state == 'Approved by HOD' && doc.is_vehicle_required == 1


Ensured both fields are optional by default, but become mandatory only when the above condition is true.


## Output screenshots (optional)
[Screencast from 27-11-25 02:32:41 PM IST.webm](https://github.com/user-attachments/assets/38dcbb34-d439-4c1d-ae8e-942a12d1a69f)


[Screencast from 27-11-25 02:35:05 PM IST.webm](https://github.com/user-attachments/assets/4b5d0536-9234-40bf-b702-d3b81f09cc32)


## Areas affected and ensured
Employee Travel Request

## Is there any existing behaviour change of other features due to this code change?
 No. 

## Was this feature tested on these browsers?
- [ ]   Chrome
