### PR TITLE
TASK-2026-00402: Preserve manual daily batta values in Bureau Trip Sheet after save

### DIFF
--- a/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.js
+++ b/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.js
@@ -166,17 +166,23 @@ function calculate_ot_batta(frm) {
 function update_all_ot_batta(frm) {
 }
 
-/* Calculate total batta by summing daily batta values */
+/* Trip batta = daily rate × number of days (or food allowance total) — matches server validate */
 function calculate_batta(frm) {
-	let batta = 0;
-
-	if (frm.doc.is_overnight_stay) {
-		batta = frm.doc.daily_batta_with_overnight_stay || 0;
+	let trip_batta_amount = 0;
+	if (frm.doc.total_food_allowance) {
+		trip_batta_amount = flt(frm.doc.total_food_allowance);
 	} else {
-		batta = frm.doc.daily_batta_without_overnight_stay || 0;
+		const total_trip_hours = flt(frm.doc.total_hours);
+		const number_of_days = Math.max(1, Math.ceil(total_trip_hours / 24));
+		if (frm.doc.is_overnight_stay) {
+			trip_batta_amount = number_of_days * flt(frm.doc.daily_batta_with_overnight_stay);
+		} else {
+			trip_batta_amount = number_of_days * flt(frm.doc.daily_batta_without_overnight_stay);
+		}
 	}
-
-	frm.set_value("batta", batta);
+	frm.set_value("batta", trip_batta_amount);
+	calculate_total_daily_batta(frm);
+	calculate_total_driver_batta(frm);
 }
 
 // Calculate total batta for the entire trip by summing up daily batta and OT batta for all rows in the child table, and update the total batta field in the parent form.
@@ -339,7 +345,8 @@ function calculate_allowance(frm) {
 			if (r.message) {
 				frm.set_value("daily_batta_with_overnight_stay", r.message.daily_batta_with_overnight_stay);
 				frm.set_value("daily_batta_without_overnight_stay", r.message.daily_batta_without_overnight_stay);
-				frm.set_value("batta", (r.message.daily_batta_with_overnight_stay || 0) + (r.message.daily_batta_without_overnight_stay || 0));
+				// Keep client behavior aligned with backend: trip batta uses daily rate x number_of_days.
+				calculate_batta(frm);
 			}
 		}
 	});

--- a/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.py
+++ b/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.py
@@ -25,13 +25,16 @@ class BureauTripSheet(Document):
 
 	def calculate_batta(self):
 		'''
-		Calculate the total batta (allowance) based on daily batta amounts.
+		Calculate total trip batta from daily rate × number of days (or food allowance total).
 		'''
 		if self.total_food_allowance:
 			self.batta = self.total_food_allowance
 		else:
-			self.batta = (self.daily_batta_without_overnight_stay or 0) + \
-						(self.daily_batta_with_overnight_stay or 0)
+			number_of_days = max(1, math.ceil(flt(self.total_hours or 0) / 24))
+			if self.is_overnight_stay:
+				self.batta = number_of_days * flt(self.daily_batta_with_overnight_stay or 0)
+			else:
+				self.batta = number_of_days * flt(self.daily_batta_without_overnight_stay or 0)
 
 	def calculate_total_distance_travelled(self):
 		""" Calculate total distance travelled in km based on odometer readings or distance travelled field."""
@@ -91,7 +94,14 @@ class BureauTripSheet(Document):
 		  - 50 to 100 KM AND >= 6 Hours → Food Allowance
 		  - 100+ KM AND 6 to 8 Hours → Food Allowance
 		  - Else → No Allowance
+		When policy allows actual (editable) daily amounts, user-entered values are preserved on save.
 		'''
+		# Preserve manually entered daily rates before reset.
+		manual_daily_batta_without_overnight = flt(self.get("daily_batta_without_overnight_stay"))
+		manual_daily_batta_with_overnight = flt(self.get("daily_batta_with_overnight_stay"))
+		has_manual_without_overnight = (not self.is_overnight_stay and manual_daily_batta_without_overnight > 0)
+		has_manual_with_overnight = (self.is_overnight_stay and manual_daily_batta_with_overnight > 0)
+
 		self.daily_batta_without_overnight_stay = 0
 		self.daily_batta_with_overnight_stay = 0
 		self.breakfast = 0
@@ -139,8 +149,23 @@ class BureauTripSheet(Document):
 			self.total_food_allowance = self.breakfast + self.lunch + self.dinner
 			self.batta = self.total_food_allowance
 
+		# Re-apply manual rate after auto logic so save does not overwrite entered values.
+		total_hours_for_manual_override = flt(self.total_hours or 0)
+		number_of_days_for_manual_override = max(1, math.ceil(total_hours_for_manual_override / 24))
+		if has_manual_without_overnight:
+			self.daily_batta_without_overnight_stay = manual_daily_batta_without_overnight
+			self.batta = number_of_days_for_manual_override * manual_daily_batta_without_overnight
+			self.breakfast = 0
+			self.lunch = 0
+			self.dinner = 0
+			self.total_food_allowance = 0
+		if has_manual_with_overnight:
+			self.daily_batta_with_overnight_stay = manual_daily_batta_with_overnight
+			self.batta = number_of_days_for_manual_override * manual_daily_batta_with_overnight
+
 	def calculate_total_batta(self):
-		pass
+		"""Calculate total driver batta on backend as daily + OT."""
+		self.total_driver_batta = flt(self.total_daily_batta) + flt(self.total_ot_batta)
 
 	def on_submit(self):
 		pass


### PR DESCRIPTION
## Feature description
Preserve manually entered daily batta values in Bureau Trip Sheet after save, and keep batta, total_daily_batta, and total_driver_batta consistent between instant UI updates and backend-saved values.

## Solution description
Updated backend batta logic to retain user-entered daily batta (overnight/non-overnight) during validate so save no longer overwrites it with policy values, then recompute trip batta using day-based calculation. Added backend total_driver_batta calculation and aligned client-side calculate_batta / allowance flow to use the same formula for immediate UI updates. 

## Output screenshots (optional)
[Screencast from 24-03-26 01:04:59 PM IST.webm](https://github.com/user-attachments/assets/597ae5ba-d413-45fd-a45f-6d1ef9272aa4)


## Was this feature tested on these browsers?
- [ ]   Chrome

