### PR TITLE
feat:check has_bureau_head_role based on Bureau User role

### DIFF
--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.json
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.json
@@ -19,6 +19,7 @@
   "is_management_employee",
   "is_budgeted",
   "is__budget_exceed",
+  "has_bureau_head_role",
   "travel_details_section",
   "travel_type",
   "batta_policy",
@@ -282,6 +283,13 @@
    "fieldtype": "Check",
    "hidden": 1,
    "label": "From Bureau"
+  },
+  {
+   "default": "0",
+   "fieldname": "has_bureau_head_role",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Has Bureau Head Role"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -304,6 +312,7 @@
    "link_fieldname": "travel_request"
   }
  ],
+
  "modified": "2025-12-12 16:02:28.896125",
  "modified_by": "Administrator",
  "module": "BEAMS",

--- a/beams/beams/doctype/employee_travel_request/employee_travel_request.py
+++ b/beams/beams/doctype/employee_travel_request/employee_travel_request.py
@@ -13,9 +13,12 @@ from beams.beams.doctype.trip_sheet.trip_sheet import get_last_odometer
 from frappe.utils.user import get_users_with_role
 from frappe.desk.form.assign_to import add as add_assign
 from frappe.utils import get_datetime
+import frappe
+from frappe import get_roles
 
 
 class EmployeeTravelRequest(Document):
+
 	def before_insert(self):
 		self.set_from_bureau_flag()
 
@@ -27,6 +30,8 @@ class EmployeeTravelRequest(Document):
 		user = frappe.session.user
 		if "Bureau User" in frappe.get_roles(user):
 			self.from_bureau = 1
+
+		self.set_bureau_flag()
 
 	def validate_reason_reject(self):
 		old_doc = self.get_doc_before_save()
@@ -428,6 +433,32 @@ class EmployeeTravelRequest(Document):
 		if frappe.db.exists("Has Role", {"parent": employee_user, "role": role_to_check}):
 			self.is_management_employee = 1
 
+	def set_bureau_flag(self):
+		"""
+		Sets `has_bureau_head_role` automatically based on:
+		- Creator's roles
+		- Employee's linked user's roles (via requested_by)
+		"""
+		creator = frappe.session.user
+		if self.has_bureau_role(creator):
+			self.has_bureau_head_role = 1
+			return
+
+		employee = self.requested_by
+		if employee:
+			emp_user = frappe.db.get_value("Employee", employee, "user_id")
+			if emp_user and self.has_bureau_role(emp_user):
+				self.has_bureau_head_role = 1
+				return
+
+		self.has_bureau_head_role = 0
+
+	def has_bureau_role(self, user):
+		"""
+		Helper: Check whether a given User has the 'Bureau User' role.
+		"""
+		roles = get_roles(user)
+		return "Bureau User" in roles
 
 
 @frappe.whitelist()


### PR DESCRIPTION
## Feature description

- [ ] TASK-2025-02808

This feature automatically sets the has_bureau_head_role checkbox in Employee Travel Request based on the role of the user who creates the document or the role of the employee linked to the request.
If either user has the "Bureau User" role, the flag is automatically checked.

## Solution description

Added a checkbox that will be automatically checked if the document is created by a user who belongs to  an employee whose linked user has the Bureau User role.
In the Employee Travel Request, the field should be hidden.

## Output screenshots (optional)
<img width="1487" height="968" alt="image" src="https://github.com/user-attachments/assets/d760d2bd-ed48-43b7-bd8a-635e906f930a" />
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
before checkbox hiding

<img width="1487" height="968" alt="image" src="https://github.com/user-attachments/assets/c2aaa210-719d-48ae-b67e-7fd236b5034c" />

## Areas affected and ensured
Employee Travel Request 

## Is there any existing behaviour change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on these browsers?
- [ ]   Chrome
- [x]   Mozilla Firefox
- [ ]   Opera Mini
- [ ]   Safari
