### PR TITLE
fix: scope duplicate account check by parentfield

### DIFF
--- a/beams/beams/doctype/budget_template/budget_template.py
+++ b/beams/beams/doctype/budget_template/budget_template.py
@@ -64,6 +64,7 @@ class BudgetTemplate(Document):
 				filters={
 					"account_head": row.account_head,
 					"parenttype": "Budget Template",
+					"parentfield": "budget_template_items",
 					"parent": ["!=", self.name],
 				},
 				fields=["parent"],


### PR DESCRIPTION
## Feature description

Add parentfield filter so duplicate account validation only considers
Budget Template Item rows from budget_template_items, avoiding false
positives when the same account is reported in another template.


## Was this feature tested on these browsers?
- [ ]   Chrome
