### PR TITLE
fix: Make trip details as mandatory in Trip Sheet

### DIFF
--- a/beams/beams/doctype/trip_details/trip_details.json
+++ b/beams/beams/doctype/trip_details/trip_details.json
@@ -19,7 +19,8 @@
    "fieldname": "departure",
    "fieldtype": "Data",
    "in_list_view": 1,
-   "label": "Departure"
+   "label": "Departure",
+   "reqd": 1
   },
   {
    "fieldname": "destination",
@@ -61,7 +62,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-05-06 09:53:53.084978",
+ "modified": "2025-11-27 15:25:26.278913",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Trip Details",

--- a/beams/beams/doctype/trip_sheet/trip_sheet.json
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.json
@@ -181,7 +181,8 @@
    "fieldname": "trip_details",
    "fieldtype": "Table",
    "label": "Trip Details",
-   "options": "Trip Details"
+   "options": "Trip Details",
+   "reqd": 1
   },
   {
    "fieldname": "section_break_ygej",
@@ -247,7 +248,7 @@
    "link_fieldname": "trip_sheet"
   }
  ],
- "modified": "2025-11-19 14:46:36.960867",
+ "modified": "2025-11-27 14:50:29.374334",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Trip Sheet",


### PR DESCRIPTION
## issue description
TASK-2025-02742
1-  An error occurs when creating a Batta Claim from the Trip Sheet because the Trip Details child table in the Trip Sheet doctype is empty


## Solution description
- seted the mandatory in child table trip details in trip sheet doctype
## Output screenshots (optional)
[Screencast from 27-11-25 03:57:57 PM IST.webm](https://github.com/user-attachments/assets/cad3a749-5198-4481-8a8c-f6eed199e03f)


## Areas affected and ensured
trip sheet and trip sheet details child table doctype
## Is there any existing behaviour change of other features due to this code change?
 No. 

## Was this feature tested on these browsers?

- [ ]   Mozilla Firefox
