### PR TITLE
TASK-2026-00060:Fix reason for rejection field handling across workflow

### DIFF
--- a/beams/beams/custom_scripts/material_request/material_request.py
+++ b/beams/beams/custom_scripts/material_request/material_request.py
@@ -6,9 +6,13 @@ from frappe.desk.form.assign_to import add as add_assign
 
 
 def validate(doc,method):
-		# Validate that "Reason for Rejection" is filled if the status is "Rejected"
-		if doc.workflow_state == "Rejected" and not doc.reason_for_rejection:
-			frappe.throw("Please provide a Reason for Rejection before rejecting this request.")
+	rejected_states = [
+		"Rejected",
+		"Rejected by Non-Technical User",
+		"Rejected by Technical User"
+	]
+	if doc.workflow_state in rejected_states and not doc.reason_for_rejection:
+		frappe.throw("Please provide a Reason for Rejection before rejecting this request.")
 
 @frappe.whitelist()
 def notify_stock_managers(doc=None, method=None):
@@ -194,7 +198,7 @@ def create_todo_for_hod(doc, method):
 def set_checkbox_for_item_type(doc, method):
 	"""
 	Sets Technical or Non-Technical checkboxes on Material Request
-    based on the Item Type of items.
+	based on the Item Type of items.
 
 	"""
 	doc.technical = 0

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -5648,9 +5648,9 @@ def get_material_request_custom_fields():
 				"fieldtype": "Small Text",
 				"label": "Reason for Rejection",
 				"insert_after": "items",
-				"depends_on":"eval:doc.workflow_state == 'Rejected' || doc.workflow_state == 'Informed Admin' || doc.workflow_state == 'Informed HR' || doc.workflow_state == 'Informed HOD'",
+				"depends_on": "eval:doc.workflow_state != 'Draft' && doc.workflow_state != 'Approved'",
 				"allow_on_submit": 1,
-				"read_only_depends_on": "eval:doc.workflow_state == 'Rejected'"
+				"read_only_depends_on": "eval:doc.workflow_state && doc.workflow_state.includes('Rejected')"
 			},
 			{
 				"fieldname": "employee_name",


### PR DESCRIPTION
## Feature description
Need to: Fix reason for rejection field handling across workflow

## Solution description
- Ensured the Reason for Rejection field is always visible, excluding in Draft state and Approved state
- Made field read-only for all rejected states
- Enforce rejection reason validation for all rejection workflows

## Output screenshots (optional)
[Screencast from 13-01-26 01:31:58 PM IST.webm](https://github.com/user-attachments/assets/5506a401-7fad-400b-8a84-6554e2760e35)

## Areas affected and ensured
Material Request Doctype

## Is there any existing behaviour change of other features due to this code change?
No.

## Was this feature tested on these browsers?
- Chrome

