### PR TITLE
TASK-2025-02814:Ensure Is Budgeted checkbox appears in Material Request

### DIFF
--- a/beams/setup.py
+++ b/beams/setup.py
@@ -5520,14 +5520,6 @@ def get_material_request_custom_fields():
 	return {
 		"Material Request": [
 			{
-				"fieldname": "budget_exceeded",
-				"fieldtype": "Check",
-				"label": " Is Budget Exceed",
-				"insert_after": "location",
-				"no_copy":1,
-				"depends_on": "eval:doc.is_budgeted == 1"
-			},
-			{
 				"fieldname": "requested_by",
 				"fieldtype": "Link",
 				"label": "Requested By",
@@ -5563,7 +5555,15 @@ def get_material_request_custom_fields():
 				"fieldtype": "Check",
 				"default": "1",
 				"label": "Is Budgeted",
-				"insert_after": "price_list",
+				"insert_after": "location",
+			},
+			{
+				"fieldname": "budget_exceeded",
+				"fieldtype": "Check",
+				"label": " Is Budget Exceed",
+				"insert_after": "is_budgeted",
+				"no_copy":1,
+				"depends_on": "eval:doc.is_budgeted == 1",
 			},
 			{
 				"fieldname": "technical",


### PR DESCRIPTION
## Feature description
Need to: Ensure Is Budgeted checkbox appears in Material Request

## Solution description

Ensured Is Budgeted checkbox appears in Material Request

## Output screenshots (optional)
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/56a445a6-fada-4dae-9bc9-33aaaad44fc7" />

## Areas affected and ensured
Material Request doctype

## Is there any existing behaviour change of other features due to this code change?
No.

## Was this feature tested on these browsers?
-  Chrome

