### PR TITLE
TASK-2026-00022: resolve invalid fetch_from field for bureau head

### DIFF
--- a/beams/beams/doctype/stringer_bill/stringer_bill.json
+++ b/beams/beams/doctype/stringer_bill/stringer_bill.json
@@ -130,7 +130,7 @@
    "label": "Is Budget Exceed"
   },
   {
-   "fetch_from": "bureau.parent_bureau_head",
+   "fetch_from": "bureau.regional_bureau_head",
    "fieldname": "bureau_head",
    "fieldtype": "Link",
    "hidden": 1,
@@ -146,7 +146,7 @@
    "link_fieldname": "stringer_bill_reference"
   }
  ],
- "modified": "2025-12-24 11:01:47.212630",
+ "modified": "2026-01-03 15:22:45.560448",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Stringer Bill",


### PR DESCRIPTION
## Feature description
Fix Bureau Head auto-fetch in Stringer Bill by correcting the linked field reference so the value is populated correctly when a Bureau is selected.
## Analysis and design (optional)
The existing configuration attempted to fetch a non-existent field (parent_bureau_head) from the Bureau DocType, which caused a query validation error.
The Bureau DocType already contains the correct field (regional_bureau_head), which is suitable for this requirement. No design changes were required.
## Solution description
- Updated the fetch_from property of the hidden Bureau Head field in Stringer Bill.
- Replaced the invalid field reference parent_bureau_head with the valid field regional_bureau_head from the Bureau DocType.
- This ensures the Bureau Head is fetched without triggering query or validation errors.

## Output screenshots (optional)
[Screencast from 01-03-2026 03:44:16 PM.webm](https://github.com/user-attachments/assets/383676d3-a353-4f44-bb1e-f761691b9bec)

## Areas affected and ensured
- Stringer Bill DocType
- Bureau Head auto-population logic
- Linked field data fetch from Bureau

## Is there any existing behaviour change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on these browsers?
- [ ]   Chrome
- [ ]   Mozilla Firefox
- [ ]   Opera Mini
- [ ]   Safari
