### PR TITLE
TASK-2025-02812:Set From Bureau checkbox when user has Bureau User role

### DIFF
--- a/beams/beams/custom_scripts/purchase_invoice/purchase_invoice.py
+++ b/beams/beams/custom_scripts/purchase_invoice/purchase_invoice.py
@@ -24,3 +24,12 @@ def validate_purchase_invoice(doc):
             # Compare the rounded totals
             if doc.rounded_total != quotation.rounded_total:
                 frappe.throw(_("The total amount of the Purchase Invoice does not match the Quotation amount. Please check and try again."))
+
+def set_from_bureau_flag(doc, method):
+    """
+	Sets the 'from_bureau' flag on the Purchase Invoice if the current user has the 'Bureau User' role.
+	"""
+    user = frappe.session.user
+    if "Bureau User" in frappe.get_roles(user):
+        doc.from_bureau = 1
+

--- a/beams/beams/doctype/batta_claim/batta_claim.json
+++ b/beams/beams/doctype/batta_claim/batta_claim.json
@@ -23,6 +23,7 @@
   "origin",
   "destination",
   "mode_of_travelling",
+  "from_bureau",
   "is_budgeted",
   "is_budget_exceed",
   "is_travelling_outside_kerala",
@@ -317,6 +318,13 @@
    "fieldname": "is_budget_exceed",
    "fieldtype": "Check",
    "label": " Is Budget Exceed"
+  },
+  {
+   "default": "0",
+   "fieldname": "from_bureau",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "From Bureau"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -331,7 +339,7 @@
    "link_fieldname": "batta_claim_reference"
   }
  ],
- "modified": "2025-12-04 14:58:19.506788",
+ "modified": "2025-12-06 11:55:57.725516",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Batta Claim",

--- a/beams/beams/doctype/batta_claim/batta_claim.py
+++ b/beams/beams/doctype/batta_claim/batta_claim.py
@@ -11,6 +11,18 @@ from frappe.model.document import Document
 
 
 class BattaClaim(Document):
+	def before_insert(self):
+		self.set_from_bureau_flag()
+
+	def set_from_bureau_flag(self):
+		"""
+		Sets the 'from_bureau' flag to 1 if the creating user has the
+		'Bureau User' role.
+		"""
+		user = frappe.session.user
+		if "Bureau User" in frappe.get_roles(user):
+			self.from_bureau = 1
+
 	def on_submit(self):
 		if self.workflow_state == 'Approved':
 			if not self.expense_type:

--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.json
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.json
@@ -15,6 +15,7 @@
   "is_unplanned",
   "column_break_ooli",
   "posting_date",
+  "from_bureau",
   "is_management_employee",
   "is_budgeted",
   "is__budget_exceed",
@@ -274,6 +275,13 @@
    "fieldname": "is__budget_exceed",
    "fieldtype": "Check",
    "label": "Is  Budget Exceed"
+  },
+  {
+   "default": "0",
+   "fieldname": "from_bureau",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "From Bureau"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -296,7 +304,7 @@
    "link_fieldname": "travel_request"
   }
  ],
- "modified": "2025-12-05 12:31:57.633771",
+ "modified": "2025-12-06 11:56:26.926500",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Employee Travel Request",

--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.py
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.py
@@ -16,6 +16,18 @@ from frappe.utils import get_datetime
 
 
 class EmployeeTravelRequest(Document):
+	def before_insert(self):
+		self.set_from_bureau_flag()
+
+	def set_from_bureau_flag(self):
+		"""
+		Sets the 'from_bureau' flag to 1 if the creating user has the
+		'Bureau User' role.
+		"""
+		user = frappe.session.user
+		if "Bureau User" in frappe.get_roles(user):
+			self.from_bureau = 1
+
 	def validate_reason_reject(self):
 		old_doc = self.get_doc_before_save()
 		if old_doc and old_doc.workflow_state != self.workflow_state:

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -197,7 +197,8 @@ doc_events = {
 		"autoname": "beams.beams.custom_scripts.quotation.quotation.autoname"
 	},
 	"Purchase Invoice": {
-		"before_save": "beams.beams.custom_scripts.purchase_invoice.purchase_invoice.before_save"
+		"before_save": "beams.beams.custom_scripts.purchase_invoice.purchase_invoice.before_save",
+		"before_insert": "beams.beams.custom_scripts.purchase_invoice.purchase_invoice.set_from_bureau_flag",
 	},
 	"Account": {
 		"after_insert": "beams.beams.custom_scripts.account.account.create_todo_on_creation_for_account"

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -1754,6 +1754,13 @@ def get_purchase_invoice_custom_fields():
 				"insert_after": "is_budgeted",
 				"depends_on": "eval:doc.is_budgeted"
 			},
+			{
+				"fieldname": "from_bureau",
+				"fieldtype": "Check",
+				"label": "From Bureau",
+				"insert_after": "budget_exceeded",
+				"hidden": 1,
+			}
 		]
 	}
 


### PR DESCRIPTION
## Feature description
Need to: 

- Add hidden checkbox field from_bureau in Batta Claim, Employee Travel Request, and Purchase Invoice
- Implement a server-side logic to set from_bureau = 1 during before_insert when the creating user has the "Bureau User" role

## Solution description
- Added hidden checkbox field from_bureau in Batta Claim, Employee Travel Request, and Purchase Invoice
- Implemented a server-side logic to set from_bureau = 1 during before_insert when the creating user has the "Bureau User" role

## Output screenshots (optional)

[Screencast from 06-12-25 11:49:49 AM IST.webm](https://github.com/user-attachments/assets/586e4c90-1856-4a6b-b4fe-fdb7f8ea5ee2)

[Screencast from 06-12-25 11:50:12 AM IST.webm](https://github.com/user-attachments/assets/8b0cca4f-ebe8-43d5-8802-e917b67a5a38)

[Screencast from 06-12-25 11:53:52 AM IST.webm](https://github.com/user-attachments/assets/7d820e7c-44eb-4f05-bdb4-7337f06e58b5)


## Areas affected and ensured
Batta Claim
Employee Travel Request
Purchase Invoice

## Is there any existing behaviour change of other features due to this code change?
No.

## Was this feature tested on these browsers?
- Chrome

