### PR TITLE
TASK-2025-02773: set permlevel for rejection reason

### DIFF
--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.json
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.json
@@ -203,6 +203,7 @@
    "fieldname": "reason_for_rejection",
    "fieldtype": "Small Text",
    "label": "Reason for Rejection ",
+   "permlevel": 1,
    "read_only_depends_on": "eval: doc.workflow_state == \"Rejected\";"
   },
   {

--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.json
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.json
@@ -305,7 +305,7 @@
    "link_fieldname": "travel_request"
   }
  ],
- "modified": "2025-12-06 11:56:26.926500",
+ "modified": "2025-12-08 12:06:49.029201",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Employee Travel Request",
@@ -323,6 +323,102 @@
    "role": "System Manager",
    "share": 1,
    "submit": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "HOD",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Admin",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Admin User",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Coordinating Editor",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "permlevel": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "HOD",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "permlevel": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Admin",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "permlevel": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Admin User",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "permlevel": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Coordinating Editor",
+   "share": 1,
    "write": 1
   }
  ],


### PR DESCRIPTION
## Feature description
Restrict editing of the Reason for Rejection field in Employee Travel Request.
Employees should be able to view the field but not edit it, since they never perform rejection actions.
## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description
- Set permlevel: 1 for the Reason for Rejection field in employee_travel_request.json.
- Ensure:
  - Employee role → Read access.
  - Rejection-performing roles → Read + Write access.

- Preserves existing workflow behavior and ensures Employees cannot modify rejection reasons.
## Output screenshots (optional)
When an employee logged-in and created a Employee Travel Request
<img width="1565" height="983" alt="image" src="https://github.com/user-attachments/assets/47849af8-f845-4398-bbf6-8c46045a0d59" />
## Areas affected and ensured
Employee Travel Request DocType:
  - Field permissions
  - Field accessibility based on user role
Workflow rejection handling
## Is there any existing behaviour change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on these browsers?
- [ ]   Chrome
- [ ]   Mozilla Firefox
- [ ]   Opera Mini
- [ ]   Safari
