### PR TITLE
feat : auto-check the checkboxes in material request doctype

### DIFF
--- a/beams/beams/custom_scripts/material_request/material_request.py
+++ b/beams/beams/custom_scripts/material_request/material_request.py
@@ -189,3 +189,24 @@ def create_todo_for_hod(doc, method):
 		"priority": "Medium",
 		"description": f"Please review Material Request {doc.name}"
 	})
+
+
+def set_checkbox_for_item_type(doc, method):
+	"""
+	Sets Technical or Non-Technical checkboxes on Material Request
+    based on the Item Type of items.
+
+	"""
+	doc.technical = 0
+	doc.non_technical = 0
+
+	for row in doc.items:
+		if not row.item_code:
+			continue
+		
+		item_type = frappe.db.get_value("Item", row.item_code, "item_type")
+		
+		if item_type == "Technical Item":
+			doc.technical = 1
+		elif item_type == "Non-Technical Item":
+			doc.non_technical = 1

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -223,7 +223,10 @@ doc_events = {
 		"on_change":"beams.beams.custom_scripts.purchase_order.purchase_order.update_equipment_quantities"
 	},
 	"Material Request":{
-		"before_save":"beams.beams.custom_scripts.purchase_order.purchase_order.validate_budget",
+		"before_save":[
+			"beams.beams.custom_scripts.purchase_order.purchase_order.validate_budget",
+			"beams.beams.custom_scripts.material_request.material_request.set_checkbox_for_item_type"
+             ],
 		"after_insert":"beams.beams.custom_scripts.material_request.material_request.notify_stock_managers",
 		"on_update": "beams.beams.custom_scripts.material_request.material_request.create_todo_for_hod",
 		"validate": "beams.beams.custom_scripts.material_request.material_request.validate"


### PR DESCRIPTION
## Feature description
TASK-2025-02805
1. Add two check box in Material Request doctype
2.  check box should be read only 
3. need to auto check the check box based on the item type in the item in item child table in material request

## Solution description
1. added two check boxes technical and non-technical  in material request doctype 
2. added res only for check boxes in the material request 
3. auto checked the checkbox technical and non technical corresponding item type in the item doctype in child table items in the material request doctype 


## Output screenshots (optional)
[Screencast from 05-12-25 03:47:24 PM IST.webm](https://github.com/user-attachments/assets/c0dc9ab3-6210-4099-9d59-61ae3d87ab9a)


## Areas affected and ensured
material request and item doctype

## Is there any existing behaviour change of other features due to this code change?
 No. 
## Was this feature tested on these browsers?

- [ ]   Mozilla Firefox
