### PR TITLE
TASK-2025-02889: set MOP as bureau's MOP

### DIFF
--- a/beams/beams/doctype/substitute_booking/substitute_booking.js
+++ b/beams/beams/doctype/substitute_booking/substitute_booking.js
@@ -125,7 +125,7 @@ frappe.ui.form.on("Substitute Booking", {
     is_budgeted(frm) {
         update_budget_exceeded_visibility(frm);
     },
-   bureau(frm) {
+    bureau(frm) {
 		fetch_mode_of_payment_from_bureau(frm, frm.doc.bureau);
 	}
 });

--- a/beams/beams/doctype/substitute_booking/substitute_booking.js
+++ b/beams/beams/doctype/substitute_booking/substitute_booking.js
@@ -124,7 +124,10 @@ frappe.ui.form.on("Substitute Booking", {
     },
     is_budgeted(frm) {
         update_budget_exceeded_visibility(frm);
-    }
+    },
+   bureau(frm) {
+		fetch_mode_of_payment_from_bureau(frm, frm.doc.bureau);
+	}
 });
 
 
@@ -202,3 +205,23 @@ function set_bureau_and_account(frm) {
 		});
 }
 
+
+/*
+	Fetch Mode of Payment from Bureau and set it
+*/
+function fetch_mode_of_payment_from_bureau(frm, bureau) {
+	if (!bureau) {
+		frm.set_value("mode_of_payment", null);
+		return;
+	}
+
+	frappe.db
+		.get_value("Bureau", bureau, "mode_of_payment")
+		.then(r => {
+			if (r.message?.mode_of_payment) {
+				frm.set_value("mode_of_payment", r.message.mode_of_payment);
+			} else {
+				frm.set_value("mode_of_payment", null);
+			}
+		});
+}


### PR DESCRIPTION
## Feature description
Only the Mode of Payment belonging to the selected Bureau should be available for selection in the document. Users must not be able to view or select Modes of Payment associated with other Bureaus in Substitute Booking

## Solution description
Set MOP as List in Bureau

## Output screenshots (optional)
![Uploading image.png…]()



## Was this feature tested on these browsers?
- [ ]   Chrome

