### PR TITLE
fix: Duplicate portal pages appear in the portal page

### DIFF
--- a/beams/setup.py
+++ b/beams/setup.py
@@ -6309,13 +6309,31 @@ def get_hd_agent_custom_fields():
 	}
 
 def update_portal_settings():
-    """ update portal settings to change routes for specific menu items """
+    """Update Portal Settings:
+       - Remove standard RFQ & SQ pages
+       - Add custom menu items with custom routes and roles
+    """
     portal_settings = frappe.get_single('Portal Settings')
-
-    for data in portal_settings.menu:
-        if data.title == "Request for Quotations" and data.enabled:
-            data.route = "/request_for_quotation_list_view"
-        if data.title == "Supplier Quotation" and data.enabled:
-            data.route = "/supplier_quotation_list_view"
-
+    replace_titles = ["Request for Quotations", "Supplier Quotation"]
+    portal_settings.menu = [row for row in portal_settings.menu if row.title not in replace_titles]
+    custom_menu = [
+        {
+            "title": "Request for Quotations",
+            "route": "/request_for_quotation_list_view",
+            "enabled": 1,
+            "reference_doctype": "Request for Quotation",
+            "role": "Supplier"
+        },
+        {
+            "title": "Supplier Quotation",
+            "route": "/supplier_quotation_list_view",
+            "enabled": 1,
+            "reference_doctype": "Supplier Quotation",
+            "role": "Supplier"
+        }
+    ]
+    existing_titles = [row.title for row in portal_settings.custom_menu]
+    for item in custom_menu:
+        if item["title"] not in existing_titles:
+            portal_settings.append("custom_menu", item)
     portal_settings.save()


### PR DESCRIPTION
## Issue description
TASK-2025-02818
1. Duplicate portal page is appear for supplier quotation and Request for quotation portal page 

## Solution description
1. implement the logic of view of portal page for the supplier quotation and request for quotation 
 - removed the existed erp portal page and add the custom menu table to avoid duplicates 
## Output screenshots (optional)
<img width="1197" height="981" alt="image" src="https://github.com/user-attachments/assets/481d5772-fbfe-46da-b7be-1493821ae20e" />
<img width="1574" height="986" alt="image" src="https://github.com/user-attachments/assets/f72ca859-ed14-4a49-825b-38adb84be9ad" />


## Areas affected and ensured
portal page settings
## Is there any existing behaviour change of other features due to this code change?
No.

## Was this feature tested on these browsers?

- [ ]   Mozilla Firefox

