### PR TITLE
TASK-2026-00405:Implement check-in based OT calculation in Bureau Trip Sheet

### DIFF
--- a/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.js
+++ b/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.js
@@ -199,8 +199,8 @@ function calculate_total_distance_travelled(frm) {
 
 // Calculate total hours for the entire trip by summing up total hours for all rows in the child table, and update the total hours field in the parent form.
 function calculate_hours(frm) {
-	if (frm.doc.starting_date_and_time && frm.doc.ending_date_and_time) {
-		let start = new Date(frm.doc.starting_date_and_time);
+	if (frm.doc.check_in_time && frm.doc.ending_date_and_time) {
+		let start = new Date(frm.doc.check_in_time);
 		let end = new Date(frm.doc.ending_date_and_time);
 		let total_hours = end > start ? Math.round((end - start) / (1000 * 60 * 60) * 100) / 100 : 0;
 		frm.set_value('total_hours', total_hours);

--- a/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.json
+++ b/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.json
@@ -17,10 +17,11 @@
   "destination_location",
   "initial_odometer_reading",
   "final_odometer_reading",
+  "distance_travelledkm",
   "column_break_cdph",
   "starting_date_and_time",
   "ending_date_and_time",
-  "distance_travelledkm",
+  "check_in_time",
   "total_hours",
   "section_break_tjbr",
   "purpose",
@@ -339,12 +340,17 @@
    "fieldtype": "Float",
    "label": "Average Mileage (KMPL)",
    "read_only": 1
+  },
+  {
+   "fieldname": "check_in_time",
+   "fieldtype": "Datetime",
+   "label": "Check In Time"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-03-18 15:56:41.737453",
+ "modified": "2026-03-26 15:50:44.470313",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Bureau Trip Sheet",

--- a/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.py
+++ b/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.py
@@ -12,6 +12,7 @@ from frappe import _
 
 class BureauTripSheet(Document):
 	def validate(self):
+		self.set_check_in_time()
 		self.validate_odometer_readings()
 		self.calculate_distance_from_odometer()
 		self.calculate_total_distance_travelled()
@@ -22,6 +23,30 @@ class BureauTripSheet(Document):
 		self.calculate_total_batta()
 		self.calculate_total_daily_batta()
 		self.validate_batta_policy()
+
+	def set_check_in_time(self):
+		"""
+		Ensure single Check-In Time per day.
+		Fetch from first created Trip Sheet of same date.
+		"""
+		if not self.starting_date_and_time:
+			return
+
+		current_date = getdate(self.starting_date_and_time)
+
+		first_trip = frappe.db.get_value(
+			"Bureau Trip Sheet",
+			{
+				"name": ["!=", self.name],
+				"docstatus": ["!=", 2],
+				"starting_date_and_time": ["between", [f"{current_date} 00:00:00", f"{current_date} 23:59:59"]]
+			},
+			"check_in_time",
+			order_by="creation asc"
+		)
+
+		if first_trip:
+			self.check_in_time = first_trip
 
 	def calculate_batta(self):
 		'''
@@ -60,10 +85,14 @@ class BureauTripSheet(Document):
 			self.distance_travelledkm = flt(self.final_odometer_reading) - flt(self.initial_odometer_reading)
 
 	def calculate_hours(self):
-		""" Calculate total hours of the trip based on starting and ending date/time."""
-		if self.get("starting_date_and_time") and self.get("ending_date_and_time"):
-			start = get_datetime(self.starting_date_and_time)
+		""" Calculate total hours based on Check-In Time and Ending Date/Time """
+
+		start_time = self.check_in_time or self.starting_date_and_time
+
+		if start_time and self.get("ending_date_and_time"):
+			start = get_datetime(start_time)
 			end = get_datetime(self.ending_date_and_time)
+
 			if end > start:
 				self.total_hours = round((end - start).total_seconds() / 3600.0, 2)
 			else:


### PR DESCRIPTION
## Feature description
Need to: 
- Add Check-In Time field
- Auto-fetch check-in from first record per day
- Calculate total hours using check-in and ending time
- Ensure consistency across same-day trip sheets
- No changes to existing logic

## Solution description
- Added "Check-In Time" field to Bureau Trip Sheet
- Implemented auto-fetch of Check-In Time from first Trip Sheet of the same date
- Ensured single consistent check-in time across same-day Trip Sheets
- Updated total hours calculation to use Check-In Time instead of Starting Time
- Removed dependency on starting_date_and_time for OT calculation
- Synced frontend and backend logic for accurate OT computation
- Maintained existing functions without modification

## Output screenshots (optional)
[Screencast from 26-03-26 04:11:31 PM IST.webm](https://github.com/user-attachments/assets/3d772d08-8a09-4a89-97bf-7503105ca8ae)


## Areas affected and ensured
Bureau tripsheet

## Is there any existing behaviour change of other features due to this code change?
No.

## Was this feature tested on these browsers?
- [ ]   Chrome

