### PR TITLE
feat: Add custom fields in the Material Request doctype

### DIFF
--- a/beams/setup.py
+++ b/beams/setup.py
@@ -5558,7 +5558,20 @@ def get_material_request_custom_fields():
 				"label": "Is Budgeted",
 				"insert_after": "price_list",
 			},
-
+			{
+				"fieldname": "technical",
+				"fieldtype": "Check",
+				"label": " Technical",
+				"insert_after": "company",
+				"read_only": 1,
+			},
+			{
+				"fieldname": "non_technical",
+				"fieldtype": "Check",
+				"label": "Non-Technical",
+				"insert_after": "technical",
+				"read_only": 1,
+			},
 		]
 	}
 


### PR DESCRIPTION
## Feature description
TASK-2025-02805
1. need Add Custom fields checkboxes the technical and non-technical  in Material Request doctype


## Solution description
1. Added the custom fields checkboxes the technical and non technical  in Material Request doctype
2. added read only 

##Output screenshots (optional
[Screencast from 06-12-25 11:21:19 AM IST.webm](https://github.com/user-attachments/assets/f6c3290a-a496-4d74-8299-521625633ed9)
 
## Areas affected and ensured
Material Request doctype

## Is there any existing behaviour change of other features due to this code change?
 No. 

## Was this feature tested on these browsers?

- [ ]   Mozilla Firefox
