### PR TITLE
TASK-2026-00360: add fuel and batta details and agrregations

### DIFF
--- a/beams/beams/custom_scripts/journal_entry/journal_entry.py
+++ b/beams/beams/custom_scripts/journal_entry/journal_entry.py
@@ -3,8 +3,8 @@ from frappe import _
 from frappe.utils import flt, getdate
 
 
-def after_insert(doc, method=None):
-	"""When a Journal Entry linked to a Bureau Trip Sheet is saved, add it to the BTS settlement table."""
+def on_submit(doc, method=None):
+	"""When a Journal Entry linked to a Bureau Trip Sheet is submitted (docstatus=1), add it to the BTS settlement table."""
 	if not getattr(doc, "bureau_trip_sheet", None):
 		return
 	bts_name = doc.bureau_trip_sheet
@@ -33,23 +33,37 @@ def after_insert(doc, method=None):
 
 
 def on_cancel(doc, method):
-    """
-    This method is called when the Journal Entry is canceled.
-    and updates the 'is_paid' field in the Substitute Booking.
-    """
-    # Check if the Journal Entry is linked to a Substitute Booking
-    substitute_booking_name = doc.substitute_booking_reference
-    if substitute_booking_name:
-        # Fetch the related Substitute Booking document
-        substitute_booking = frappe.get_doc('Substitute Booking', substitute_booking_name)
+	# Remove this JE from Bureau Trip Sheet settlement_journal_entries if linked
+	bts_name = getattr(doc, "bureau_trip_sheet", None)
+	if bts_name and frappe.db.exists("Bureau Trip Sheet", bts_name):
+		child = frappe.db.get_value(
+			"Bureau Trip Sheet Journal Entry",
+			{"parent": bts_name, "parenttype": "Bureau Trip Sheet", "journal_entry": doc.name},
+			"name",
+		)
+		if child:
+			bts = frappe.get_doc("Bureau Trip Sheet", bts_name)
+			bts.flags.ignore_validate_update_after_submit = True
+			for i, row in enumerate(bts.settlement_journal_entries or []):
+				if row.journal_entry == doc.name:
+					bts.settlement_journal_entries.pop(i)
+					break
+			bts.save(ignore_permissions=True)
 
-        # Uncheck 'is_paid' in Substitute Booking
-        substitute_booking.db_set('is_paid', 0)
-        substitute_booking.save()
+	# This method is called when the Journal Entry is canceled.
+	# Updates the 'is_paid' field in the Substitute Booking.
+	substitute_booking_name = doc.substitute_booking_reference
+	if substitute_booking_name:
+		# Fetch the related Substitute Booking document
+		substitute_booking = frappe.get_doc('Substitute Booking', substitute_booking_name)
 
-        # Display success message
-        frappe.msgprint(_("Journal Entry cancelled, and Substitute Booking updated successfully."))
+		# Uncheck 'is_paid' in Substitute Booking
+		substitute_booking.db_set('is_paid', 0)
+		substitute_booking.save()
 
-    else:
-        # Handle case where no Substitute Booking is linked
-        frappe.msgprint(_("No Substitute Booking linked to this Journal Entry."))
+		# Display success message
+		frappe.msgprint(_("Journal Entry cancelled, and Substitute Booking updated successfully."))
+
+	else:
+		# Handle case where no Substitute Booking is linked
+		frappe.msgprint(_("No Substitute Booking linked to this Journal Entry."))

--- a/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.js
+++ b/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.js
@@ -42,5 +42,50 @@ frappe.ui.form.on('Beams Accounts Settings', {
                 }
             };
         });
+        Bureau_trip_sheet_filters(frm);
     }
 });
+
+// filters to get service items for Bureau trip sheet related fields
+function Bureau_trip_sheet_filters(frm) {
+
+    frm.set_query("batta_expense_item", function() {
+        return {
+            filters: {
+                "is_stock_item" : 0,
+                "is_fixed_asset": 0,
+                "is_bundle_item": 0
+            }
+        }
+    })
+
+    frm.set_query("fuel_expense_item", function() {
+        return {
+            filters: {
+                "is_stock_item" : 0,
+                "is_fixed_asset": 0,
+                "is_bundle_item": 0
+            }
+        }
+    })
+
+    frm.set_query("rent_expense_item", function() {
+        return {
+            filters: {
+                "is_stock_item" : 0,
+                "is_fixed_asset": 0,
+                "is_bundle_item": 0
+            }
+        }
+    })
+
+    frm.set_query("batta_ot_expense_item", function() {
+        return {
+            filters: {
+                "is_stock_item" : 0,
+                "is_fixed_asset": 0,
+                "is_bundle_item": 0
+            }
+        }
+    })
+}

--- a/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.json
+++ b/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.json
@@ -26,7 +26,13 @@
   "default_debit_account",
   "stringer_settings_tab",
   "stringer_service_item",
-  "column_break_ixlf"
+  "column_break_ixlf",
+  "bureau_settings_tab",
+  "batta_expense_item",
+  "fuel_expense_item",
+  "column_break_jkfg",
+  "rent_expense_item",
+  "batta_ot_expense_item"
  ],
  "fields": [
   {
@@ -150,12 +156,45 @@
    "fieldtype": "Link",
    "label": "Default Indirect Expense Account",
    "options": "Account"
+  },
+  {
+   "fieldname": "bureau_settings_tab",
+   "fieldtype": "Tab Break",
+   "label": "Bureau Trip Sheet Settings"
+  },
+  {
+   "fieldname": "batta_expense_item",
+   "fieldtype": "Link",
+   "label": "Batta Expense Item",
+   "options": "Item"
+  },
+  {
+   "fieldname": "fuel_expense_item",
+   "fieldtype": "Link",
+   "label": "Fuel Expense Item",
+   "options": "Item"
+  },
+  {
+   "fieldname": "column_break_jkfg",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "rent_expense_item",
+   "fieldtype": "Link",
+   "label": "Rent Expense Item",
+   "options": "Item"
+  },
+  {
+   "fieldname": "batta_ot_expense_item",
+   "fieldtype": "Link",
+   "label": "OT Expense Item",
+   "options": "Item"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-11-18 10:03:19.688942",
+ "modified": "2026-03-13 14:44:11.652364",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Beams Accounts Settings",

--- a/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.js
+++ b/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.js
@@ -237,10 +237,7 @@ function calculate_fuel(frm) {
 	if (distance && mileage) {
 		let fuel_consumption = distance / mileage;
 		frm.set_value("fuel_consumption_l", fuel_consumption);
-		let expense = fuel_consumption * rate;
-		frm.set_value("total_fuel_expense", expense);
 		frm.refresh_field("fuel_consumption_l");
-		frm.refresh_field("total_fuel_expense");
 	}
 }
 

--- a/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.json
+++ b/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.json
@@ -25,10 +25,8 @@
   "purpose",
   "fuel_details_section",
   "average_mileage_kmpl",
-  "fuel_rate__litre",
   "column_break_vvvy",
   "fuel_consumption_l",
-  "total_fuel_expense",
   "section_break_xxsb",
   "total_distance_km",
   "column_break_fgob",
@@ -327,11 +325,6 @@
    "label": "Fuel Details"
   },
   {
-   "fieldname": "fuel_rate__litre",
-   "fieldtype": "Float",
-   "label": "Fuel Rate / Litre"
-  },
-  {
    "fieldname": "fuel_consumption_l",
    "fieldtype": "Float",
    "label": "Fuel Consumption (L)",
@@ -340,12 +333,6 @@
   {
    "fieldname": "column_break_vvvy",
    "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "total_fuel_expense",
-   "fieldtype": "Float",
-   "label": "Total Fuel Expense",
-   "read_only": 1
   },
   {
    "fieldname": "average_mileage_kmpl",
@@ -357,7 +344,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-03-12 14:46:56.188025",
+ "modified": "2026-03-13 09:23:13.957430",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Bureau Trip Sheet",

--- a/beams/beams/doctype/bureau_trip_sheet_journal_entry/bureau_trip_sheet_journal_entry.json
+++ b/beams/beams/doctype/bureau_trip_sheet_journal_entry/bureau_trip_sheet_journal_entry.json
@@ -1,0 +1,56 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2026-03-12 00:00:00",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "journal_entry",
+  "posting_date",
+  "amount",
+  "status"
+ ],
+ "fields": [
+  {
+   "fieldname": "journal_entry",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Journal Entry",
+   "options": "Journal Entry",
+   "read_only": 1
+  },
+  {
+   "fieldname": "posting_date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "Posting Date",
+   "read_only": 1
+  },
+  {
+   "fieldname": "amount",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Amount",
+   "read_only": 1
+  },
+  {
+   "fieldname": "status",
+   "fieldtype": "Data",
+   "label": "Status"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2026-03-12 14:00:58.150076",
+ "modified_by": "Administrator",
+ "module": "BEAMS",
+ "name": "Bureau Trip Sheet Journal Entry",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/beams/beams/doctype/bureau_trip_sheet_journal_entry/bureau_trip_sheet_journal_entry.py
+++ b/beams/beams/doctype/bureau_trip_sheet_journal_entry/bureau_trip_sheet_journal_entry.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, efeone and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class BureauTripSheetJournalEntry(Document):
+	pass

--- a/beams/beams/doctype/monthly_consolidated_trip_sheet/monthly_consolidated_trip_sheet.js
+++ b/beams/beams/doctype/monthly_consolidated_trip_sheet/monthly_consolidated_trip_sheet.js
@@ -6,6 +6,13 @@ frappe.ui.form.on('Monthly Consolidated Trip Sheet', {
     onload(frm) {
         set_yeat(frm);
         set_supplier_filter(frm);
+        add_fetch_trip_sheets_button(frm);
+    },
+    refresh(frm) {
+        add_fetch_trip_sheets_button(frm);
+    },
+    fuel_rate__litre: function(frm) {
+        calculate_fuel_expense(frm)
     }
 });
 
@@ -23,6 +30,54 @@ function set_supplier_filter(frm) {
             filters: {
                 is_transporter: 1
             }
+        };
+    });
+}
+
+// Button to fetch Bureau Trip Sheets for the selected supplier, bureau, month and year
+function add_fetch_trip_sheets_button(frm) {
+    frm.add_custom_button(__("Fetch Trip Sheets"), function() {
+        if (!frm.doc.supplier || !frm.doc.bureau || !frm.doc.month || !frm.doc.year) {
+            frappe.msgprint(__("Please set Supplier, Bureau, Month and Year first."));
+            return;
         }
-    })
+        frappe.call({
+            method: "beams.beams.doctype.monthly_consolidated_trip_sheet.monthly_consolidated_trip_sheet.fetch_trip_sheets",
+            args: {
+                supplier: frm.doc.supplier,
+                bureau: frm.doc.bureau,
+                month: frm.doc.month,
+                year: frm.doc.year
+            },
+            callback: function(r) {
+                if (r.message && r.message.length) {
+                    frm.clear_table("monthly_consolidated_trip_sheet_details");
+                    (r.message || []).forEach(function(row) {
+                        frm.add_child("monthly_consolidated_trip_sheet_details", row);
+                    });
+                    frm.refresh_field("monthly_consolidated_trip_sheet_details");
+                    frappe.show_alert({ message: __("Fetched {0} trip sheet(s).", [r.message.length]), indicator: "green" });
+                } else {
+                    frappe.msgprint(__("No trip sheets found for the selected criteria."));
+                }
+            }
+        });
+    });
+}
+
+// calculate fuel expense of monthly_consolidated_trip_sheet_details
+function calculate_fuel_expense(frm) {
+
+    let fuel_rate__litre = frm.doc.fuel_rate__litre || 0;
+    let total_fuel = 0;
+
+    (frm.doc.monthly_consolidated_trip_sheet_details || []).forEach(row => {
+        total_fuel += row.fuel_consumption_l || 0;
+    });
+
+    frm.set_value("total_fuel_consumed", total_fuel);
+
+    let total_expense = fuel_rate__litre * total_fuel;
+
+    frm.set_value("total_fuel_expense", total_expense);
 }

--- a/beams/beams/doctype/monthly_consolidated_trip_sheet/monthly_consolidated_trip_sheet.js
+++ b/beams/beams/doctype/monthly_consolidated_trip_sheet/monthly_consolidated_trip_sheet.js
@@ -7,9 +7,11 @@ frappe.ui.form.on('Monthly Consolidated Trip Sheet', {
         set_yeat(frm);
         set_supplier_filter(frm);
         add_fetch_trip_sheets_button(frm);
+        add_create_purchase_invoice_button(frm);
     },
     refresh(frm) {
         add_fetch_trip_sheets_button(frm);
+        add_create_purchase_invoice_button(frm);
         calculate_batta_totals(frm);
     },
     fuel_rate__litre: function(frm) {
@@ -71,18 +73,121 @@ function add_fetch_trip_sheets_button(frm) {
     });
 }
 
-// Sum total_batta and total_ot_batta from child rows into Batta Details section
+// Create Purchase Invoice: open popup with items/rates from Beams Accounts Settings and doc totals
+function add_create_purchase_invoice_button(frm) {
+    frm.add_custom_button(__("Create Purchase Invoice"), function() {
+        if (frm.is_dirty()) {
+            frappe.msgprint(__("Please save the document first."));
+            return;
+        }
+        if (!frm.doc.name) {
+            frappe.msgprint(__("Please save the document first."));
+            return;
+        }
+        frappe.call({
+            method: "beams.beams.doctype.monthly_consolidated_trip_sheet.monthly_consolidated_trip_sheet.get_purchase_invoice_details",
+            args: { monthly_consolidated_trip_sheet_name: frm.doc.name },
+            callback: function(r) {
+                if (r.message && r.message.items && r.message.items.length) {
+                    show_create_pi_dialog(frm, r.message);
+                } else {
+                    frappe.msgprint(
+                        __("No expense items to show. Open Beams Accounts Settings, go to the Bureau Trip Sheet Settings tab, and set at least one of: Batta Expense Item, Fuel Expense Item, Rent Expense Item, Batta Ot Expense Item. Save the settings and try again."),
+                        __("Settings required")
+                    );
+                }
+            }
+        });
+    });
+}
+
+function show_create_pi_dialog(frm, details) {
+    var table_data = (details.items || []).map(function(row) {
+        return {
+            expense_type: row.label || "",
+            item: row.item_name || row.item_code || "",
+            rate: flt(row.rate)
+        };
+    });
+
+    var d = new frappe.ui.Dialog({
+        title: __("Create Purchase Invoice"),
+        size: "medium",
+        fields: [
+            {
+                fieldtype: "Table",
+                fieldname: "items_table",
+                label: __("Invoice lines (from Bureau Trip Sheet Settings)"),
+                cannot_add_rows: true,
+                in_list_view: 1,
+                fields: [
+                    {
+                        fieldtype: "Data",
+                        fieldname: "expense_type",
+                        label: __("Expense"),
+                        read_only: 1,
+                        in_list_view: 1
+                    },
+                    {
+                        fieldtype: "Data",
+                        fieldname: "item",
+                        label: __("Item"),
+                        read_only: 1,
+                        in_list_view: 1
+                    },
+                    {
+                        fieldtype: "Currency",
+                        fieldname: "rate",
+                        label: __("Rate"),
+                        read_only: 1,
+                        in_list_view: 1
+                    }
+                ],
+                data: table_data
+            }
+        ],
+        primary_action_label: __("Create"),
+        primary_action: function() {
+            d.hide();
+            // Open new Purchase Invoice with data pre-filled; user saves manually
+            frappe.model.with_doctype("Purchase Invoice", function() {
+                var doc = frappe.model.get_new_doc("Purchase Invoice");
+                doc.supplier = details.supplier;
+                doc.bureau = details.bureau || "";
+                doc.company = details.company || frappe.defaults.get_default("company");
+                doc.cost_center = details.cost_center || "";
+                doc.set_posting_time = 1;
+                doc.posting_date = details.posting_date || frappe.datetime.get_today();
+                (details.items || []).forEach(function(row) {
+                    if (flt(row.rate) === 0) return;
+                    var child = frappe.model.add_child(doc, "Purchase Invoice Item", "items");
+                    child.item_code = row.item_code;
+                    child.qty = 1;
+                    child.rate = flt(row.rate);
+                });
+                frappe.set_route("Form", "Purchase Invoice", doc.name);
+            });
+        }
+    });
+    d.show();
+}
+
+// Sum total_batta, total_ot_batta and amount_received_driver from child rows
 function calculate_batta_totals(frm) {
     var total_batta = 0;
     var total_ot_batta = 0;
+    var total_amount_received_driver = 0;
     (frm.doc.monthly_consolidated_trip_sheet_details || []).forEach(function(row) {
         total_batta += flt(row.total_batta);
         total_ot_batta += flt(row.total_ot_batta);
+        total_amount_received_driver += flt(row.amount_received_driver);
     });
     frm.set_value("total_batta", total_batta);
     frm.set_value("total_ot_batta", total_ot_batta);
+    frm.set_value("total_amount_received_driver", total_amount_received_driver);
     frm.refresh_field("total_batta");
     frm.refresh_field("total_ot_batta");
+    frm.refresh_field("total_amount_received_driver");
 }
 
 // Calculate fuel expense of monthly_consolidated_trip_sheet_details

--- a/beams/beams/doctype/monthly_consolidated_trip_sheet/monthly_consolidated_trip_sheet.js
+++ b/beams/beams/doctype/monthly_consolidated_trip_sheet/monthly_consolidated_trip_sheet.js
@@ -162,6 +162,8 @@ function show_create_pi_dialog(frm, details) {
                     if (flt(row.rate) === 0) return;
                     var child = frappe.model.add_child(doc, "Purchase Invoice Item", "items");
                     child.item_code = row.item_code;
+                    child.item_name = row.item_name || row.item_code;
+                    child.uom = row.uom || "Nos";
                     child.qty = 1;
                     child.rate = flt(row.rate);
                 });

--- a/beams/beams/doctype/monthly_consolidated_trip_sheet/monthly_consolidated_trip_sheet.js
+++ b/beams/beams/doctype/monthly_consolidated_trip_sheet/monthly_consolidated_trip_sheet.js
@@ -10,9 +10,13 @@ frappe.ui.form.on('Monthly Consolidated Trip Sheet', {
     },
     refresh(frm) {
         add_fetch_trip_sheets_button(frm);
+        calculate_batta_totals(frm);
     },
     fuel_rate__litre: function(frm) {
-        calculate_fuel_expense(frm)
+        calculate_fuel_expense(frm);
+    },
+    monthly_consolidated_trip_sheet_details_on_form_rendered: function(frm, cdt, cdn) {
+        calculate_batta_totals(frm);
     }
 });
 
@@ -56,6 +60,8 @@ function add_fetch_trip_sheets_button(frm) {
                         frm.add_child("monthly_consolidated_trip_sheet_details", row);
                     });
                     frm.refresh_field("monthly_consolidated_trip_sheet_details");
+                    calculate_batta_totals(frm);
+                    calculate_fuel_expense(frm);
                     frappe.show_alert({ message: __("Fetched {0} trip sheet(s).", [r.message.length]), indicator: "green" });
                 } else {
                     frappe.msgprint(__("No trip sheets found for the selected criteria."));
@@ -65,7 +71,21 @@ function add_fetch_trip_sheets_button(frm) {
     });
 }
 
-// calculate fuel expense of monthly_consolidated_trip_sheet_details
+// Sum total_batta and total_ot_batta from child rows into Batta Details section
+function calculate_batta_totals(frm) {
+    var total_batta = 0;
+    var total_ot_batta = 0;
+    (frm.doc.monthly_consolidated_trip_sheet_details || []).forEach(function(row) {
+        total_batta += flt(row.total_batta);
+        total_ot_batta += flt(row.total_ot_batta);
+    });
+    frm.set_value("total_batta", total_batta);
+    frm.set_value("total_ot_batta", total_ot_batta);
+    frm.refresh_field("total_batta");
+    frm.refresh_field("total_ot_batta");
+}
+
+// Calculate fuel expense of monthly_consolidated_trip_sheet_details
 function calculate_fuel_expense(frm) {
 
     let fuel_rate__litre = frm.doc.fuel_rate__litre || 0;

--- a/beams/beams/doctype/monthly_consolidated_trip_sheet/monthly_consolidated_trip_sheet.json
+++ b/beams/beams/doctype/monthly_consolidated_trip_sheet/monthly_consolidated_trip_sheet.json
@@ -22,7 +22,11 @@
   "batta_details_section",
   "total_batta",
   "column_break_jykh",
-  "total_ot_batta"
+  "total_ot_batta",
+  "rent_details_section",
+  "total_montly_rent",
+  "column_break_qfbo",
+  "total_amount_received_driver"
  ],
  "fields": [
   {
@@ -116,12 +120,34 @@
    "fieldtype": "Currency",
    "label": "Total OT Batta",
    "read_only": 1
+  },
+  {
+   "fieldname": "rent_details_section",
+   "fieldtype": "Section Break",
+   "label": "Rent Details"
+  },
+  {
+   "fetch_from": "supplier.montly_rent",
+   "fieldname": "total_montly_rent",
+   "fieldtype": "Currency",
+   "label": "Montly Rent (Driver)",
+   "read_only": 1
+  },
+  {
+   "fieldname": "total_amount_received_driver",
+   "fieldtype": "Currency",
+   "label": "Total amount Received (Driver)",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_qfbo",
+   "fieldtype": "Column Break"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-03-12 18:14:33.812991",
+ "modified": "2026-03-13 10:58:15.965104",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Monthly Consolidated Trip Sheet",

--- a/beams/beams/doctype/monthly_consolidated_trip_sheet/monthly_consolidated_trip_sheet.json
+++ b/beams/beams/doctype/monthly_consolidated_trip_sheet/monthly_consolidated_trip_sheet.json
@@ -12,7 +12,17 @@
   "year",
   "month",
   "section_break_vkfd",
-  "monthly_consolidated_trip_sheet_details"
+  "monthly_consolidated_trip_sheet_details",
+  "fuel_details_section",
+  "fuel_rate__litre",
+  "column_break_aulq",
+  "total_fuel_consumed",
+  "column_break_dqtr",
+  "total_fuel_expense",
+  "batta_details_section",
+  "total_batta",
+  "column_break_jykh",
+  "total_ot_batta"
  ],
  "fields": [
   {
@@ -55,12 +65,63 @@
    "fieldtype": "Table",
    "label": "Monthly Consolidated Trip Sheet Details",
    "options": "Monthly Consolidated Trip Sheet Details"
+  },
+  {
+   "fieldname": "fuel_details_section",
+   "fieldtype": "Section Break",
+   "label": "Fuel Details"
+  },
+  {
+   "fieldname": "fuel_rate__litre",
+   "fieldtype": "Currency",
+   "label": "Fuel Rate / Litre"
+  },
+  {
+   "fieldname": "column_break_aulq",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "total_fuel_consumed",
+   "fieldtype": "Float",
+   "label": "Total Fuel Consumed",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_dqtr",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "total_fuel_expense",
+   "fieldtype": "Float",
+   "label": "Total Fuel Expense",
+   "read_only": 1
+  },
+  {
+   "fieldname": "batta_details_section",
+   "fieldtype": "Section Break",
+   "label": "Batta Details"
+  },
+  {
+   "fieldname": "total_batta",
+   "fieldtype": "Currency",
+   "label": "Total Batta",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_jykh",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "total_ot_batta",
+   "fieldtype": "Currency",
+   "label": "Total OT Batta",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-03-10 10:16:43.397333",
+ "modified": "2026-03-12 18:14:33.812991",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Monthly Consolidated Trip Sheet",

--- a/beams/beams/doctype/monthly_consolidated_trip_sheet/monthly_consolidated_trip_sheet.py
+++ b/beams/beams/doctype/monthly_consolidated_trip_sheet/monthly_consolidated_trip_sheet.py
@@ -4,6 +4,7 @@
 import frappe
 from frappe.model.document import Document
 from frappe.utils import flt, get_first_day, get_last_day, getdate
+from frappe import _
 
 
 class MonthlyConsolidatedTripSheet(Document):
@@ -20,14 +21,17 @@ class MonthlyConsolidatedTripSheet(Document):
 		return None
 
 	def _set_batta_totals_from_details(self):
-		"""Set total_batta and total_ot_batta from sum of child table rows."""
+		"""Set total_batta, total_ot_batta and total_amount_received_driver from sum of child table rows."""
 		total_batta = 0
 		total_ot_batta = 0
+		total_amount_received_driver = 0
 		for row in self.get("monthly_consolidated_trip_sheet_details") or []:
 			total_batta += flt(row.get("total_batta"))
 			total_ot_batta += flt(row.get("total_ot_batta"))
+			total_amount_received_driver += flt(row.get("amount_received_driver"))
 		self.total_batta = total_batta
 		self.total_ot_batta = total_ot_batta
+		self.total_amount_received_driver = total_amount_received_driver
 
 
 @frappe.whitelist()
@@ -49,7 +53,7 @@ def fetch_trip_sheets(supplier, bureau, month, year):
 	last_day = get_last_day(first_day)
 	trip_sheets = frappe.db.get_all(
 		"Bureau Trip Sheet",
-		filters={"supplier": supplier, "bureau": bureau},
+		filters={"supplier": supplier, "bureau": bureau, "docstatus": 1},
 		fields=[
 			"name", "departure_location", "destination_location",
 			"initial_odometer_reading", "final_odometer_reading",
@@ -63,6 +67,16 @@ def fetch_trip_sheets(supplier, bureau, month, year):
 		start_date = ts.get("starting_date_and_time") and getdate(ts["starting_date_and_time"])
 		if not start_date or not (first_day <= start_date <= last_day):
 			continue
+		# Sum of settlement_journal_entries.amount for this Bureau Trip Sheet
+		amount_received = frappe.db.sql(
+			"""
+			SELECT COALESCE(SUM(amount), 0) FROM `tabBureau Trip Sheet Journal Entry`
+			WHERE parent = %s
+			""",
+			(ts.get("name"),),
+			as_dict=False,
+		)
+		amount_received_driver = flt(amount_received[0][0]) if amount_received else 0
 		rows.append({
 			"departure_location": ts.get("departure_location") or "",
 			"destination_location": ts.get("destination_location") or "",
@@ -74,7 +88,96 @@ def fetch_trip_sheets(supplier, bureau, month, year):
 			"bureau_trip_sheet": ts.get("name"),
 			"total_batta": ts.get("total_daily_batta"),
 			"total_ot_batta": ts.get("total_ot_batta"),
+			"amount_received_driver": amount_received_driver,
 			"average_mileage_kmpl": ts.get("average_mileage_kmpl"),
 			"fuel_consumption_l": ts.get("fuel_consumption_l"),
 		})
 	return rows
+
+
+@frappe.whitelist()
+def get_purchase_invoice_details(monthly_consolidated_trip_sheet_name):
+	"""
+	Get expense items from Beams Accounts Settings (Bureau Trip Sheet Settings) and
+	rates from the Monthly Consolidated Trip Sheet for the Create Purchase Invoice popup.
+	"""
+	doc = frappe.get_doc("Monthly Consolidated Trip Sheet", monthly_consolidated_trip_sheet_name)
+	company = None
+	cost_center = None
+	if doc.bureau:
+		bureau_doc = frappe.db.get_value(
+			"Bureau", doc.bureau, ["company", "cost_center"], as_dict=True
+		)
+		if bureau_doc:
+			company = bureau_doc.get("company")
+			cost_center = bureau_doc.get("cost_center")
+	if not company:
+		company = frappe.defaults.get_default("company")
+
+	# Rent: Montly Rent (Driver) - Total amount Received (Driver), per Monthly Consolidated Trip Sheet
+	rent_rate = flt(doc.total_montly_rent)
+
+	# Order and labels match Beams Accounts Settings > Bureau Trip Sheet Settings tab
+	# Read each item from Single doctype via db so values are always loaded
+	item_specs = [
+		("batta_expense_item", "Batta Expense Item", flt(doc.total_batta)),
+		("fuel_expense_item", "Fuel Expense Item", flt(doc.total_fuel_expense)),
+		("rent_expense_item", "Rent Expense Item", rent_rate),
+		("batta_ot_expense_item", "Batta Ot Expense Item", flt(doc.total_ot_batta)),
+	]
+	items = []
+	for field, label, rate in item_specs:
+		item_code = frappe.db.get_single_value("Beams Accounts Settings", field)
+		if not item_code:
+			continue
+		item_name = frappe.db.get_value("Item", item_code, "item_name") or item_code
+		items.append({
+			"item_code": item_code,
+			"item_name": item_name,
+			"label": label,
+			"rate": rate,
+		})
+
+	return {
+		"supplier": doc.supplier,
+		"bureau": doc.bureau,
+		"company": company,
+		"cost_center": cost_center,
+		"posting_date": frappe.utils.nowdate(),
+		"items": items,
+	}
+
+
+@frappe.whitelist()
+def create_purchase_invoice_from_monthly_consolidated(monthly_consolidated_trip_sheet_name):
+	"""
+	Create a Purchase Invoice from Monthly Consolidated Trip Sheet using
+	Beams Accounts Settings (Bureau Trip Sheet Settings) items and doc totals.
+	"""
+	details = get_purchase_invoice_details(monthly_consolidated_trip_sheet_name)
+	if not details.get("supplier"):
+		frappe.throw(_("Supplier is not set on Monthly Consolidated Trip Sheet."))
+	if not details.get("items"):
+		frappe.throw(_("No expense items configured in Beams Accounts Settings > Bureau Trip Sheet Settings."))
+
+	pi = frappe.new_doc("Purchase Invoice")
+	pi.supplier = details["supplier"]
+	pi.bureau = details.get("bureau")
+	pi.company = details.get("company") or frappe.defaults.get_default("company")
+	pi.cost_center = details.get("cost_center")
+	pi.set_posting_time = 1
+	pi.posting_date = frappe.utils.nowdate()
+
+	for row in details["items"]:
+		if flt(row.get("rate")) == 0:
+			continue
+		pi.append("items", {
+			"item_code": row["item_code"],
+			"qty": 1,
+			"rate": row["rate"],
+		})
+
+	pi.flags.ignore_permissions = True
+	pi.insert()
+
+	return pi.name

--- a/beams/beams/doctype/monthly_consolidated_trip_sheet/monthly_consolidated_trip_sheet.py
+++ b/beams/beams/doctype/monthly_consolidated_trip_sheet/monthly_consolidated_trip_sheet.py
@@ -130,10 +130,15 @@ def get_purchase_invoice_details(monthly_consolidated_trip_sheet_name):
 		item_code = frappe.db.get_single_value("Beams Accounts Settings", field)
 		if not item_code:
 			continue
-		item_name = frappe.db.get_value("Item", item_code, "item_name") or item_code
+		item_row = frappe.db.get_value(
+			"Item", item_code, ["item_name", "stock_uom"], as_dict=True
+		)
+		item_name = (item_row and item_row.get("item_name")) or item_code
+		uom = (item_row and item_row.get("stock_uom")) or "Nos"
 		items.append({
 			"item_code": item_code,
 			"item_name": item_name,
+			"uom": uom,
 			"label": label,
 			"rate": rate,
 		})

--- a/beams/beams/doctype/monthly_consolidated_trip_sheet/monthly_consolidated_trip_sheet.py
+++ b/beams/beams/doctype/monthly_consolidated_trip_sheet/monthly_consolidated_trip_sheet.py
@@ -3,10 +3,13 @@
 
 import frappe
 from frappe.model.document import Document
-from frappe.utils import get_first_day, get_last_day, getdate
+from frappe.utils import flt, get_first_day, get_last_day, getdate
 
 
 class MonthlyConsolidatedTripSheet(Document):
+	def validate(self):
+		self._set_batta_totals_from_details()
+
 	def _month_name_to_number(self, month_name):
 		months = [
 			"January", "February", "March", "April", "May", "June",
@@ -15,6 +18,16 @@ class MonthlyConsolidatedTripSheet(Document):
 		if month_name in months:
 			return months.index(month_name) + 1
 		return None
+
+	def _set_batta_totals_from_details(self):
+		"""Set total_batta and total_ot_batta from sum of child table rows."""
+		total_batta = 0
+		total_ot_batta = 0
+		for row in self.get("monthly_consolidated_trip_sheet_details") or []:
+			total_batta += flt(row.get("total_batta"))
+			total_ot_batta += flt(row.get("total_ot_batta"))
+		self.total_batta = total_batta
+		self.total_ot_batta = total_ot_batta
 
 
 @frappe.whitelist()

--- a/beams/beams/doctype/monthly_consolidated_trip_sheet/monthly_consolidated_trip_sheet.py
+++ b/beams/beams/doctype/monthly_consolidated_trip_sheet/monthly_consolidated_trip_sheet.py
@@ -7,47 +7,6 @@ from frappe.utils import get_first_day, get_last_day, getdate
 
 
 class MonthlyConsolidatedTripSheet(Document):
-	def validate(self):
-		self.fetch_trip_sheets()
-
-	def fetch_trip_sheets(self):
-		"""Fetch Bureau Trip Sheets for the given supplier, bureau, month and year; add rows to child table."""
-		if not all([self.supplier, self.bureau, self.month, self.year]):
-			return
-		month_number = self._month_name_to_number(self.month)
-		if not month_number:
-			return
-		first_day = get_first_day(f"{self.year}-{month_number:02d}-01")
-		last_day = get_last_day(first_day)
-		trip_sheets = frappe.db.get_all(
-			"Bureau Trip Sheet",
-			filters={
-				"supplier": self.supplier,
-				"bureau": self.bureau,
-			},
-			fields=[
-				"name", "departure_location", "destination_location",
-				"initial_odometer_reading", "final_odometer_reading",
-				"starting_date_and_time", "ending_date_and_time",
-				"distance_travelledkm",
-			],
-		)
-		self.monthly_consolidated_trip_sheet_details = []
-		for ts in trip_sheets:
-			start_date = ts.get("starting_date_and_time") and getdate(ts["starting_date_and_time"])
-			if not start_date or not (first_day <= start_date <= last_day):
-				continue
-			self.append("monthly_consolidated_trip_sheet_details", {
-				"departure_location": ts.get("departure_location") or "",
-				"destination_location": ts.get("destination_location") or "",
-				"initial_odometer_reading": ts.get("initial_odometer_reading"),
-				"final_odometer_reading": ts.get("final_odometer_reading"),
-				"starting_date_and_time": ts.get("starting_date_and_time"),
-				"ending_date_and_time": ts.get("ending_date_and_time"),
-				"distance_travelledkm": ts.get("distance_travelledkm"),
-				"bureau_trip_sheet": ts.get("name")
-			})
-
 	def _month_name_to_number(self, month_name):
 		months = [
 			"January", "February", "March", "April", "May", "June",
@@ -56,3 +15,53 @@ class MonthlyConsolidatedTripSheet(Document):
 		if month_name in months:
 			return months.index(month_name) + 1
 		return None
+
+
+@frappe.whitelist()
+def fetch_trip_sheets(supplier, bureau, month, year):
+	"""
+	Fetch Bureau Trip Sheets for the given supplier, bureau, month and year.
+	Returns a list of row dicts for the child table (monthly_consolidated_trip_sheet_details).
+	"""
+	if not all([supplier, bureau, month, year]):
+		return []
+	months = [
+		"January", "February", "March", "April", "May", "June",
+		"July", "August", "September", "October", "November", "December",
+	]
+	month_number = months.index(month) + 1 if month in months else None
+	if not month_number:
+		return []
+	first_day = get_first_day(f"{year}-{month_number:02d}-01")
+	last_day = get_last_day(first_day)
+	trip_sheets = frappe.db.get_all(
+		"Bureau Trip Sheet",
+		filters={"supplier": supplier, "bureau": bureau},
+		fields=[
+			"name", "departure_location", "destination_location",
+			"initial_odometer_reading", "final_odometer_reading",
+			"starting_date_and_time", "ending_date_and_time",
+			"distance_travelledkm", "total_daily_batta", "total_ot_batta",
+			"average_mileage_kmpl", "fuel_consumption_l",
+		],
+	)
+	rows = []
+	for ts in trip_sheets:
+		start_date = ts.get("starting_date_and_time") and getdate(ts["starting_date_and_time"])
+		if not start_date or not (first_day <= start_date <= last_day):
+			continue
+		rows.append({
+			"departure_location": ts.get("departure_location") or "",
+			"destination_location": ts.get("destination_location") or "",
+			"initial_odometer_reading": ts.get("initial_odometer_reading"),
+			"final_odometer_reading": ts.get("final_odometer_reading"),
+			"starting_date_and_time": ts.get("starting_date_and_time"),
+			"ending_date_and_time": ts.get("ending_date_and_time"),
+			"distance_travelledkm": ts.get("distance_travelledkm"),
+			"bureau_trip_sheet": ts.get("name"),
+			"total_batta": ts.get("total_daily_batta"),
+			"total_ot_batta": ts.get("total_ot_batta"),
+			"average_mileage_kmpl": ts.get("average_mileage_kmpl"),
+			"fuel_consumption_l": ts.get("fuel_consumption_l"),
+		})
+	return rows

--- a/beams/beams/doctype/monthly_consolidated_trip_sheet_details/monthly_consolidated_trip_sheet_details.json
+++ b/beams/beams/doctype/monthly_consolidated_trip_sheet_details/monthly_consolidated_trip_sheet_details.json
@@ -10,36 +10,44 @@
   "destination_location",
   "initial_odometer_reading",
   "final_odometer_reading",
+  "total_batta",
+  "total_ot_batta",
   "column_break_qnaw",
   "starting_date_and_time",
   "ending_date_and_time",
   "distance_travelledkm",
-  "bureau_trip_sheet"
+  "bureau_trip_sheet",
+  "average_mileage_kmpl",
+  "fuel_consumption_l"
  ],
  "fields": [
   {
    "fieldname": "departure_location",
    "fieldtype": "Data",
    "in_list_view": 1,
-   "label": "Departure Location"
+   "label": "Departure Location",
+   "read_only": 1
   },
   {
    "fieldname": "destination_location",
    "fieldtype": "Data",
    "in_list_view": 1,
-   "label": "Destination Location"
+   "label": "Destination Location",
+   "read_only": 1
   },
   {
    "fieldname": "initial_odometer_reading",
    "fieldtype": "Int",
    "in_list_view": 1,
-   "label": "Initial Odometer Reading"
+   "label": "Initial Odometer Reading",
+   "read_only": 1
   },
   {
    "fieldname": "final_odometer_reading",
    "fieldtype": "Int",
    "in_list_view": 1,
-   "label": "Final Odometer Reading"
+   "label": "Final Odometer Reading",
+   "read_only": 1
   },
   {
    "fieldname": "column_break_qnaw",
@@ -48,31 +56,59 @@
   {
    "fieldname": "starting_date_and_time",
    "fieldtype": "Datetime",
-   "label": "Starting Date and Time "
+   "label": "Starting Date and Time ",
+   "read_only": 1
   },
   {
    "fieldname": "ending_date_and_time",
    "fieldtype": "Datetime",
-   "label": "Ending Date and Time "
+   "label": "Ending Date and Time ",
+   "read_only": 1
   },
   {
    "fieldname": "distance_travelledkm",
    "fieldtype": "Float",
    "in_list_view": 1,
-   "label": "Distance Travelled(km) "
+   "label": "Distance Travelled(km) ",
+   "read_only": 1
   },
   {
    "fieldname": "bureau_trip_sheet",
    "fieldtype": "Link",
    "label": "Bureau Trip Sheet",
-   "options": "Bureau Trip Sheet"
+   "options": "Bureau Trip Sheet",
+   "read_only": 1
+  },
+  {
+   "fieldname": "total_batta",
+   "fieldtype": "Currency",
+   "label": "Total Batta",
+   "read_only": 1
+  },
+  {
+   "fieldname": "total_ot_batta",
+   "fieldtype": "Currency",
+   "label": "Total Ot Batta",
+   "read_only": 1
+  },
+  {
+   "fieldname": "average_mileage_kmpl",
+   "fieldtype": "Float",
+   "label": "Average Mileage (KMPL)",
+   "read_only": 1
+  },
+  {
+   "fieldname": "fuel_consumption_l",
+   "fieldtype": "Float",
+   "label": "Fuel Consumption (L)",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-03-10 11:05:19.938754",
+ "modified": "2026-03-12 15:10:22.630078",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Monthly Consolidated Trip Sheet Details",

--- a/beams/beams/doctype/monthly_consolidated_trip_sheet_details/monthly_consolidated_trip_sheet_details.json
+++ b/beams/beams/doctype/monthly_consolidated_trip_sheet_details/monthly_consolidated_trip_sheet_details.json
@@ -12,6 +12,7 @@
   "final_odometer_reading",
   "total_batta",
   "total_ot_batta",
+  "amount_received_driver",
   "column_break_qnaw",
   "starting_date_and_time",
   "ending_date_and_time",
@@ -102,13 +103,19 @@
    "fieldtype": "Float",
    "label": "Fuel Consumption (L)",
    "read_only": 1
+  },
+  {
+   "fieldname": "amount_received_driver",
+   "fieldtype": "Currency",
+   "label": "Amount Received (Driver)",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-03-12 15:10:22.630078",
+ "modified": "2026-03-13 10:38:52.748469",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Monthly Consolidated Trip Sheet Details",

--- a/beams/hooks.py
+++ b/beams/hooks.py
@@ -267,7 +267,7 @@ doc_events = {
 
 	"Journal Entry": {
 		"on_cancel": "beams.beams.custom_scripts.journal_entry.journal_entry.on_cancel",
-		"after_insert": "beams.beams.custom_scripts.journal_entry.journal_entry.after_insert",
+		"on_submit": "beams.beams.custom_scripts.journal_entry.journal_entry.on_submit",
 		"before_validate": "beams.beams.custom_scripts.purchase_order.purchase_order.set_is_budgeted",
 	},
 	"Job Applicant": {

--- a/beams/setup.py
+++ b/beams/setup.py
@@ -1885,6 +1885,13 @@ def get_supplier_custom_fields():
     			"label": "Average Mileage(kmpl)",
 				"insert_after": "ot_working_hours",
 				"depends_on": "eval:doc.is_transporter == 1"
+			},
+			{
+				"fieldname": "montly_rent",
+				"fieldtype": "Currency",
+				"label": "Montly Rent",
+				"insert_after": "designation",
+				"depends_on": "eval:doc.is_transporter == 1"
 			}
 		]
 	}


### PR DESCRIPTION
## Feature description
1. Button to fetch bureau trip sheet in Monthly Consolidated Trip Sheet .
2. Add fuel and batta related fields in Monthly Consolidated Trip Sheet and map the values .
3. In Beams Accounts Settings add four fields , link it to service item (Batta, ot, fuel, rent)  expense item.
4. In supplier add a field to mark montly rent. and fetch it also in montly consolidated trip sheet.
5. From Monthly Consolidated Trip Sheet feature to create purchase invoice.
6. Task :- TASK-2026-00363

## Solution description
instead of fetching trips sheet after save brought button to fetch related ones and mapped data from bureau trip sheet and aggregated .
- Aggregate total_batta and total_ot_batta from details table after fetch and on validate
- On fetch: set amount_received_driver per row from BTS settlement_journal_entries amount sum
- Aggregate amount_received_driver into total_amount_received_driver (client + server)
- Add Create Purchase Invoice button: popup with Bureau Trip Sheet Settings items and rates (batta, batta OT, fuel, rent); show lines in Frappe Table dialog; open new PI with data pre-filled (user saves manually)
- Read expense items via frappe.db.get_single_value for Beams Accounts Settings

## Output screenshots (optional)
<img width="1890" height="736" alt="image" src="https://github.com/user-attachments/assets/25f3a5cd-3f45-4b5c-855d-1986ef431a89" />
<img width="1808" height="545" alt="image" src="https://github.com/user-attachments/assets/89ad3c99-9703-4d8f-8adb-6e9f1033ffc7" />
<img width="1903" height="843" alt="image" src="https://github.com/user-attachments/assets/13274b4a-d0ef-464e-8ae7-576aed656640" />


[Screencast from 13-03-26 11:18:29 AM IST.webm](https://github.com/user-attachments/assets/1243c8ea-33ac-48bd-81fe-dbecb023acdc)


## Was this feature tested on these browsers?
- [ ]   Chrome

