### PR TITLE
TASK-2025-02751:Ensure validation in substitute booking

### DIFF
--- a/beams/beams/doctype/substitute_booking/substitute_booking.py
+++ b/beams/beams/doctype/substitute_booking/substitute_booking.py
@@ -182,9 +182,14 @@ class SubstituteBooking(Document):
 			})
 
 	def validate_duplicate_assignment(self):
+		"""
+		Validate that no other active Substitute Booking exists for the same 'substituting_for' and 'date'.
+		Cancelled entries (docstatus = 2) are excluded from the check.
+		"""
 		# Iterate over each row in the child table 'substitution_bill_date'
 		for row in self.substitution_bill_date:
-			# Check if any other Substitute Booking exists for the same 'substituting_for' and 'date'
+			# Check if any other active Substitute Booking exists for the same 'substituting_for' and 'date'
+			# Exclude cancelled documents (docstatus = 2)
 			duplicate_exists = frappe.db.sql("""
 				SELECT
 					parent
@@ -200,12 +205,14 @@ class SubstituteBooking(Document):
 					sbd.date = %s
 				AND
 					`tabSubstitute Booking`.name != %s
+				AND
+					`tabSubstitute Booking`.docstatus != 2
 			""", (self.substituting_for, row.date, self.name))
 
 			# If a duplicate is found, raise an error
 			if duplicate_exists:
 				frappe.throw(_("A substitute is already assigned for {0} on {1}. No duplicate bookings are allowed.")
-							 .format(self.substituting_for, row.date))
+							.format(self.substituting_for, row.date))
 
 
 @frappe.whitelist()


### PR DESCRIPTION
## Feature description
Need to: fix the issue in validation in substitute booking

## Solution description
Validated that no other active Substitute Booking exists for the same 'substituting_for' and 'date'.
Cancelled entries (docstatus = 2) are excluded from the check.

## Output screenshots (optional)
[Screencast from 28-11-25 10:24:13 AM IST.webm](https://github.com/user-attachments/assets/c18c24be-bd5b-4d17-8165-99de2bf80ec2)

[Screencast from 28-11-25 10:25:37 AM IST.webm](https://github.com/user-attachments/assets/698de2a0-8641-407e-a01b-d5b9ec5a96ba)

[Screencast from 28-11-25 10:36:41 AM IST.webm](https://github.com/user-attachments/assets/e33469f5-ec84-4325-b8e9-588cfc7fcd6e)

<img width="1920" height="1080" alt="Screenshot from 2025-11-28 10-25-00" src="https://github.com/user-attachments/assets/8690ac8d-92e1-4876-b780-4096ece007f0" />

## Areas affected and ensured
Substitute booking

## Is there any existing behaviour change of other features due to this code change?
 No. 

## Was this feature tested on these browsers?
- [ ]   Chrome

