### PR TITLE
feat: validate duplicate company and default account in Cost Head

### DIFF
--- a/beams/beams/doctype/cost_head/cost_head.py
+++ b/beams/beams/doctype/cost_head/cost_head.py
@@ -1,9 +1,32 @@
 # Copyright (c) 2025, efeone and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
+from frappe import _
 
 
 class CostHead(Document):
-	pass
+	def validate(self):
+		self.validate_no_duplicate_company_account()
+
+	def validate_no_duplicate_company_account(self):
+		"""No duplicate rows with same Company and Default Account in this Cost Head."""
+		if not getattr(self, "accounts", None):
+			return
+
+		seen = set()
+		for row in self.accounts:
+			if not row.company or not row.default_account:
+				continue
+			key = (row.company, row.default_account)
+			if key in seen:
+				print(seen, "set")
+				frappe.throw(
+					_(
+						"Duplicate Company and Account: <b>{0}</b> and <b>{1}</b> are already used in another row."
+					).format(row.company, row.default_account),
+					title=_("Duplicate Company & Account"),
+				)
+			seen.add(key)
+

--- a/beams/beams/doctype/cost_head/cost_head.py
+++ b/beams/beams/doctype/cost_head/cost_head.py
@@ -12,8 +12,6 @@ class CostHead(Document):
 
 	def validate_duplicate_company(self):
 		"""Allow only one row per Company in this Cost Head."""
-		if not getattr(self, "accounts", None):
-			return
 
 		seen_companies = set()
 

--- a/beams/beams/doctype/cost_head/cost_head.py
+++ b/beams/beams/doctype/cost_head/cost_head.py
@@ -8,25 +8,24 @@ from frappe import _
 
 class CostHead(Document):
 	def validate(self):
-		self.validate_no_duplicate_company_account()
+		self.validate_duplicate_company()
 
-	def validate_no_duplicate_company_account(self):
-		"""No duplicate rows with same Company and Default Account in this Cost Head."""
+	def validate_duplicate_company(self):
+		"""Allow only one row per Company in this Cost Head."""
 		if not getattr(self, "accounts", None):
 			return
 
-		seen = set()
+		seen_companies = set()
+
 		for row in self.accounts:
-			if not row.company or not row.default_account:
+			if not row.company:
 				continue
-			key = (row.company, row.default_account)
-			if key in seen:
-				print(seen, "set")
+
+			if row.company in seen_companies:
 				frappe.throw(
-					_(
-						"Duplicate Company and Account: <b>{0}</b> and <b>{1}</b> are already used in another row."
-					).format(row.company, row.default_account),
-					title=_("Duplicate Company & Account"),
+					_("Cannot set multiple Item Defaults for a company."),
+					title=_("Duplicate Company"),
 				)
-			seen.add(key)
+
+			seen_companies.add(row.company)
 


### PR DESCRIPTION
## Feature description
prevent duplicate company and account in cost head

## Solution description
Added a validation in the CostHead doctype that checks all child account rows and blocks saving when a duplicate Company + Default Account combination is detected.

## Output screenshots (optional)
<img width="1857" height="830" alt="image" src="https://github.com/user-attachments/assets/ab94708b-bde3-4ca1-af63-e4775bac96ab" />


## Was this feature tested on these browsers?
- [ ]   Chrome
