### PR TITLE
TASK-2026-00419: add Last Trip logic to prevent duplicate OT calculation

### DIFF
--- a/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.json
+++ b/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.json
@@ -23,6 +23,7 @@
   "ending_date_and_time",
   "check_in_time",
   "total_hours",
+  "last_trip",
   "section_break_tjbr",
   "purpose",
   "fuel_details_section",
@@ -341,12 +342,18 @@
    "fieldname": "check_in_time",
    "fieldtype": "Datetime",
    "label": "Check In Time"
+  },
+  {
+   "default": "0",
+   "fieldname": "last_trip",
+   "fieldtype": "Check",
+   "label": "Last Trip"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-03-26 15:50:44.470313",
+ "modified": "2026-04-01 10:46:15.616295",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Bureau Trip Sheet",

--- a/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.py
+++ b/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.py
@@ -105,14 +105,25 @@ class BureauTripSheet(Document):
 		self.total_daily_batta = flt(self.batta) or 0
 
 	def calculate_total_ot_batta(self):
-		"""Total OT batta = (total_hours - ot_working_hours) * ot_batta rate, when supplier and hours are set."""
+		"""
+		Calculate OT batta ONLY when last_trip is checked
+		"""
+
+		if not self.last_trip:
+			self.total_ot_batta = 0
+			return
+
 		total_hours = flt(self.total_hours or 0)
 		ot_rate = flt(self.ot_batta or 0)
+
 		if not self.supplier or not total_hours:
 			self.total_ot_batta = 0
 			return
+
 		ot_working_hours = flt(get_ot_working_hours(self.supplier) or 0)
+
 		ot_hours = max(0, total_hours - ot_working_hours)
+
 		self.total_ot_batta = round(ot_hours * ot_rate, 2)
 
 	def calculate_daily_batta(self):


### PR DESCRIPTION
## Feature description
Need to: Add Last Trip logic to prevent duplicate OT calculation

## Solution description
Added Last Trip logic to prevent duplicate OT calculation

## Output screenshots (optional)

[Screencast from 01-04-26 10:36:13 AM IST.webm](https://github.com/user-attachments/assets/f859e6f1-d2d9-4831-a7bf-67eaedbcf4db)

<img width="1920" height="1080" alt="Screenshot from 2026-04-01 10-43-43" src="https://github.com/user-attachments/assets/f55a7c39-e878-49ac-9c4a-37001460db6e" />



## Areas affected and ensured
Bureau Trip sheet

## Is there any existing behaviour change of other features due to this code change?
No. 

## Was this feature tested on these browsers?
- [ ]   Chrome
