### PR TITLE
TASK-2025-02753: prevent submission of Petty Cash Request

### DIFF
--- a/beams/beams/custom_scripts/voucher_entry/voucher_entry.py
+++ b/beams/beams/custom_scripts/voucher_entry/voucher_entry.py
@@ -19,7 +19,4 @@ def create_petty_cash_request(voucher_entry_name, bureau, mode_of_payment, accou
     })
 
     petty_cash.insert(ignore_permissions=True)
-    petty_cash.submit()
-    frappe.db.commit()
-
     return {"status": "success", "message": "Petty Cash Request Created Successfully!", "docname": petty_cash.name}


### PR DESCRIPTION
## Feature description
Prevent auto-submission of Petty Cash Request when it is created through the Voucher Entry.
The request should remain in Draft after creation.
## Analysis and design (optional)
Auto-submission was happening because the function create_petty_cash_request included:
- petty_cash.submit()
- frappe.db.commit(
Both caused the document to immediately move from Draft → Submitted.
Removing these lines ensures the document remains in Draft and follows the normal workflow.
## Solution description
beams/beams/custom_scripts/voucher_entry/voucher_entry.py
-----------------------------------------------------------------------------------
Code changes:
  - Removed petty_cash.submit() to stop auto-submission.
  - Removed frappe.db.commit() as it was only used to finalize the submission.
  - Ensured petty_cash.insert(ignore_permissions=True) creates the document in Draft status.
This prevents unintended workflow transitions.
## Output screenshots (optional)
**Created a Voucher Entry and then created a Petty Cash Request from it.**
<img width="1501" height="928" alt="image" src="https://github.com/user-attachments/assets/a08d6969-d593-480d-a571-d732febec1ea" />
[Uploading Screencast from 11-28-2025 11:37:37 AM.webm…]()

## Areas affected and ensured
- Petty Cash Request creation from Voucher Entry
- Voucher Entry → "Create Petty Cash Request" functionality
- Workflow behavior for Petty Cash Request (now stays in Draft)

## Is there any existing behaviour change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on these browsers?
- [ ]   Chrome
- [ ]   Mozilla Firefox
- [ ]   Opera Mini
- [ ]   Safari
