### PR TITLE
TASK-2026-00002:Make total amount editable in Material Request

### DIFF
--- a/beams/beams/custom_scripts/material_request/material_request.js
+++ b/beams/beams/custom_scripts/material_request/material_request.js
@@ -9,11 +9,16 @@ frappe.ui.form.on('Material Request', {
 					}
 				});
 		}
+		frm.total_edited = false;
 	},
 	refresh(frm) {
 		clear_checkbox_exceed(frm);
-		calculate_total_amount(frm);
-
+		if (!frm.total_edited) {
+			calculate_total_amount(frm);
+		}
+	},
+	total_amount: function(frm) {
+		frm.total_edited = true;
 	},
 	is_budgeted: function(frm){	
 		clear_checkbox_exceed(frm);
@@ -21,31 +26,47 @@ frappe.ui.form.on('Material Request', {
 });
 
 frappe.ui.form.on('Material Request Item', {
+	items_add: function(frm, cdt, cdn) {
+		frm.total_edited = false;
+		calculate_total_amount(frm);
+	},
 	amount: function(frm, cdt, cdn) {
+		frm.total_edited = false;
 		calculate_total_amount(frm);
 	},
 	qty: function(frm, cdt, cdn) {
+		frm.total_edited = false;
 		calculate_total_amount(frm);
 	},
 	rate: function(frm, cdt, cdn) {
+		frm.total_edited = false;
 		calculate_total_amount(frm);
 	},
 	items_remove: function(frm, cdt, cdn) {
+		frm.total_edited = false;
+		calculate_total_amount(frm);
+	},
+	item_code: function(frm, cdt, cdn) {
+		frm.total_edited = false;
 		calculate_total_amount(frm);
 	}
 });
-
 /**
  * Calculates total amount from qty × rate for all items
  */
 function calculate_total_amount(frm) {
 	let total = 0.0;
-	if (frm.doc.items && frm.doc.items.length) {
-		frm.doc.items.forEach(function(item) {
-			total += (item.amount || 0);
+
+	if (frm.doc.items?.length) {
+		frm.doc.items.forEach(item => {
+			total += flt(item.amount);
 		});
 	}
-	frm.set_value('total_amount', total);
+
+	if (!frm.total_edited) {
+		frm.set_value('total_amount', total);
+		frm.refresh_field('total_amount');
+	}
 }
 
 /**

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -5694,7 +5694,6 @@ def get_material_request_custom_fields():
 				"fieldtype": "Currency",
 				"label": "Total Amount",
 				"insert_after": "items",
-				"read_only": 1,
 				"description": "Auto calculated from item amounts"
 			},
 		]


### PR DESCRIPTION
## Feature description
Need to: Make total amount editable in Material Request

## Solution description
The Total Amount field in Material Request must be editable. When a user edits this value, the modified amount must be saved and should not revert to the previously calculated amount.

## Output screenshots (optional)
[Screencast from 02-01-26 02:07:31 PM IST.webm](https://github.com/user-attachments/assets/fec11562-cec8-478e-8861-9b513ea830a9)


## Areas affected and ensured
Material Request doctype

## Is there any existing behaviour change of other features due to this code change?
 No. 

## Was this feature tested on these browsers?
-  Chrome

