### PR TITLE
feat:Show Bureaus marked as Is Parent Bureau = 1

### DIFF
--- a/beams/beams/doctype/bureau/bureau.js
+++ b/beams/beams/doctype/bureau/bureau.js
@@ -1,8 +1,21 @@
 // Copyright (c) 2024, efeone and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Bureau", {
-// 	refresh(frm) {
+frappe.ui.form.on("Bureau", {
+	setup(frm) {
+		set_filters(frm);
+	}
+});
 
-// 	},
-// });
+/*
+Show Bureaus marked as "Is Parent Bureau = 1" appear in the selection list.
+*/
+let set_filters = function (frm) {
+	frm.set_query("regional_bureau", function() {
+		return {
+			filters: {
+				is_parent_bureau: 1
+			}
+		}
+	});
+}

--- a/beams/beams/doctype/bureau/bureau.json
+++ b/beams/beams/doctype/bureau/bureau.json
@@ -83,17 +83,17 @@
    "label": "Is Parent Bureau"
   },
   {
-   "depends_on": "eval:!doc.is_parent_bureau",
+   "fetch_from": "regional_bureau.parent_bureau_head",
    "fieldname": "parent_bureau_head",
    "fieldtype": "Link",
    "in_list_view": 1,
-   "label": "Parent Bureau Head",
+   "label": "Bureau Head",
    "options": "Employee"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-11-26 12:16:52.601463",
+ "modified": "2025-12-01 14:26:58.708333",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Bureau",


### PR DESCRIPTION
## Feature description

- [x]  TASK-2025-02776

- The Bureau Head must be fetched from the Parent Bureau
- The Bureau Head field must be visible regardless of the value of Is Parent Bureau

## Solution description
In Bureau DocType

- Renamed Parent Bureau Head => Bureau Head
- Removed the depends on condition for the Bureau Head field
- Fetch Bureau Head from Parent Bureau if selected
- Add a filter to the Parent Bureau field, wherein only Bureaus with Is Parent Bureau checked should come

## Output screenshots (optional)

<img width="1678" height="969" alt="image" src="https://github.com/user-attachments/assets/0977dea0-b59a-42b3-8717-f488df33268f" />


[Screencast from 01-12-25 03:01:38 PM IST.webm](https://github.com/user-attachments/assets/3d2480ad-8b3a-40c8-85e2-2cb5899dd527)

## Areas affected and ensured
Bureau

## Is there any existing behaviour change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on these browsers?
- [ ]   Chrome
- [x]   Mozilla Firefox
- [ ]   Opera Mini
- [ ]   Safari
