### PR TITLE
feat: role base permission for fields in employee separation

### DIFF
--- a/beams/beams/custom_scripts/employee_separation/employee_separation.js
+++ b/beams/beams/custom_scripts/employee_separation/employee_separation.js
@@ -4,6 +4,7 @@
 frappe.ui.form.on('Employee Separation', {
 	refresh: function(frm) {
 		apply_template_filter(frm);
+		apply_employee_field_visibility(frm);
 	},
 	department: function(frm) {
 		apply_template_filter(frm);
@@ -16,7 +17,11 @@ frappe.ui.form.on('Employee Separation', {
 	},
 	employee: function(frm) {
 		set_employee_exit_clearance_filter(frm);
+	},
+	boarding_begins_on: function(frm){
+		set_notice_period_end_date(frm);
 	}
+
 });
 
 /**
@@ -53,3 +58,59 @@ function set_employee_exit_clearance_filter(frm) {
 	};
 }
 
+/**
+ * Apply field visibility rules for Employee Separation based on user roles.
+ *
+ * This function:
+ * 1. Determines whether the logged-in user has ONLY the default employee roles.
+ * 2. If YES → Shows only selected fields (employee view).
+ * 3. If NO → Shows all fields (HOD / HR / Admin view).
+ */
+function apply_employee_field_visibility(frm){
+		const roles = frappe.user_roles || [];
+		const default_employee_roles = ["Employee", "All", "Guest", "Desk User"];
+
+		const has_only_employee_roles =
+			roles.every(r => default_employee_roles.includes(r)) &&
+			roles.length === default_employee_roles.length;
+
+		const allowed_fields = [
+			"employee",
+			"boarding_begins_on",
+			"remarks",
+			"notice_period_end_date",
+			"employee_name",
+			"department",
+			"designation",
+			"employee_grade"
+		];
+
+		frm.fields.forEach(f => {
+			frm.toggle_display(f.df.fieldname, true);
+			frm.toggle_enable(f.df.fieldname, true);
+		});
+
+		if (has_only_employee_roles) {
+			frm.fields.forEach(f => {
+				const fn = f.df.fieldname;
+				if (!allowed_fields.includes(fn)) {
+					frm.toggle_display(fn, false);
+					frm.toggle_enable(fn, false);
+				}
+			});
+		}
+}
+
+/**
+ * Calculate notice period end date = boarding_begins_on + employee.notice_number_of_days
+ */
+function set_notice_period_end_date(frm) {
+	if(!frm.doc.employee || !frm.doc.boarding_begins_on) return;
+
+	frappe.db.get_value("Employee", frm.doc.employee, "notice_number_of_days")
+		.then(res => {
+			const days = res.message.notice_number_of_days || 0;
+			const end_days = frappe.datetime.add_days(frm.doc.boarding_begins_on, days);
+			frm.set_value("notice_period_end_date", end_days)
+		})
+}

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -3713,7 +3713,19 @@ def get_employee_separation_custom_fields():
 				"options":"Pending\nCompleted",
 				"insert_after": "employee_clearance",
 				"read_only": 1
-			}
+			},
+			{
+				"fieldname": "remarks",
+				"fieldtype": "Small Text",
+				"label": "Remarks",
+				"insert_after": "notice_period_end_date",
+			},
+			{
+				"fieldname": "notice_period_end_date",
+				"fieldtype": "Date",
+				"label": "Notice Period End Date",
+				"insert_after": "boarding_begins_on",
+			},
 		]
 	}
 


### PR DESCRIPTION
## Feature description

- [x] TASK-2025-02559

- Added a field in  employee separation
- Added role-based permission for fields in employee separation
- Set Notice Period End Date in employee separation

## Solution description

- Added a new field called “Remarks” in Employee Separation (so employees can mention their reason for separation).
- Added a new field called “notice period end date,” which should be the sum of the notice days for the employee, plus the separation begins on the employee separation.
- In the Employee Separation form, only the following fields must be visible/editable to the Employee:

      "employee",
      "boarding_begins_on",
      "remarks",
      "notice_period_end_date",
      "employee_name",
      "department",
      "designation",
      "employee_grade"

- All other fields in the form must be hidden from the Employee and only visible/editable by other users

## Output screenshots (optional)
whether the logged-in user has ONLY the default employee roles.

[Screencast from 03-12-25 11:58:20 AM IST.webm](https://github.com/user-attachments/assets/729d80c4-6042-49dd-a325-bd2ae6f85f21)

----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Whether the logged-in user has the default HOD roles(or other roles)

[Screencast from 03-12-25 12:00:24 PM IST.webm](https://github.com/user-attachments/assets/a0e8c7b9-32da-44d4-ab7e-1bbc2cdbe0ae)


## Areas affected and ensured
employee separation

## Is there any existing behaviour change of other features due to this code change?
Mention Yes or No. If yes, provide the appropriate explanation.

## Was this feature tested on these browsers?
- [ ]   Chrome
- [x]   Mozilla Firefox
- [ ]   Opera Mini
- [ ]   Safari
