### PR TITLE
TASK-2025-02831: move food allowance and total batta calculations to server-side

### DIFF
--- a/beams/beams/doctype/batta_claim/batta_claim.js
+++ b/beams/beams/doctype/batta_claim/batta_claim.js
@@ -2,219 +2,215 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Batta Claim', {
-    validate: function(frm) {
-        calculate_total_distance_travelled(frm);
-        calculate_total_daily_batta(frm);
-        update_all_daily_batta(frm);
-        calculate_batta(frm);
-        calculate_total_hours(frm);
-    },
-    batta: function(frm) {
-        update_all_daily_batta(frm);
-    },
-    ot_batta: function(frm) {
-        update_all_daily_batta(frm);
-    },
-    room_rent_batta: function(frm) {
-        calculate_batta(frm);
-        if (frm.doc.room_rent_batta < 0) {
-            frappe.msgprint({
-                message: "Room Rent Batta cannot be negative.",
-                indicator: "red"
-            });
-            frm.set_value("room_rent_batta", 0);
-        }
-    },
-    daily_batta_without_overnight_stay: function(frm) {
-        calculate_batta(frm);
-        if (frm.doc.daily_batta_without_overnight_stay < 0) {
-            frappe.msgprint({
-                message: "Daily Batta Without Overnight Stay cannot be negative.",
-                indicator: "red"
-            });
-            frm.set_value("daily_batta_without_overnight_stay", 0);
-        }
-    },
-    daily_batta_with_overnight_stay: function(frm) {
-        calculate_batta(frm);
-        if (frm.doc.daily_batta_with_overnight_stay < 0) {
-            frappe.msgprint({
-                message: "Daily Batta With Overnight Stay cannot be negative.",
-                indicator: "red"
-            });
-            frm.set_value("daily_batta_with_overnight_stay", 0);
-        }
-    },
-    is_travelling_outside_kerala: function(frm) {
-        update_all_daily_batta(frm);
-        calculate_allowance(frm);
-    },
-    is_overnight_stay: function(frm) {
-        update_all_daily_batta(frm);
-        calculate_allowance(frm);
-        frm.doc.work_detail.forEach(row => {
-          set_batta_for_food_allowance(frm, row["doctype"], row["name"]);
-          set_batta_for_food_allowance(frm, row["doctype"], row["name"]);
-        })
-    },
-    is_avail_room_rent: function(frm) {
-        update_all_daily_batta(frm);
-        calculate_allowance(frm);
-    },
-    is_delhi_bureau: function(frm) {
-      frm.doc.work_detail.forEach(row => {
-        set_batta_for_food_allowance(frm, row["doctype"], row["name"]);
-        set_batta_for_food_allowance(frm, row["doctype"], row["name"]);
-      })
-    },
-    //fetching policy values and setting fields read-only accordingly
-    refresh: function(frm) {
-        clear_checkbox_exceed(frm);
-        frappe.call({
-            method: "beams.beams.doctype.batta_claim.batta_claim.get_batta_policy_values",
-            callback: function(response) {
-                if (response.message) {
-                    let is_actual_daily_batta_without_overnight_stay = response.message.is_actual__;
-                    let is_actual_daily_batta_with_overnight_stay = response.message.is_actual_;
-                    let is_actual_room_rent_batta = response.message.is_actual;
-                    let is_actual_food_allowance = response.message.is_actual___;
+	validate: function(frm) {
+		calculate_total_distance_travelled(frm);
+		calculate_total_daily_batta(frm);
+		update_all_daily_batta(frm);
+		calculate_batta(frm);
+		calculate_total_hours(frm);
+	},
+	batta: function(frm) {
+		update_all_daily_batta(frm);
+	},
+	ot_batta: function(frm) {
+		update_all_daily_batta(frm);
+	},
+	room_rent_batta: function(frm) {
+		calculate_batta(frm);
+		if (frm.doc.room_rent_batta < 0) {
+			frappe.msgprint({
+				message: "Room Rent Batta cannot be negative.",
+				indicator: "red"
+			});
+			frm.set_value("room_rent_batta", 0);
+		}
+	},
+	daily_batta_without_overnight_stay: function(frm) {
+		calculate_batta(frm);
+		if (frm.doc.daily_batta_without_overnight_stay < 0) {
+			frappe.msgprint({
+				message: "Daily Batta Without Overnight Stay cannot be negative.",
+				indicator: "red"
+			});
+			frm.set_value("daily_batta_without_overnight_stay", 0);
+		}
+	},
+	daily_batta_with_overnight_stay: function(frm) {
+		calculate_batta(frm);
+		if (frm.doc.daily_batta_with_overnight_stay < 0) {
+			frappe.msgprint({
+				message: "Daily Batta With Overnight Stay cannot be negative.",
+				indicator: "red"
+			});
+			frm.set_value("daily_batta_with_overnight_stay", 0);
+		}
+	},
+	is_travelling_outside_kerala: function(frm) {
+		update_all_daily_batta(frm);
+		calculate_allowance(frm);
+	},
+	is_overnight_stay: function(frm) {
+		update_all_daily_batta(frm);
+		calculate_allowance(frm);
+		frm.doc.work_detail.forEach(row => {
+		  set_batta_for_food_allowance(frm, row["doctype"], row["name"]);
+		  set_batta_for_food_allowance(frm, row["doctype"], row["name"]);
+		})
+	},
+	is_avail_room_rent: function(frm) {
+		update_all_daily_batta(frm);
+		calculate_allowance(frm);
+	},
+	is_delhi_bureau: function(frm) {
+	  frm.doc.work_detail.forEach(row => {
+		set_batta_for_food_allowance(frm, row["doctype"], row["name"]);
+		set_batta_for_food_allowance(frm, row["doctype"], row["name"]);
+	  })
+	},
+	refresh: function(frm) {
+		clear_checkbox_exceed(frm);
+		frappe.call({
+			method: "beams.beams.doctype.batta_claim.batta_claim.get_batta_policy_values",
+			callback: function(response) {
+				if (response.message) {
+					let is_actual_daily_batta_without_overnight_stay = response.message.is_actual__;
+					let is_actual_daily_batta_with_overnight_stay = response.message.is_actual_;
+					let is_actual_room_rent_batta = response.message.is_actual;
+					let is_actual_food_allowance = response.message.is_actual___;
 
-                    // Set read-only based on conditions
-                    frm.set_df_property('daily_batta_without_overnight_stay', 'read_only', is_actual_daily_batta_without_overnight_stay == 0);
-                    frm.set_df_property('daily_batta_with_overnight_stay', 'read_only', is_actual_daily_batta_with_overnight_stay == 0);
-                    frm.set_df_property('room_rent_batta', 'read_only', is_actual_room_rent_batta == 0);
+					frm.set_df_property('daily_batta_without_overnight_stay', 'read_only', is_actual_daily_batta_without_overnight_stay == 0);
+					frm.set_df_property('daily_batta_with_overnight_stay', 'read_only', is_actual_daily_batta_with_overnight_stay == 0);
+					frm.set_df_property('room_rent_batta', 'read_only', is_actual_room_rent_batta == 0);
 
-                    // Refresh the fields to reflect the changes
-                    frm.refresh_field('daily_batta_without_overnight_stay');
-                    frm.refresh_field('daily_batta_with_overnight_stay');
-                    frm.refresh_field('room_rent_batta');
+					frm.refresh_field('daily_batta_without_overnight_stay');
+					frm.refresh_field('daily_batta_with_overnight_stay');
+					frm.refresh_field('room_rent_batta');
 
-                    frm.fields_dict['work_detail'].grid.update_docfield_property('breakfast', 'read_only', is_actual_food_allowance == 0);
-                    frm.fields_dict['work_detail'].grid.update_docfield_property('lunch', 'read_only', is_actual_food_allowance == 0);
-                    frm.fields_dict['work_detail'].grid.update_docfield_property('dinner', 'read_only', is_actual_food_allowance == 0);
+					frm.fields_dict['work_detail'].grid.update_docfield_property('breakfast', 'read_only', is_actual_food_allowance == 0);
+					frm.fields_dict['work_detail'].grid.update_docfield_property('lunch', 'read_only', is_actual_food_allowance == 0);
+					frm.fields_dict['work_detail'].grid.update_docfield_property('dinner', 'read_only', is_actual_food_allowance == 0);
 
-                    // Refresh child table
-                    frm.refresh_field('work_detail');
-                }
-            }
-        });
-    },
-    is_budgeted: function(frm){
-        clear_checkbox_exceed(frm);
-    }
+					frm.refresh_field('work_detail');
+				}
+			}
+		});
+	},
+	is_budgeted: function(frm){
+		clear_checkbox_exceed(frm);
+	}
 });
 
 frappe.ui.form.on('Work Detail', {
-    distance_travelled_km: function(frm, cdt, cdn) {
-        calculate_total_distance_travelled(frm);
-        setTimeout(() => {
-            set_batta_for_food_allowance(frm, cdt, cdn);
-            calculate_batta(frm, cdt, cdn);
-        }, 30);
-    },
-    daily_batta: function(frm, cdt, cdn) {
-        calculate_total_batta(frm, cdt, cdn);
-    },
-    breakfast: function(frm, cdt, cdn) {
-        let child = locals[cdt][cdn];
-        if (child.breakfast < 0) {
-            frappe.msgprint({
-                message: "Breakfast cannot be negative.",
-                indicator: "red"
-            });
+	distance_travelled_km: function(frm, cdt, cdn) {
+		calculate_total_distance_travelled(frm);
+		setTimeout(() => {
+			set_batta_for_food_allowance(frm, cdt, cdn);
+			calculate_batta(frm, cdt, cdn);
+		}, 30);
+	},
+	daily_batta: function(frm, cdt, cdn) {
+		calculate_total_batta(frm, cdt, cdn);
+	},
+	breakfast: function(frm, cdt, cdn) {
+		let child = locals[cdt][cdn];
+		if (child.breakfast < 0) {
+			frappe.msgprint({
+				message: "Breakfast cannot be negative.",
+				indicator: "red"
+			});
 
-            frappe.model.set_value(cdt, cdn, "breakfast", 0); // Reset to 0
-        }
-        calculate_total_food_allowance(frm, cdt, cdn);
-        calculate_total_batta(frm, cdt, cdn);
-    },
-    lunch: function(frm, cdt, cdn) {
-        let child = locals[cdt][cdn];
-        if (child.lunch < 0) {
-            frappe.msgprint({
-                message: "Lunch cannot be negative.",
-                indicator: "red"
-            });
+			frappe.model.set_value(cdt, cdn, "breakfast", 0);
+		}
+		calculate_total_food_allowance(frm, cdt, cdn);
+		calculate_total_batta(frm, cdt, cdn);
+	},
+	lunch: function(frm, cdt, cdn) {
+		let child = locals[cdt][cdn];
+		if (child.lunch < 0) {
+			frappe.msgprint({
+				message: "Lunch cannot be negative.",
+				indicator: "red"
+			});
 
-            frappe.model.set_value(cdt, cdn, "lunch", 0); // Reset to 0
-        }
-        calculate_total_food_allowance(frm, cdt, cdn);
-        calculate_total_batta(frm, cdt, cdn);
-    },
-    dinner: function(frm, cdt, cdn) {
-        let child = locals[cdt][cdn];
-        if (child.dinner < 0) {
-            frappe.msgprint({
-                message: "Dinner cannot be negative.",
-                indicator: "red"
-            });
+			frappe.model.set_value(cdt, cdn, "lunch", 0);
+		}
+		calculate_total_food_allowance(frm, cdt, cdn);
+		calculate_total_batta(frm, cdt, cdn);
+	},
+	dinner: function(frm, cdt, cdn) {
+		let child = locals[cdt][cdn];
+		if (child.dinner < 0) {
+			frappe.msgprint({
+				message: "Dinner cannot be negative.",
+				indicator: "red"
+			});
 
-            frappe.model.set_value(cdt, cdn, "dinner", 0); // Reset to 0
-        }
-        calculate_total_food_allowance(frm, cdt, cdn);
-        calculate_total_batta(frm, cdt, cdn);
-    },
-    total_batta: function(frm, cdt, cdn) {
-      calculate_total_daily_batta(frm, cdt, cdn);
-    },
-    total_food_allowance: function(frm, cdt, cdn) {
-        calculate_total_batta(frm, cdt, cdn);
-    },
-    work_detail_add: function(frm, cdt, cdn) {
-      const { origin, destination } = frm.doc;
-        frappe.model.set_value(cdt, cdn, 'origin', origin);
-        frappe.model.set_value(cdt, cdn, 'destination', destination);
+			frappe.model.set_value(cdt, cdn, "dinner", 0);
+		}
+		calculate_total_food_allowance(frm, cdt, cdn);
+		calculate_total_batta(frm, cdt, cdn);
+	},
+	total_batta: function(frm, cdt, cdn) {
+	  calculate_total_daily_batta(frm, cdt, cdn);
+	},
+	total_food_allowance: function(frm, cdt, cdn) {
+		calculate_total_batta(frm, cdt, cdn);
+	},
+	work_detail_add: function(frm, cdt, cdn) {
+	  const { origin, destination } = frm.doc;
+		frappe.model.set_value(cdt, cdn, 'origin', origin);
+		frappe.model.set_value(cdt, cdn, 'destination', destination);
 
-        calculate_total_distance_travelled(frm);
-        calculate_total_daily_batta(frm);
-        calculate_total_hours(frm);
-        setTimeout(() => {
-            calculate_batta(frm, cdt, cdn);
-        }, 30);
-    },
-    work_detail_remove: function(frm, cdt, cdn) {
-        calculate_total_distance_travelled(frm);
-        calculate_total_daily_batta(frm);
-        calculate_total_hours(frm);
-        setTimeout(() => {
-            calculate_batta(frm, cdt, cdn);
-        }, 30);
-    },
-    total_hours: function(frm, cdt, cdn) {
-        calculate_daily_batta(frm, cdt, cdn);
-        calculate_total_hours(frm,cdt,cdn);
-        set_batta_for_food_allowance(frm, cdt, cdn);
-    },
-    ot_hours: function(frm, cdt, cdn) {
-        calculate_daily_batta(frm, cdt, cdn);
-    },
-    from_date_and_time: function(frm, cdt, cdn) {
-        calculate_hours(frm, cdt, cdn);
-        calculate_daily_batta(frm, cdt, cdn);
-        setTimeout(() => {
-            set_batta_for_food_allowance(frm, cdt, cdn);
-            calculate_batta(frm, cdt, cdn);
-        }, 500);
-    },
-    to_date_and_time: function(frm, cdt, cdn) {
-      let row = locals[cdt][cdn];
+		calculate_total_distance_travelled(frm);
+		calculate_total_daily_batta(frm);
+		calculate_total_hours(frm);
+		setTimeout(() => {
+			calculate_batta(frm, cdt, cdn);
+		}, 30);
+	},
+	work_detail_remove: function(frm, cdt, cdn) {
+		calculate_total_distance_travelled(frm);
+		calculate_total_daily_batta(frm);
+		calculate_total_hours(frm);
+		setTimeout(() => {
+			calculate_batta(frm, cdt, cdn);
+		}, 30);
+	},
+	total_hours: function(frm, cdt, cdn) {
+		calculate_daily_batta(frm, cdt, cdn);
+		calculate_total_hours(frm,cdt,cdn);
+		set_batta_for_food_allowance(frm, cdt, cdn);
+	},
+	ot_hours: function(frm, cdt, cdn) {
+		calculate_daily_batta(frm, cdt, cdn);
+	},
+	from_date_and_time: function(frm, cdt, cdn) {
+		calculate_hours(frm, cdt, cdn);
+		calculate_daily_batta(frm, cdt, cdn);
+		setTimeout(() => {
+			set_batta_for_food_allowance(frm, cdt, cdn);
+			calculate_batta(frm, cdt, cdn);
+		}, 500);
+	},
+	to_date_and_time: function(frm, cdt, cdn) {
+	  let row = locals[cdt][cdn];
 
-      if (row.from_date_and_time && row.to_date_and_time) {
-          let from_date = new Date(row.from_date_and_time);
-          let to_date = new Date(row.to_date_and_time);
+	  if (row.from_date_and_time && row.to_date_and_time) {
+		  let from_date = new Date(row.from_date_and_time);
+		  let to_date = new Date(row.to_date_and_time);
 
-          if (to_date <= from_date) {
-              frappe.msgprint(__('To Date & Time must be greater than From Date & Time'));
-              frappe.model.set_value(cdt, cdn, 'to_date_and_time', null);
-              return;
-        }
-        calculate_hours(frm, cdt, cdn);
-        calculate_daily_batta(frm, cdt, cdn);
-        setTimeout(() => {
-            set_batta_for_food_allowance(frm, cdt, cdn);
-            calculate_batta(frm, cdt, cdn);
-        }, 500);
-    }
+		  if (to_date <= from_date) {
+			  frappe.msgprint(__('To Date & Time must be greater than From Date & Time'));
+			  frappe.model.set_value(cdt, cdn, 'to_date_and_time', null);
+			  return;
+		}
+		calculate_hours(frm, cdt, cdn);
+		calculate_daily_batta(frm, cdt, cdn);
+		setTimeout(() => {
+			set_batta_for_food_allowance(frm, cdt, cdn);
+			calculate_batta(frm, cdt, cdn);
+		}, 500);
+	}
   }
 });
 
@@ -222,230 +218,228 @@ frappe.ui.form.on('Work Detail', {
   Calculates the total distance traveled based on all work detail entries.
 */
 function calculate_total_distance_travelled(frm) {
-    let totalDistance = 0;
-    frm.doc.work_detail.forEach(row => {
-        totalDistance += row.distance_travelled_km || 0;
-    });
-    frm.set_value('total_distance_travelled_km', totalDistance);
+	let totalDistance = 0;
+	frm.doc.work_detail.forEach(row => {
+		totalDistance += row.distance_travelled_km || 0;
+	});
+	frm.set_value('total_distance_travelled_km', totalDistance);
 }
 
 /*
   Calculates the total hours worked based on all work detail entries.
 */
 function calculate_total_hours(frm) {
-    let totalHours = 0;
-    frm.doc.work_detail.forEach(row => {
-        totalHours += row.total_hours || 0;
-    });
-    frm.set_value('total_hours', totalHours);
+	let totalHours = 0;
+	frm.doc.work_detail.forEach(row => {
+		totalHours += row.total_hours || 0;
+	});
+	frm.set_value('total_hours', totalHours);
 }
 
 /*
   Calculates hours worked for a specific row based on the from and to date/time fields.
 */
 function calculate_hours(frm, cdt, cdn) {
-    let row = frappe.get_doc(cdt, cdn);
-    if (row.from_date_and_time && row.to_date_and_time) {
-        let total_hours = (new Date(row.to_date_and_time) - new Date(row.from_date_and_time)) / (1000 * 60 * 60);
-                frappe.model.set_value(cdt, cdn, 'total_hours', total_hours.toFixed(2));
-    }
+	let row = frappe.get_doc(cdt, cdn);
+	if (row.from_date_and_time && row.to_date_and_time) {
+		let total_hours = (new Date(row.to_date_and_time) - new Date(row.from_date_and_time)) / (1000 * 60 * 60);
+				frappe.model.set_value(cdt, cdn, 'total_hours', total_hours.toFixed(2));
+	}
 }
 
 /*
   Calculates the daily batta based on the total hours worked and the batta type.
 */
 function calculate_daily_batta(frm, cdt, cdn) {
-    let row = frappe.get_doc(cdt, cdn);
-    let total_hours = row.total_hours || 0;
-    let distance = row.distance_travelled_km || 0;
-    let number_of_days = Math.max(1, Math.ceil(total_hours / 24));
-    frappe.model.set_value(cdt, cdn, "number_of_days", number_of_days);
-    frappe.model.set_value(cdt, cdn, "daily_batta", 0);
-    if (frm.doc.batta_based_on === 'Daily') {
-    if (distance >= 100 && total_hours >= 8) {
-        let parent_batta = frm.doc.daily_batta_without_overnight_stay || 0;
-        let daily_batta = number_of_days * parent_batta;
+	let row = frappe.get_doc(cdt, cdn);
+	let total_hours = row.total_hours || 0;
+	let distance = row.distance_travelled_km || 0;
+	let number_of_days = Math.max(1, Math.ceil(total_hours / 24));
+	frappe.model.set_value(cdt, cdn, "number_of_days", number_of_days);
+	frappe.model.set_value(cdt, cdn, "daily_batta", 0);
+	if (frm.doc.batta_based_on === 'Daily') {
+	if (distance >= 100 && total_hours >= 8) {
+		let parent_batta = frm.doc.daily_batta_without_overnight_stay || 0;
+		let daily_batta = number_of_days * parent_batta;
 
-        frappe.model.set_value(cdt, cdn, "daily_batta", daily_batta);
+		frappe.model.set_value(cdt, cdn, "daily_batta", daily_batta);
 
-    }
-    } 
-    
+	}
+	}
 }
 
 /*
   Updates daily batta for all child rows in the work detail table.
 */
 function update_all_daily_batta(frm) {
-    if (frm.doc.work_detail) {
-        frm.doc.work_detail.forEach(row => {
-            calculate_daily_batta(frm, row.doctype, row.name);
-        });
-    }
+	if (frm.doc.work_detail) {
+		frm.doc.work_detail.forEach(row => {
+			calculate_daily_batta(frm, row.doctype, row.name);
+		});
+	}
 }
 
 /*
   Calculates the total daily batta across all work detail entries.
 */
 function calculate_total_daily_batta(frm) {
-    let totalDailyBatta = 0;
-    frm.doc.work_detail.forEach(row => {
-        totalDailyBatta += row.total_batta || 0;
-    });
-    frm.set_value('total_daily_batta', totalDailyBatta);
+	let totalDailyBatta = 0;
+	frm.doc.work_detail.forEach(row => {
+		totalDailyBatta += row.total_batta || 0;
+	});
+	frm.set_value('total_daily_batta', totalDailyBatta);
 }
 
 /* Sets the batta-based options based on the selected batta type.*/
 function set_batta_based_on_options(frm) {
-    if (frm.doc.batta_type === 'Internal') {
-        frm.set_df_property('batta_based_on', 'options', ['Daily']);
-        frm.set_value('batta_based_on', 'Daily');
-    }
+	if (frm.doc.batta_type === 'Internal') {
+		frm.set_df_property('batta_based_on', 'options', ['Daily']);
+		frm.set_value('batta_based_on', 'Daily');
+	}
 }
 
 /* Calculates total batta based on room rent, daily batta with and without overnight stay.*/
 function calculate_batta(frm) {
-    let total_batta = (frm.doc.room_rent_batta || 0)
-                    + (frm.doc.daily_batta_without_overnight_stay || 0)
-                    + (frm.doc.daily_batta_with_overnight_stay || 0);
+	let total_batta = (frm.doc.room_rent_batta || 0)
+					+ (frm.doc.daily_batta_without_overnight_stay || 0)
+					+ (frm.doc.daily_batta_with_overnight_stay || 0);
 
-    frm.set_value('batta', total_batta);
+	frm.set_value('batta', total_batta);
 }
 
 function calculate_allowance(frm) {
-    if (!frm.doc.designation.length) {
-        frappe.msgprint(__("Please select a designation."));
-        return;
-    }
+	if (!frm.doc.designation.length) {
+		frappe.msgprint(__("Please select a designation."));
+		return;
+	}
 
-    frappe.call({
-        method: "beams.beams.doctype.batta_claim.batta_claim.calculate_batta_allowance",
-        args: {
-            designation: frm.doc.designation,
-            is_travelling_outside_kerala: frm.doc.is_travelling_outside_kerala || 0,
-            is_overnight_stay: frm.doc.is_overnight_stay || 0,
-            is_avail_room_rent: frm.doc.is_avail_room_rent || 0,
-            total_distance_travelled_km: frm.doc.total_distance_travelled_km || 0,
-            total_hours: frm.doc.total_hours || 0
-        },
-        callback: function(r) {
-            if (r.message) {
-                frm.set_value("room_rent_batta", r.message.room_rent_batta);
-                frm.set_value("daily_batta_with_overnight_stay", r.message.daily_batta_with_overnight_stay);
-                frm.set_value("daily_batta_without_overnight_stay", r.message.daily_batta_without_overnight_stay);
-                frm.set_value("batta", r.message.batta);
-            }
-        }
-    });
+	frappe.call({
+		method: "beams.beams.doctype.batta_claim.batta_claim.calculate_batta_allowance",
+		args: {
+			designation: frm.doc.designation,
+			is_travelling_outside_kerala: frm.doc.is_travelling_outside_kerala || 0,
+			is_overnight_stay: frm.doc.is_overnight_stay || 0,
+			is_avail_room_rent: frm.doc.is_avail_room_rent || 0,
+			total_distance_travelled_km: frm.doc.total_distance_travelled_km || 0,
+			total_hours: frm.doc.total_hours || 0
+		},
+		callback: function(r) {
+			if (r.message) {
+				frm.set_value("room_rent_batta", r.message.room_rent_batta);
+				frm.set_value("daily_batta_with_overnight_stay", r.message.daily_batta_with_overnight_stay);
+				frm.set_value("daily_batta_without_overnight_stay", r.message.daily_batta_without_overnight_stay);
+				frm.set_value("batta", r.message.batta);
+			}
+		}
+	});
 }
 /* Determines eligibility for food allowance and updates fields accordingly.*/
 function set_batta_for_food_allowance(frm, cdt, cdn) {
-    let child = locals[cdt][cdn];
-    let designation = frm.doc.designation;
-    let is_overnight_stay = frm.doc.is_overnight_stay;
-    let is_delhi_bureau = frm.doc.is_delhi_bureau;
+	let child = locals[cdt][cdn];
+	let designation = frm.doc.designation;
+	let is_overnight_stay = frm.doc.is_overnight_stay;
+	let is_delhi_bureau = frm.doc.is_delhi_bureau;
 
-    if (!designation) return;
-    let distance = parseFloat(child.distance_travelled_km) || 0;
-    let total_hours = parseFloat(child.total_hours) || 0;
+	if (!designation) return;
+	let distance = parseFloat(child.distance_travelled_km) || 0;
+	let total_hours = parseFloat(child.total_hours) || 0;
 
-    let is_eligible = false;
-    if (is_delhi_bureau) {
-        if (distance >= 30 && total_hours >= 4) {
-            is_eligible = true;
-        } else {
-            frappe.model.set_value(child.doctype, child.name, "breakfast", 0);
-            frappe.model.set_value(child.doctype, child.name, "lunch", 0);
-            frappe.model.set_value(child.doctype, child.name, "dinner", 0);
-            frappe.model.set_value(child.doctype, child.name, "total_food_allowance", 0);
-            return;
-        }
-    } 
-    else {
-        if (distance >= 50 && total_hours >= 6 && total_hours <= 8) {
-            is_eligible = true;
-        }
-        else if (distance >= 100 && total_hours >= 8) {
-            frappe.model.set_value(child.doctype, child.name, "breakfast", 0);
-            frappe.model.set_value(child.doctype, child.name, "lunch", 0);
-            frappe.model.set_value(child.doctype, child.name, "dinner", 0);
-            frappe.model.set_value(child.doctype, child.name, "total_food_allowance", 0);
-            return;
-        }
-    }
-    if (is_overnight_stay) {
-        frappe.model.set_value(child.doctype, child.name, "breakfast", 0);
-        frappe.model.set_value(child.doctype, child.name, "lunch", 0);
-        frappe.model.set_value(child.doctype, child.name, "dinner", 0);
-        frappe.model.set_value(child.doctype, child.name, "total_food_allowance", 0);
-        return;
-    }
-    if (is_eligible && !is_overnight_stay) {
-        frappe.call({
-            method: "beams.beams.doctype.batta_claim.batta_claim.get_batta_for_food_allowance",
-            args: {
-                designation: designation,
-                from_date_time: child.from_date_and_time,
-                to_date_time: child.to_date_and_time,
-                total_hrs: total_hours,
-                is_delhi_bureau: is_delhi_bureau
-            },
-            callback: function (r) {
-                if (r && r.message) {
-                    let response = r.message;
-                    frappe.model.set_value(child.doctype, child.name, "breakfast", response.break_fast);
-                    frappe.model.set_value(child.doctype, child.name, "lunch", response.lunch);
-                    frappe.model.set_value(child.doctype, child.name, "dinner", response.dinner);
-                    frappe.model.set_value(child.doctype, child.name, "total_food_allowance", response.break_fast + response.lunch + response.dinner);
-                }
-            }
-        });
-    }
+	let is_eligible = false;
+	if (is_delhi_bureau) {
+		if (distance >= 30 && total_hours >= 4) {
+			is_eligible = true;
+		} else {
+			frappe.model.set_value(child.doctype, child.name, "breakfast", 0);
+			frappe.model.set_value(child.doctype, child.name, "lunch", 0);
+			frappe.model.set_value(child.doctype, child.name, "dinner", 0);
+			frappe.model.set_value(child.doctype, child.name, "total_food_allowance", 0);
+			return;
+		}
+	} 
+	else {
+		if (distance >= 50 && total_hours >= 6 && total_hours <= 8) {
+			is_eligible = true;
+		}
+		else if (distance >= 100 && total_hours >= 8) {
+			frappe.model.set_value(child.doctype, child.name, "breakfast", 0);
+			frappe.model.set_value(child.doctype, child.name, "lunch", 0);
+			frappe.model.set_value(child.doctype, child.name, "dinner", 0);
+			frappe.model.set_value(child.doctype, child.name, "total_food_allowance", 0);
+			return;
+		}
+	}
+	if (is_overnight_stay) {
+		frappe.model.set_value(child.doctype, child.name, "breakfast", 0);
+		frappe.model.set_value(child.doctype, child.name, "lunch", 0);
+		frappe.model.set_value(child.doctype, child.name, "dinner", 0);
+		frappe.model.set_value(child.doctype, child.name, "total_food_allowance", 0);
+		return;
+	}
+	if (is_eligible && !is_overnight_stay) {
+		frappe.call({
+			method: "beams.beams.doctype.batta_claim.batta_claim.get_batta_for_food_allowance",
+			args: {
+				designation: designation,
+				from_date_time: child.from_date_and_time,
+				to_date_time: child.to_date_and_time,
+				total_hrs: total_hours,
+				is_delhi_bureau: is_delhi_bureau
+			},
+			callback: function (r) {
+				if (r && r.message) {
+					let response = r.message;
+					frappe.model.set_value(child.doctype, child.name, "breakfast", response.break_fast);
+					frappe.model.set_value(child.doctype, child.name, "lunch", response.lunch);
+					frappe.model.set_value(child.doctype, child.name, "dinner", response.dinner);
+					frappe.model.set_value(child.doctype, child.name, "total_food_allowance", response.break_fast + response.lunch + response.dinner);
+				}
+			}
+		});
+	}
 }
-
 
 /* Calculation of Total Food Allowance. */
 function calculate_total_food_allowance(frm, cdt, cdn) {
-    let row = locals[cdt][cdn];
-    frm.call({
-        method: "beams.beams.doctype.batta_claim.batta_claim.calculate_total_food_allowance_server",
-        args: {
-            breakfast: row.breakfast || 0,
-            lunch: row.lunch || 0,
-            dinner: row.dinner || 0
-        },
-        callback: function(r) {
-            if (r.message) {
-                row.total_food_allowance = r.message.total_food_allowance;
-                frm.refresh_field("work_detail");
-            }
-        }
-    });
+	let row = locals[cdt][cdn];
+	frm.call({
+		method: "beams.beams.doctype.batta_claim.batta_claim.calculate_total_food_allowance",
+		args: {
+			breakfast: row.breakfast || 0,
+			lunch: row.lunch || 0,
+			dinner: row.dinner || 0
+		},
+		callback: function(r) {
+			if (r.message) {
+				row.total_food_allowance = r.message.total_food_allowance;
+				frm.refresh_field("work_detail");
+			}
+		}
+	});
 }
 
 /* Calculation of total batta based on daily batta and food allowance. */
 function calculate_total_batta(frm, cdt, cdn) {
-    let row = locals[cdt][cdn];
-    frm.call({
-        method: "beams.beams.doctype.batta_claim.batta_claim.calculate_total_batta_server",
-        args: {
-            daily_batta: row.daily_batta || 0,
-            total_food_allowance: row.total_food_allowance || 0
-        },
-        callback: function(r) {
-            if (r.message) {
-                frappe.model.set_value(cdt, cdn, "total_batta", r.message.total_batta);
-                frm.refresh_field("work_detail");
-            }
-        }
-    });
+	let row = locals[cdt][cdn];
+	frm.call({
+		method: "beams.beams.doctype.batta_claim.batta_claim.calculate_total_batta",
+		args: {
+			daily_batta: row.daily_batta || 0,
+			total_food_allowance: row.total_food_allowance || 0
+		},
+		callback: function(r) {
+			if (r.message) {
+				frappe.model.set_value(cdt, cdn, "total_batta", r.message.total_batta);
+				frm.refresh_field("work_detail");
+			}
+		}
+	});
 }
 
 /**
 * Clears the "is_budget_exceed" checkbox if "is_budgeted" is unchecked.
-*/      
+*/    
 function clear_checkbox_exceed(frm){
-    if(frm.doc.is_budgeted == 0){
-        frm.set_value("is_budget_exceed", 0);
-    }
+	if(frm.doc.is_budgeted == 0){
+		frm.set_value("is_budget_exceed", 0);
+	}
 }

--- a/beams/beams/doctype/batta_claim/batta_claim.js
+++ b/beams/beams/doctype/batta_claim/batta_claim.js
@@ -407,16 +407,38 @@ function set_batta_for_food_allowance(frm, cdt, cdn) {
 /* Calculation of Total Food Allowance. */
 function calculate_total_food_allowance(frm, cdt, cdn) {
     let row = locals[cdt][cdn];
-    row.total_food_allowance = (row.breakfast || 0) + (row.lunch || 0) + (row.dinner || 0);
-
-    frm.refresh_field("work_detail");
+    frm.call({
+        method: "beams.beams.doctype.batta_claim.batta_claim.calculate_total_food_allowance_server",
+        args: {
+            breakfast: row.breakfast || 0,
+            lunch: row.lunch || 0,
+            dinner: row.dinner || 0
+        },
+        callback: function(r) {
+            if (r.message) {
+                row.total_food_allowance = r.message.total_food_allowance;
+                frm.refresh_field("work_detail");
+            }
+        }
+    });
 }
 
 /* Calculation of total batta based on daily batta and food allowance. */
 function calculate_total_batta(frm, cdt, cdn) {
     let row = locals[cdt][cdn];
-    frappe.model.set_value(cdt, cdn, "total_batta", (row.daily_batta || 0) + (row.total_food_allowance || 0));
-    frm.refresh_field("work_detail");
+    frm.call({
+        method: "beams.beams.doctype.batta_claim.batta_claim.calculate_total_batta_server",
+        args: {
+            daily_batta: row.daily_batta || 0,
+            total_food_allowance: row.total_food_allowance || 0
+        },
+        callback: function(r) {
+            if (r.message) {
+                frappe.model.set_value(cdt, cdn, "total_batta", r.message.total_batta);
+                frm.refresh_field("work_detail");
+            }
+        }
+    });
 }
 
 /**

--- a/beams/beams/doctype/batta_claim/batta_claim.py
+++ b/beams/beams/doctype/batta_claim/batta_claim.py
@@ -359,3 +359,23 @@ def get_batta_for_food_allowance(designation, from_date_time, to_date_time, tota
 			current_date = add_days(current_date, 1)
 
 	return values
+
+@frappe.whitelist()
+def calculate_total_food_allowance_server(breakfast=0, lunch=0, dinner=0):
+    try:
+        total = (frappe.utils.flt(breakfast) +
+                 frappe.utils.flt(lunch) +
+                 frappe.utils.flt(dinner))
+        return {"total_food_allowance": total}
+    except Exception as e:
+        frappe.throw(f"Error calculating food allowance: {e}")
+
+@frappe.whitelist()
+def calculate_total_batta_server(daily_batta=0, total_food_allowance=0):
+    try:
+        total = (frappe.utils.flt(daily_batta) +
+                 frappe.utils.flt(total_food_allowance))
+        return {"total_batta": total}
+    except Exception as e:
+        frappe.throw(f"Error calculating total batta: {e}")
+

--- a/beams/beams/doctype/batta_claim/batta_claim.py
+++ b/beams/beams/doctype/batta_claim/batta_claim.py
@@ -5,7 +5,7 @@ import frappe
 from frappe import _
 import json
 import re
-from frappe.utils import getdate, get_datetime, date_diff, add_days,flt
+from frappe.utils import getdate, get_datetime, date_diff, add_days, flt, cint
 import math
 from frappe.model.document import Document
 
@@ -166,40 +166,70 @@ class BattaClaim(Document):
 		Auto creation logic:
 
 			✔ 100+ KM AND >= 8 Hours      → BATTA (no food allowance)
-			✔ 50–100 KM AND >= 6 Hours    → Food Allowance
-			✔ 100+ KM AND 6–8 Hours       → Food Allowance
+			✔ 50-100 KM AND >= 6 Hours    → Food Allowance
+			✔ 100+ KM AND 6-8 Hours       → Food Allowance
 			✔ Else → No Allowance
+
+		When policy is Actual (relevant flag=1):
+		- Skip all resets and calculations for that component.
+		- Preserve manual entries in fields (e.g., row.daily_batta, row.breakfast).
+		- Parent fields (e.g., daily_batta_without_overnight_stay) are not reset/overridden.
 		"""
-		self.daily_batta_without_overnight_stay = 0
 		if not self.get("work_detail"):
 			return
+
+		batta_policy = frappe.get_all('Batta Policy', filters={'designation': self.designation}, fields=['*'])
+		if not batta_policy:
+			return
+		policy = batta_policy[0]
+
+		is_actual_with = cint(policy.get('is_actual_', 0))
+		is_actual_without = cint(policy.get('is_actual__', 0))
+		is_actual_food = cint(policy.get('is_actual___', 0))
+
+		if not is_actual_without:
+			self.daily_batta_without_overnight_stay = 0
+		if not is_actual_with:
+			self.daily_batta_with_overnight_stay = 0
+
 		for row in self.work_detail:
 			total_hours = flt(row.total_hours or 0)
 			distance = flt(row.distance_travelled_km or 0)
 			row.number_of_days = max(1, math.ceil(total_hours / 24))
-			row.daily_batta = 0
-			row.breakfast = 0
-			row.lunch = 0
-			row.dinner = 0
-			row.total_food_allowance = 0
-			if distance >= 100 and total_hours >= 8:
-				batta_data = calculate_batta_allowance(
-					designation=self.designation,
-					is_travelling_outside_kerala=self.is_travelling_outside_kerala,
-					is_overnight_stay=self.is_overnight_stay,
-					is_avail_room_rent=self.is_avail_room_rent,
-					total_distance_travelled_km=distance,
-					total_hours=total_hours
-				)
-				parent_daily_batta_value = flt(
-					batta_data.get("daily_batta_without_overnight_stay", 0)
-				)
-				self.daily_batta_without_overnight_stay = parent_daily_batta_value
-				row.daily_batta = row.number_of_days * parent_daily_batta_value
+
+			full_batta_condition = (distance >= 100 and total_hours >= 8)
+			food_condition = (not self.is_overnight_stay and
+							((50 <= distance < 100 and total_hours >= 6) or
+							(distance >= 100 and 6 <= total_hours < 8)))
+
+			if full_batta_condition:
+				if self.is_overnight_stay:
+					actual_flag = is_actual_with
+					rate_key = "daily_batta_with_overnight_stay"
+					parent_field = "daily_batta_with_overnight_stay"
+				else:
+					actual_flag = is_actual_without
+					rate_key = "daily_batta_without_overnight_stay"
+					parent_field = "daily_batta_without_overnight_stay"
+
+				if not actual_flag:
+					batta_data = calculate_batta_allowance(
+						designation=self.designation,
+						is_travelling_outside_kerala=self.is_travelling_outside_kerala,
+						is_overnight_stay=self.is_overnight_stay,
+						is_avail_room_rent=self.is_avail_room_rent,
+						total_distance_travelled_km=distance,
+						total_hours=total_hours
+					)
+					parent_rate = flt(batta_data.get(rate_key, 0))
+					setattr(self, parent_field, parent_rate)
+					row.daily_batta = row.number_of_days * parent_rate
 				continue
-			if not self.is_overnight_stay:
-				if (50 <= distance < 100 and total_hours >= 6) or \
-				(distance >= 100 and 6 <= total_hours < 8):
+
+			actual_flag = is_actual_without
+
+			if food_condition:
+				if not is_actual_food:
 					values = get_batta_for_food_allowance(
 						designation=self.designation,
 						from_date_time=row.from_date_and_time,
@@ -212,9 +242,14 @@ class BattaClaim(Document):
 					row.total_food_allowance = (
 						flt(row.breakfast) + flt(row.lunch) + flt(row.dinner)
 					)
-
+				if not actual_flag:
 					row.daily_batta = 0
-					continue
+				continue
+
+			if not actual_flag and not self.is_overnight_stay:
+				row.daily_batta = 0
+			if not is_actual_food:
+				row.breakfast = 0
 				row.lunch = 0
 				row.dinner = 0
 				row.total_food_allowance = 0
@@ -231,8 +266,6 @@ class BattaClaim(Document):
 			daily_batta = row.daily_batta or 0
 			food_allowance = row.total_food_allowance or 0
 			row.total_batta = daily_batta + food_allowance
-
-			
 
 @frappe.whitelist()
 def calculate_batta_allowance(designation=None, is_travelling_outside_kerala=0, is_overnight_stay=0, is_avail_room_rent=0, total_distance_travelled_km=0, total_hours=0):
@@ -361,21 +394,24 @@ def get_batta_for_food_allowance(designation, from_date_time, to_date_time, tota
 	return values
 
 @frappe.whitelist()
-def calculate_total_food_allowance_server(breakfast=0, lunch=0, dinner=0):
-    try:
-        total = (frappe.utils.flt(breakfast) +
-                 frappe.utils.flt(lunch) +
-                 frappe.utils.flt(dinner))
-        return {"total_food_allowance": total}
-    except Exception as e:
-        frappe.throw(f"Error calculating food allowance: {e}")
+def calculate_total_food_allowance(breakfast=0, lunch=0, dinner=0):
+	try:
+		total = (frappe.utils.flt(breakfast) +
+				 frappe.utils.flt(lunch) +
+				 frappe.utils.flt(dinner))
+		return {"total_food_allowance": total}
+	except Exception as e:
+		return {
+			"total_food_allowance": 0
+		}
 
 @frappe.whitelist()
-def calculate_total_batta_server(daily_batta=0, total_food_allowance=0):
-    try:
-        total = (frappe.utils.flt(daily_batta) +
-                 frappe.utils.flt(total_food_allowance))
-        return {"total_batta": total}
-    except Exception as e:
-        frappe.throw(f"Error calculating total batta: {e}")
-
+def calculate_total_batta(daily_batta=0, total_food_allowance=0):
+	try:
+		total = (frappe.utils.flt(daily_batta) +
+				 frappe.utils.flt(total_food_allowance))
+		return {"total_batta": total}
+	except Exception as e:
+		return {
+			"total_batta": 0
+		}


### PR DESCRIPTION
- [x] TASK-2025-02831
- [x] TASK-2025-02832

## Feature description

- Moved food allowance and total batta calculations from client-side JavaScript to server-side whitelisted methods
- Ensure Actual batta amounts are saved correctly in Batta Claim

## Analysis and design (optional)
The earlier implementation performed critical calculations purely in the browser, which could lead to:
  - Data inconsistency
  - Tampering risks
  - Duplication of logic across clients
To address this, calculation logic was centralized in backend methods and invoked via frm.call(), following Frappe best practices.

## Solution description
- Removed direct arithmetic calculations from batta_claim.js
- Introduced two new whitelisted backend methods:
  - calculate_total_food_allowance_server
  - calculate_total_batta_server
- Updated client-side functions to call backend methods and update fields using returned values
- Ensured all values are safely converted using frappe.utils.flt
- Ensured Actual batta amounts are saved correctly in Batta Claim

## Output screenshots (optional)
[Screencast from 12-18-2025 04:24:35 PM.webm](https://github.com/user-attachments/assets/1f4e86fb-3378-4b82-a860-0532dc781598)

[Screencast from 23-12-25 12:07:55 PM IST.webm](https://github.com/user-attachments/assets/912a105d-0e22-4d0c-b415-1c515d9e175f)

## Areas affected and ensured

Batta Claim form calculations
Food allowance total calculation
Total batta calculation
Client–server interaction via frm.call()

## Is there any existing behaviour change of other features due to this code change?
 No. 

## Was this feature tested on these browsers?
  Chrome
