### PR TITLE
TASK-2025-02804:Implement auto reset of is budget exceeded when is budgeted is unchecked

### DIFF
--- a/beams/beams/custom_scripts/voucher_entry/voucher_entry.js
+++ b/beams/beams/custom_scripts/voucher_entry/voucher_entry.js
@@ -20,6 +20,7 @@ frappe.ui.form.on("Voucher Entry", {
 			});
 		}
 		update_parent_checkboxes(frm);
+		update_budget_exceeded_visibility(frm);
 	},
 	voucher_accounts_add: function(frm) {
 		update_parent_checkboxes(frm);
@@ -30,10 +31,17 @@ frappe.ui.form.on("Voucher Entry", {
 });
 
 frappe.ui.form.on('Voucher Account', {
-	is_budgeted: function(frm) {
+	is_budgeted: function(frm, cdt, cdn) {
+		let row = locals[cdt][cdn];
+
+		if (!row.is_budgeted) {
+			frappe.model.set_value(cdt, cdn, "is_budget_exceeded", 0);
+		}
+
 		update_parent_checkboxes(frm);
+		update_budget_exceeded_visibility(frm);
 	},
-	budget_exceeded: function(frm) {
+	is_budget_exceeded: function(frm) {
 		update_parent_checkboxes(frm);
 	}
 });
@@ -51,7 +59,7 @@ function update_parent_checkboxes(frm) {
 			if (row.is_budgeted !== 1 && row.is_budgeted !== '1') {
 				is_budgeted_all = false;
 			}
-			if (row.budget_exceeded === 1 || row.budget_exceeded === '1') {
+			if (row.is_budget_exceeded === 1 || row.is_budget_exceeded === '1') {
 				is_budget_exceeded_any = true;
 			}
 		});
@@ -60,11 +68,18 @@ function update_parent_checkboxes(frm) {
 		is_budget_exceeded_any = false;
 	}
 
-	if (frm.doc.is_budgeted !== (is_budgeted_all ? 1 : 0)) {
-		frm.set_value('is_budgeted', is_budgeted_all ? 1 : 0);
+	let parent_is_budgeted = frm.doc.is_budgeted ? cint(frm.doc.is_budgeted) : 0;
+	let parent_is_budget_exceeded = frm.doc.is_budget_exceeded ? cint(frm.doc.is_budget_exceeded) : 0;
+
+	let new_is_budgeted = is_budgeted_all ? 1 : 0;
+	let new_is_budget_exceeded = is_budget_exceeded_any ? 1 : 0;
+
+	if (parent_is_budgeted !== new_is_budgeted) {
+		frm.set_value("is_budgeted", new_is_budgeted);
 	}
-	if (frm.doc.is_budget_exceeded !== (is_budget_exceeded_any ? 1 : 0)) {
-		frm.set_value('is_budget_exceeded', is_budget_exceeded_any ? 1 : 0);
+
+	if (parent_is_budget_exceeded !== new_is_budget_exceeded) {
+		frm.set_value("is_budget_exceeded", new_is_budget_exceeded);
 	}
 
 	frm.refresh_field('is_budgeted');
@@ -134,4 +149,15 @@ function submit_petty_cash_request(frm, values, dialog) {
 			}
 		}
 	});
+}
+
+/*
+ Handles showing / hiding is_budget_exceeded
+*/
+function update_budget_exceeded_visibility(frm) {
+	frm.toggle_display("is_budget_exceeded", frm.doc.is_budgeted == 1);
+
+	if (!frm.doc.is_budgeted) {
+		frm.set_value("is_budget_exceeded", 0);
+	}
 }

--- a/beams/beams/doctype/substitute_booking/substitute_booking.js
+++ b/beams/beams/doctype/substitute_booking/substitute_booking.js
@@ -21,6 +21,7 @@ frappe.ui.form.on("Substitute Booking", {
 },
 
   refresh: function(frm) {
+      update_budget_exceeded_visibility(frm);
       frm.add_custom_button(__('Leave Application List'), function() {
           if (!frm.doc.substitution_bill_date || frm.doc.substitution_bill_date.length === 0) {
               frappe.msgprint(__('No dates found in Substitution Bill Date child table.'));
@@ -119,6 +120,9 @@ frappe.ui.form.on("Substitute Booking", {
         } else {
             frm.set_value('paid_amount', null); // Clear paid amount if not paid
         }
+    },
+    is_budgeted(frm) {
+        update_budget_exceeded_visibility(frm);
     }
 });
 
@@ -167,3 +171,15 @@ if (no_of_days && daily_wage) {
   frm.set_value('total_wage', total_wage);
 }
 }
+
+/*
+ Handles showing / hiding is_budget_exceeded
+*/
+function update_budget_exceeded_visibility(frm) {
+    frm.toggle_display("is_budget_exceeded", frm.doc.is_budgeted);
+
+    if (!frm.doc.is_budgeted) {
+        frm.set_value("is_budget_exceeded", 0);
+    }
+}
+

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -2310,7 +2310,7 @@ def get_voucher_entry_custom_fields():
 						{
 				"fieldname": "is_budget_exceeded",
 				"fieldtype": "Check",
-				"label": "Is Budgete Exceeded",
+				"label": "Is Budget Exceeded",
 				"insert_after": "is_budgeted",
 				"depends_on": "eval:doc.is_budgeted == 1"
 			},
@@ -2324,9 +2324,9 @@ def get_voucher_entry_custom_fields():
 				"default": "1"
 			},
 			{
-				"fieldname": "budget_exceeded",
+				"fieldname": "is_budget_exceeded",
 				"fieldtype": "Check",
-				"label": "Budget Exceeded",
+				"label": "Is Budget Exceeded",
 				"insert_after": "is_budgeted",
 				"depends_on": "eval:doc.is_budgeted",
 			},


### PR DESCRIPTION
## Feature description
Need to: Implement auto-reset of is_budget_exceeded checkbox when is_budgeted check box  is unchecked

## Solution description

- Added client-side scripts to Substitute Booking and Voucher Entry doctypes.
- When Is Budgeted is unchecked:
    - Is Budget Exceeded is automatically reset to 0.
    - Is Budget Exceeded field is hidden immediately.
- When Is Budgeted is checked:
    - Is Budget Exceeded is visible.

## Output screenshots (optional)

[Screencast from 05-12-25 03:12:23 PM IST.webm](https://github.com/user-attachments/assets/1a2557bd-400e-4603-adc0-bd5de4a15913)


## Areas affected and ensured

Substitute booking doctype Voucher Entry doctype

## Is there any existing behaviour change of other features due to this code change?
 No.

## Was this feature tested on these browsers?
-  Chrome

