### PR TITLE
TASK-2025-02905: Add Total Amount field in Material Request doctype

### DIFF
--- a/beams/beams/custom_scripts/material_request/material_request.js
+++ b/beams/beams/custom_scripts/material_request/material_request.js
@@ -12,11 +12,41 @@ frappe.ui.form.on('Material Request', {
 	},
 	refresh(frm) {
 		clear_checkbox_exceed(frm);
+		calculate_total_amount(frm);
+
 	},
 	is_budgeted: function(frm){	
 		clear_checkbox_exceed(frm);
 	}
 });
+
+frappe.ui.form.on('Material Request Item', {
+	amount: function(frm, cdt, cdn) {
+		calculate_total_amount(frm);
+	},
+	qty: function(frm, cdt, cdn) {
+		calculate_total_amount(frm);
+	},
+	rate: function(frm, cdt, cdn) {
+		calculate_total_amount(frm);
+	},
+	items_remove: function(frm, cdt, cdn) {
+		calculate_total_amount(frm);
+	}
+});
+
+/**
+ * Calculates total amount from qty × rate for all items
+ */
+function calculate_total_amount(frm) {
+	let total = 0.0;
+	if (frm.doc.items && frm.doc.items.length) {
+		frm.doc.items.forEach(function(item) {
+			total += (item.amount || 0);
+		});
+	}
+	frm.set_value('total_amount', total);
+}
 
 /**
 * Clears the "budget_exceeded" checkbox if "is_budgeted" is unchecked.

--- a/beams/beams/doctype/batta_claim/batta_claim.json
+++ b/beams/beams/doctype/batta_claim/batta_claim.json
@@ -33,6 +33,7 @@
   "attach",
   "trip_sheet",
   "travel_request",
+  "hod_user",
   "section_break_bkxb",
   "room_rent_batta",
   "batta_based_on",
@@ -325,6 +326,14 @@
    "fieldtype": "Check",
    "hidden": 1,
    "label": "From Bureau"
+  },
+  {
+   "fieldname": "hod_user",
+   "fieldtype": "Link",
+   "hidden": 1,
+   "label": "HOD User",
+   "options": "User",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
@@ -339,7 +348,7 @@
    "link_fieldname": "batta_claim_reference"
   }
  ],
- "modified": "2025-12-06 11:55:57.725516",
+ "modified": "2025-12-31 14:38:53.705321",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Batta Claim",

--- a/beams/beams/doctype/batta_claim/batta_claim.py
+++ b/beams/beams/doctype/batta_claim/batta_claim.py
@@ -36,6 +36,7 @@ class BattaClaim(Document):
 				self.create_journal_entry_from_batta_claim()
 
 	def validate(self):
+		self.assign_hod_role()
 		self.calculate_total_hours()
 		self.calculate_total_distance_travelled()
 		self.calculate_daily_batta()
@@ -289,6 +290,31 @@ class BattaClaim(Document):
 			daily_batta = row.daily_batta or 0
 			food_allowance = row.total_food_allowance or 0
 			row.total_batta = daily_batta + food_allowance
+
+	def assign_hod_role(self):
+		if not self.employee:
+			return
+
+		department = frappe.db.get_value("Employee", self.employee, "department")
+		if not department:
+			return
+
+		hod = frappe.db.get_value("Department", department, "head_of_department")
+		if not hod:
+			return
+
+		hod_user = frappe.db.get_value("Employee", hod, "user_id")
+		if not hod_user:
+			return
+
+		if not frappe.db.exists(
+			"Has Role",
+			{"parent": hod_user, "role": "HOD"}
+		):
+			user = frappe.get_doc("User", hod_user)
+			user.append("roles", {"role": "HOD"})
+			user.save(ignore_permissions=True)
+
 
 @frappe.whitelist()
 def calculate_batta_allowance(designation=None, is_travelling_outside_kerala=0, is_overnight_stay=0, is_avail_room_rent=0, total_distance_travelled_km=0, total_hours=0):

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -5682,6 +5682,14 @@ def get_material_request_custom_fields():
 				"insert_after": "technical",
 				"read_only": 1,
 			},
+			{
+				"fieldname": "total_amount",
+				"fieldtype": "Currency",
+				"label": "Total Amount",
+				"insert_after": "items",
+				"read_only": 1,
+				"description": "Auto calculated from item amounts"
+			},
 		]
 	}
 


### PR DESCRIPTION
- [x] TASK-2025-02905
- [x] TASK-2025-02895

## Feature description

 Need to:

- Add Total Amount field in Material Request doctype and calculate it 
- The field will display the total of all item amounts in the MR Items table and will be read-only.
- Implement role based HOD notification for Batta Claim

## Solution description

-  Added a new read-only Currency field `total_amount` in Material Request DocType.
- Implemented client-side script to automatically calculate Total Amount whenever:
  - Item quantity changes
  - Item rate changes
  - Item amount changes
  - Items are added or removed

- Implemented role-based HOD notification for Batta Claim

## Output screenshots (optional)
[Screencast from 31-12-25 12:46:28 PM IST.webm](https://github.com/user-attachments/assets/209058e9-a6ad-4d06-b40c-d894a6fce3ff)

[Screencast from 31-12-25 04:19:13 PM IST.webm](https://github.com/user-attachments/assets/46c7bac8-5273-4416-85fc-4abcb63ce624)


## Areas affected and ensured
Material Request doctype

## Is there any existing behaviour change of other features due to this code change?
No.
## Was this feature tested on these browsers?
- Chrome

