### PR TITLE
TASK-2025-02744: make Bureau field mandatory in Bureau Trip Sheet

### DIFF
--- a/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.json
+++ b/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.json
@@ -66,7 +66,8 @@
    "fieldname": "bureau",
    "fieldtype": "Link",
    "label": "Bureau",
-   "options": "Bureau"
+   "options": "Bureau",
+   "reqd": 1
   },
   {
    "fieldname": "section_break_qavf",
@@ -245,7 +246,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-11-25 11:26:52.163599",
+ "modified": "2025-11-27 15:30:49.607339",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Bureau Trip Sheet",


### PR DESCRIPTION
## Feature description
Need to: Make Bureau field mandatory in Bureau Trip Sheet

## Solution description
Made Bureau field mandatory in Bureau Trip Sheet

## Output screenshots (optional)

[Screencast from 27-11-25 03:33:24 PM IST.webm](https://github.com/user-attachments/assets/a88ebcba-a525-4d01-ad9b-815fec7160d3)

## Areas affected and ensured
Bureau Trip Sheet doctype

## Is there any existing behaviour change of other features due to this code change?
 No.

## Was this feature tested on these browsers?
- [ ]   Chrome

