### PR TITLE
TASK-2026-00003: resolve invalid depends_on expression in Budget form

### DIFF
--- a/beams/setup.py
+++ b/beams/setup.py
@@ -1103,7 +1103,7 @@ def get_budget_custom_fields():
 				"label": "Rejection Feedback",
 				"options":"Rejection Feedback",
 				"insert_after": "december",
-				"depends_on": "eval: doc.workflow_state.includes('Rejected')"
+				"depends_on": "eval: doc.workflow_state == 'Rejected'"
 			},
 			{
 				"fieldname": "total_amount",


### PR DESCRIPTION
## Feature description
Fixed an issue where the Budget form failed to load due to invalid depends_on expressions in custom fields. The error occurred because unsupported JavaScript logic was used in field dependency conditions.
The issue occurred is:
<img width="1252" height="933" alt="Screenshot from 2026-01-01 13-07-06" src="https://github.com/user-attachments/assets/12c7bba5-a4c9-4342-b03d-36136fd4f30a" />

## Analysis and design (optional)
The issue was identified in the Rejection Feedback field configuration within the Budget DocType.
Frappe does not support complex JavaScript expressions such as .includes() inside depends_on.
The logic was analyzed and simplified to use a supported conditional expression compatible with Frappe’s form renderer.
## Solution description
- Updated the depends_on condition for the Rejection Feedback field.
- Replaced the invalid expression using .includes() with a valid equality check.
- Ensured the field visibility depends correctly on the workflow state being Rejected.
- Verified that the Budget form loads without runtime errors.

Code Change:
  - "depends_on": "eval: doc.workflow_state.includes('Rejected')"
  + "depends_on": "eval: doc.workflow_state == 'Rejected'"

## Output screenshots (optional)
[Screencast from 01-01-2026 01:25:18 PM.webm](https://github.com/user-attachments/assets/2f21a3e4-867b-4a27-a46a-0ff7cc7690af)

## Areas affected and ensured
- Budget DocType
- Rejection Feedback field visibility
- Form rendering and validation logic

## Is there any existing behaviour change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on these browsers?
- [ ]   Chrome
- [ ]   Mozilla Firefox
- [ ]   Opera Mini
- [ ]   Safari
