### PR TITLE
TASK-2025-01472: Clear default warehouse for service items

### DIFF
--- a/beams/beams/custom_scripts/item/item.js
+++ b/beams/beams/custom_scripts/item/item.js
@@ -1,0 +1,46 @@
+frappe.ui.form.on('Item', {
+	item_group: function(frm) {
+		if (frm.doc.item_group === 'Services') {
+			frm.set_value('is_stock_item', 0);
+			clear_warehouse_fields(frm);
+		}
+	},
+	
+	refresh: function(frm) {
+		if (frm.doc.item_group === 'Services' && frm.doc.is_stock_item === 1) {
+			frm.set_value('is_stock_item', 0);
+			clear_warehouse_fields(frm);
+		}
+	},    
+	
+	is_stock_item: function(frm) {
+		if (frm.doc.is_stock_item === 0) {
+			clear_warehouse_fields(frm);
+		}
+	}
+});
+
+frappe.ui.form.on('Item Default', {
+	item_defaults_add: function(frm, cdt, cdn) {
+		let row = locals[cdt][cdn];
+		if (frm.doc.item_group === 'Services' || !frm.doc.is_stock_item) {
+			frappe.model.set_value(cdt, cdn, 'default_warehouse', '');
+		}
+	}
+});
+
+/**
+ * Clears all warehouse assignments from Item Defaults child table.
+ * 
+ * This function iterates through all rows in the item_defaults child table
+ * and sets the default_warehouse field to empty string, then refreshes the
+ * field to update the UI.
+ */
+function clear_warehouse_fields(frm) {    
+	if (frm.doc.item_defaults) {
+		frm.doc.item_defaults.forEach(row => {
+			frappe.model.set_value(row.doctype, row.name, 'default_warehouse', '');
+		});
+	}
+	frm.refresh_field('item_defaults');
+}

--- a/beams/beams/custom_scripts/item/item.py
+++ b/beams/beams/custom_scripts/item/item.py
@@ -10,6 +10,14 @@ def before_insert(doc, method):
         service_item = create_service_item(doc)
         doc.service_item = service_item
 
+def clear_warehouse_for_service_items(doc, method):
+	"""Before saving an Item, ensure warehouse fields are cleared for Service Items."""
+
+	# clear warehouse fields for Service Items
+	if doc.item_group == "Services" or not doc.is_stock_item:
+		for d in doc.item_defaults:
+			d.default_warehouse = None
+
 def create_service_item(doc):
     """Creates a Service Item and ensures 'Hireable' is disabled."""
 

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -75,6 +75,7 @@ doctype_js = {
 	"Purchase Order":"beams/custom_scripts/purchase_order/purchase_order.js",
 	"Employment Type":"beams/custom_scripts/employment_type/employment_type.js",
 	"HD Team":"beams/custom_scripts/hd_team/hd_team.js",
+	"Item":"beams/custom_scripts/item/item.js",
 }
 
 doctype_list_js = {
@@ -382,7 +383,10 @@ doc_events = {
 	"Item": {
 		"before_insert": [
 			"beams.beams.custom_scripts.item.item.before_insert"
-		]
+		],
+		"before_save": [
+			"beams.beams.custom_scripts.item.item.clear_warehouse_for_service_items"
+		],
 	},
 	"Asset Movement": {
 		"on_submit": [


### PR DESCRIPTION
## Feature description
Ensure that Service Items cannot have a default warehouse assigned.
## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description
Server-Side Changes
- Added clear_warehouse_for_service_items method in item.py.
- Hooked it into before_save event in hooks.py.
- It checks:
  - If item_group == "Services" OR is_stock_item == 0
  - Then clears default_warehouse for all rows in Item Defaults.

Client-Side Changes

- Registered new Item JS file in hooks.
- In the Item form:
  - When Item Group changes to "Services", is_stock_item is set to 0 and warehouse fields are cleared.
  - When is_stock_item becomes 0, warehouse fields are cleared.
  - On refresh, ensures invalid previous data is reset.
- In the Item Default child table:
  - Prevents assigning warehouse if the item is a Service or non-stock item.
-Added reusable utility clear_warehouse_fields(frm).
## Output screenshots (optional)
[Screencast from 12-03-2025 02:28:28 PM.webm](https://github.com/user-attachments/assets/b8aa78ee-9cb5-4bb4-b49a-e785251228a3)
## Areas affected and ensured
List out the areas affected by your code changes.

## Is there any existing behaviour change of other features due to this code change?

- Item DocType
  - Before Save Event
  - Item Group Behavior
  - Stock Item toggle
  - Item Default child table
- Client-Side UI (warehouse field clearing)
- Server-side validation (ensuring data consistency)

## Was this feature tested on these browsers?
- [x]   Chrome
- [ ]   Mozilla Firefox
- [ ]   Opera Mini
- [ ]   Safari
