### PR TITLE
TASK-2025-02903: set regional bureau head based on selected bureau

### DIFF
--- a/beams/beams/doctype/bureau/bureau.js
+++ b/beams/beams/doctype/bureau/bureau.js
@@ -6,18 +6,7 @@ frappe.ui.form.on("Bureau", {
 		set_filters(frm);
 	},
 	regional_bureau(frm) {
-		if (frm.doc.regional_bureau) {
-			frappe.db.get_value(
-				'Bureau',
-				frm.doc.regional_bureau,
-				'regional_bureau_head',
-				(r) => {
-					if (r && r.regional_bureau_head) {
-						frm.set_value('regional_bureau_head', r.regional_bureau_head);
-					}
-				}
-			);
-		}
+		set_regional_bureau_head(frm);
 	}
 });
 
@@ -33,3 +22,22 @@ let set_filters = function (frm) {
 		}
 	});
 }
+
+/**
+ * Fetches and sets the Regional Bureau Head based on the selected Regional Bureau.
+ */
+function set_regional_bureau_head(frm) {
+	if (frm.doc.regional_bureau) {
+			frappe.db.get_value(
+				'Bureau',
+				frm.doc.regional_bureau,
+				'regional_bureau_head',
+				(r) => {
+					if (r && r.regional_bureau_head) {
+						frm.set_value('regional_bureau_head', r.regional_bureau_head);
+					}
+				}
+			);
+	}
+}
+

--- a/beams/beams/doctype/bureau/bureau.js
+++ b/beams/beams/doctype/bureau/bureau.js
@@ -4,6 +4,20 @@
 frappe.ui.form.on("Bureau", {
 	setup(frm) {
 		set_filters(frm);
+	},
+	regional_bureau(frm) {
+		if (frm.doc.regional_bureau) {
+			frappe.db.get_value(
+				'Bureau',
+				frm.doc.regional_bureau,
+				'regional_bureau_head',
+				(r) => {
+					if (r && r.regional_bureau_head) {
+						frm.set_value('regional_bureau_head', r.regional_bureau_head);
+					}
+				}
+			);
+		}
 	}
 });
 

--- a/beams/beams/doctype/bureau/bureau.json
+++ b/beams/beams/doctype/bureau/bureau.json
@@ -84,13 +84,12 @@
    "label": "Is Parent Bureau"
   },
   {
-  "fetch_from": "regional_bureau.bureau_head",
-  "fieldname": "regional_bureau_head",
-  "fieldtype": "Link",
-  "label": "Regional Bureau Head",
-  "options": "Employee",
-  "in_list_view": 1
-    },
+   "fieldname": "regional_bureau_head",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Regional Bureau Head",
+   "options": "Employee"
+  },
   {
    "fieldname": "bureau_head",
    "fieldtype": "Link",
@@ -100,7 +99,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-12-30 14:21:11.929685",
+ "modified": "2026-01-01 15:25:28.045824",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Bureau",


### PR DESCRIPTION
## Feature description
sets the Regional Bureau Head when a Regional Bureau is selected in Bureau

## Analysis and design (optional)
Previously, the Regional Bureau Head was not being set when a Bureau was selected due to an incorrect fetch_from configuration, and the field remained read-only.
## Solution description
- Added a client-side event handler for the regional_bureau field.
- When a Regional Bureau is selected, the system fetches the corresponding regional_bureau_head from the Bureau master.
- Automatically sets the fetched value in the current document.
- Removed the static fetch_from configuration to avoid conflicts and ensure dynamic behavior.

## Output screenshots (optional)
[Uploading Screencast from 01-01-2026 04:41:56 PM.webm…]()

## Areas affected and ensured
- Bureau DocType
- Regional Bureau selection logic
- population of Regional Bureau Head field

## Is there any existing behaviour change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on these browsers?
- [ ]   Chrome
- [ ]   Mozilla Firefox
- [ ]   Opera Mini
- [ ]   Safari
