### PR TITLE
feat: reset is_budget_exceed when is_budgeted is unchecked

### DIFF
--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.js
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.js
@@ -13,7 +13,6 @@ frappe.ui.form.on('Employee Travel Request', {
 		set_expense_claim_html(frm)
 	},
 	refresh: function (frm) {
-		clear_checkbox_exceed(frm)
 
 		create_batta_claim_from_travel(frm);
 		if (!frm.is_new() && frappe.user.has_role("Admin")) {

--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.js
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.js
@@ -13,6 +13,7 @@ frappe.ui.form.on('Employee Travel Request', {
 		set_expense_claim_html(frm)
 	},
 	refresh: function (frm) {
+		clear_checkbox_exceed(frm)
 
 		create_batta_claim_from_travel(frm);
 		if (!frm.is_new() && frappe.user.has_role("Admin")) {
@@ -296,8 +297,13 @@ frappe.ui.form.on('Employee Travel Request', {
 
 	is_unplanned: function (frm) {
 		update_number_of_travellers_visibility(frm);
-	}
+	},
+
+	is_budgeted: function(frm){
+		clear_checkbox_exceed(frm);
+	},
 });
+
 // Toggles visibility of 'number_of_travellers' field based on 'is_group' status and 'travellers' table length.
 
 function update_number_of_travellers_visibility(frm) {
@@ -509,3 +515,11 @@ function create_batta_claim_from_travel(frm) {
 	}, __("Create"));
 }
 
+/**
+* clear the "budget_exceeded" checkbox if "is_budgeted" is unchecked.
+*/
+function clear_checkbox_exceed(frm){
+	if(!frm.doc.is_budgeted){
+		frm.set_value("is__budget_exceed",0);
+	}
+}


### PR DESCRIPTION
## Feature description

- [x] TASK-2025-02807

Reset is_budget_exceed when is_budgeted is unchecked

## Solution description

Reset is_budget_exceed when is_budgeted is unchecked

Refactored the entire code file

## Output screenshots (optional)

[Screencast from 05-12-25 03:29:16 PM IST.webm](https://github.com/user-attachments/assets/9bcd619c-2b8c-4f7d-a151-caa42ea2c004)

## Areas affected and ensured
ETR

## Is there any existing behaviour change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on these browsers?
- [ ]   Chrome
- [x]   Mozilla Firefox
- [ ]   Opera Mini
- [ ]   Safari
