### PR TITLE
TASK-2025-02756: is_budgeted checkbox field across expense-related doctypes

### DIFF
--- a/beams/beams/doctype/batta_claim/batta_claim.json
+++ b/beams/beams/doctype/batta_claim/batta_claim.json
@@ -23,6 +23,7 @@
   "origin",
   "destination",
   "mode_of_travelling",
+  "is_budgeted",
   "is_travelling_outside_kerala",
   "is_overnight_stay",
   "is_avail_room_rent",
@@ -302,6 +303,12 @@
    "fieldtype": "Link",
    "label": "Travel Request",
    "options": "Employee Travel Request"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_budgeted",
+   "fieldtype": "Check",
+   "label": "Is Budgeted"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -316,7 +323,7 @@
    "link_fieldname": "batta_claim_reference"
   }
  ],
- "modified": "2025-11-18 10:37:46.469811",
+ "modified": "2025-11-29 09:26:33.695459",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Batta Claim",

--- a/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.json
+++ b/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.json
@@ -13,6 +13,7 @@
   "bureau",
   "company",
   "section_break_qavf",
+  "is_budgeted",
   "is_overnight_stay",
   "is_travelling_outside_kerala",
   "daily_batta_with_overnight_stay",
@@ -241,12 +242,18 @@
    "label": "Purchase Invoice",
    "options": "Purchase Invoice",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "is_budgeted",
+   "fieldtype": "Check",
+   "label": "Is Budgeted"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-11-27 15:30:49.607339",
+ "modified": "2025-11-29 10:27:43.300740",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Bureau Trip Sheet",

--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.json
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.json
@@ -13,6 +13,7 @@
   "number_of_travellers",
   "is_vehicle_required",
   "is_unplanned",
+  "is_budgeted",
   "column_break_ooli",
   "posting_date",
   "is_management_employee",
@@ -259,6 +260,12 @@
    "fieldname": "remarks",
    "fieldtype": "Small Text",
    "label": "Remarks"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_budgeted",
+   "fieldtype": "Check",
+   "label": "Is Budgeted"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -277,7 +284,7 @@
    "link_fieldname": "employee_travel_request"
   }
  ],
- "modified": "2025-11-27 13:32:29.099720",
+ "modified": "2025-11-29 10:35:23.823497",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Employee Travel Request",

--- a/beams/beams/doctype/petty_cash_request/petty_cash_request.json
+++ b/beams/beams/doctype/petty_cash_request/petty_cash_request.json
@@ -15,7 +15,8 @@
   "petty_cash_account",
   "account",
   "requested_amount",
-  "reason"
+  "reason",
+  "is_budgeted"
  ],
  "fields": [
   {
@@ -77,12 +78,18 @@
    "fieldname": "reason",
    "fieldtype": "Small Text",
    "label": "Reason"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_budgeted",
+   "fieldtype": "Check",
+   "label": "Is Budgeted"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-03-24 16:15:48.424785",
+ "modified": "2025-11-29 10:37:22.784579",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Petty Cash Request",
@@ -103,6 +110,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/beams/beams/doctype/stringer_bill/stringer_bill.json
+++ b/beams/beams/doctype/stringer_bill/stringer_bill.json
@@ -14,6 +14,7 @@
   "date",
   "bureau",
   "cost_center",
+  "is_budgeted",
   "section_break_njgm",
   "stringer_bill_detail",
   "section_break_zcsv",
@@ -112,6 +113,12 @@
    "fieldtype": "Data",
    "label": "Area",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "is_budgeted",
+   "fieldtype": "Check",
+   "label": "Is Budgeted"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -122,7 +129,7 @@
    "link_fieldname": "stringer_bill_reference"
   }
  ],
- "modified": "2025-03-22 09:35:39.704283",
+ "modified": "2025-11-29 10:26:41.561924",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Stringer Bill",
@@ -143,6 +150,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/beams/beams/doctype/trip_sheet/trip_sheet.json
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.json
@@ -28,6 +28,7 @@
   "safety_inspection_completed",
   "trip_details_section",
   "trip_details",
+  "is_budgeted",
   "section_break_ygej",
   "initial_odometer_reading",
   "final_odometer_reading",
@@ -238,6 +239,12 @@
    "ignore_user_permissions": 1,
    "label": "Employees",
    "options": "Employees"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_budgeted",
+   "fieldtype": "Check",
+   "label": "Is Budgeted"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -248,7 +255,7 @@
    "link_fieldname": "trip_sheet"
   }
  ],
- "modified": "2025-11-27 14:50:29.374334",
+ "modified": "2025-11-29 11:24:23.153422",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Trip Sheet",

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -1022,7 +1022,13 @@ def get_purchase_order_custom_fields():
 				"insert_after": "rejection_section",
 				"depends_on": "eval:doc.workflow_state == 'Rejected' || doc.workflow_state == 'Pending Accounts Approval'  || doc.workflow_state == 'Pending CEO Approval'",
 				"read_only_depends_on": "eval:!(doc.workflow_state == 'Pending Accounts Approval' || doc.workflow_state == 'Pending CEO Approval')"
-			}
+			},
+			{
+				"fieldname": "is_budgeted",
+				"fieldtype": "Check",
+				"label": "Is Budgeted",
+				"insert_after": "is_subcontracted"
+			},
 		],
 		"Purchase Order Item": [
 			{
@@ -1730,7 +1736,13 @@ def get_purchase_invoice_custom_fields():
 				"fieldtype": "Attach",
 				"label": "Attachments",
 				"insert_after": "base_net_total"
-			}
+			},
+			{
+				"fieldname": "is_budgeted",
+				"fieldtype": "Check",
+				"label": "Is Budgeted",
+				"insert_after": "is_reverse_charge"
+			},
 		]
 	}
 
@@ -2276,7 +2288,13 @@ def get_voucher_entry_custom_fields():
 				"options": "Bureau",
 				"label": "Bureau",
 				"insert_after": "naming_series"
-			}
+			},
+			{
+				"fieldname": "is_budgeted",
+				"fieldtype": "Check",
+				"label": "Is Budgeted",
+				"insert_after": "project"
+			},
 		]
 	}
 
@@ -5182,11 +5200,10 @@ def get_material_request_custom_fields():
 				"fieldname": "budget_exceeded",
 				"fieldtype": "Check",
 				"label": "Budget Exceeded",
-				"insert_after": "schedule_date",
+				"insert_after": "location",
 				"read_only":1,
 				"no_copy":1,
 				"depends_on": "eval:doc.budget_exceeded == 1"
-
 			},
 			{
 				"fieldname": "requested_by",
@@ -5218,7 +5235,14 @@ def get_material_request_custom_fields():
 				"insert_after": "requested_by",
 				"read_only": 1,
 				"fetch_from": "requested_by.employee_name"
-			}
+			},
+			{
+				"fieldname": "is_budgeted",
+				"fieldtype": "Check",
+				"label": "Is Budgeted",
+				"insert_after": "buying_price_list",
+			},
+
 		]
 	}
 


### PR DESCRIPTION
## Feature description
Add an “Is Budgeted” checkbox field across various BEAMS DocTypes and relevant ERPNext documents.
This field will be used to mark whether a claim, request, trip, bill, or transaction is part of the approved budget.

The following DocTypes were updated:

BEAMS DocTypes
------------------------
- Batta Claim
- Bureau Trip Sheet
- Employee Travel Reques
- Petty Cash Request
- Stringer Bill
- Trip Sheet

ERPNext Core DocTypes (via Custom Fields)
-----------------------------------------------------------
- Purchase Order
- Purchase Invoice
- Voucher Entry
- Material Request

## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description
- Added Is Budgeted field in the following BEAMS DocTypes:
     Batta Claim, Bureau Trip Sheet, Employee Travel Request, Petty Cash Request, Stringer Bill, Trip Sheet

- Added Is Budgeted as a Custom Field in:
      Purchase Order, Purchase Invoice, Voucher Entry, Material Request
- The field is added as a simple checkbox with default value 0.
- The field is positioned appropriately using insert_after for ERPNext documents.
## Output screenshots (optional)
**Tripsheet**
<img width="1443" height="815" alt="image" src="https://github.com/user-attachments/assets/c667a663-3845-493e-84cf-b570823c3a08" />
**Batta Claim**
<img width="1441" height="692" alt="image" src="https://github.com/user-attachments/assets/92726fc5-c350-49c4-a609-d3758ef3118f" />
**Purchase Order**
<img width="1466" height="586" alt="image" src="https://github.com/user-attachments/assets/321829ee-5c09-4692-9fba-62f0ec766c2f" />
**Voucher Entry**
<img width="1523" height="930" alt="image" src="https://github.com/user-attachments/assets/c8799291-6579-40a2-9e49-6ca02a6cd3c9" />
**Stringer Bill**
<img width="1515" height="657" alt="image" src="https://github.com/user-attachments/assets/b727ca40-4785-4730-bff7-8de3fdfd5a65" />
**Bureau Trip Sheet**
<img width="1515" height="657" alt="image" src="https://github.com/user-attachments/assets/7a5892bf-7830-4037-8ca9-1f0aef5da1a9" />
**Employee Travel Request**
<img width="1515" height="657" alt="image" src="https://github.com/user-attachments/assets/66bb6055-b374-4509-849d-1d26d78ef94c" />
**Petty Cash Request**
<img width="1509" height="538" alt="image" src="https://github.com/user-attachments/assets/b8d998ca-3f44-492a-841e-0f9869e1ba56" />
**Material Request**
<img width="1509" height="538" alt="image" src="https://github.com/user-attachments/assets/ea3a17fb-ad84-4b75-9b12-1f6b8c63ffd3" />
**Purchase Invoice**
<img width="1262" height="727" alt="image" src="https://github.com/user-attachments/assets/7e2b5fd3-4b6a-4ef3-97ea-797e4cbbebe8" />

## Areas affected and ensured

- BEAMS DocType JSON files
- BEAMS setup.py custom field creation logic
- Client-side forms for the above DocTypes

## Is there any existing behaviour change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on these browsers?
- [ ]   Chrome
- [ ]   Mozilla Firefox
- [ ]   Opera Mini
- [ ]   Safari
