### PR TITLE
TASK-2025-02784:correct Total Batta and Batta calculations in Batta Claim

### DIFF
--- a/beams/beams/doctype/batta_claim/batta_claim.py
+++ b/beams/beams/doctype/batta_claim/batta_claim.py
@@ -26,9 +26,9 @@ class BattaClaim(Document):
 	def validate(self):
 		self.calculate_total_hours()
 		self.calculate_total_distance_travelled()
-		self.calculate_batta()
 		self.calculate_daily_batta()
 		self.calculate_total_daily_batta()
+		self.calculate_batta()
 		self.calculate_total_batta()
 
 	def create_purchase_invoice_from_batta_claim(self):
@@ -129,7 +129,17 @@ class BattaClaim(Document):
 		'''
 			Calculation of Total Daily Batta
 		'''
-		total_daily_batta = 0
+		rows_total = 0.0
+		sum_food = 0.0
+
+		for row in self.get("work_detail") or []:
+			rows_total += flt(row.daily_batta or 0)
+			sum_food += flt(row.total_food_allowance or 0)
+
+		parent_components = flt(self.room_rent_batta or 0) \
+						+ flt(self.daily_batta_with_overnight_stay or 0)
+
+		self.total_daily_batta = flt(rows_total + parent_components + sum_food)
 
 	def calculate_batta(self):
 		'''


### PR DESCRIPTION
## Feature description
Need to:  Correct the  Batta and Total Batta field In Batta Claim

## Solution description
 Corrected Batta and Total Batta field In Batta Claim 
 Moved calculate_batta() call after daily batta and total daily batta computations.

Updated calculate_total_daily_batta() logic:
  - Sum row-level daily batta values.
  - Include total food allowance from each row.
  - Include parent-level components (room rent batta, overnight stay batta).
  - Ensured final total_daily_batta reflects all components.
  - Improved overall calculation order and accuracy in Batta Claim

## Output screenshots (optional)
 

[Screencast from 03-12-25 12:35:38 PM IST.webm](https://github.com/user-attachments/assets/f087fcf5-b3f2-4141-a48e-d7d117d5238a)


[Screencast from 03-12-25 12:20:57 PM IST.webm](https://github.com/user-attachments/assets/ad8bac67-9903-42d9-a37b-2d9ede4e5058)



## Areas affected and ensured
Batta Claim

## Is there any existing behaviour change of other features due to this code change?
No.

## Was this feature tested on these browsers?
- Chrome
