### PR TITLE
TASK-2025-02891: fetch bureau head

### DIFF
--- a/beams/beams/doctype/stringer_bill/stringer_bill.json
+++ b/beams/beams/doctype/stringer_bill/stringer_bill.json
@@ -16,6 +16,7 @@
   "cost_center",
   "is_budgeted",
   "is_budget_exceed",
+  "bureau_head",
   "section_break_njgm",
   "stringer_bill_detail",
   "section_break_zcsv",
@@ -127,6 +128,14 @@
    "fieldname": "is_budget_exceed",
    "fieldtype": "Check",
    "label": "Is Budget Exceed"
+  },
+  {
+   "fetch_from": "bureau.parent_bureau_head",
+   "fieldname": "bureau_head",
+   "fieldtype": "Link",
+   "hidden": 1,
+   "label": "Bureau Head",
+   "options": "Employee"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -137,7 +146,7 @@
    "link_fieldname": "stringer_bill_reference"
   }
  ],
- "modified": "2025-12-04 14:59:10.669682",
+ "modified": "2025-12-24 11:01:47.212630",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Stringer Bill",


### PR DESCRIPTION
## Feature description
Add a field in the Stringer Bill to automatically fetch and display the Bureau Head based on the Bureau selected in the Bureau field.
When a Bureau is selected:
The system should fetch the corresponding Bureau Head value.
The fetched Bureau Head should be displayed in the Stringer Bill.
 hide the field

## Solution description
Fetched Bureau head as given in bureau


## Was this feature tested on these browsers?
- [x]   Chrome

