### PR TITLE
TASK-2025-02895:Implement role based HOD notification for Batta Claim

### DIFF
--- a/beams/beams/doctype/batta_claim/batta_claim.json
+++ b/beams/beams/doctype/batta_claim/batta_claim.json
@@ -33,7 +33,7 @@
   "attach",
   "trip_sheet",
   "travel_request",
-  "hod_user",
+  "hod_email",
   "section_break_bkxb",
   "room_rent_batta",
   "batta_based_on",
@@ -328,11 +328,11 @@
    "label": "From Bureau"
   },
   {
-   "fieldname": "hod_user",
-   "fieldtype": "Link",
+   "fieldname": "hod_email",
+   "fieldtype": "Data",
    "hidden": 1,
-   "label": "HOD User",
-   "options": "User",
+   "label": "HOD Email",
+   "options": "Email",
    "read_only": 1
   }
  ],
@@ -348,7 +348,7 @@
    "link_fieldname": "batta_claim_reference"
   }
  ],
- "modified": "2025-12-31 14:38:53.705321",
+ "modified": "2026-01-05 14:51:52.507275",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Batta Claim",

--- a/beams/beams/doctype/batta_claim/batta_claim.py
+++ b/beams/beams/doctype/batta_claim/batta_claim.py
@@ -292,28 +292,37 @@ class BattaClaim(Document):
 			row.total_batta = daily_batta + food_allowance
 
 	def assign_hod_role(self):
-		if not self.employee:
+		'''
+			Set the Head of Department (HOD) for the Leave Application based on the Employee's department.
+		'''
+		if not self.employee or self.hod_email:
 			return
 
-		department = frappe.db.get_value("Employee", self.employee, "department")
+		department = frappe.db.get_value(
+			"Employee",
+			self.employee,
+			"department"
+		)
 		if not department:
 			return
 
-		hod = frappe.db.get_value("Department", department, "head_of_department")
-		if not hod:
+		hod_employee = frappe.db.get_value(
+			"Department",
+			department,
+			"head_of_department"
+		)
+		if not hod_employee:
 			return
 
-		hod_user = frappe.db.get_value("Employee", hod, "user_id")
+		hod_user = frappe.db.get_value(
+			"Employee",
+			hod_employee,
+			"user_id"
+		)
 		if not hod_user:
 			return
 
-		if not frappe.db.exists(
-			"Has Role",
-			{"parent": hod_user, "role": "HOD"}
-		):
-			user = frappe.get_doc("User", hod_user)
-			user.append("roles", {"role": "HOD"})
-			user.save(ignore_permissions=True)
+		self.hod_email = hod_user
 
 
 @frappe.whitelist()


### PR DESCRIPTION
## Feature description
Need to fix the issue in  Implement role based HOD notification for Batta Claim

## Solution description
  HOD Field Added to Batta Claim
   - A hidden field (hod) was introduced in the Batta Claim DocType.
   - This field stores the User ID (email) of the department’s Head of Department.
  
  On saving a Batta Claim, the system:
   - Retrieves the employee’s department   
   - Fetches the assigned Head of Department from the Department master
   - Resolves the corresponding User ID from the Employee record
   - Stores this value in the hidden hod field
  
  Role-based notifications were removed.
   - Notifications are now sent using Receiver by Document Field, referencing the hod field.
   - The notification is triggered when the workflow state changes to Pending Approval.

## Output screenshots (optional)

[Screencast from 05-01-26 09:47:40 AM IST.webm](https://github.com/user-attachments/assets/88a64fb2-66b3-4a5c-9655-55b6aef2917c)

<img width="1920" height="1080" alt="Screenshot from 2026-01-05 10-34-44" src="https://github.com/user-attachments/assets/1711ca8d-5c78-4455-b5fd-fac6b1d1f1b1" />


## Areas affected and ensured
Batta Claim

## Is there any existing behaviour change of other features due to this code change?
 No. 

## Was this feature tested on these browsers?
- Chrome

