### PR TITLE
fix:start date not able to change manually

### DIFF
--- a/beams/beams/custom_scripts/payroll_entry/payroll_entry.js
+++ b/beams/beams/custom_scripts/payroll_entry/payroll_entry.js
@@ -1,16 +1,17 @@
 frappe.ui.form.on('Payroll Entry', {
 	refresh: function(frm) {
-		set_previous_month_dates(frm);
+		if (frm.is_new() && frm.doc.posting_date && frm.doc.payroll_frequency === 'Monthly' && !frm.__dates_set_by_beams) {
+			set_previous_month_dates(frm);
+			frm.__dates_set_by_beams = true;
+		}
 	},
-	
+
 	posting_date: function(frm) {
 		set_previous_month_dates(frm);
 	},
-	
-	onload: function(frm) {
-		setTimeout(() => {
-			set_previous_month_dates(frm);
-		}, 500);
+
+	payroll_frequency: function(frm) {
+		set_previous_month_dates(frm);
 	}
 });
 
@@ -19,29 +20,35 @@ frappe.ui.form.on('Payroll Entry', {
 * relative to the selected `posting_date`.
 */
 function set_previous_month_dates(frm) {
-	if (!frm.doc.posting_date) {
+	if (!frm.doc.posting_date || frm.doc.payroll_frequency !== 'Monthly') {
 		return;
 	}
-	
+
 	let posting_date = frappe.datetime.str_to_obj(frm.doc.posting_date);
+	if (!posting_date) {
+		return;
+	}
+
 	let prev_year = posting_date.getFullYear();
 	let prev_month = posting_date.getMonth() - 1;
-	
+
 	if (prev_month < 0) {
 		prev_month = 11;
 		prev_year = prev_year - 1;
 	}
-	
+
 	let start_date = new Date(prev_year, prev_month, 1);
 	let end_date = new Date(prev_year, prev_month + 1, 0);
 	let start_date_formatted = frappe.datetime.obj_to_str(start_date);
 	let end_date_formatted = frappe.datetime.obj_to_str(end_date);
-	
+
 	if (frm.doc.start_date !== start_date_formatted) {
-		frm.set_value('start_date', start_date_formatted);
+		frm.doc.start_date = start_date_formatted;
+		frm.refresh_field('start_date');
 	}
-	
+
 	if (frm.doc.end_date !== end_date_formatted) {
-		frm.set_value('end_date', end_date_formatted);
+		frm.doc.end_date = end_date_formatted;
+		frm.refresh_field('end_date');
 	}
 }

--- a/beams/beams/custom_scripts/payroll_entry/payroll_entry.py
+++ b/beams/beams/custom_scripts/payroll_entry/payroll_entry.py
@@ -2,19 +2,12 @@ import frappe
 from frappe.utils import add_months, get_first_day, get_last_day, getdate
 
 def set_previous_month_dates(doc, method=None):
-    """Auto-set start_date and end_date to PREVIOUS month based on posting_date"""
-    
-    if not doc.posting_date:
-        return
-    
-    # Convert posting_date to date object
-    posting_date = getdate(doc.posting_date)
-    
-    # Get PREVIOUS month's first and last day
-    prev_month_date = add_months(posting_date, -1)
-    start_date = get_first_day(prev_month_date)
-    end_date = get_last_day(prev_month_date)
-    
-    # Set the dates to previous month
-    doc.start_date = start_date
-    doc.end_date = end_date 
+	"""Auto-set start_date and end_date to PREVIOUS month based on posting_date"""
+	if doc.posting_date and doc.payroll_frequency == 'Monthly':
+		if not doc.start_date or not doc.end_date:
+			# Get the first day of the previous month
+			posting_date = getdate(doc.posting_date)
+			prev_month_date = add_months(posting_date, -1)
+
+			doc.start_date = get_first_day(prev_month_date)
+			doc.end_date = get_last_day(prev_month_date)


### PR DESCRIPTION
## Feature description
Task: TASK-2026-00284
Fixes Payroll Entry date calculation to set previous month dates only for Monthly payroll frequency and ensures manual edits to start_date and end_date are not overridden.



## Was this feature tested on these browsers?
- [x]   Chrome
