### PR TITLE
refactor: rename parent bureau head to regional bureau head

### DIFF
--- a/beams/beams/doctype/bureau/bureau.json
+++ b/beams/beams/doctype/bureau/bureau.json
@@ -11,12 +11,13 @@
   "cost_center",
   "amended_from",
   "mode_of_payment",
+  "bureau_head",
   "column_break_xpwx",
   "company",
   "location",
   "is_parent_bureau",
   "regional_bureau",
-  "parent_bureau_head"
+  "regional_bureau_head"
  ],
  "fields": [
   {
@@ -83,36 +84,29 @@
    "label": "Is Parent Bureau"
   },
   {
-   "fetch_from": "regional_bureau.parent_bureau_head",
-   "fieldname": "parent_bureau_head",
+  "fetch_from": "regional_bureau.bureau_head",
+  "fieldname": "regional_bureau_head",
+  "fieldtype": "Link",
+  "label": "Regional Bureau Head",
+  "options": "Employee",
+  "in_list_view": 1
+    },
+  {
+   "fieldname": "bureau_head",
    "fieldtype": "Link",
-   "in_list_view": 1,
    "label": "Bureau Head",
    "options": "Employee"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-12-01 14:26:58.708333",
+ "modified": "2025-12-30 14:21:11.929685",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Bureau",
  "naming_rule": "By fieldname",
  "owner": "Administrator",
- "permissions": [
-  {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "System Manager",
-   "share": 1,
-   "write": 1
-  }
- ],
+ "permissions": [],
  "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",


### PR DESCRIPTION
## Feature description
In Stringer Bill, the role currently labeled as “Bureau Head” should be updated to “Regional Bureau Head” in all labels, workflows, user-facing areas, codes as well .
add a new field in Bureau to define the Bureau Head (the head of that specific bureau, not the parent or regional bureau).

## Solution description
Added respective field in bureau with proper naming and link

## Output screenshots (optional)
<img width="1906" height="818" alt="image" src="https://github.com/user-attachments/assets/5750304c-6beb-440d-bf65-e1855fa208cc" />

## Was this feature tested on these browsers?
- [ ]   Chrome
