### PR TITLE
feat : Add Fields Is Budget and Is Budget Exceed in doctypes

### DIFF
--- a/beams/beams/doctype/batta_claim/batta_claim.json
+++ b/beams/beams/doctype/batta_claim/batta_claim.json
@@ -24,6 +24,7 @@
   "destination",
   "mode_of_travelling",
   "is_budgeted",
+  "is_budget_exceed",
   "is_travelling_outside_kerala",
   "is_overnight_stay",
   "is_avail_room_rent",
@@ -305,10 +306,17 @@
    "options": "Employee Travel Request"
   },
   {
-   "default": "0",
+   "default": "1",
    "fieldname": "is_budgeted",
    "fieldtype": "Check",
    "label": "Is Budgeted"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.is_budgeted == 1",
+   "fieldname": "is_budget_exceed",
+   "fieldtype": "Check",
+   "label": " Is Budget Exceed"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -323,7 +331,7 @@
    "link_fieldname": "batta_claim_reference"
   }
  ],
- "modified": "2025-11-29 09:26:33.695459",
+ "modified": "2025-12-04 14:58:19.506788",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Batta Claim",

--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.json
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.json
@@ -14,6 +14,7 @@
   "is_vehicle_required",
   "is_unplanned",
   "is_budgeted",
+  "is__budget_exceed",
   "column_break_ooli",
   "posting_date",
   "is_management_employee",
@@ -262,10 +263,17 @@
    "label": "Remarks"
   },
   {
-   "default": "0",
+   "default": "1",
    "fieldname": "is_budgeted",
    "fieldtype": "Check",
    "label": "Is Budgeted"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.is_budgeted == 1",
+   "fieldname": "is__budget_exceed",
+   "fieldtype": "Check",
+   "label": "Is  Budget Exceed"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -288,7 +296,7 @@
    "link_fieldname": "travel_request"
   }
  ],
- "modified": "2025-12-02 15:35:03.167518",
+ "modified": "2025-12-04 14:57:36.267473",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Employee Travel Request",

--- a/beams/beams/doctype/stringer_bill/stringer_bill.json
+++ b/beams/beams/doctype/stringer_bill/stringer_bill.json
@@ -15,6 +15,7 @@
   "bureau",
   "cost_center",
   "is_budgeted",
+  "is_budget_exceed",
   "section_break_njgm",
   "stringer_bill_detail",
   "section_break_zcsv",
@@ -115,10 +116,17 @@
    "read_only": 1
   },
   {
-   "default": "0",
+   "default": "1",
    "fieldname": "is_budgeted",
    "fieldtype": "Check",
    "label": "Is Budgeted"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.is_budgeted == 1",
+   "fieldname": "is_budget_exceed",
+   "fieldtype": "Check",
+   "label": "Is Budget Exceed"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -129,7 +137,7 @@
    "link_fieldname": "stringer_bill_reference"
   }
  ],
- "modified": "2025-11-29 10:26:41.561924",
+ "modified": "2025-12-04 14:59:10.669682",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Stringer Bill",

--- a/beams/beams/doctype/trip_sheet/trip_sheet.json
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.json
@@ -29,6 +29,7 @@
   "trip_details_section",
   "trip_details",
   "is_budgeted",
+  "is_budget_exceed",
   "section_break_ygej",
   "initial_odometer_reading",
   "final_odometer_reading",
@@ -241,10 +242,17 @@
    "options": "Employees"
   },
   {
-   "default": "0",
+   "default": "1",
    "fieldname": "is_budgeted",
    "fieldtype": "Check",
    "label": "Is Budgeted"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.is_budgeted == 1",
+   "fieldname": "is_budget_exceed",
+   "fieldtype": "Check",
+   "label": "Is Budget Exceed "
   }
  ],
  "index_web_pages_for_search": 1,
@@ -259,7 +267,7 @@
    "link_fieldname": "trip_sheet"
   }
  ],
- "modified": "2025-12-01 09:46:08.527134",
+ "modified": "2025-12-04 15:00:58.861731",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Trip Sheet",

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -1002,9 +1002,8 @@ def get_purchase_order_custom_fields():
 				"fieldtype": "Check",
 				"label": "Is Budget Exceed",
 				"insert_after": "items_section",
-				"read_only":1,
 				"no_copy":1,
-				"depends_on": "eval:doc.is_budget_exceed == 1"
+				"depends_on": "eval:doc.is_budgeted == 1"
 
 			},
 			{
@@ -1030,6 +1029,7 @@ def get_purchase_order_custom_fields():
 			{
 				"fieldname": "is_budgeted",
 				"fieldtype": "Check",
+				"default": "1",
 				"label": "Is Budgeted",
 				"insert_after": "is_subcontracted"
 			},
@@ -5515,11 +5515,10 @@ def get_material_request_custom_fields():
 			{
 				"fieldname": "budget_exceeded",
 				"fieldtype": "Check",
-				"label": "Budget Exceeded",
+				"label": " Is Budget Exceed",
 				"insert_after": "location",
-				"read_only":1,
 				"no_copy":1,
-				"depends_on": "eval:doc.budget_exceeded == 1"
+				"depends_on": "eval:doc.is_budgeted == 1"
 			},
 			{
 				"fieldname": "requested_by",
@@ -5555,8 +5554,9 @@ def get_material_request_custom_fields():
 			{
 				"fieldname": "is_budgeted",
 				"fieldtype": "Check",
+				"default": "1",
 				"label": "Is Budgeted",
-				"insert_after": "buying_price_list",
+				"insert_after": "price_list",
 			},
 
 		]
@@ -5695,7 +5695,21 @@ def get_journal_entry_custom_fields():
 				"options": "Vehicle Incident Record",
 				"insert_after": "reference_voucher_entry",
 				"read_only": 1
-			}
+			},
+			{
+				"fieldname": "is_budgeted",
+				"fieldtype": "Check",
+				"default": "1",
+				"label": "Is Budgeted",
+				"insert_after": "apply_tds",
+			},
+			{
+				"fieldname": "budget_exceeded",
+				"fieldtype": "Check",
+				"label": " Is Budget Exceed",
+				"insert_after": "is_budgeted",
+				"depends_on": "eval:doc.is_budgeted == 1"
+			},
 		]
 	}
 
@@ -6078,7 +6092,22 @@ def get_expense_claim_custom_fields():
 				"options": "Employee Travel Request",
 				"insert_after": "approval_status",
 				"read_only": 1
-			}
+			},
+			{
+				"fieldname": "is_budgeted",
+				"fieldtype": "Check",
+				"default": "1",
+				"label": "Is Budgeted",
+				"insert_after": "travel_request",
+			},
+			{
+				"fieldname": "budget_exceeded",
+				"fieldtype": "Check",
+				"label": " Is Budget Exceed",
+				"insert_after": "is_budgeted",
+				"depends_on": "eval:doc.is_budgeted == 1"
+			},
+
 		]
 	}
 


### PR DESCRIPTION
## Feature description
TASK-2025-02796
1. Need to add fields (check )Is budget and is budget exceed  in Purchase Order Employee Travel Request, Batta Claim, Material Request,Journal Entry ,Expense Claim,Stringer Bill and  Trip Sheet doctype
2. Is budget is should be Is Budgeted must be checked by default.
3. Is Budget Exceed checkbox must be visible only when Is Budgeted is checked.and also If Is Budgeted is unchecked, the Is Budget Exceed checkbox should be hidden.


## Solution description
1. added  fields (check )Is budget and is budget exceed  in  Employee Travel Request, Batta Claim, Material Request,Journal Entry ,Expense Claim,Stringer Bill and  Trip Sheet doctype
2. set fields Is budget is should be Is Budgeted  as default = 1 in doctypes
3. added display depends on the  Is Budget Exceed field to achieve
## Output screenshots (optional)
<img width="1694" height="907" alt="image" src="https://github.com/user-attachments/assets/53473488-33e7-44a2-951e-3cc1c8fd7937" />
<img width="1694" height="907" alt="image" src="https://github.com/user-attachments/assets/55ded454-3752-40fb-b792-b9caf38b8acb" />
<img width="1694" height="907" alt="image" src="https://github.com/user-attachments/assets/f3437f70-9a68-43c2-bba4-d4000ecbb401" />
<img width="1694" height="907" alt="image" src="https://github.com/user-attachments/assets/d7dc1654-9ae0-4254-b949-dcf96d5b6191" />
<img width="1694" height="907" alt="image" src="https://github.com/user-attachments/assets/16d4cf74-d355-47de-94ea-cbd71b50e98f" />
<img width="1694" height="907" alt="image" src="https://github.com/user-attachments/assets/16ebfa5e-9c63-4983-9a52-e2bbd1c41609" />
<img width="1694" height="907" alt="image" src="https://github.com/user-attachments/assets/939806a4-de16-46f2-8a05-21546bce213a" />
<img width="1694" height="907" alt="image" src="https://github.com/user-attachments/assets/0da73330-d4be-40ac-962f-120c95dc45c9" />



## Areas affected and ensured

 Purchase Order Employee Travel Request, Batta Claim, Material Request,Journal Entry ,Expense Claim,Stringer Bill and  Trip Sheet doctype
## Is there any existing behaviour change of other features due to this code change?
 No. 
## Was this feature tested on these browsers?

- [ ]   Mozilla Firefox

