### PR TITLE
fix: Auto cleared the budget exceed checkbox in doctypes

### DIFF
--- a/beams/beams/custom_scripts/expense_claim/expense_claim.js
+++ b/beams/beams/custom_scripts/expense_claim/expense_claim.js
@@ -1,0 +1,17 @@
+frappe.ui.form.on('Expense Claim',{
+	refresh(frm){
+		clear_checkbox_exceed(frm);
+	},
+	is_budgeted:function(frm){
+		clear_checkbox_exceed(frm);
+	},
+});
+
+/**
+* clear the "budget_exceeded" checkbox if "is_budgeted" is unchecked.
+*/
+function clear_checkbox_exceed(frm){
+	if(frm.doc.is_budgeted == 0){
+		frm.set_value("budget_exceeded", 0);
+	}
+}

--- a/beams/beams/custom_scripts/journal_entry/journal_entry.js
+++ b/beams/beams/custom_scripts/journal_entry/journal_entry.js
@@ -1,0 +1,17 @@
+frappe.ui.form.on('Journal Entry',{
+	refresh(frm){
+		clear_checkbox_exceed(frm);
+	},
+	is_budgeted:function(frm){
+		clear_checkbox_exceed(frm);
+	},
+});
+
+/**
+* Clears the "budget_exceeded" checkbox if "is_budgeted" is unchecked.
+*/
+function clear_checkbox_exceed(frm){
+	if(frm.doc.is_budgeted == 0){
+		frm.set_value("budget_exceeded", 0);
+	}
+}

--- a/beams/beams/custom_scripts/material_request/material_request.js
+++ b/beams/beams/custom_scripts/material_request/material_request.js
@@ -10,19 +10,22 @@ frappe.ui.form.on('Material Request', {
 				});
 		}
 	},
-    refresh(frm) {
+	refresh(frm) {
+		clear_checkbox_exceed(frm);
+		setTimeout(() => {
+			handle_workflow_actions(frm);
 
-        setTimeout(() => {
-            handle_workflow_actions(frm);
-
-            if (['Approved by HOD', 'Approved by Admin'].includes(frm.doc.workflow_state)) {
-                add_asset_movement_button(frm);
-                add_stock_entry_button(frm);
-            } else {
-                customize_material_request_buttons(frm);
-            }
-        }, 50);
-    }
+			if (['Approved by HOD', 'Approved by Admin'].includes(frm.doc.workflow_state)) {
+				add_asset_movement_button(frm);
+				add_stock_entry_button(frm);
+			} else {
+				customize_material_request_buttons(frm);
+			}
+		}, 50);
+	},
+	is_budgeted: function(frm){	
+		clear_checkbox_exceed(frm);
+	}
 });
 
 /**
@@ -315,4 +318,13 @@ function customize_material_request_buttons(frm) {
 	frm.remove_custom_button('Purchase Order', 'Create');
 	frm.remove_custom_button('Request for Quotation', 'Create');
 	frm.remove_custom_button('Supplier Quotation', 'Create');
+}
+
+/**
+* Clears the "budget_exceeded" checkbox if "is_budgeted" is unchecked.
+*/
+function clear_checkbox_exceed(frm){
+	if (frm.doc.is_budgeted == 0){
+		frm.set_value("budget_exceeded", 0);
+	}
 }

--- a/beams/beams/custom_scripts/purchase_order/purchase_order.js
+++ b/beams/beams/custom_scripts/purchase_order/purchase_order.js
@@ -1,6 +1,10 @@
 frappe.ui.form.on('Purchase Order', {
 	refresh(frm) {
 		workflow_actions(frm);
+		clear_checkbox_exceed(frm);
+	},
+	is_budgeted: function(frm){
+		clear_checkbox_exceed(frm);
 	}
 });
 
@@ -35,4 +39,13 @@ function workflow_actions(frm) {
 			});
 		}
 
+}
+
+/**
+* Clears the "is_budget_exceed" checkbox if "is_budgeted" is unchecked.
+*/
+function clear_checkbox_exceed(frm){
+	if (frm.doc.is_budgeted == 0){
+		frm.set_value("is_budget_exceed", 0);
+	}
 }

--- a/beams/beams/doctype/batta_claim/batta_claim.js
+++ b/beams/beams/doctype/batta_claim/batta_claim.js
@@ -69,6 +69,7 @@ frappe.ui.form.on('Batta Claim', {
     },
     //fetching policy values and setting fields read-only accordingly
     refresh: function(frm) {
+        clear_checkbox_exceed(frm);
         frappe.call({
             method: "beams.beams.doctype.batta_claim.batta_claim.get_batta_policy_values",
             callback: function(response) {
@@ -97,6 +98,9 @@ frappe.ui.form.on('Batta Claim', {
                 }
             }
         });
+    },
+    is_budgeted: function(frm){
+        clear_checkbox_exceed(frm);
     }
 });
 
@@ -413,4 +417,13 @@ function calculate_total_batta(frm, cdt, cdn) {
     let row = locals[cdt][cdn];
     frappe.model.set_value(cdt, cdn, "total_batta", (row.daily_batta || 0) + (row.total_food_allowance || 0));
     frm.refresh_field("work_detail");
+}
+
+/**
+* Clears the "is_budget_exceed" checkbox if "is_budgeted" is unchecked.
+*/      
+function clear_checkbox_exceed(frm){
+    if(frm.doc.is_budgeted == 0){
+        frm.set_value("is_budget_exceed", 0);
+    }
 }

--- a/beams/beams/doctype/stringer_bill/stringer_bill.js
+++ b/beams/beams/doctype/stringer_bill/stringer_bill.js
@@ -1,34 +1,47 @@
 frappe.ui.form.on('Stringer Bill', {
-    onload: function(frm) {
-      /*
-      * Set a query filter for the 'supplier' field to only show suppliers with 'is_stringer' set to 1
-      */
-        frm.set_query('supplier', function() {
-            return {
-                filters: {
-                    'is_stringer': 1
-                }
-            };
-        });
-    },
-    refresh: function (frm) {
-        calculate_total(frm);
-    }
+	onload: function(frm) {
+	  /*
+	  * Set a query filter for the 'supplier' field to only show suppliers with 'is_stringer' set to 1
+	  */
+		frm.set_query('supplier', function() {
+			return {
+				filters: {
+					'is_stringer': 1
+				}
+			};
+		});
+	},
+	refresh: function (frm) {
+		calculate_total(frm);
+		clear_checkbox_exceed(frm);
+	},
+	is_budgeted: function(frm){
+		clear_checkbox_exceed(frm);
+	}
 });
 
 frappe.ui.form.on('Stringer Bill Detail', {
-    stringer_amount: function (frm) {
-        calculate_total(frm);
-    },
-    stringer_bill_detail_remove: function (frm) {
-        calculate_total(frm);
-    }
+	stringer_amount: function (frm) {
+		calculate_total(frm);
+	},
+	stringer_bill_detail_remove: function (frm) {
+		calculate_total(frm);
+	}
 });
 
 function calculate_total(frm) {
-    let total = 0;
-    (frm.doc.stringer_bill_detail || []).forEach(row => {
-        total += row.stringer_amount || 0;  // Summing up child table amounts
-    });
-    frm.set_value('stringer_amount', total);
+	let total = 0;
+	(frm.doc.stringer_bill_detail || []).forEach(row => {
+		total += row.stringer_amount || 0;  // Summing up child table amounts
+	});
+	frm.set_value('stringer_amount', total);
+}
+
+/**
+* Clears the "is_budget_exceed" checkbox if "is_budgeted" is unchecked.
+*/
+function clear_checkbox_exceed(frm){
+	if(frm.doc.is_budgeted == 0){
+		frm.set_value("is_budget_exceed", 0);
+	}
 }

--- a/beams/beams/doctype/trip_sheet/trip_sheet.js
+++ b/beams/beams/doctype/trip_sheet/trip_sheet.js
@@ -24,6 +24,7 @@ frappe.ui.form.on('Trip Sheet', {
 		frm.call("calculate_and_validate_fuel_data");
 	},
 	refresh: function(frm) {
+		clear_checkbox_exceed(frm);
 		if (!frm.is_new()&& frm.doc.workflow_state === 'Approved') {
 			frm.add_custom_button(__('Request Batta'), function () {
 				frappe.call({
@@ -177,6 +178,9 @@ frappe.ui.form.on('Trip Sheet', {
 	vehicle_safety_inspection_details: function(frm) {
 		let all_fit_for_use = frm.doc.vehicle_safety_inspection_details.every(row => row.fit_for_use === 1);
 		frm.set_value('safety_inspection_completed', all_fit_for_use ? 1 : 0);
+	},
+	is_budgeted: function(frm){
+		clear_checkbox_exceed(frm);
 	}
 });
 
@@ -241,3 +245,12 @@ frappe.ui.form.on('Trip Details', {
 		});
 	}
 });
+
+/*
+clears the "is_budget_exceed" checkbox if "is_budgeted" is unchecked.
+*/
+function clear_checkbox_exceed(frm){
+	if (frm.doc.is_budgeted == 0){
+		frm.set_value("is_budget_exceed", 0);
+	}
+}

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -76,6 +76,8 @@ doctype_js = {
 	"Employment Type":"beams/custom_scripts/employment_type/employment_type.js",
 	"HD Team":"beams/custom_scripts/hd_team/hd_team.js",
 	"Item":"beams/custom_scripts/item/item.js",
+    "Journal Entry":"beams/custom_scripts/journal_entry/journal_entry.js",
+    "Expense Claim":"beams/custom_scripts/expense_claim/expense_claim.js",
 }
 
 doctype_list_js = {


### PR DESCRIPTION
## Issue description
TASK-2025-02806
 - when the is budgeted is unchecked the is budget exceed is remain checked means remain value is not cleared i
 Purchase Order, Bata Claim ,Material Request ,Journal Entry ,Expense Claim ,Stringer Bill  and Trip Sheet doctypes

## Solution description
- implemented  that when the is budgeted is unchecked the auto cleared the budget exceed checkbox in doctypes 
- Purchase Order, Bata Claim ,Material Request ,Journal Entry ,Expense Claim ,Stringer Bill  and Trip Sheet doctypes

##Output screenshots (optional)
[Screencast from 05-12-25 12:24:53 PM IST.webm](https://github.com/user-attachments/assets/de73402c-dde8-4006-93b6-f7bd283b6e34)
[Screencast from 05-12-25 12:15:03 PM IST.webm](https://github.com/user-attachments/assets/15fcaa7a-0dbe-48b0-a57a-1c020eb52920)


[Screencast from 05-12-25 12:26:41 PM IST.webm](https://github.com/user-attachments/assets/ebcbdf02-e561-4415-808e-71caa6b7c9bb)
[Screencast from 05-12-25 12:27:28 PM IST.webm](https://github.com/user-attachments/assets/aa2419f2-7da0-47bc-83d9-a5f77bcb365e)
[Uploading Screencast from 05-12-25 12:25:55 PM IST.webm…]()
[Screencast from 05-12-25 12:23:35 PM IST.webm](https://github.com/user-attachments/assets/c06796a5-429e-4a5c-b540-561cfb9e319e)
[Screencast from 05-12-25 12:22:04 PM IST.webm](https://github.com/user-attachments/asse
[Screencast from 05-12-25 12:16:10 PM IST.webm](https://github.com/user-attachments/assets/c22a1da7-563d-4ef5-99ae-96f40a3f6aca)
ts/51c4cb65-7a39-4ba2-9343-a54260b63f7a)





## Areas affected and ensured
Purchase Order, Bata Claim ,Material Request ,Journal Entry ,Expense Claim ,Stringer Bill  and Trip Sheet doctypes


## Is there any existing behaviour change of other features due to this code change?
 No. 

## Was this feature tested on these browsers?

- [ ]   Mozilla Firefox

