### PR TITLE
feat:enhancement in shift assignment

### DIFF
--- a/beams/beams/custom_scripts/shift_assignment/shift_assignment.js
+++ b/beams/beams/custom_scripts/shift_assignment/shift_assignment.js
@@ -1,0 +1,7 @@
+frappe.ui.form.on('Shift Assignment', {
+	start_date: function(frm) {
+		if (frm.doc.start_date) {
+			frm.set_value('end_date', frm.doc.start_date);
+		}
+	}
+});

--- a/beams/beams/custom_scripts/shift_assignment/shift_assignment.py
+++ b/beams/beams/custom_scripts/shift_assignment/shift_assignment.py
@@ -1,0 +1,20 @@
+import frappe
+
+def validate(doc, method=None):
+	"""
+	Check if the employee has another shift assignment on the same day.
+	If yes, set roster_type to 'Double Shift'.
+	"""
+	if not doc.employee or not doc.start_date:
+		return
+
+	# Check for existing assignments on the same day for the same employee
+	existing_assignments = frappe.get_all("Shift Assignment", filters={
+		"employee": doc.employee,
+		"start_date": doc.start_date,
+		"name": ["!=", doc.name],
+		"docstatus": ["!=", 2]
+	})
+
+	if existing_assignments:
+		doc.roster_type = "Double Shift"

--- a/beams/beams/custom_scripts/shift_assignment_tool/shift_assignment_tool.js
+++ b/beams/beams/custom_scripts/shift_assignment_tool/shift_assignment_tool.js
@@ -1,0 +1,23 @@
+frappe.ui.form.on('Shift Assignment Tool', {
+	onload: function(frm) {
+		if (!frm.doc.department || !frm.doc.company) {
+			frappe.db.get_value('Employee', {'user_id': frappe.session.user}, ['department', 'company'])
+				.then(r => {
+					let values = r.message;
+					if (values) {
+						if (!frm.doc.department && values.department) {
+							frm.set_value('department', values.department);
+						}
+						if (!frm.doc.company && values.company) {
+							frm.set_value('company', values.company);
+						}
+					}
+				});
+		}
+	},
+	start_date: function(frm) {
+		if (frm.doc.start_date) {
+			frm.set_value('end_date', frm.doc.start_date);
+		}
+	}
+});

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -79,6 +79,8 @@ doctype_js = {
 	"Item":"beams/custom_scripts/item/item.js",
 	"Journal Entry":"beams/custom_scripts/journal_entry/journal_entry.js",
 	"Expense Claim":"beams/custom_scripts/expense_claim/expense_claim.js",
+	"Shift Assignment":"beams/custom_scripts/shift_assignment/shift_assignment.js",
+	"Shift Assignment Tool":"beams/custom_scripts/shift_assignment_tool/shift_assignment_tool.js",
 }
 
 doctype_list_js = {
@@ -438,6 +440,9 @@ doc_events = {
 	},
 	"Supplier Quotation": {
 		"validate":"beams.beams.custom_scripts.supplier_quotation.supplier_quotation.clear_rate_if_no_rate_provided"
+	},
+	"Shift Assignment": {
+		"validate": "beams.beams.custom_scripts.shift_assignment.shift_assignment.validate"
 	},
 }
 

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -370,7 +370,7 @@ def get_shift_assignment_custom_fields():
 				"fieldname": "roster_type",
 				"fieldtype": "Select",
 				"label": "Roster Type",
-				"options":"\nRegular\nDouble Shift",
+				"options":"Regular\nDouble Shift",
 				"insert_after": "shift_type"
 			},
 			{


### PR DESCRIPTION
## Feature description
Task: TASK-2026-00274
1. Set Start Date auto-populates End Date in both Shift Assignment form and Shift Assignment Tool.
2. The Shift Assignment Tool now automatically defaults the 'Department' and 'Company' fields to the session user's details.
3. Implemented server side logic in Shift Assignment to detect existing assignments for the same Employee and Date, automatically upgrading the Roster Type to "Double Shift" if a conflict exists.
4. Removed blank line in Roster Type option.


## Was this feature tested on these browsers?
- [x]   Chrome

