### PR TITLE
TASK-2025-02869: pass item with qty

### DIFF
--- a/beams/beams/custom_scripts/supplier_quotation/supplier_quotation.py
+++ b/beams/beams/custom_scripts/supplier_quotation/supplier_quotation.py
@@ -40,6 +40,7 @@ def make_purchase_order_from_supplier_quotation(source_name, target_doc=None):
 			},
 			"Supplier Quotation Item": {
 				"doctype": "Purchase Order Item",
+				"condition": lambda doc: flt(doc.qty) > 0,
 				"field_map": [
 					["name", "supplier_quotation_item"],
 					["parent", "supplier_quotation"],


### PR DESCRIPTION
## Feature description
Even though the quantity and rate are not entered, the values are still being fetched for both the item we suggested and the item they suggested. However, according to the task, these values should not be fetched in either case if the quantity or the rate is missing.in supplier quotation and purchase odder

## Solution description
1. Before creating purchase order pass those item with qty greater than 0

## Output screenshots (optional)
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/ad069f38-046c-4409-abb6-8da1831245ea" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/ff313014-695a-4a25-8318-9ac3ff6fee8b" />



## Was this feature tested on these browsers?
- [ ]   Chrome

