### PR TITLE
chore: designation as searchfield for Employee

### DIFF
--- a/beams/beams/custom_scripts/hd_ticket/hd_ticket.py
+++ b/beams/beams/custom_scripts/hd_ticket/hd_ticket.py
@@ -2,11 +2,10 @@ import frappe
 import json
 
 from frappe import _
+from frappe.utils import now_datetime
 from frappe.desk.form.assign_to import add as assign_to_user
 from frappe.desk.form.assign_to import clear as clear_all_assignments
-from frappe.utils import now_datetime
 from helpdesk.helpdesk.doctype.hd_ticket.hd_ticket import HDTicket, get_customer, is_admin, is_agent
-from frappe.utils.user import get_user_fullname
 
 class HDTicketOverride(HDTicket):
 

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -2264,7 +2264,6 @@ def get_employee_custom_fields():
 			{
 				"fieldname": "permanent_pin_code",
 				"fieldtype": "Data",
-				"options": "Pin",
 				"label": "Pin Code",
 				"insert_after": "permanent_address"
 			},
@@ -5607,6 +5606,13 @@ def get_property_setters():
 			"property": "default",
 			"property_type": "Small Text",
 			"value": 0
+		},
+		{
+			"doctype_or_field": "DocType",
+			"doc_type": "Employee",
+			"property": "search_fields",
+			"property_type": "Data",
+			"value": "employee_name, designation"
 		},
 	]
 


### PR DESCRIPTION
## Feature description
Designation as searchfield for Employee
Removed Pin from Options of permanent_pin_code

## Is there any existing behaviour change of other features due to this code change?
No

## Was this feature tested on these browsers?
- [x]   Chrome
- [ ]   Mozilla Firefox
- [ ]   Opera Mini
- [ ]   Safari
