### PR TITLE
TASK-2026-00440:Corrected Journal Entry creation logic for Batta Claim

### DIFF
--- a/beams/beams/doctype/batta_claim/batta_claim.json
+++ b/beams/beams/doctype/batta_claim/batta_claim.json
@@ -287,11 +287,10 @@
    "label": "Is Delhi Bureau"
   },
   {
-   "depends_on": "eval:doc.workflow_state==\"Pending Approval\"",
+   "depends_on": "eval:(frappe.user.has_role(\"HOD\") || frappe.user.has_role(\"Admin User\"))",
    "fieldname": "expense_type",
    "fieldtype": "Select",
    "label": "Expense Type",
-   "mandatory_depends_on": "eval:doc.workflow_state==\"Pending Approval\"",
    "options": "\nDirect\nIndirect",
    "permlevel": 1
   },
@@ -346,7 +345,7 @@
    "link_fieldname": "batta_claim_reference"
   }
  ],
- "modified": "2026-02-05 14:16:38.084292",
+ "modified": "2026-04-06 12:13:50.993598",
  "modified_by": "Administrator",
  "module": "BEAMS",
  "name": "Batta Claim",

--- a/beams/beams/doctype/batta_claim/batta_claim.py
+++ b/beams/beams/doctype/batta_claim/batta_claim.py
@@ -24,7 +24,7 @@ class BattaClaim(Document):
 			self.from_bureau = 1
 
 	def on_submit(self):
-		if self.workflow_state == 'Approved':
+		if self.workflow_state in ["Approved by CEO", "Approved"] and self.docstatus == 1:
 			if not self.expense_type:
 				frappe.throw(
 					title="Expense Type Required",


### PR DESCRIPTION
## Feature description
Need to:

-  Correct Journal Entry creation logic for Batta Claim
- Configure the Display Depends On property of the Expense Type field.The Expense Type field should be visible only to users with roles:
     - HOD
    - Admin User

## Solution description

- Corrected Journal Entry creation logic for Batta Claim that is, feat: create Journal Entry on Batta Claim submission for Approved and Approved by CEO states

- Configured the Display Depends On property of the Expense Type field.
eval:(frappe.user.has_role("HOD") || frappe.user.has_role("Admin User"))

## Output screenshots (optional)
[Screencast from 06-04-26 12:51:18 PM IST.webm](https://github.com/user-attachments/assets/79b4fab1-0a3f-4ab4-b95d-e8b45edb42a6)


## Areas affected and ensured
Batta claim doctype

## Is there any existing behaviour change of other features due to this code change?
No.

## Was this feature tested on these browsers?
- [ ]   Chrome

