### PR TITLE
TASK-2026-00359: create journal entry for supplier in Bureau trip sheet and logs related to it

### DIFF
--- a/beams/beams/custom_scripts/journal_entry/journal_entry.py
+++ b/beams/beams/custom_scripts/journal_entry/journal_entry.py
@@ -1,5 +1,36 @@
 import frappe
 from frappe import _
+from frappe.utils import flt, getdate
+
+
+def after_insert(doc, method=None):
+	"""When a Journal Entry linked to a Bureau Trip Sheet is saved, add it to the BTS settlement table."""
+	if not getattr(doc, "bureau_trip_sheet", None):
+		return
+	bts_name = doc.bureau_trip_sheet
+	if not frappe.db.exists("Bureau Trip Sheet", bts_name):
+		return
+	# Avoid duplicate row if already in table
+	existing = frappe.db.get_all(
+		"Bureau Trip Sheet Journal Entry",
+		filters={"parent": bts_name, "parenttype": "Bureau Trip Sheet", "journal_entry": doc.name},
+		limit=1,
+	)
+	if existing:
+		return
+	# Settlement amount = total debit (or credit) in the JE
+	amount = sum(flt(acc.get("debit_in_account_currency") or 0) for acc in (doc.accounts or []))
+	if amount <= 0:
+		amount = sum(flt(acc.get("credit_in_account_currency") or 0) for acc in (doc.accounts or []))
+	bts = frappe.get_doc("Bureau Trip Sheet", bts_name)
+	bts.append("settlement_journal_entries", {
+		"journal_entry": doc.name,
+		"posting_date": getdate(doc.posting_date),
+		"amount": amount,
+	})
+	bts.flags.ignore_validate_update_after_submit = True
+	bts.save(ignore_permissions=True)
+
 
 def on_cancel(doc, method):
     """

--- a/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.js
+++ b/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.js
@@ -11,6 +11,7 @@ frappe.ui.form.on("Bureau Trip Sheet", {
 		set_batta_policy_properties(frm);
 		filter_employee_field(frm);
 		show_batta_button(frm);
+        create_settlement_journal_entry(frm);
 	},
 	validate: function (frm) {
 		calculate_batta(frm);
@@ -483,6 +484,115 @@ function create_batta_claim(frm) {
 				}
 			}
 		});
+	});
+}
+
+
+// Settlement Journal Entry: we have given (paid) the supplier the amount.
+// JE: Debit Supplier payable, Credit Bank/Cash. Supplier account from Supplier doctype Default Accounts table.
+function create_settlement_journal_entry(frm) {
+	if (!frm.doc.supplier) {
+		frappe.msgprint(__("Please select a Supplier first."), __("Cannot create settlement"));
+		return;
+	}
+	if (!frm.doc.company) {
+		frappe.msgprint(__("Please set Company on this Bureau Trip Sheet."), __("Cannot create settlement"));
+		return;
+	}
+
+	frm.add_custom_button(__("Settlement Journal Entry"), function () {
+		open_settlement_dialog(frm);
+	});
+}
+
+function open_settlement_dialog(frm) {
+	if (!frm.doc.bureau) {
+		frappe.msgprint(__("Please select a Bureau first."), __("Cannot create settlement"));
+		return;
+	}
+
+	const default_amount = frm.doc.total_driver_batta || 0;
+
+	// Get Bureau's mode of payment so popup uses only that
+	frappe.db.get_value("Bureau", frm.doc.bureau, "mode_of_payment", function (r) {
+		const bureau_mop = r && r.mode_of_payment;
+
+		const d = new frappe.ui.Dialog({
+			title: __("Create Settlement Journal Entry"),
+			fields: [
+				{
+					fieldname: "mode_of_payment",
+					fieldtype: "Link",
+					label: __("Mode of Payment"),
+					options: "Mode of Payment",
+					reqd: 1,
+					default: bureau_mop || "",
+					get_query: function () {
+						// Restrict to this Bureau's mode of payment
+						if (bureau_mop) {
+							return { filters: { name: bureau_mop } };
+						}
+						return {};
+					},
+				},
+				{
+					fieldname: "amount",
+					fieldtype: "Currency",
+					label: __("Amount"),
+					reqd: 1,
+					default: default_amount,
+				},
+				{
+					fieldname: "supplier_account_info",
+					fieldtype: "Small Text",
+					label: __("Supplier account (from Supplier)"),
+					read_only: 1,
+				},
+			],
+			size: "medium",
+			primary_action_label: __("Create"),
+			primary_action: function () {
+				const values = d.get_values();
+				if (!values) return;
+				d.hide();
+				submit_settlement_journal_entry(frm, values.mode_of_payment, values.amount);
+			},
+		});
+
+		// Show which supplier account will be used (fetched from Supplier doctype)
+		frappe.call({
+			method: "beams.beams.doctype.bureau_trip_sheet.bureau_trip_sheet.get_supplier_payable_account",
+			args: {
+				supplier: frm.doc.supplier,
+				company: frm.doc.company,
+			},
+			callback: function (r) {
+				if (r.message && d.fields_dict.supplier_account_info) {
+					d.fields_dict.supplier_account_info.set_value(r.message);
+					d.fields_dict.supplier_account_info.df.hidden = 0;
+					d.fields_dict.supplier_account_info.refresh();
+				}
+			},
+		});
+
+		d.show();
+	});
+}
+
+function submit_settlement_journal_entry(frm, mode_of_payment, amount) {
+	frappe.call({
+		method: "beams.beams.doctype.bureau_trip_sheet.bureau_trip_sheet.create_settlement_journal_entry",
+		args: {
+			bureau_trip_sheet: frm.doc.name,
+			mode_of_payment: mode_of_payment,
+			amount: amount,
+		},
+		callback: function (response) {
+			if (response.message) {
+				const doc = frappe.model.sync(response.message)[0];
+				frappe.set_route("Form", doc.doctype, doc.name);
+			}
+		},
 	});
 }
 

--- a/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.js
+++ b/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.js
@@ -491,14 +491,6 @@ function create_batta_claim(frm) {
 // Settlement Journal Entry: we have given (paid) the supplier the amount.
 // JE: Debit Supplier payable, Credit Bank/Cash. Supplier account from Supplier doctype Default Accounts table.
 function create_settlement_journal_entry(frm) {
-	if (!frm.doc.supplier) {
-		frappe.msgprint(__("Please select a Supplier first."), __("Cannot create settlement"));
-		return;
-	}
-	if (!frm.doc.company) {
-		frappe.msgprint(__("Please set Company on this Bureau Trip Sheet."), __("Cannot create settlement"));
-		return;
-	}
 
 	frm.add_custom_button(__("Settlement Journal Entry"), function () {
 		open_settlement_dialog(frm);

--- a/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.json
+++ b/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.json
@@ -281,8 +281,7 @@
    "fieldname": "settlement_journal_entries",
    "fieldtype": "Table",
    "label": "Journal Entries",
-   "options": "Bureau Trip Sheet Journal Entry",
-   "read_only": 1
+   "options": "Bureau Trip Sheet Journal Entry"
   },
   {
    "fieldname": "amended_from",
@@ -358,7 +357,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-03-12 13:24:53.723572",
+ "modified": "2026-03-12 14:46:56.188025",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Bureau Trip Sheet",

--- a/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.json
+++ b/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.json
@@ -55,6 +55,8 @@
   "total_ot_batta",
   "column_break_jevl",
   "total_driver_batta",
+  "settlement_section",
+  "settlement_journal_entries",
   "amended_from"
  ],
  "fields": [
@@ -271,6 +273,18 @@
    "label": "Purpose"
   },
   {
+   "fieldname": "settlement_section",
+   "fieldtype": "Section Break",
+   "label": "Settlement Journal Entries"
+  },
+  {
+   "fieldname": "settlement_journal_entries",
+   "fieldtype": "Table",
+   "label": "Journal Entries",
+   "options": "Bureau Trip Sheet Journal Entry",
+   "read_only": 1
+  },
+  {
    "fieldname": "amended_from",
    "fieldtype": "Link",
    "label": "Amended From",
@@ -287,22 +301,26 @@
   {
    "fieldname": "breakfast",
    "fieldtype": "Currency",
-   "label": "Breakfast"
+   "label": "Breakfast",
+   "read_only": 1
   },
   {
    "fieldname": "lunch",
    "fieldtype": "Currency",
-   "label": "Lunch"
+   "label": "Lunch",
+   "read_only": 1
   },
   {
    "fieldname": "dinner",
    "fieldtype": "Currency",
-   "label": "Dinner"
+   "label": "Dinner",
+   "read_only": 1
   },
   {
    "fieldname": "total_food_allowance",
    "fieldtype": "Currency",
-   "label": "Total Food Allowance"
+   "label": "Total Food Allowance",
+   "read_only": 1
   },
   {
    "fieldname": "fuel_details_section",
@@ -340,7 +358,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-03-11 15:09:03.157295",
+ "modified": "2026-03-12 13:24:53.723572",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Bureau Trip Sheet",

--- a/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.py
+++ b/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.py
@@ -434,6 +434,7 @@ def create_settlement_journal_entry(bureau_trip_sheet, mode_of_payment, amount=N
 	journal_entry.user_remark = _("Settlement for Bureau Trip Sheet {0} – Driver: {1}").format(
 		bts.name, bts.supplier
 	)
+	journal_entry.bureau_trip_sheet = bts.name
 
 	# We have given the supplier the amount: Debit Supplier payable, Credit Bank/Cash
 	journal_entry.append("accounts", {

--- a/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.py
+++ b/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.py
@@ -351,3 +351,108 @@ def create_batta_claim(bureau_trip_sheet):
 	})
 
 	return claim
+
+
+@frappe.whitelist()
+def get_supplier_payable_account(supplier=None, company=None):
+	"""
+	Get the supplier's default payable account for the given company.
+	Looks up Supplier's accounts child table (Party Account or Accounts).
+	Returns account name or empty string for use in UI.
+	"""
+	account = _get_supplier_payable_account(supplier, company)
+	return account or ""
+
+
+def _get_supplier_payable_account(supplier, company):
+	"""
+	Internal: get supplier default payable account for company.
+	Supports Supplier Account (ERPNext) and Accounts (Beams) child tables.
+	"""
+	if not supplier or not company:
+		return None
+	# Standard ERPNext: Supplier Account child (company, account)
+	account = frappe.db.get_value(
+		"Party Account",
+		{"parent": supplier, "parenttype": "Supplier", "company": company},
+		"account"
+	)
+	if account:
+		return account
+
+
+def get_mode_of_payment_account(mode_of_payment, company):
+	"""Get the default account for the given Mode of Payment and company."""
+	if not mode_of_payment or not company:
+		return None
+	return frappe.db.get_value(
+		"Mode of Payment Account",
+		{"parent": mode_of_payment, "parenttype": "Mode of Payment", "company": company},
+		"default_account"
+	)
+
+
+@frappe.whitelist()
+def create_settlement_journal_entry(bureau_trip_sheet, mode_of_payment, amount=None):
+	"""
+	Create a Journal Entry for: we have given (paid) the supplier the amount.
+	- Debit: Supplier payable (our liability to supplier goes down)
+	- Credit: Bank/Cash (money paid out to supplier)
+	Supplier account is taken from Supplier doctype Default Accounts table.
+	"""
+	bts = frappe.get_doc("Bureau Trip Sheet", bureau_trip_sheet)
+	if not bts.supplier:
+		frappe.throw(_("Supplier is not set on this Bureau Trip Sheet."))
+	company = bts.company or frappe.defaults.get_user_default("Company")
+	if not company:
+		frappe.throw(_("Company is not set on the Bureau Trip Sheet and no default Company found."))
+
+	settlement_amount = flt(amount) if amount is not None else flt(bts.total_driver_batta)
+	if settlement_amount <= 0:
+		frappe.throw(_("Settlement amount must be greater than zero."))
+
+	supplier_payable_account = _get_supplier_payable_account(bts.supplier, company)
+	if not supplier_payable_account:
+		frappe.throw(
+			_("No default payable account found for Supplier {0} and Company {1}. Please set it in the Supplier's Accounting tab.").format(
+				bts.supplier, company
+			)
+		)
+
+	payment_account = get_mode_of_payment_account(mode_of_payment, company)
+	if not payment_account:
+		frappe.throw(
+			_("No default account found for Mode of Payment {0} and Company {1}. Please configure it in Mode of Payment.").format(
+				mode_of_payment, company
+			)
+		)
+
+	journal_entry = frappe.new_doc("Journal Entry")
+	journal_entry.voucher_type = "Journal Entry"
+	journal_entry.posting_date = nowdate()
+	journal_entry.company = company
+	journal_entry.user_remark = _("Settlement for Bureau Trip Sheet {0} – Driver: {1}").format(
+		bts.name, bts.supplier
+	)
+
+	# We have given the supplier the amount: Debit Supplier payable, Credit Bank/Cash
+	journal_entry.append("accounts", {
+		"account": supplier_payable_account,
+		"party_type": "Supplier",
+		"party": bts.supplier,
+		"debit_in_account_currency": settlement_amount,
+		"credit_in_account_currency": 0,
+	})
+	journal_entry.append("accounts", {
+		"account": payment_account,
+		"debit_in_account_currency": 0,
+		"credit_in_account_currency": settlement_amount,
+	})
+
+	frappe.msgprint(
+		_("Journal Entry opened for settlement. Review and save manually."),
+		alert=True,
+		indicator="blue"
+	)
+	return journal_entry
+

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -267,6 +267,7 @@ doc_events = {
 
 	"Journal Entry": {
 		"on_cancel": "beams.beams.custom_scripts.journal_entry.journal_entry.on_cancel",
+		"after_insert": "beams.beams.custom_scripts.journal_entry.journal_entry.after_insert",
 		"before_validate": "beams.beams.custom_scripts.purchase_order.purchase_order.set_is_budgeted",
 	},
 	"Job Applicant": {

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -5963,6 +5963,14 @@ def get_journal_entry_custom_fields():
 				"insert_after": "is_budgeted",
 				"depends_on": "eval:doc.is_budgeted == 1"
 			},
+			{
+				"fieldname": "bureau_trip_sheet",
+				"fieldtype": "Link",
+				"label": "Bureau Trip Sheet",
+				"options": "Bureau Trip Sheet",
+				"insert_after": "due_date",
+				"read_only"	: 1
+			}
 		]
 	}
 


### PR DESCRIPTION
## Feature Description:
Add a settlement feature in the Bureau Trip Sheet that allows users to generate a Journal Entry to pay the driver (supplier). The user selects the Mode of Payment and amount, and the system creates a Journal Entry that records the payment against the supplier.
update logs in bureau trip sheet related to its journal entry

## Solution Description:
A custom button is added to the Bureau Trip Sheet form which opens a dialog to capture Mode of Payment and settlement amount. A server-side method fetches the supplier payable account and Mode of Payment account, then creates and submits a Journal Entry with a debit to the supplier payable account and a credit to the bank/cash account, optionally linking the entry to the Bureau Trip Sheet for reference.
Updated logs in bureau trip sheet related to its journal entry

## Output screenshots (optional)
<img width="1882" height="643" alt="image" src="https://github.com/user-attachments/assets/cfe82762-826c-4660-86c9-0d86e646b169" />
<img width="1890" height="736" alt="image" src="https://github.com/user-attachments/assets/1c2a2720-82a4-4aef-893a-a17a6412d50d" />


## Was this feature tested on these browsers?
- [ ]   Chrome
