### PR TITLE
feat: Is budget and is budget exceed value mapping from ETR

### DIFF
--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.js
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.js
@@ -81,7 +81,9 @@ frappe.ui.form.on('Employee Travel Request', {
 								employee: frm.doc.requested_by,
 								employee_travel_request: frm.doc.name,
 								expenses: expenses,
-								mode_of_payment: values.mode_of_payment
+								mode_of_payment: values.mode_of_payment,
+								is_budgeted: frm.doc.is_budgeted || 0,
+								budget_exceeded: frm.doc.is__budget_exceed || 0
 							},
 							callback: function (r) {
 								if (!r.exc) {
@@ -196,7 +198,9 @@ frappe.ui.form.on('Employee Travel Request', {
 							args: {
 								employee: frm.doc.requested_by,
 								travel_request: frm.doc.name,
-								expenses: expenses
+								expenses: expenses,
+								is_budgeted: frm.doc.is_budgeted || 0,
+								budget_exceeded: frm.doc.is__budget_exceed || 0
 							},
 							callback: function (r) {
 								if (!r.exc) {
@@ -485,19 +489,23 @@ function validate_expense_date(field, frm) {
 Helper Function: Add Batta Claim Button
 */
 function create_batta_claim_from_travel(frm) {
-    if (frm.is_new() || frm.doc.workflow_state !== "Approved") {
-        return;
-    }
+	if (frm.is_new() || frm.doc.workflow_state !== "Approved") {
+		return;
+	}
 
-    frm.add_custom_button(__('Batta Claim'), () => {
+	frm.add_custom_button(__('Batta Claim'), () => {
 				frappe.call({
 					method: "beams.beams.doctype.employee_travel_request.employee_travel_request.create_batta_claim_from_etr",
-					args: {travel_request: frm.doc.name },
+					args: {
+						travel_request: frm.doc.name,
+						is_budgeted: frm.doc.is_budgeted || 0,
+						is_budget_exceed: frm.doc.is__budget_exceed || 0
+					},
 					callback: function (r) {
 						if (!r.message) return;
 						frappe.set_route("Form", "Batta Claim", r.message.name);
 					}
 				});
-    }, __("Create"));
+	}, __("Create"));
 }
 

--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.json
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.json
@@ -13,11 +13,11 @@
   "number_of_travellers",
   "is_vehicle_required",
   "is_unplanned",
-  "is_budgeted",
-  "is__budget_exceed",
   "column_break_ooli",
   "posting_date",
   "is_management_employee",
+  "is_budgeted",
+  "is__budget_exceed",
   "travel_details_section",
   "travel_type",
   "batta_policy",
@@ -296,7 +296,7 @@
    "link_fieldname": "travel_request"
   }
  ],
- "modified": "2025-12-04 14:57:36.267473",
+ "modified": "2025-12-05 12:31:57.633771",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Employee Travel Request",

--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.py
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.py
@@ -462,7 +462,7 @@ def filter_mode_of_travel(batta_policy_name):
 		return []
 
 @frappe.whitelist()
-def create_expense_claim(employee, travel_request, expenses):
+def create_expense_claim(employee, travel_request, expenses, is_budgeted, budget_exceeded):
 	'''
 	Create an Expense Claim from Travel Request.
 	'''
@@ -475,11 +475,14 @@ def create_expense_claim(employee, travel_request, expenses):
 
 	expense_claim = frappe.new_doc("Expense Claim")
 	expense_claim.travel_request = travel_request
+	expense_claim.is_budgeted = is_budgeted
+	expense_claim.budget_exceeded = budget_exceeded
 	expense_claim.employee = employee
 	expense_claim.approval_status = "Draft"
 	expense_claim.posting_date = today()
 	employee_doc = frappe.db.get_value("Employee", employee,["company","expense_approver"],as_dict=True)
 	company = employee_doc.company
+
 	expense_approver = employee_doc.expense_approver
 	expense_claim.expense_approver = expense_approver
 
@@ -663,7 +666,7 @@ def get_permission_query_conditions(user):
 	return " OR ".join(f"({cond.strip()})" for cond in conditions)
 
 @frappe.whitelist()
-def create_journal_entry_from_travel(employee, employee_travel_request, expenses, mode_of_payment):
+def create_journal_entry_from_travel(employee, employee_travel_request, expenses, mode_of_payment, is_budgeted, budget_exceeded):
 	"""
 		Create a Journal Entry from Travel Request
 	"""
@@ -693,6 +696,8 @@ def create_journal_entry_from_travel(employee, employee_travel_request, expenses
 	jv.user_remark = f"Journal Entry for Travel Request {employee_travel_request}"
 	jv.employee = employee
 	jv.employee_travel_request = employee_travel_request
+	jv.budget_exceeded = budget_exceeded
+	jv.is_budgeted = is_budgeted
 	jv.docstatus = 0
 
 	total_amount = 0
@@ -766,7 +771,7 @@ def assign_todo_for_accounts(employee_travel_request, journal_entry_name):
 				})
 
 @frappe.whitelist()
-def create_batta_claim_from_etr(travel_request):
+def create_batta_claim_from_etr(travel_request, is_budgeted, is_budget_exceed):
 	'''
 	Create Batta Claim from Employee Travel Request.
 	'''
@@ -783,6 +788,8 @@ def create_batta_claim_from_etr(travel_request):
 	bc = frappe.new_doc("Batta Claim")
 	bc.travel_request = doc.name
 	bc.employee = employee
+	bc.is_budgeted = is_budgeted
+	bc.is_budget_exceed = is_budget_exceed
 	bc.origin = doc.source
 	bc.destination = doc.destination
 	bc.purpose= doc.travel_type


### PR DESCRIPTION
## Feature description
Is  budget and is budget exceed value mapping from ETR to Journal Entry, Expense Claim, Batta Claim

- [x] TASK-2025-02799

## Solution description

- When the Is Budgeted and Is Budget Exceed checkbox is selected in the Employee Travel Request, the same value must be automatically mapped to the following documents when they are created from the Employee Travel Request:

      Journal Entry
      Expense Claim
      Batta Claim

-  changed the position of fields Is Budgeted & Is Budget Exceed  to below the posting date

## Output screenshots (optional)

[Screencast from 05-12-25 12:27:20 PM IST.webm](https://github.com/user-attachments/assets/0d910632-9321-45aa-b12b-beb21deda798)

[Screencast from 05-12-25 12:29:07 PM IST.webm](https://github.com/user-attachments/assets/563ebc3a-0b69-4708-97b4-45021eb81354)

<img width="1474" height="967" alt="image" src="https://github.com/user-attachments/assets/ecb6e277-b0e1-4885-a136-fe72a008b9c5" />


## Areas affected and ensured
      Journal Entry
      Expense Claim
      Batta Claim

## Is there any existing behaviour change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on these browsers?
- [ ]   Chrome
- [x]   Mozilla Firefox
- [ ]   Opera Mini
- [ ]   Safari
