### PR TITLE
TASK-2025-02893:Reflect manual batta values in total batta for actual policy

### DIFF
--- a/beams/beams/doctype/batta_claim/batta_claim.js
+++ b/beams/beams/doctype/batta_claim/batta_claim.js
@@ -58,6 +58,7 @@ frappe.ui.form.on('Batta Claim', {
 		})
 	},
 	is_avail_room_rent: function(frm) {
+		toggle_room_rent_batta_field(frm);
 		update_all_daily_batta(frm);
 		calculate_allowance(frm);
 	},
@@ -68,6 +69,7 @@ frappe.ui.form.on('Batta Claim', {
 	  })
 	},
 	refresh: function(frm) {
+		toggle_room_rent_batta_field(frm);
 		clear_checkbox_exceed(frm);
 		frappe.call({
 			method: "beams.beams.doctype.batta_claim.batta_claim.get_batta_policy_values",
@@ -213,6 +215,19 @@ frappe.ui.form.on('Work Detail', {
 	}
   }
 });
+
+/*
+  Toggle room_rent_batta field visibility based on is_avail_room_rent checkbox
+*/
+function toggle_room_rent_batta_field(frm) {
+	if (frm.doc.is_avail_room_rent) {
+		frm.set_df_property('room_rent_batta', 'hidden', 0);
+	} else {
+		frm.set_df_property('room_rent_batta', 'hidden', 1);
+		frm.set_value('room_rent_batta', 0);
+	}
+	frm.refresh_field('room_rent_batta');
+}
 
 /*
   Calculates the total distance traveled based on all work detail entries.

--- a/beams/beams/doctype/batta_claim/batta_claim.py
+++ b/beams/beams/doctype/batta_claim/batta_claim.py
@@ -139,7 +139,9 @@ class BattaClaim(Document):
 
 	def calculate_total_daily_batta(self):
 		'''
-			Calculation of Total Daily Batta
+		Calculation of Total Daily Batta
+		- If policy is ACTUAL → take manual parent values directly
+		- Else → calculate from rows
 		'''
 		rows_total = 0.0
 		sum_food = 0.0
@@ -148,10 +150,31 @@ class BattaClaim(Document):
 			rows_total += flt(row.daily_batta or 0)
 			sum_food += flt(row.total_food_allowance or 0)
 
-		parent_components = flt(self.room_rent_batta or 0) \
-						+ flt(self.daily_batta_with_overnight_stay or 0)
+		is_actual_with = 0
+		is_actual_without = 0
 
-		self.total_daily_batta = flt(rows_total + parent_components + sum_food)
+		if self.designation:
+			batta_policy = frappe.get_all(
+				'Batta Policy',
+				filters={'designation': self.designation},
+				fields=['is_actual_', 'is_actual__'],
+				limit=1
+			)
+			if batta_policy:
+				is_actual_with = cint(batta_policy[0].get('is_actual_', 0))
+				is_actual_without = cint(batta_policy[0].get('is_actual__', 0))
+
+		parent_components = 0.0
+
+		if is_actual_with:
+			parent_components += flt(self.daily_batta_with_overnight_stay or 0)
+
+		if is_actual_without:
+			parent_components += flt(self.daily_batta_without_overnight_stay or 0)
+
+		parent_components += flt(self.room_rent_batta or 0)
+
+		self.total_daily_batta = flt(rows_total + sum_food + parent_components)
 
 	def calculate_batta(self):
 		'''


### PR DESCRIPTION
- [x]  TASK-2025-02893

## Feature description

- Enable users to manually enter batta amounts when the Batta Policy is set to Actual, without enforcing distance, hour, or eligibility criteria.

- Any manually entered batta value must be accurately reflected in the total batta calculation.

- Dynamically control the visibility and mandatory status of the Room Rent Batta field in the Batta Claim form based on the Is Avail Room Rent checkbox.

## Solution description

- Updated batta calculation logic to bypass policy-based eligibility checks when the policy is marked as Actual.

- Ensured that all manually entered batta amounts at the parent level are directly included in total batta calculations.

- show and mark the Room Rent Batta field  when the Is Avail Room Rent checkbox is enabled.

- Hide the Room Rent Batta field and clear its value when the checkbox is disabled to prevent stale or invalid data.

## Output screenshots (optional)
[Screencast from 30-12-25 03:58:08 PM IST.webm](https://github.com/user-attachments/assets/3b8b8d87-dade-4fbf-a3fe-6e7abd1cdafc)



## Areas affected and ensured
Batta Claim Doctype

## Is there any existing behaviour change of other features due to this code change?
No

## Was this feature tested on these browsers?
-  Chrome
