### PR TITLE
TASK-2025-02827:Make Mode of Payment mandatory before submission in Voucher Entry doctype

### DIFF
--- a/beams/setup.py
+++ b/beams/setup.py
@@ -5510,6 +5510,13 @@ def get_property_setters():
 			"property_type": "Small Text",
 			"value": "Open",
 		},
+		{
+			"doctype_or_field": "DocField",
+			"doc_type": "Voucher Entry",
+			"field_name": "mode_of_payment",
+			"property": "mandatory_depends_on",
+			"value": "eval: doc.workflow_state == 'Approved By Accounts User'",
+		},
 	]
 
 def get_material_request_custom_fields():
@@ -5864,7 +5871,7 @@ def get_beams_roles():
 		'Front Desk User', 'Asset Manager', 'Asset User',
 		'Management', 'Expense Approver', 'Bureau Head', 'News Coordinator',
 		'Expense Approver', 'Bureau Reporter', 'Expense Manager', 'News Coordinator', 'Budget Approver',
-		'Regional Bureau Head', 'Budget Manager', 'Stringer',
+		'Regional Bureau Head', 'Budget Manager', 'Stringer', 'Expense user',
 	]
 
 def get_custom_translations():


### PR DESCRIPTION
## Feature description
Need to: 

- Make Mode of Payment mandatory before submission in Voucher Entry doctype
- Add Expense User role

## Solution description
- Made Mode of Payment mandatory before submission in Voucher Entry doctype
- Added Expense User role

## Output screenshots (optional)

[Screencast from 08-12-25 02:44:50 PM IST.webm](https://github.com/user-attachments/assets/c003131d-ab7f-4502-ac24-d7ef6096fac7)

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/9c99eb2b-4af0-4017-aeba-85533f1fedc2" />


## Areas affected and ensured
Voucher entry doctype

## Is there any existing behaviour change of other features due to this code change?
No.

## Was this feature tested on these browsers?
-  Chrome

