### PR TITLE
TASK-2026-00376: Bureau Trip Sheet and Monthly Consolidated Trip Sheet Enhancements for Bata, Fuel Expense, OT, and Supplier Settlement Calculation

### DIFF
--- a/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.js
+++ b/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.js
@@ -49,37 +49,8 @@ frappe.ui.form.on('Beams Accounts Settings', {
 // filters to get service items for Bureau trip sheet related fields
 function Bureau_trip_sheet_filters(frm) {
 
-    frm.set_query("batta_expense_item", function() {
-        return {
-            filters: {
-                "is_stock_item" : 0,
-                "is_fixed_asset": 0,
-                "is_bundle_item": 0
-            }
-        }
-    })
-
-    frm.set_query("fuel_expense_item", function() {
-        return {
-            filters: {
-                "is_stock_item" : 0,
-                "is_fixed_asset": 0,
-                "is_bundle_item": 0
-            }
-        }
-    })
 
     frm.set_query("rent_expense_item", function() {
-        return {
-            filters: {
-                "is_stock_item" : 0,
-                "is_fixed_asset": 0,
-                "is_bundle_item": 0
-            }
-        }
-    })
-
-    frm.set_query("batta_ot_expense_item", function() {
         return {
             filters: {
                 "is_stock_item" : 0,

--- a/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.json
+++ b/beams/beams/doctype/beams_accounts_settings/beams_accounts_settings.json
@@ -30,9 +30,11 @@
   "bureau_settings_tab",
   "batta_expense_item",
   "fuel_expense_item",
+  "fuel_card_account",
   "column_break_jkfg",
   "rent_expense_item",
-  "batta_ot_expense_item"
+  "batta_ot_expense_item",
+  "advance_account"
  ],
  "fields": [
   {
@@ -165,14 +167,14 @@
   {
    "fieldname": "batta_expense_item",
    "fieldtype": "Link",
-   "label": "Batta Expense Item",
-   "options": "Item"
+   "label": "Batta Expense Account",
+   "options": "Account"
   },
   {
    "fieldname": "fuel_expense_item",
    "fieldtype": "Link",
-   "label": "Fuel Expense Item",
-   "options": "Item"
+   "label": "Fuel Expense Account",
+   "options": "Account"
   },
   {
    "fieldname": "column_break_jkfg",
@@ -187,14 +189,26 @@
   {
    "fieldname": "batta_ot_expense_item",
    "fieldtype": "Link",
-   "label": "OT Expense Item",
-   "options": "Item"
+   "label": "OT Expense Account",
+   "options": "Account"
+  },
+  {
+   "fieldname": "fuel_card_account",
+   "fieldtype": "Link",
+   "label": "Fuel Card / Fuel Log Account",
+   "options": "Account"
+  },
+  {
+   "fieldname": "advance_account",
+   "fieldtype": "Link",
+   "label": "Advance Account",
+   "options": "Account"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-03-13 14:44:11.652364",
+ "modified": "2026-03-17 14:51:14.096058",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Beams Accounts Settings",

--- a/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.js
+++ b/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.js
@@ -11,7 +11,7 @@ frappe.ui.form.on("Bureau Trip Sheet", {
 		set_batta_policy_properties(frm);
 		filter_employee_field(frm);
 		show_batta_button(frm);
-        create_settlement_journal_entry(frm);
+		add_settlement_journal_entry_button(frm);
 	},
 	validate: function (frm) {
 		calculate_batta(frm);
@@ -23,6 +23,7 @@ frappe.ui.form.on("Bureau Trip Sheet", {
 	batta: function (frm) {
 	},
 	ot_batta: function (frm) {
+        calculate_ot_batta(frm);
 	},
 	daily_batta_with_overnight_stay: function (frm) {
 		calculate_batta(frm);
@@ -55,11 +56,13 @@ frappe.ui.form.on("Bureau Trip Sheet", {
 		calculate_distance_from_odometer_parent(frm);
 	},
 	starting_date_and_time: function(frm) {
-		calculate_hours(frm);
+		// Update total hours and OT batta when trip start time changes
+		calculate_hours_and_days(frm);
 		calculate_allowance(frm);
 	},
 	ending_date_and_time: function(frm) {
-		calculate_hours(frm);
+		// Update total hours and OT batta when trip end time changes
+		calculate_hours_and_days(frm);
 		calculate_allowance(frm);
 	},
 	supplier: function(frm) {
@@ -127,44 +130,37 @@ function set_batta_policy_properties(frm) {
 	});
 }
 
-// Calculate total hours, OT hours and number of days for a given row based on from and to date/time, and update the respective fields in the child table.
-function calculate_hours_and_days(frm, cdt, cdn) {
-	let row = locals[cdt][cdn];
-	if (!row || !row.from_date_and_time || !row.to_date_and_time) return;
-	let from_date = new Date(row.from_date_and_time);
-	let to_date = new Date(row.to_date_and_time);
-	let total_hours = (to_date - from_date) / (1000 * 60 * 60);
-	total_hours = Math.round(total_hours * 100) / 100;
-	if (!frm.doc.supplier) {
-		frappe.msgprint(__('Please select a Supplier to calculate OT hours.'));
+// Calculate total hours on the parent and then compute OT batta using the parent's OT batta rate.
+function calculate_hours_and_days(frm) {
+	// Ensure total hours on the parent are up to date.
+	calculate_hours(frm);
+	// Then calculate OT batta based on those hours.
+	calculate_ot_batta(frm);
+}
+
+// Calculate OT batta on the parent document based on total hours and supplier-specific OT working hours.
+function calculate_ot_batta(frm) {
+	const total_hours = frm.doc.total_hours || 0;
+	// Require supplier and some hours before hitting the server
+	if (!frm.doc.supplier || !total_hours) {
 		return;
 	}
+
 	frappe.call({
 		method: "beams.beams.doctype.bureau_trip_sheet.bureau_trip_sheet.get_ot_working_hours",
 		args: { supplier: frm.doc.supplier },
 		callback: function (r) {
-			if (r.message != null) {
-				let ot_working_hours = parseFloat(r.message) || 0;
-				let ot_hours = total_hours > ot_working_hours ? total_hours - ot_working_hours : 0;
-				frappe.model.set_value(cdt, cdn, 'total_hours', total_hours.toFixed(2));
-				frappe.model.set_value(cdt, cdn, 'ot_hours', ot_hours.toFixed(2));
-				frappe.model.set_value(cdt, cdn, 'number_of_days', Math.ceil(total_hours / 24));
-				setTimeout(() => {
-					calculate_ot_batta(frm, cdt, cdn);
-					calculate_row_allowances(frm, cdt, cdn);
-				}, 200);
+			if (r && r.message != null) {
+				const ot_working_hours = parseFloat(r.message) || 0;
+				const ot_hours = total_hours > ot_working_hours ? (total_hours - ot_working_hours) : 0;
+				const ot_rate = frm.doc.ot_batta || 0; // per-hour OT batta fetched from Supplier
+				const total_ot_batta = ot_hours * ot_rate;
+
+				frm.set_value('total_ot_batta', total_ot_batta);
+				calculate_total_driver_batta(frm);
 			}
 		}
 	});
-}
-
-// Calculate OT batta for a given row based on OT hours and OT batta rate, and update the respective field in the child table.
-function calculate_ot_batta(frm, cdt, cdn) {
-	let row = locals[cdt][cdn];
-	if (!row) return;
-	let ot_hours = row.ot_hours || 0;
-	let ot_batta = ot_hours * (frm.doc.ot_batta || 0);
-	frappe.model.set_value(cdt, cdn, 'ot_batta', ot_batta);
 }
 
 function update_all_ot_batta(frm) {
@@ -214,10 +210,9 @@ function calculate_total_daily_batta(frm) {
 	frm.refresh_field("total_daily_batta");
 }
 
-//  Calculate total OT batta by summing up OT batta for all rows in the child table, and update the total OT batta field in the parent form.
+//  Calculate total OT batta on the parent (wrapper to keep existing hooks working).
 function calculate_total_ot_batta(frm) {
-	frm.set_value('total_ot_batta', frm.doc.ot_batta || 0);
-	frm.refresh_field("total_ot_batta");
+	calculate_ot_batta(frm);
 }
 
 /* Calculate total driver batta as the sum of total daily batta and total OT batta */
@@ -488,13 +483,12 @@ function create_batta_claim(frm) {
 
 // Patty Cash Payment: we have given (paid) the supplier the amount.
 // JE: Debit Supplier payable, Credit Bank/Cash. Supplier account from Supplier doctype Default Accounts table.
-function create_settlement_journal_entry(frm) {
-
-    if (!frm.is_new()) {
-        frm.add_custom_button(__("Patty Cash Payment"), function () {
-            open_settlement_dialog(frm);
-        });
-    }
+function add_settlement_journal_entry_button(frm) {
+	if (!frm.is_new()) {
+		frm.add_custom_button(__("Patty Cash Payment"), function () {
+			open_settlement_dialog(frm);
+		});
+	}
 }
 
 function open_settlement_dialog(frm) {
@@ -581,10 +575,12 @@ function submit_settlement_journal_entry(frm, mode_of_payment, amount) {
 		},
 		callback: function (response) {
 			if (response.message) {
-				const doc = frappe.model.sync(response.message)[0];
-				frappe.set_route("Form", doc.doctype, doc.name);
+				frappe.msgprint({
+					title: __("Success"),
+					message: __("Settlement Journal Entry {0} created in Draft.", [response.message]),
+					indicator: "green"
+				});
 			}
-		},
+		}
 	});
 }
-

--- a/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.json
+++ b/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.json
@@ -207,7 +207,7 @@
   {
    "fieldname": "total_ot_batta",
    "fieldtype": "Currency",
-   "label": "Total Ot Batta",
+   "label": "Total OT Batta",
    "read_only": 1
   },
   {
@@ -344,7 +344,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-03-16 11:55:32.456585",
+ "modified": "2026-03-18 15:56:41.737453",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Bureau Trip Sheet",

--- a/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.py
+++ b/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.py
@@ -72,7 +72,15 @@ class BureauTripSheet(Document):
 		self.total_daily_batta = flt(self.batta) or 0
 
 	def calculate_total_ot_batta(self):
-		self.total_ot_batta = flt(self.ot_batta) or 0
+		"""Total OT batta = (total_hours - ot_working_hours) * ot_batta rate, when supplier and hours are set."""
+		total_hours = flt(self.total_hours or 0)
+		ot_rate = flt(self.ot_batta or 0)
+		if not self.supplier or not total_hours:
+			self.total_ot_batta = 0
+			return
+		ot_working_hours = flt(get_ot_working_hours(self.supplier) or 0)
+		ot_hours = max(0, total_hours - ot_working_hours)
+		self.total_ot_batta = round(ot_hours * ot_rate, 2)
 
 	def calculate_daily_batta(self):
 		'''
@@ -459,11 +467,7 @@ def create_settlement_journal_entry(bureau_trip_sheet, mode_of_payment, amount=N
 		"credit_in_account_currency": settlement_amount,
 		"is_advance": "Yes"
 	})
+	journal_entry.insert(ignore_permissions=True)
 
-	frappe.msgprint(
-		_("Journal Entry opened for settlement. Review and save manually."),
-		alert=True,
-		indicator="blue"
-	)
-	return journal_entry
+	return journal_entry.name
 

--- a/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.py
+++ b/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.py
@@ -450,7 +450,8 @@ def create_settlement_journal_entry(bureau_trip_sheet, mode_of_payment, amount=N
 	journal_entry.user_remark = _("Settlement for Bureau Trip Sheet {0} – Driver: {1}").format(
 		bts.name, bts.supplier
 	)
-	journal_entry.bureau_trip_sheet = bts.name
+	if frappe.get_meta("Journal Entry").has_field("bureau_trip_sheet"):
+		journal_entry.bureau_trip_sheet = bts.name
 
 	# We have given the supplier the amount: Debit Supplier payable, Credit Bank/Cash
 	journal_entry.append("accounts", {

--- a/beams/beams/doctype/fuel_card/fuel_card.json
+++ b/beams/beams/doctype/fuel_card/fuel_card.json
@@ -28,12 +28,12 @@
   {
    "fieldname": "fuel_card_limit",
    "fieldtype": "Currency",
-   "label": "Fuel Card Limit"
+   "label": "Fuel Card Amount"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-08-20 16:02:10.561448",
+ "modified": "2026-03-17 12:07:12.324566",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Fuel Card",
@@ -54,6 +54,7 @@
   }
  ],
  "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/beams/beams/doctype/monthly_consolidated_trip_sheet/monthly_consolidated_trip_sheet.js
+++ b/beams/beams/doctype/monthly_consolidated_trip_sheet/monthly_consolidated_trip_sheet.js
@@ -90,22 +90,48 @@ function add_create_journal_entry_button(frm) {
     }
 }
 
-// Sum total_batta, total_ot_batta and amount_received_driver from child rows
+// Sum totals; per row: deduct amount_received_driver from batta first, then from OT
 function calculate_batta_totals(frm) {
     var total_batta = 0;
     var total_ot_batta = 0;
     var total_amount_received_driver = 0;
+    var total_batta_after = 0;
+    var total_ot_after = 0;
     (frm.doc.monthly_consolidated_trip_sheet_details || []).forEach(function(row) {
-        total_batta += flt(row.total_batta);
-        total_ot_batta += flt(row.total_ot_batta);
-        total_amount_received_driver += flt(row.amount_received_driver);
+        var batta = flt(row.total_batta);
+        var ot = flt(row.total_ot_batta);
+        var advance = flt(row.amount_received_driver);
+        total_batta += batta;
+        total_ot_batta += ot;
+        total_amount_received_driver += advance;
+        var remaining_after_batta = Math.max(0, advance - batta);
+        var batta_after = Math.max(0, batta - advance);
+        var ot_after = Math.max(0, ot - remaining_after_batta);
+        frappe.model.set_value(
+            row.doctype,
+            row.name,
+            "total_batta_amount_after_advances",
+            batta_after
+        );
+        frappe.model.set_value(
+            row.doctype,
+            row.name,
+            "total_ot_amount_after_advances",
+            ot_after
+        );
+        total_batta_after += batta_after;
+        total_ot_after += ot_after;
     });
     frm.set_value("total_batta", total_batta);
     frm.set_value("total_ot_batta", total_ot_batta);
     frm.set_value("total_amount_received_driver", total_amount_received_driver);
+    frm.set_value("total_batta_amount_after_advances", total_batta_after);
+    frm.set_value("total_ot_amount_after_advances", total_ot_after);
     frm.refresh_field("total_batta");
     frm.refresh_field("total_ot_batta");
     frm.refresh_field("total_amount_received_driver");
+    frm.refresh_field("total_batta_amount_after_advances");
+    frm.refresh_field("total_ot_amount_after_advances");
 }
 
 // Calculate fuel expense of monthly_consolidated_trip_sheet_details

--- a/beams/beams/doctype/monthly_consolidated_trip_sheet/monthly_consolidated_trip_sheet.js
+++ b/beams/beams/doctype/monthly_consolidated_trip_sheet/monthly_consolidated_trip_sheet.js
@@ -6,10 +6,10 @@ frappe.ui.form.on('Monthly Consolidated Trip Sheet', {
     onload(frm) {
         set_yeat(frm);
         set_supplier_filter(frm);
-        add_create_purchase_invoice_button(frm);
+        add_create_journal_entry_button(frm);
     },
     refresh(frm) {
-        add_create_purchase_invoice_button(frm);
+        add_create_journal_entry_button(frm);
         calculate_batta_totals(frm);
     },
     fetch_trip_sheets_btn: function(frm) {
@@ -20,6 +20,7 @@ frappe.ui.form.on('Monthly Consolidated Trip Sheet', {
     },
     monthly_consolidated_trip_sheet_details_on_form_rendered: function(frm, cdt, cdn) {
         calculate_batta_totals(frm);
+        calculate_fuel_expense(frm);
     }
 });
 
@@ -72,107 +73,21 @@ function run_fetch_trip_sheets(frm) {
     });
 }
 
-// Create Purchase Invoice: open popup with items/rates from Beams Accounts Settings and doc totals
-function add_create_purchase_invoice_button(frm) {
-    frm.add_custom_button(__("Create Purchase Invoice"), function() {
-        if (frm.is_dirty()) {
-            frappe.msgprint(__("Please save the document first."));
-            return;
-        }
-        if (!frm.doc.name) {
-            frappe.msgprint(__("Please save the document first."));
-            return;
-        }
-        frappe.call({
-            method: "beams.beams.doctype.monthly_consolidated_trip_sheet.monthly_consolidated_trip_sheet.get_purchase_invoice_details",
-            args: { monthly_consolidated_trip_sheet_name: frm.doc.name },
-            callback: function(r) {
-                if (r.message && r.message.items && r.message.items.length) {
-                    show_create_pi_dialog(frm, r.message);
-                } else {
-                    frappe.msgprint(
-                        __("No expense items to show. Open Beams Accounts Settings, go to the Bureau Trip Sheet Settings tab, and set at least one of: Batta Expense Item, Fuel Expense Item, Rent Expense Item, Batta Ot Expense Item. Save the settings and try again."),
-                        __("Settings required")
-                    );
-                }
-            }
-        });
-    });
-}
-
-function show_create_pi_dialog(frm, details) {
-    var table_data = (details.items || []).map(function(row) {
-        return {
-            expense_type: row.label || "",
-            item: row.item_name || row.item_code || "",
-            rate: flt(row.rate)
-        };
-    });
-
-    var d = new frappe.ui.Dialog({
-        title: __("Create Purchase Invoice"),
-        size: "medium",
-        fields: [
-            {
-                fieldtype: "Table",
-                fieldname: "items_table",
-                label: __("Invoice lines (from Bureau Trip Sheet Settings)"),
-                cannot_add_rows: true,
-                in_list_view: 1,
-                fields: [
-                    {
-                        fieldtype: "Data",
-                        fieldname: "expense_type",
-                        label: __("Expense"),
-                        read_only: 1,
-                        in_list_view: 1
-                    },
-                    {
-                        fieldtype: "Data",
-                        fieldname: "item",
-                        label: __("Item"),
-                        read_only: 1,
-                        in_list_view: 1
-                    },
-                    {
-                        fieldtype: "Currency",
-                        fieldname: "rate",
-                        label: __("Rate"),
-                        read_only: 1,
-                        in_list_view: 1
+// Create Journal Entry for supplier settlement (Batta, OT, Fuel Expense, Fuel Card, Advance; no rent)
+function add_create_journal_entry_button(frm) {
+    if (!frm.is_new()) {
+        frm.add_custom_button(__("Create Journal Entry"), function() {
+            frappe.call({
+                method: "beams.beams.doctype.monthly_consolidated_trip_sheet.monthly_consolidated_trip_sheet.create_journal_entry",
+                args: { monthly_consolidated_trip_sheet_name: frm.doc.name },
+                callback: function(r) {
+                    if (r.message) {
+                        frappe.set_route("Form", "Journal Entry", r.message);
                     }
-                ],
-                data: table_data
-            }
-        ],
-        primary_action_label: __("Create"),
-        primary_action: function() {
-            d.hide();
-            // Open new Purchase Invoice with data pre-filled; user saves manually
-            frappe.model.with_doctype("Purchase Invoice", function() {
-                var doc = frappe.model.get_new_doc("Purchase Invoice");
-                doc.supplier = details.supplier;
-                doc.bureau = details.bureau || "";
-                doc.company = details.company || frappe.defaults.get_default("company");
-                doc.cost_center = details.cost_center || "";
-                doc.set_posting_time = 1;
-                doc.posting_date = details.posting_date || frappe.datetime.get_today();
-                doc.allocate_advances_automatically = 1;
-                (details.items || []).forEach(function(row) {
-                    if (flt(row.rate) === 0) return;
-                    var child = frappe.model.add_child(doc, "Purchase Invoice Item", "items");
-                    child.item_code = row.item_code;
-                    child.item_name = row.item_name || row.item_code;
-                    child.uom = row.uom || "Nos";
-                    child.qty = 1;
-                    child.rate = flt(row.rate);
-                });
-                frappe.route_options = { fetch_advances_from_mcts: 1 };
-                frappe.set_route("Form", "Purchase Invoice", doc.name);
+                }
             });
-        }
-    });
-    d.show();
+        });
+    }
 }
 
 // Sum total_batta, total_ot_batta and amount_received_driver from child rows
@@ -198,14 +113,25 @@ function calculate_fuel_expense(frm) {
 
     let fuel_rate__litre = frm.doc.fuel_rate__litre || 0;
     let total_fuel = 0;
+    let total_distance_travelledkm = 0;
+    let avg_mileage = 0;
 
     (frm.doc.monthly_consolidated_trip_sheet_details || []).forEach(row => {
         total_fuel += row.fuel_consumption_l || 0;
+        total_distance_travelledkm += row.distance_travelledkm || 0;
+        avg_mileage = row.average_mileage_kmpl;
     });
 
     frm.set_value("total_fuel_consumed", total_fuel);
+    frm.set_value("total_distance_travelled", total_distance_travelledkm);
 
     let total_expense = fuel_rate__litre * total_fuel;
 
     frm.set_value("total_fuel_expense", total_expense);
+    frm.set_value("avg_mileage", avg_mileage)
+
+    frm.refresh_field("total_distance_travelled");
+    frm.refresh_field("total_fuel_consumed");
+    frm.refresh_field("total_fuel_expense");
+    frm.refresh_field("avg_mileage");
 }

--- a/beams/beams/doctype/monthly_consolidated_trip_sheet/monthly_consolidated_trip_sheet.json
+++ b/beams/beams/doctype/monthly_consolidated_trip_sheet/monthly_consolidated_trip_sheet.json
@@ -15,11 +15,14 @@
   "section_break_vkfd",
   "monthly_consolidated_trip_sheet_details",
   "fuel_details_section",
+  "total_distance_travelled",
   "fuel_rate__litre",
   "column_break_aulq",
-  "total_fuel_consumed",
-  "column_break_dqtr",
+  "avg_mileage",
   "total_fuel_expense",
+  "column_break_dqtr",
+  "total_fuel_consumed",
+  "total_fuel_card_expense",
   "batta_details_section",
   "total_batta",
   "column_break_jykh",
@@ -148,12 +151,29 @@
   {
    "fieldname": "column_break_qfbo",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "total_distance_travelled",
+   "fieldtype": "Float",
+   "label": "Total Distance Travelled",
+   "read_only": 1
+  },
+  {
+   "fieldname": "total_fuel_card_expense",
+   "fieldtype": "Currency",
+   "label": "Total Fuel Card Expense"
+  },
+  {
+   "fieldname": "avg_mileage",
+   "fieldtype": "Float",
+   "label": "Avg Mileage",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-03-13 10:58:15.965104",
+ "modified": "2026-03-17 12:15:03.431200",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Monthly Consolidated Trip Sheet",

--- a/beams/beams/doctype/monthly_consolidated_trip_sheet/monthly_consolidated_trip_sheet.json
+++ b/beams/beams/doctype/monthly_consolidated_trip_sheet/monthly_consolidated_trip_sheet.json
@@ -25,8 +25,10 @@
   "total_fuel_card_expense",
   "batta_details_section",
   "total_batta",
+  "total_batta_amount_after_advances",
   "column_break_jykh",
   "total_ot_batta",
+  "total_ot_amount_after_advances",
   "rent_details_section",
   "total_montly_rent",
   "column_break_qfbo",
@@ -168,12 +170,24 @@
    "fieldtype": "Float",
    "label": "Avg Mileage",
    "read_only": 1
+  },
+  {
+   "fieldname": "total_batta_amount_after_advances",
+   "fieldtype": "Currency",
+   "label": "Total Batta Amount After Advances",
+   "read_only": 1
+  },
+  {
+   "fieldname": "total_ot_amount_after_advances",
+   "fieldtype": "Currency",
+   "label": "Total OT Amount After Advances",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-03-17 12:15:03.431200",
+ "modified": "2026-03-18 14:34:37.846618",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Monthly Consolidated Trip Sheet",

--- a/beams/beams/doctype/monthly_consolidated_trip_sheet/monthly_consolidated_trip_sheet.py
+++ b/beams/beams/doctype/monthly_consolidated_trip_sheet/monthly_consolidated_trip_sheet.py
@@ -2,14 +2,24 @@
 # For license information, please see license.txt
 
 import frappe
-from frappe.model.document import Document
-from frappe.utils import flt, get_first_day, get_last_day, getdate
 from frappe import _
+from frappe.model.document import Document
+from frappe.utils import flt, get_first_day, get_last_day, getdate, nowdate
+
+from beams.beams.doctype.bureau_trip_sheet.bureau_trip_sheet import _get_supplier_payable_account
 
 
 class MonthlyConsolidatedTripSheet(Document):
 	def validate(self):
 		self._set_batta_totals_from_details()
+		self._set_total_distance_and_fuel_from_details()
+		self._validate_and_prepare_fuel_card_deduction()
+
+	def on_update(self):
+		self._apply_fuel_card_deduction()
+
+	def on_trash(self):
+		self._restore_fuel_card_on_delete()
 
 	def _month_name_to_number(self, month_name):
 		months = [
@@ -32,6 +42,80 @@ class MonthlyConsolidatedTripSheet(Document):
 		self.total_batta = total_batta
 		self.total_ot_batta = total_ot_batta
 		self.total_amount_received_driver = total_amount_received_driver
+
+	def _set_total_distance_and_fuel_from_details(self):
+		"""Set total_distance_travelled, total_fuel_consumed and total_fuel_expense from child table rows."""
+		total_distance = 0
+		total_fuel = 0
+		for row in self.get("monthly_consolidated_trip_sheet_details") or []:
+			total_distance += flt(row.get("distance_travelledkm"))
+			total_fuel += flt(row.get("fuel_consumption_l"))
+		self.total_distance_travelled = total_distance
+		self.total_fuel_consumed = total_fuel
+		fuel_rate = flt(self.get("fuel_rate__litre"))
+		self.total_fuel_expense = total_fuel * fuel_rate
+
+	def _validate_and_prepare_fuel_card_deduction(self):
+		"""Validate total_fuel_card_expense against bureau's fuel card limit; store old value for on_update."""
+		expense = flt(self.get("total_fuel_card_expense"))
+		if not self.bureau or expense <= 0:
+			self._old_total_fuel_card_expense = 0
+			return
+		fuel_card_name = frappe.db.get_value("Bureau", self.bureau, "fuel_card")
+		if not fuel_card_name:
+			return
+		old_expense = flt(
+			frappe.db.get_value(self.doctype, self.name, "total_fuel_card_expense")
+			if self.name else 0
+		)
+		self._old_total_fuel_card_expense = old_expense
+		fuel_card = frappe.get_doc("Fuel Card", fuel_card_name)
+		current_limit = flt(fuel_card.fuel_card_limit)
+		# After we add back old deduction, available = current_limit + old_expense
+		available = current_limit + old_expense
+		if expense > available:
+			frappe.throw(
+				_("Total Fuel Card Expense ({0}) cannot exceed the bureau's Fuel Card available amount ({1}).").format(
+					expense, available
+				),
+				title=_("Fuel Card Limit Exceeded"),
+			)
+
+	def _apply_fuel_card_deduction(self):
+		"""Reduce the bureau's Fuel Card limit by total_fuel_card_expense (after adding back previous deduction)."""
+		new_expense = flt(self.get("total_fuel_card_expense"))
+		old_expense = getattr(self, "_old_total_fuel_card_expense", None)
+		if old_expense is None and self.name:
+			old_expense = flt(frappe.db.get_value(self.doctype, self.name, "total_fuel_card_expense"))
+		if old_expense is None:
+			old_expense = 0
+		if not self.bureau:
+			return
+		fuel_card_name = frappe.db.get_value("Bureau", self.bureau, "fuel_card")
+		if not fuel_card_name:
+			return
+		# No change
+		if new_expense == old_expense:
+			return
+		fuel_card = frappe.get_doc("Fuel Card", fuel_card_name)
+		current = flt(fuel_card.fuel_card_limit)
+		# Add back what we had deducted before, then deduct new amount
+		fuel_card.fuel_card_limit = current + old_expense - new_expense
+		fuel_card.flags.ignore_permissions = True
+		fuel_card.save(ignore_version=True)
+
+	def _restore_fuel_card_on_delete(self):
+		"""Restore total_fuel_card_expense to the bureau's Fuel Card when this doc is deleted."""
+		expense = flt(self.get("total_fuel_card_expense"))
+		if not self.bureau or expense <= 0:
+			return
+		fuel_card_name = frappe.db.get_value("Bureau", self.bureau, "fuel_card")
+		if not fuel_card_name:
+			return
+		fuel_card = frappe.get_doc("Fuel Card", fuel_card_name)
+		fuel_card.fuel_card_limit = flt(fuel_card.fuel_card_limit) + expense
+		fuel_card.flags.ignore_permissions = True
+		fuel_card.save(ignore_version=True)
 
 
 @frappe.whitelist()
@@ -96,12 +180,19 @@ def fetch_trip_sheets(supplier, bureau, month, year):
 
 
 @frappe.whitelist()
-def get_purchase_invoice_details(monthly_consolidated_trip_sheet_name):
+def create_journal_entry(monthly_consolidated_trip_sheet_name):
 	"""
-	Get expense items from Beams Accounts Settings (Bureau Trip Sheet Settings) and
-	rates from the Monthly Consolidated Trip Sheet for the Create Purchase Invoice popup.
+	Create a Journal Entry for Monthly Consolidated Trip Sheet settlement.
+	Uses accounts from Beams Accounts Settings (Bureau Trip Sheet Settings).
+
+	Debit: Total Batta, Total OT, Total Fuel Expense (expenses).
+	Credit: Total Fuel Card Expense (Fuel Log), Total Advance (amount received by driver).
+	Balancing: Supplier Account (final settlement = Batta + OT + Fuel Expense - Fuel Log - Advance).
 	"""
 	doc = frappe.get_doc("Monthly Consolidated Trip Sheet", monthly_consolidated_trip_sheet_name)
+	if not doc.supplier:
+		frappe.throw(_("Supplier is not set on Monthly Consolidated Trip Sheet."))
+
 	company = None
 	cost_center = None
 	if doc.bureau:
@@ -113,77 +204,93 @@ def get_purchase_invoice_details(monthly_consolidated_trip_sheet_name):
 			cost_center = bureau_doc.get("cost_center")
 	if not company:
 		company = frappe.defaults.get_default("company")
+	if not company:
+		frappe.throw(_("Company could not be determined. Set Bureau or default Company."))
 
-	# Rent: Montly Rent (Driver) - Total amount Received (Driver), per Monthly Consolidated Trip Sheet
-	rent_rate = flt(doc.total_montly_rent)
+	settings = frappe.get_single("Beams Accounts Settings")
+	batta_account = settings.get("batta_expense_item")
+	fuel_expense_account = settings.get("fuel_expense_item")
+	ot_account = settings.get("batta_ot_expense_item")
+	fuel_card_account = settings.get("fuel_card_account")
+	advance_account = settings.get("advance_account")
 
-	# Order and labels match Beams Accounts Settings > Bureau Trip Sheet Settings tab
-	# Read each item from Single doctype via db so values are always loaded
-	item_specs = [
-		("batta_expense_item", "Batta Expense Item", flt(doc.total_batta)),
-		("fuel_expense_item", "Fuel Expense Item", flt(doc.total_fuel_expense)),
-		("rent_expense_item", "Rent Expense Item", rent_rate),
-		("batta_ot_expense_item", "Batta Ot Expense Item", flt(doc.total_ot_batta)),
-	]
-	items = []
-	for field, label, rate in item_specs:
-		item_code = frappe.db.get_single_value("Beams Accounts Settings", field)
-		if not item_code:
-			continue
-		item_row = frappe.db.get_value(
-			"Item", item_code, ["item_name", "stock_uom"], as_dict=True
+	supplier_payable_account = _get_supplier_payable_account(doc.supplier, company)
+	if not supplier_payable_account:
+		frappe.throw(
+			_("No default payable account for Supplier {0} and Company {1}. Set it in Supplier or Company.").format(
+				doc.supplier, company
+			)
 		)
-		item_name = (item_row and item_row.get("item_name")) or item_code
-		uom = (item_row and item_row.get("stock_uom")) or "Nos"
-		items.append({
-			"item_code": item_code,
-			"item_name": item_name,
-			"uom": uom,
-			"label": label,
-			"rate": rate,
+
+	total_batta = flt(doc.total_batta)
+	total_ot = flt(doc.total_ot_batta)
+	total_fuel_expense = flt(doc.total_fuel_expense)
+	total_fuel_log = flt(doc.total_fuel_card_expense)
+	total_advance = flt(doc.total_amount_received_driver)
+
+	supplier_amount = total_batta + total_ot + total_fuel_expense - total_fuel_log - total_advance
+
+	accounts = []
+	if batta_account and total_batta:
+		accounts.append({
+			"account": batta_account,
+			"debit_in_account_currency": total_batta,
+			"credit_in_account_currency": 0,
+		})
+	if ot_account and total_ot:
+		accounts.append({
+			"account": ot_account,
+			"debit_in_account_currency": total_ot,
+			"credit_in_account_currency": 0,
+		})
+	if fuel_expense_account and total_fuel_expense:
+		accounts.append({
+			"account": fuel_expense_account,
+			"debit_in_account_currency": total_fuel_expense,
+			"credit_in_account_currency": 0,
+		})
+	if fuel_card_account and total_fuel_log:
+		accounts.append({
+			"account": fuel_card_account,
+			"debit_in_account_currency": 0,
+			"credit_in_account_currency": total_fuel_log,
+		})
+	if advance_account and total_advance:
+		accounts.append({
+			"account": advance_account,
+			"debit_in_account_currency": 0,
+			"credit_in_account_currency": total_advance,
+		})
+	if supplier_payable_account and supplier_amount != 0:
+		accounts.append({
+			"account": supplier_payable_account,
+			"party_type": "Supplier",
+			"party": doc.supplier,
+			"debit_in_account_currency": supplier_amount if supplier_amount > 0 else 0,
+			"credit_in_account_currency": abs(supplier_amount) if supplier_amount < 0 else 0,
 		})
 
-	return {
-		"supplier": doc.supplier,
-		"bureau": doc.bureau,
-		"company": company,
-		"cost_center": cost_center,
-		"posting_date": frappe.utils.nowdate(),
-		"items": items,
-	}
+	if not accounts:
+		frappe.throw(_("No amounts to post. Set Batta, OT, Fuel Expense, Fuel Card or Advance, and ensure accounts are set in Beams Accounts Settings > Bureau Trip Sheet Settings."))
 
+	je = frappe.new_doc("Journal Entry")
+	je.voucher_type = "Journal Entry"
+	je.posting_date = nowdate()
+	je.company = company
+	je.cost_center = cost_center or None
+	je.user_remark = _("Settlement for Monthly Consolidated Trip Sheet {0} – {1}").format(doc.name, doc.supplier)
 
-@frappe.whitelist()
-def create_purchase_invoice_from_monthly_consolidated(monthly_consolidated_trip_sheet_name):
-	"""
-	Create a Purchase Invoice from Monthly Consolidated Trip Sheet using
-	Beams Accounts Settings (Bureau Trip Sheet Settings) items and doc totals.
-	"""
-	details = get_purchase_invoice_details(monthly_consolidated_trip_sheet_name)
-	if not details.get("supplier"):
-		frappe.throw(_("Supplier is not set on Monthly Consolidated Trip Sheet."))
-	if not details.get("items"):
-		frappe.throw(_("No expense items configured in Beams Accounts Settings > Bureau Trip Sheet Settings."))
+	for row in accounts:
+		je.append("accounts", row)
 
-	pi = frappe.new_doc("Purchase Invoice")
-	pi.supplier = details["supplier"]
-	pi.bureau = details.get("bureau")
-	pi.company = details.get("company") or frappe.defaults.get_default("company")
-	pi.cost_center = details.get("cost_center")
-	pi.set_posting_time = 1
-	pi.posting_date = frappe.utils.nowdate()
-	pi.allocate_advances_automatically = 1
+	# requires party_type and party for Receivable/Payable accounts
+	for d in je.get("accounts"):
+		account_type = frappe.get_cached_value("Account", d.account, "account_type")
+		if account_type in ("Receivable", "Payable") and not (d.party_type and d.party):
+			d.party_type = "Supplier"
+			d.party = doc.supplier
 
-	for row in details["items"]:
-		if flt(row.get("rate")) == 0:
-			continue
-		pi.append("items", {
-			"item_code": row["item_code"],
-			"qty": 1,
-			"rate": row["rate"],
-		})
+	je.flags.ignore_permissions = True
+	je.insert()
 
-	pi.flags.ignore_permissions = True
-	pi.insert()
-
-	return pi.name
+	return je.name

--- a/beams/beams/doctype/monthly_consolidated_trip_sheet/monthly_consolidated_trip_sheet.py
+++ b/beams/beams/doctype/monthly_consolidated_trip_sheet/monthly_consolidated_trip_sheet.py
@@ -31,17 +31,32 @@ class MonthlyConsolidatedTripSheet(Document):
 		return None
 
 	def _set_batta_totals_from_details(self):
-		"""Set total_batta, total_ot_batta and total_amount_received_driver from sum of child table rows."""
+		"""Set total_batta, total_ot_batta, total_amount_received_driver; per-row and parent after-advance amounts."""
 		total_batta = 0
 		total_ot_batta = 0
 		total_amount_received_driver = 0
+		total_batta_after = 0
+		total_ot_after = 0
 		for row in self.get("monthly_consolidated_trip_sheet_details") or []:
-			total_batta += flt(row.get("total_batta"))
-			total_ot_batta += flt(row.get("total_ot_batta"))
-			total_amount_received_driver += flt(row.get("amount_received_driver"))
+			batta = flt(row.get("total_batta"))
+			ot = flt(row.get("total_ot_batta"))
+			advance = flt(row.get("amount_received_driver"))
+			total_batta += batta
+			total_ot_batta += ot
+			total_amount_received_driver += advance
+			# Advance applies to batta first, remainder to OT
+			remaining_after_batta = max(0, advance - batta)
+			batta_after = max(0, batta - advance)
+			ot_after = max(0, ot - remaining_after_batta)
+			row.total_batta_amount_after_advances = round(batta_after, 2)
+			row.total_ot_amount_after_advances = round(ot_after, 2)
+			total_batta_after += batta_after
+			total_ot_after += ot_after
 		self.total_batta = total_batta
 		self.total_ot_batta = total_ot_batta
 		self.total_amount_received_driver = total_amount_received_driver
+		self.total_batta_amount_after_advances = round(total_batta_after, 2)
+		self.total_ot_amount_after_advances = round(total_ot_after, 2)
 
 	def _set_total_distance_and_fuel_from_details(self):
 		"""Set total_distance_travelled, total_fuel_consumed and total_fuel_expense from child table rows."""
@@ -222,45 +237,40 @@ def create_journal_entry(monthly_consolidated_trip_sheet_name):
 			)
 		)
 
-	total_batta = flt(doc.total_batta)
-	total_ot = flt(doc.total_ot_batta)
-	total_fuel_expense = flt(doc.total_fuel_expense)
-	total_fuel_log = flt(doc.total_fuel_card_expense)
-	total_advance = flt(doc.total_amount_received_driver)
+	total_batta = round(flt(doc.total_batta), 2)
+	total_ot = round(flt(doc.total_ot_batta), 2)
+	total_fuel_expense = round(flt(doc.total_fuel_expense), 2)
+	total_fuel_log = round(flt(doc.total_fuel_card_expense), 2)
+	total_advance = round(flt(doc.total_amount_received_driver), 2)
 
-	supplier_amount = total_batta + total_ot + total_fuel_expense - total_fuel_log - total_advance
+	supplier_amount = round(total_batta + total_ot + total_fuel_expense - total_fuel_log - total_advance, 2)
 
 	accounts = []
 	if batta_account and total_batta:
 		accounts.append({
 			"account": batta_account,
-			"debit_in_account_currency": total_batta,
-			"credit_in_account_currency": 0,
+			"debit_in_account_currency": 0,
+			"credit_in_account_currency": doc.total_batta_amount_after_advances,
 		})
 	if ot_account and total_ot:
 		accounts.append({
 			"account": ot_account,
-			"debit_in_account_currency": total_ot,
-			"credit_in_account_currency": 0,
+			"debit_in_account_currency": 0,
+			"credit_in_account_currency": doc.total_ot_amount_after_advances,
 		})
 	if fuel_expense_account and total_fuel_expense:
 		accounts.append({
 			"account": fuel_expense_account,
-			"debit_in_account_currency": total_fuel_expense,
-			"credit_in_account_currency": 0,
+			"debit_in_account_currency": 0,
+			"credit_in_account_currency": total_fuel_expense,
 		})
 	if fuel_card_account and total_fuel_log:
 		accounts.append({
 			"account": fuel_card_account,
-			"debit_in_account_currency": 0,
-			"credit_in_account_currency": total_fuel_log,
+			"debit_in_account_currency": total_fuel_log,
+			"credit_in_account_currency": 0,
 		})
-	if advance_account and total_advance:
-		accounts.append({
-			"account": advance_account,
-			"debit_in_account_currency": 0,
-			"credit_in_account_currency": total_advance,
-		})
+
 	if supplier_payable_account and supplier_amount != 0:
 		accounts.append({
 			"account": supplier_payable_account,

--- a/beams/beams/doctype/monthly_consolidated_trip_sheet_details/monthly_consolidated_trip_sheet_details.json
+++ b/beams/beams/doctype/monthly_consolidated_trip_sheet_details/monthly_consolidated_trip_sheet_details.json
@@ -19,7 +19,9 @@
   "distance_travelledkm",
   "bureau_trip_sheet",
   "average_mileage_kmpl",
-  "fuel_consumption_l"
+  "fuel_consumption_l",
+  "total_batta_amount_after_advances",
+  "total_ot_amount_after_advances"
  ],
  "fields": [
   {
@@ -89,7 +91,7 @@
   {
    "fieldname": "total_ot_batta",
    "fieldtype": "Currency",
-   "label": "Total Ot Batta",
+   "label": "Total OT Batta",
    "read_only": 1
   },
   {
@@ -109,13 +111,25 @@
    "fieldtype": "Currency",
    "label": "Amount Received (Driver)",
    "read_only": 1
+  },
+  {
+   "fieldname": "total_batta_amount_after_advances",
+   "fieldtype": "Currency",
+   "label": "Total Batta Amount After Advances",
+   "read_only": 1
+  },
+  {
+   "fieldname": "total_ot_amount_after_advances",
+   "fieldtype": "Currency",
+   "label": "Total OT Amount After Advances",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-03-13 10:38:52.748469",
+ "modified": "2026-03-18 14:33:56.758370",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Monthly Consolidated Trip Sheet Details",


### PR DESCRIPTION
## Feature description
Bureau Trip Sheet and Monthly Consolidated Trip Sheet updates: parent-only OT/total hours and batta calculation (no child table), correct total OT batta on save, fuel card expense deduction from bureau fuel card, and settlement via Journal Entry instead of Purchase Invoice

## Solution description
**Bureau Trip Sheet:** calculate_hours_and_days() and calculate_ot_batta() now work on parent fields (starting_date_and_time, ending_date_and_time, total_hours, ot_batta). Server-side calculate_total_ot_batta() computes OT using get_ot_working_hours(supplier) so saved docs show the right total. Renamed settlement button/add vs submit to avoid calling the API on refresh; added supplier/total_hours checks before calling get_ot_working_hours.

**Monthly Consolidated Trip Sheet:** Server sets total_distance_travelled, total_fuel_consumed, and total_fuel_expense on validate. Entered total_fuel_card_expense is validated against bureau fuel card limit and applied in on_update (and restored on delete). Replaced Purchase Invoice with Journal Entry creation: debits (Batta, OT, Fuel Expense) and credits (Fuel Card, Advance) from Beams Accounts Settings, balancing on Supplier; set party_type/party on Payable/Receivable rows so ERPNext validation passes.

## Output screenshots (optional)
<img width="1917" height="857" alt="Screenshot from 2026-03-17 15-13-10" src="https://github.com/user-attachments/assets/c1128ea9-4373-430f-8a10-3cbb0a570fcf" />
<img width="1917" height="857" alt="Screenshot from 2026-03-17 15-11-13" src="https://github.com/user-attachments/assets/93822f68-ea99-49d4-9875-ffde1af642c6" />
<img width="1917" height="857" alt="Screenshot from 2026-03-17 15-10-59" src="https://github.com/user-attachments/assets/0820201c-e2d0-42c8-915a-0b0ee476a243" />





## Was this feature tested on these browsers?
- [ ]   Chrome
