### PR TITLE
TASK-2025-02780: budget tracking fields to Purchase Invoice and Voucher Entry

### DIFF
--- a/beams/setup.py
+++ b/beams/setup.py
@@ -1743,7 +1743,15 @@ def get_purchase_invoice_custom_fields():
 				"fieldname": "is_budgeted",
 				"fieldtype": "Check",
 				"label": "Is Budgeted",
-				"insert_after": "is_reverse_charge"
+				"insert_after": "is_reverse_charge",
+				"default": "1"
+			},
+			{
+				"fieldname": "budget_exceeded",
+				"fieldtype": "Check",
+				"label": "Budget Exceeded",
+				"insert_after": "is_budgeted",
+				"depends_on": "eval:doc.is_budgeted"
 			},
 		]
 	}
@@ -2295,7 +2303,24 @@ def get_voucher_entry_custom_fields():
 				"fieldname": "is_budgeted",
 				"fieldtype": "Check",
 				"label": "Is Budgeted",
-				"insert_after": "project"
+				"insert_after": "project",
+				"default": "1",
+			},
+		],
+		"Voucher Account": [
+			{
+				"fieldname": "is_budgeted",
+				"fieldtype": "Check",
+				"label": "Is Budgeted",
+				"insert_after": "party",
+				"default": "1"
+			},
+			{
+				"fieldname": "budget_exceeded",
+				"fieldtype": "Check",
+				"label": "Budget Exceeded",
+				"insert_after": "is_budgeted",
+				"depends_on": "eval:doc.is_budgeted",
 			},
 		]
 	}


### PR DESCRIPTION
## Feature description
This feature enhances the budgeting workflow in Purchase Invoice, Voucher Entry, and Voucher Account by:
  - checking the Is Budgeted field by default.
  - Introducing a new Budget Exceeded checkbox that becomes visible only when Is Budgeted is enabled.

## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description
The following changes were made in beams/setup.py:

Purchase Invoice Custom Fields
--------------------------------------------
- Added "default": "1" to the Is Budgeted field so it is checked by default.
- Added new checkbox field Budget Exceeded, placed after is_budgeted, with a dependency on doc.is_budgeted.

Voucher Entry Custom Fields
---------------------------------------
- Added "default": "1" to the Is Budgeted field.

Voucher Account Custom Fields
------------------------------------------

Added Is Budgeted field with "default": "1", inserted after the party field.
Added Budget Exceeded field dependent on doc.is_budgeted.
## Output screenshots (optional)
**When a new Purchase Invoice form is opened,**
<img width="1492" height="931" alt="image" src="https://github.com/user-attachments/assets/9a65db7f-e5bb-4c64-89be-a78cfcb42964" />
**When a new Voucher Entry form is opened,**
<img width="1492" height="931" alt="image" src="https://github.com/user-attachments/assets/dbbe8158-422c-4280-8c77-cc7a1ae649b8" />
**In Voucher Accounts table in Voucher Entry**
<img width="1492" height="931" alt="image" src="https://github.com/user-attachments/assets/514434ea-dbce-4642-af80-3b7d9dab0c00" />

## Areas affected and ensured
- Purchase Invoice form
- Voucher Entry form
- Voucher Account child table

## Is there any existing behaviour change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on these browsers?
- [ ]   Chrome
- [ ]   Mozilla Firefox
- [ ]   Opera Mini
- [ ]   Safari
