### PR TITLE
TASK-2025-02790:Budget control fields in Substitute Booking

### DIFF
--- a/beams/beams/doctype/substitute_booking/substitute_booking.json
+++ b/beams/beams/doctype/substitute_booking/substitute_booking.json
@@ -17,6 +17,8 @@
   "phone_number",
   "column_break_unny",
   "email_id",
+  "is_budgeted",
+  "is_budget_exceeded",
   "section_break_lftz",
   "column_break_rbcg",
   "bureau",
@@ -220,6 +222,19 @@
    "fieldtype": "Check",
    "label": "Is Paid",
    "mandatory_depends_on": "eval:doc.workflow_state === \"Pending Approval\";"
+  },
+  {
+   "default": "1",
+   "fieldname": "is_budgeted",
+   "fieldtype": "Check",
+   "label": "Is Budgeted"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.is_budgeted == 1",
+   "fieldname": "is_budget_exceeded",
+   "fieldtype": "Check",
+   "label": "Is Budget Exceeded"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -230,7 +245,7 @@
    "link_fieldname": "substitute_booking_reference"
   }
  ],
- "modified": "2025-11-28 17:10:33.801865",
+ "modified": "2025-12-03 14:13:49.862015",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Substitute Booking",


### PR DESCRIPTION
## Feature description
Need to: Add  budget control fields ( Is Budgeted and Is Budget Exceeded) in Substitute Booking

## Solution description

- Added “Is Budgeted” checkbox (default checked)
- Added “Is Budget Exceeded” checkbox with conditional visibility

## Output screenshots (optional)

[Screencast from 03-12-25 02:20:09 PM IST.webm](https://github.com/user-attachments/assets/1a14f6f7-ad2d-46a6-961e-33224f183a63)


## Areas affected and ensured
Substitute Booking doctype

## Is there any existing behaviour change of other features due to this code change?
 No.

## Was this feature tested on these browsers?
- Chrome
