### PR TITLE
TASK-2026-00433:Fixed Editable Fields Overwritten by Auto Calculation in Bureau Trip Sheet

### DIFF
--- a/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.py
+++ b/beams/beams/doctype/bureau_trip_sheet/bureau_trip_sheet.py
@@ -53,6 +53,20 @@ class BureauTripSheet(Document):
 		'''
 		Calculate total trip batta from daily rate × number of days (or food allowance total).
 		'''
+		policy = get_batta_policy_values(supplier=self.supplier)
+
+		if policy.get("is_actual_with") or policy.get("is_actual_without") or policy.get("is_actual_food"):
+
+			self.total_food_allowance = (
+				flt(self.breakfast) +
+				flt(self.lunch) +
+				flt(self.dinner)
+			)
+
+			self.batta = self.total_food_allowance
+
+			return
+
 		if self.total_food_allowance:
 			self.batta = self.total_food_allowance
 		else:
@@ -126,6 +140,11 @@ class BureauTripSheet(Document):
 		  - Else → No Allowance
 		When policy allows actual (editable) daily amounts, user-entered values are preserved on save.
 		'''
+		policy = get_batta_policy_values(supplier=self.supplier)
+
+		if policy.get("is_actual_with") or policy.get("is_actual_without") or policy.get("is_actual_food"):
+			return
+
 		# Preserve manually entered daily rates before reset.
 		manual_daily_batta_without_overnight = flt(self.get("daily_batta_without_overnight_stay"))
 		manual_daily_batta_with_overnight = flt(self.get("daily_batta_with_overnight_stay"))


### PR DESCRIPTION
## Feature description
Need to: FixEditable Fields Overwritten by Auto Calculation in Bureau Trip Sheet

## Solution description
Fixed Editable Fields Overwritten by Auto Calculation in Bureau Trip Sheet

## Output screenshots (optional)
[Screencast from 01-04-26 12:35:11 PM IST.webm](https://github.com/user-attachments/assets/e7f95b89-4c19-4fc0-af0f-fedc8760d26b)

## Areas affected and ensured
bureau trip sheet

## Is there any existing behaviour change of other features due to this code change?
 No.

## Was this feature tested on these browsers?
- [ ]   Chrome
