### PR TITLE
TASK-2025-02760: Connection for Batta Claim

### DIFF
--- a/beams/beams/doctype/trip_sheet/trip_sheet.json
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.json
@@ -253,9 +253,13 @@
   {
    "link_doctype": "Vehicle Incident Record",
    "link_fieldname": "trip_sheet"
+  },
+  {
+   "link_doctype": "Batta Claim",
+   "link_fieldname": "trip_sheet"
   }
  ],
- "modified": "2025-11-29 11:24:23.153422",
+ "modified": "2025-12-01 09:46:08.527134",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Trip Sheet",


### PR DESCRIPTION
## Feature description
Add a connection for Batta Claim inside the Trip Sheet DocType so users can directly view related Batta Claim records from the Trip Sheet.
## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description
Updated trip_sheet.json to add a new entry in the links section:
- link_doctype: Batta Claim
- link_fieldname: trip_sheet
This enables the Connections section inside Trip Sheet to display related Batta Claim records.
## Output screenshots (optional)
<img width="1565" height="934" alt="image" src="https://github.com/user-attachments/assets/c1fe36d0-dfba-48c8-8c63-13d6518c4a83" />
<img width="1565" height="934" alt="image" src="https://github.com/user-attachments/assets/8065c52c-118b-485f-99fb-b0d520624a3a" />

## Areas affected and ensured
- Trip Sheet DocType metadata
- Connections section of Trip Sheet UI
## Is there any existing behaviour change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on these browsers?
- [ ]   Chrome
- [ ]   Mozilla Firefox
- [ ]   Opera Mini
- [ ]   Safari
