### PR TITLE
feat: applied company currency to currency field to handle muti currency

### DIFF
--- a/beams/beams/custom_scripts/budget/budget.py
+++ b/beams/beams/custom_scripts/budget/budget.py
@@ -3,29 +3,38 @@ import frappe
 month_fields = ['january', 'february', 'march', 'april', 'may', 'june', 'july', 'august', 'september', 'october', 'november', 'december']
 
 def beams_budget_validate(doc, method=None):
-    """method runs custom validations for budget doctype"""
-    update_total_amount(doc, method)
-    convert_currency(doc, method)
-    update_budget_against(doc, method)
-
+	'''
+		Method trigger on `validate` event of Budget
+	'''
+	update_budget_against(doc, method)
+	update_total_amount(doc, method)
+	convert_currency(doc, method)
 
 def update_total_amount(doc, method):
-	total = sum([row.budget_amount for row in doc.get("accounts") if row.budget_amount])
+	total = sum([row.budget_amount for row in doc.get('accounts') if row.budget_amount])
 	doc.total_amount = total
 
 def populate_og_accounts(doc, method=None):
+	'''
+		Method trigger on `before_validate` event of Budget
+		Populate OPEX budget accounts in the main table for better reporting and to avoid issues with child table data retrieval in case of large number of rows
+	'''
 	doc.accounts = []
 	accounts_map = {}
 
 	#Process OPEX budget accounts
 	for row in doc.budget_accounts:
+		#Set Company Currency in each row for reference during currency conversion in case company currency is not INR
+		if doc.company_currency:
+			row.company_currency = doc.company_currency
+
 		# Accumulate amounts per account
 		account = row.account
 		# Initialize account if not exists
 		if account not in accounts_map:
 			accounts_map[account] = {
-				"account": account,
-				"budget_amount": 0
+				'account': account,
+				'budget_amount': 0
 			}
 			# Initialize all months
 			for month in month_fields:
@@ -34,46 +43,47 @@ def populate_og_accounts(doc, method=None):
 		for month in month_fields:
 			month_value = row.get(month) or 0
 			accounts_map[account][month] += month_value
-			accounts_map[account]["budget_amount"] += month_value
+			accounts_map[account]['budget_amount'] += month_value
 
 	#Update accumulated amounts for each account in main table
 	for account_data in accounts_map.values():
-		doc.append("accounts", account_data)
+		doc.append('accounts', account_data)
 
 def convert_currency(doc, method):
-	"""
+	'''
 		Convert budget amounts for non-INR companies
-	"""
-	company_currency = frappe.db.get_value("Company", doc.company, "default_currency")
+	'''
+	company_currency = frappe.db.get_value('Company', doc.company, 'default_currency')
 	exchange_rate = 1
 
-	if company_currency != "INR":
-		exchange_rate = frappe.db.get_value("Company", doc.company, "exchange_rate_to_inr")
+	if company_currency != 'INR':
+		exchange_rate = frappe.db.get_value('Company', doc.company, 'exchange_rate_to_inr')
 		if not exchange_rate:
 			frappe.throw(
-				f"Please set Exchange Rate from <b>{company_currency}</b> to <b>INR</b> for <b>{doc.company}</b>",
-				title="Message",
+				f'Please set Exchange Rate from <b>{company_currency}</b> to <b>INR</b> for <b>{doc.company}</b>',
+				title='Message',
 			)
 
 	months = [
-		"january", "february", "march", "april", "may", "june",
-		"july", "august", "september", "october", "november", "december"
+		'january', 'february', 'march', 'april', 'may', 'june',
+		'july', 'august', 'september', 'october', 'november', 'december'
 	]
 
 	def apply_conversion(row):
-		"""
+		'''
 			Apply exchange rate conversion to a budget row
-		"""
+		'''
 		row.budget_amount_inr = row.budget_amount * exchange_rate
 		for month in months:
-			setattr(row, f"{month}_inr", (getattr(row, month, 0) or 0) * exchange_rate)
+			setattr(row, f'{month}_inr', (getattr(row, month, 0) or 0) * exchange_rate)
 
 	for row in (*doc.accounts, *doc.budget_accounts):
 		apply_conversion(row)
 
 
 def update_budget_against(doc, method=None):
-    """Set budget_against field based on budget_for selection"""
-    if doc.budget_for:
-        doc.budget_against = doc.budget_for
-
+	'''
+		Set budget_against field based on budget_for selection
+	'''
+	if doc.budget_for:
+		doc.budget_against = doc.budget_for

--- a/beams/beams/doctype/m1_budget_account/m1_budget_account.json
+++ b/beams/beams/doctype/m1_budget_account/m1_budget_account.json
@@ -10,6 +10,7 @@
   "budget_group",
   "account",
   "cost_category",
+  "company_currency",
   "column_break_ndgp",
   "cost_description",
   "equal_monthly_distribution",
@@ -104,6 +105,7 @@
    "fieldtype": "Currency",
    "in_list_view": 1,
    "label": "Budget Amount",
+   "options": "company_currency",
    "reqd": 1
   },
   {
@@ -115,25 +117,29 @@
    "default": "0",
    "fieldname": "january",
    "fieldtype": "Currency",
-   "label": "January"
+   "label": "January",
+   "options": "company_currency"
   },
   {
    "default": "0",
    "fieldname": "february",
    "fieldtype": "Currency",
-   "label": "February"
+   "label": "February",
+   "options": "company_currency"
   },
   {
    "default": "0",
    "fieldname": "march",
    "fieldtype": "Currency",
-   "label": "March"
+   "label": "March",
+   "options": "company_currency"
   },
   {
    "default": "0",
    "fieldname": "april",
    "fieldtype": "Currency",
-   "label": "April"
+   "label": "April",
+   "options": "company_currency"
   },
   {
    "fieldname": "column_break_qqgq",
@@ -143,25 +149,29 @@
    "default": "0",
    "fieldname": "may",
    "fieldtype": "Currency",
-   "label": "May"
+   "label": "May",
+   "options": "company_currency"
   },
   {
    "default": "0",
    "fieldname": "june",
    "fieldtype": "Currency",
-   "label": "June"
+   "label": "June",
+   "options": "company_currency"
   },
   {
    "default": "0",
    "fieldname": "july",
    "fieldtype": "Currency",
-   "label": "July"
+   "label": "July",
+   "options": "company_currency"
   },
   {
    "default": "0",
    "fieldname": "august",
    "fieldtype": "Currency",
-   "label": "August"
+   "label": "August",
+   "options": "company_currency"
   },
   {
    "fieldname": "column_break_iiwj",
@@ -171,25 +181,29 @@
    "default": "0",
    "fieldname": "september",
    "fieldtype": "Currency",
-   "label": "September"
+   "label": "September",
+   "options": "company_currency"
   },
   {
    "default": "0",
    "fieldname": "october",
    "fieldtype": "Currency",
-   "label": "October"
+   "label": "October",
+   "options": "company_currency"
   },
   {
    "default": "0",
    "fieldname": "november",
    "fieldtype": "Currency",
-   "label": "November"
+   "label": "November",
+   "options": "company_currency"
   },
   {
    "default": "0",
    "fieldname": "december",
    "fieldtype": "Currency",
-   "label": "December"
+   "label": "December",
+   "options": "company_currency"
   },
   {
    "collapsible": 1,
@@ -295,13 +309,19 @@
    "fieldtype": "Currency",
    "label": "August (INR)",
    "read_only": 1
+  },
+  {
+   "fieldname": "company_currency",
+   "fieldtype": "Link",
+   "label": "Company Currency",
+   "options": "Currency"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-02-03 16:48:05.678640",
+ "modified": "2026-02-07 12:11:36.342976",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "M1 Budget Account",

--- a/beams/patches.txt
+++ b/beams/patches.txt
@@ -2,7 +2,7 @@
 beams.patches.rename_hod_role #30-10-2024
 beams.patches.no_of_children_patch  #06-03-2025
 beams.patches.delete_property_setter  #21-11-2025
-beams.patches.delete_custom_fields  #05-02-2026
+beams.patches.delete_custom_fields  #07-02-2026
 
 [post_model_sync]
 # Patches added in this section will be executed after doctypes are migrated

--- a/beams/patches/delete_custom_fields.py
+++ b/beams/patches/delete_custom_fields.py
@@ -288,6 +288,10 @@ fields_to_remove = [
 	{
 		'dt':'Purchase Order',
 		'fieldname': 'is_budget_exceed'
+	},
+	{
+		'dt':'Budget',
+		'fieldname': 'column_break_ab'
 	}
 ]
 

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -1178,12 +1178,6 @@ def get_budget_custom_fields():
 				"in_standard_filter": 1,
 			},
 			{
-				"fieldtype": "Column Break",
-				"fieldname": "column_break_ab",
-				"label": " ",
-				"insert_after": "division"
-			},
-			{
 				"fieldname": "budget_head",
 				"fieldtype": "Data",
 				"label": "Budget Head",
@@ -1197,7 +1191,8 @@ def get_budget_custom_fields():
 				"label": "Budget Head User",
 				"insert_after": "budget_head",
 				"read_only": 1,
-				"fetch_from": "budget_template.budget_head_user"
+				"fetch_from": "budget_template.budget_head_user",
+				"hidden": 1
 			}
 			
 		],
@@ -1266,7 +1261,7 @@ def get_budget_custom_fields():
 				"fieldname": "column_break_ab",
 				"fieldtype": "Column Break",
 				"label": " ",
-				"insert_after": "august"
+				"insert_after": "july"
 			},
 			{
 				"fieldname": "september",
@@ -5623,6 +5618,12 @@ def get_property_setters():
 			"property": "in_standard_filter",
 			"property_type": "Check",
 			"value": "0"
+		},
+		{
+			"doctype_or_field": "DocType",
+			"doc_type": "Budget",
+			"property": "field_order",
+			"value": "[\"workflow_state\", \"naming_series\", \"budget_against\", \"budget_for\", \"project\", \"cost_center\", \"cost_head\", \"fiscal_year\", \"budget_head\", \"budget_head_user\", \"total_amount\", \"column_break_3\", \"company\", \"department\", \"division\", \"budget_template\", \"region\", \"monthly_distribution\", \"amended_from\", \"section_break_6\", \"applicable_on_material_request\", \"action_if_annual_budget_exceeded_on_mr\", \"action_if_accumulated_monthly_budget_exceeded_on_mr\", \"column_break_13\", \"applicable_on_purchase_order\", \"action_if_annual_budget_exceeded_on_po\", \"action_if_accumulated_monthly_budget_exceeded_on_po\", \"section_break_16\", \"applicable_on_booking_actual_expenses\", \"action_if_annual_budget_exceeded\", \"action_if_accumulated_monthly_budget_exceeded\", \"section_break_21\", \"accounts\", \"budget_accounts\", \"default_currency\", \"company_currency\", \"rejection_feedback\"]"
 		},
 	]
 


### PR DESCRIPTION
## Feature description

- Applied Company currency to child table field to handle multi currency companies.
- Refactored budget file with single quotes
- Field re-order on Budget doctype


## Is there any existing behaviour change of other features due to this code change?
No

## Was this feature tested on these browsers?
- [x]   Chrome
- [ ]   Mozilla Firefox
- [ ]   Opera Mini
- [ ]   Safari
