### PR TITLE
fix: set the correct Credit Account journal Entry in Substitute Booking

### DIFF
--- a/beams/beams/doctype/substitute_booking/substitute_booking.js
+++ b/beams/beams/doctype/substitute_booking/substitute_booking.js
@@ -3,103 +3,104 @@
 
 frappe.ui.form.on("Substitute Booking", {
   daily_wage: function(frm) {
-      calculate_total_wage(frm);
+	  calculate_total_wage(frm);
   },
 
   onload: function(frm) {
-    if (frm.is_new() && !frm.doc.expense_account) {  // Check if it's a new form and the field is empty
-    // Fetch the default debit account from Beams Account Settings
-      frappe.db.get_single_value('Beams Accounts Settings', 'default_debit_account')
-        .then(default_account => {
-          if (default_account) {
-            frm.set_value('expense_account', default_account);
-          } else {
-            frappe.msgprint(__('Default Debit Account is not set in Beams Account Settings.'));
-                  }
-             });
-    }
+	if (frm.is_new() && !frm.doc.expense_account) {  // Check if it's a new form and the field is empty
+	// Fetch the default debit account from Beams Account Settings
+	  frappe.db.get_single_value('Beams Accounts Settings', 'default_debit_account')
+		.then(default_account => {
+		  if (default_account) {
+			frm.set_value('expense_account', default_account);
+		  } else {
+			frappe.msgprint(__('Default Debit Account is not set in Beams Account Settings.'));
+				  }
+			 });
+	}
 },
 
   refresh: function(frm) {
       update_budget_exceeded_visibility(frm);
-      frm.add_custom_button(__('Leave Application List'), function() {
-          if (!frm.doc.substitution_bill_date || frm.doc.substitution_bill_date.length === 0) {
-              frappe.msgprint(__('No dates found in Substitution Bill Date child table.'));
-              return;
-          }
+	  set_bureau_and_account(frm);
+	  frm.add_custom_button(__('Leave Application List'), function() {
+		  if (!frm.doc.substitution_bill_date || frm.doc.substitution_bill_date.length === 0) {
+			  frappe.msgprint(__('No dates found in Substitution Bill Date child table.'));
+			  return;
+		  }
 
-          // Collect dates from the child table
-          let dates = frm.doc.substitution_bill_date.map(row => row.date);
-          if (dates.length === 0) {
-              frappe.msgprint(__('Please enter at least one date in the Substitution Bill Date table.'));
-              return;
-          }
+		  // Collect dates from the child table
+		  let dates = frm.doc.substitution_bill_date.map(row => row.date);
+		  if (dates.length === 0) {
+			  frappe.msgprint(__('Please enter at least one date in the Substitution Bill Date table.'));
+			  return;
+		  }
 
-          frappe.call({
-              method: 'beams.beams.doctype.substitute_booking.substitute_booking.check_leave_application',
-              args: {
-                  employee: frm.doc.substituting_for,
-                  dates: JSON.stringify(dates)
-              },
-              callback: function(r) {
-                  if (r.message) {
-                      let { leave_applications, missing_dates } = r.message;
+		  frappe.call({
+			  method: 'beams.beams.doctype.substitute_booking.substitute_booking.check_leave_application',
+			  args: {
+				  employee: frm.doc.substituting_for,
+				  dates: JSON.stringify(dates)
+			  },
+			  callback: function(r) {
+				  if (r.message) {
+					  let { leave_applications, missing_dates } = r.message;
 
-                      if (missing_dates && missing_dates.length > 0) {
-                          frappe.msgprint(__('No approved leave applications found for these dates: {0}', [missing_dates.join(', ')]));
-                      }
+					  if (missing_dates && missing_dates.length > 0) {
+						  frappe.msgprint(__('No approved leave applications found for these dates: {0}', [missing_dates.join(', ')]));
+					  }
 
-                      // Display approved leave applications
-                      if (leave_applications && Object.keys(leave_applications).length > 0) {
-                          let leaveDetails = Object.entries(leave_applications).map(([date, applications]) => {
-                              return `For date ${date}: ` + applications.map(leave =>
-                                  `Leave Application ${leave.name} from ${leave.from_date} to ${leave.to_date}`
-                              ).join(', ');
-                          }).join('<br>');
+					  // Display approved leave applications
+					  if (leave_applications && Object.keys(leave_applications).length > 0) {
+						  let leaveDetails = Object.entries(leave_applications).map(([date, applications]) => {
+							  return `For date ${date}: ` + applications.map(leave =>
+								  `Leave Application ${leave.name} from ${leave.from_date} to ${leave.to_date}`
+							  ).join(', ');
+						  }).join('<br>');
 
-                          frappe.msgprint(__('Approved Leave Applications:<br>{0}', [leaveDetails]));
+						  frappe.msgprint(__('Approved Leave Applications:<br>{0}', [leaveDetails]));
 
-                          // Navigate to Leave Application list view with filters
-                          frappe.set_route('List', 'Leave Application', {
-                              employee: frm.doc.substituting_for,
-                              status: 'Approved',
-                              from_date: ['<=', dates[0]],
-                              to_date: ['>=', dates[dates.length - 1]]
-                          });
-                      } else {
-                          frappe.msgprint(__('No approved leave applications found for the specified dates.'));
-                      }
-                  } else {
-                      frappe.msgprint(__('Error: No response received from the server.'));
-                  }
-              }
-          });
-      }, __("View"));
-
-
-
+						  // Navigate to Leave Application list view with filters
+						  frappe.set_route('List', 'Leave Application', {
+							  employee: frm.doc.substituting_for,
+							  status: 'Approved',
+							  from_date: ['<=', dates[0]],
+							  to_date: ['>=', dates[dates.length - 1]]
+						  });
+					  } else {
+						  frappe.msgprint(__('No approved leave applications found for the specified dates.'));
+					  }
+				  } else {
+					  frappe.msgprint(__('Error: No response received from the server.'));
+				  }
+			  }
+		  });
+	  }, __("View"));
 
 
-        // Check for payment button visibility
-        if (!frm.is_new() && !frm.doc.is_paid && frm.doc.workflow_state === "Approved") {
-            frm.add_custom_button(__('Make Payment'), function() {
-                frm.set_value("is_paid", 1); // Set payment status
-                frm.remove_custom_button(__('Make Payment')); // Remove button after setting paid
 
-                frm.call({
-                    doc: frm.doc,
-                    method: "create_journal_entry_from_substitute_booking",
-                });
-            });
-        }
 
-        // disabled '+' icon in connections for creating journal entry manually
-        if (frm.doc.status === 'Approved') {
-            frm.fields_dict['connections'].grid.wrapper.find('.grid-add').hide();
-        } else {
-            frm.fields_dict['connections'].grid.wrapper.find('.grid-add').show();
-        }
-    },
+
+		// Check for payment button visibility
+		if (!frm.is_new() && !frm.doc.is_paid && frm.doc.workflow_state === "Approved") {
+			frm.add_custom_button(__('Make Payment'), function() {
+				frm.set_value("is_paid", 1); // Set payment status
+				frm.remove_custom_button(__('Make Payment')); // Remove button after setting paid
+
+				frm.call({
+					doc: frm.doc,
+					method: "create_journal_entry_from_substitute_booking",
+				});
+			});
+		}
+
+		// disabled '+' icon in connections for creating journal entry manually
+		if (frm.doc.status === 'Approved') {
+			frm.fields_dict['connections'].grid.wrapper.find('.grid-add').hide();
+		} else {
+			frm.fields_dict['connections'].grid.wrapper.find('.grid-add').show();
+		}
+	},
 
     // Triggered when the 'substituting_for' field is changed
     substituting_for: function(frm) {
@@ -181,5 +182,23 @@ function update_budget_exceeded_visibility(frm) {
     if (!frm.doc.is_budgeted) {
         frm.set_value("is_budget_exceeded", 0);
     }
+}
+
+/*
+Set Bureau and Mode of Payment based on logged-in user's Employee record.
+*/
+function set_bureau_and_account(frm) {
+	frappe.db.get_value("Employee", { "user_id": frappe.session.user }, "bureau")
+		.then(res => {
+			if (res.message && res.message.bureau) {
+				frm.set_value("bureau", res.message.bureau);
+				frappe.db.get_value("Bureau", res.message.bureau, "mode_of_payment")
+					.then(r2 => {
+						if (r2.message && r2.message.mode_of_payment) {
+							frm.set_value("mode_of_payment", r2.message.mode_of_payment);
+						}
+					});
+			}
+		});
 }
 

--- a/beams/beams/doctype/substitute_booking/substitute_booking.py
+++ b/beams/beams/doctype/substitute_booking/substitute_booking.py
@@ -43,12 +43,22 @@ class SubstituteBooking(Document):
 		"""
 		Creation of Journal Entry on the Approval of the Substitute Booking.
 		"""
-		# Fetch debit and credit accounts from custom settings or any relevant logic
-		default_credit_account = frappe.db.get_single_value('Beams Accounts Settings', 'default_credit_account')
+		mode_of_payment = self.mode_of_payment
+		if not mode_of_payment:
+			frappe.throw("Mode of Payment is not selected. Please select a Mode of Payment.")
+		credit_account = frappe.db.get_value(
+			"Mode of Payment Account",
+			{
+				"parent": mode_of_payment,
+				"parenttype": "Mode of Payment"
+			},
+			"default_account"
+		)
 		default_debit_account = frappe.db.get_single_value('Beams Accounts Settings', 'default_debit_account')
 		# Validate that both debit and credit accounts are configured and different
-		if not default_credit_account:
-			frappe.throw("Please configure the Default Credit Account in the Beams Accounts Settings.")
+		if not credit_account:
+			frappe.throw(f"Please Configure for the Selected Mode of Payment "f"<b>{mode_of_payment}</b> Account")
+
 		if not default_debit_account:
 			frappe.throw("Please configure the Default Debit Account in the Beams Accounts Settings.")
 		if not self.is_paid:
@@ -64,24 +74,19 @@ class SubstituteBooking(Document):
 				journal_entry.substitute_booking_reference = self.name
 				journal_entry.posting_date = frappe.utils.nowdate()
 				journal_entry.append('accounts', {
-					'account': default_credit_account,
-					'party_type': 'Employee',
-					'party': self.substituting_for,
+					'account': credit_account,
 					'debit_in_account_currency': 0,
 					'credit_in_account_currency': self.total_wage,
 				})
 				journal_entry.append('accounts', {
 					'account': default_debit_account,
-					'party_type': 'Employee',
-					'party': self.substituting_for,
 					'debit_in_account_currency': self.total_wage,
 					'credit_in_account_currency': 0,
 				})
+				journal_entry.user_remark = f"Created from Substitute Booking.{self.name}  Substitute Person: {self.substituted_by} and substituted to {self.substituting_for}"
 				# Insert and submit the Journal Entry
 				journal_entry.insert(ignore_permissions=True)
-				journal_entry.submit()
 				frappe.msgprint(f"Journal Entry {journal_entry.name} has been created successfully.", alert=True)
-
 
 	def before_save(self):
 		self.calculate_no_of_days()


### PR DESCRIPTION
## Issue description
TASK-2025-02778
1. When creating journal entry from the substitute booking and do not use the Creditors account from Beams Account Settings.
2. Journal entry  created Should be  in draft state
3. Need to auto fetch the Bureau in Substitute Booking 
4 .No Party or Party Type should be included in the Journal Entry.
5 also set the user remark in journal entry 

## Solution description
1.Implemented that when creating journal entry from the substitute booking  use mode of payment field account as credit account
2. remove the submit line of code to make journal entry as draft state
3. This code checks the logged-in user’s linked Employee record and fetches their Bureau.
If a Bureau is found, it automatically sets the Bureau field in the form and then fetches the Bureau’s Mode of Payment, updating the mode_of_payment field accordingly
4. remove the code line to set the party and party type in journal enrty
5. set the user remark in journal entry 


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.
[Screencast from 04-12-25 09:54:11 AM IST.webm](https://github.com/user-attachments/assets/0bba06d0-2913-4cca-bef0-0405df6a3044)
<img width="1813" height="983" alt="image" src="https://github.com/user-attachments/assets/f99c9a73-32c7-4959-bf36-3803b4784d6b" />


## Areas affected and ensured
Substitute Booking and Journal enrty
## Is there any existing behaviour change of other features due to this code change?
No. 

## Was this feature tested on these browsers?

- [ ]   Mozilla Firefox

